### PR TITLE
Improve help app layout and add close confirmation for app replacement

### DIFF
--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -81,6 +81,7 @@ type TexelTerm struct {
 }
 
 var _ texel.CloseRequester = (*TexelTerm)(nil)
+var _ texel.CloseCallbackRequester = (*TexelTerm)(nil)
 
 // termSelection tracks the current text selection state and multi-click history.
 //
@@ -125,13 +126,17 @@ func New(title, command string) texel.App {
 }
 
 func (a *TexelTerm) RequestClose() bool {
+	return a.RequestCloseWithCallback(func() {
+		// External close confirmed - stop the app
+		a.Stop()
+	})
+}
+
+func (a *TexelTerm) RequestCloseWithCallback(onConfirm func()) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.confirmClose = true
-	a.confirmCallback = func() {
-		// External close confirmed - stop the app
-		a.Stop()
-	}
+	a.confirmCallback = onConfirm
 	a.requestRefresh()
 	return false
 }

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	flag.Parse()
-	if err := devshell.RunApp("welcome", flag.Args()); err != nil {
-		log.Fatalf("welcome: %v", err)
+	if err := devshell.RunApp("help", flag.Args()); err != nil {
+		log.Fatalf("help: %v", err)
 	}
 }

--- a/texel/app.go
+++ b/texel/app.go
@@ -78,6 +78,17 @@ type CloseRequester interface {
 	RequestClose() bool
 }
 
+// CloseCallbackRequester extends CloseRequester with callback support.
+// This allows the container to specify what action to take after confirmation,
+// enabling app replacement flows where the action isn't just "stop".
+type CloseCallbackRequester interface {
+	// RequestCloseWithCallback is called when the container wants to close/replace the app.
+	// The onConfirm callback should be called if the user confirms the close.
+	// Returns true if the app is ready to close immediately (callback not needed).
+	// Returns false if the app is showing a confirmation dialog.
+	RequestCloseWithCallback(onConfirm func()) bool
+}
+
 // ControlBusProvider is implemented by apps that expose a control bus for signaling.
 // This allows apps to communicate events (like launcher app selection) without direct coupling.
 type ControlBusProvider interface {

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -635,6 +635,11 @@ func (d *DesktopEngine) handleEvent(ev tcell.Event) {
 	for i := len(d.floatingPanels) - 1; i >= 0; i-- {
 		fp := d.floatingPanels[i]
 		if fp.modal {
+			// ESC closes modal floating panels
+			if key.Key() == tcell.KeyEsc {
+				d.CloseFloatingPanel(fp)
+				return
+			}
 			// Route to pipeline (or app as fallback)
 			if fp.pipeline != nil {
 				fp.pipeline.HandleKey(key)


### PR DESCRIPTION
## Summary

This PR includes three related improvements:

### 1. Help App Redesign
- Restructured with sections (`helpSection`) and key/description pairs (`helpEntry`)
- Section titles are centered with bold active color styling
- Two-column grid layout: keys right-aligned in active color, descriptions left-aligned in secondary color
- Uses semantic theme colors (`text.primary`, `text.secondary`, `text.active`)
- Fixed `cmd/help/main.go` to use "help" instead of old "welcome" app name

### 2. Close Confirmation for App Replacement
- Added `CloseCallbackRequester` interface with `RequestCloseWithCallback(onConfirm func()) bool`
- This allows the container to specify what action to take after confirmation
- Updated texelterm to implement `CloseCallbackRequester`
- Updated `ReplaceWithApp` to check for this interface before replacing apps
- When launcher selects an app to replace a running texelterm, the "Close terminal? (y/n)" dialog now appears

### 3. Modal Floating Panel ESC Support
- ESC now closes any modal floating panel (help, launcher, etc.)
- Previously only F1 could close the help panel

## Files Changed
- `apps/help/help.go` - Complete redesign with structured layout
- `apps/texelterm/term.go` - Implement `CloseCallbackRequester`
- `cmd/help/main.go` - Fix app name from "welcome" to "help"
- `texel/app.go` - Add `CloseCallbackRequester` interface
- `texel/desktop_engine_core.go` - ESC closes modal floating panels
- `texel/pane.go` - Check `CloseCallbackRequester` in `ReplaceWithApp`

## Test plan
- [x] `make build-apps` - builds successfully
- [x] `make test` - all tests pass
- [ ] Manual: Run `./bin/help` to see new structured layout
- [ ] Manual: Press F1 in texelation, verify ESC closes the help panel
- [ ] Manual: Open launcher (Ctrl+A L), select app to replace texelterm, verify confirmation dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)