### PR TITLE
Handle app exit by pruning pane and respawning welcome

### DIFF
--- a/texel/app_lifecycle.go
+++ b/texel/app_lifecycle.go
@@ -16,11 +16,14 @@ type LocalAppLifecycle struct {
 }
 
 // StartApp launches the app's Run method asynchronously.
-func (l *LocalAppLifecycle) StartApp(app App) {
+func (l *LocalAppLifecycle) StartApp(app App, onExit func(error)) {
 	l.wg.Add(1)
 	go func() {
 		defer l.wg.Done()
-		_ = app.Run()
+		err := app.Run()
+		if onExit != nil {
+			onExit(err)
+		}
 	}()
 }
 
@@ -38,5 +41,5 @@ func (l *LocalAppLifecycle) Wait() {
 // out and should not be invoked.
 type NoopAppLifecycle struct{}
 
-func (NoopAppLifecycle) StartApp(app App) {}
-func (NoopAppLifecycle) StopApp(app App)  {}
+func (NoopAppLifecycle) StartApp(app App, _ func(error)) {}
+func (NoopAppLifecycle) StopApp(app App)                 {}

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -264,7 +264,7 @@ func (d *DesktopEngine) AddStatusPane(app App, side Side, size int) {
 		app.SetRefreshNotifier(d.activeWorkspace.refreshChan)
 	}
 
-	d.appLifecycle.StartApp(app)
+	d.appLifecycle.StartApp(app, nil)
 	d.recalculateLayout()
 	d.broadcastTreeChanged()
 }

--- a/texel/pane.go
+++ b/texel/pane.go
@@ -106,7 +106,10 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 	}
 	// The app is resized considering the space for borders.
 	p.app.Resize(p.drawableWidth(), p.drawableHeight())
-	p.screen.appLifecycle.StartApp(p.app)
+	currentApp := p.app
+	p.screen.appLifecycle.StartApp(p.app, func(err error) {
+		p.screen.handleAppExit(p, currentApp, err)
+	})
 	if p.screen != nil && p.screen.desktop != nil {
 		p.screen.desktop.notifyPaneState(p.ID(), p.IsActive, p.IsResizing, p.ZOrder, p.handlesSelection)
 	}

--- a/texel/runtime_interfaces.go
+++ b/texel/runtime_interfaces.go
@@ -44,6 +44,6 @@ type EventRouter interface {
 // default implementation simply runs apps locally, but remote runtimes can
 // provide their own orchestration while preserving the same call sites.
 type AppLifecycleManager interface {
-	StartApp(app App)
+	StartApp(app App, onExit func(error))
 	StopApp(app App)
 }

--- a/texel/tree.go
+++ b/texel/tree.go
@@ -326,6 +326,23 @@ func (t *Tree) findFirstLeaf(node *Node) *Node {
 	return curr
 }
 
+// FindNodeWithPane returns the first node whose pane matches the provided pane pointer.
+func (t *Tree) FindNodeWithPane(target *pane) *Node {
+	if t == nil || target == nil {
+		return nil
+	}
+	var result *Node
+	t.Traverse(func(n *Node) {
+		if result != nil || n == nil {
+			return
+		}
+		if n.Pane == target {
+			result = n
+		}
+	})
+	return result
+}
+
 // findParentOf finds the parent of the given node.
 func (t *Tree) findParentOf(current, parent, target *Node) *Node {
 	if current == nil {


### PR DESCRIPTION
Now panel is removed when apps end.
Respawns the welcome app when no pane left on a workspace