### PR TITLE
Fix stuttery terminal resize

### DIFF
--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -23,7 +23,7 @@ import (
 	"texelation/texel/theme"
 )
 
-const resizeDebounce = 45 * time.Millisecond
+const resizeDebounce = 10 * time.Millisecond
 
 // Options configures the remote client runtime.
 type Options struct {

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -64,6 +64,16 @@ func (s *clientState) setRenderChannel(ch chan<- struct{}) {
 	}
 }
 
+// triggerRender requests a render on the render channel (non-blocking).
+func (s *clientState) triggerRender() {
+	if s.renderCh != nil {
+		select {
+		case s.renderCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
 func (s *clientState) setThemeValue(section, key string, value interface{}) {
 	if s.themeValues == nil {
 		s.themeValues = make(map[string]map[string]interface{})

--- a/internal/runtime/client/input_handler.go
+++ b/internal/runtime/client/input_handler.go
@@ -114,7 +114,8 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 	case *tcell.EventResize:
 		cols, rows := screen.Size()
 		state.scheduleResize(writeMu, conn, sessionID, protocol.Resize{Cols: uint16(cols), Rows: uint16(rows)})
-		screen.Sync()
+		// Trigger render instead of expensive Sync() - tcell handles internal resize sync automatically
+		state.triggerRender()
 	case *tcell.EventInterrupt:
 		// Ignore; used to wake PollEvent for shutdown.
 	case *tcell.EventPaste:


### PR DESCRIPTION
## Summary
- Replace expensive `screen.Sync()` with lightweight `triggerRender()` on resize events
- Tcell already handles its internal buffer resizing automatically, so the explicit Sync was redundant and causing visible stutter
- Reduce resize debounce from 45ms to 10ms for more responsive updates

## Test plan
- [x] Build succeeds (`make build`)
- [x] All tests pass (`make test`)
- [x] Manual testing: terminal resize is now as smooth as panel resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)