### PR TITLE
Extract reusable primitives from ColorPicker widget

### DIFF
--- a/docs/plans/TEXELUI_PLAN.md
+++ b/docs/plans/TEXELUI_PLAN.md
@@ -2,9 +2,11 @@
 
 This document tracks the design and implementation plan for TexelUI — a reusable, text‑only UI library intended to run inside TexelApps (and other tcell‑based apps). Keep this file up to date as work progresses.
 
-Last updated: 2025-11-18 (evening session)
+Last updated: 2025-12-27
 
 ## Current Status & Next Steps
+
+**Primitives Package Added (2025-12-27)**: Reusable primitive components extracted to `texelui/primitives` package. ColorPicker refactored to use these primitives.
 
 **Core Widgets Completed (2025-11-18)**: Priority 1 and 2 widgets from the architecture review have been implemented, tested, and polished.
 
@@ -19,17 +21,24 @@ Last updated: 2025-11-18 (evening session)
 - ✅ HBox layout manager (horizontal row with spacing)
 - ✅ Comprehensive tests (12 test cases, all passing)
 - ✅ Demo application (`texelui/examples/widget_demo.go`)
+- ✅ ScrollableList primitive (vertical list with scrolling, custom renderers)
+- ✅ Grid primitive (2D grid with dynamic columns, custom cell renderers)
+- ✅ TabBar primitive (horizontal tabs with keyboard/mouse navigation)
+- ✅ ColorPicker widget (semantic, palette, OKLCH modes)
+  - ✅ SemanticPicker uses ScrollableList internally
+  - ✅ PalettePicker uses Grid internally
+  - ✅ DrawColorSwatch helper functions
 
 **Ready for Production:**
 The core widget set is now stable and ready for use in forms and applications.
 All widgets have consistent focus behavior (reverse video) and proper keyboard/mouse support.
+The primitives package provides reusable building blocks for complex widgets.
 
 **Next Priority:**
 - RadioButton widget (mutually exclusive groups)
-- Grid layout manager
 - Form helper widget for automatic label/input pairing
 - Validation framework (Required, Email, MinLength, etc.)
-- Advanced container widgets (ScrollPane, Tabs, SplitPane)
+- Advanced container widgets (ScrollPane, SplitPane)
 
 ## Goals
 - Provide a clean widget kernel that can be embedded in any TexelApp/pane.
@@ -135,8 +144,14 @@ All widgets have consistent focus behavior (reverse video) and proper keyboard/m
 - [x] HBox layout manager (horizontal arrangement)
 - [x] Widget tests (12 comprehensive test cases)
 - [x] Demo application (texelui/examples/widget_demo.go)
+- [x] ScrollableList primitive (vertical list with scrolling)
+- [x] Grid primitive (2D grid with dynamic columns)
+- [x] TabBar primitive (horizontal tab navigation)
+- [x] ColorPicker refactored to use primitives
+- [x] Code quality: TextArea legacy theme API fixed
+- [x] Code quality: Removed dead code from TextArea
+- [x] Code quality: Removed unused BaseWidget fields
 - [ ] RadioButton widget (mutually exclusive groups)
-- [ ] Grid layout manager (rows × columns)
 - [ ] Form helper widget
 - [ ] Validation framework
 - [ ] Benchmarks for redraw cost (typing and selection)

--- a/docs/plans/TEXELUI_WIDGET_EXTRACTION_PLAN.md
+++ b/docs/plans/TEXELUI_WIDGET_EXTRACTION_PLAN.md
@@ -1,0 +1,494 @@
+# TexelUI Widget Extraction Plan
+
+This document details the plan to extract reusable widgets from the ColorPicker implementation and address code quality issues in the TexelUI library.
+
+**Created:** 2025-12-27
+**Status:** ✅ Completed (2025-12-27)
+
+## Executive Summary
+
+The ColorPicker widget works perfectly but contains patterns that should be reusable:
+- **TabBar**: Horizontal tab navigation (used for mode switching)
+- **ScrollableList**: Vertical scrollable list with selection (used in SemanticPicker)
+- **Grid**: 2D grid layout with selection (used in PalettePicker)
+- **ColorSwatch**: Color preview pattern `[██]` (used everywhere)
+
+Additionally, we'll fix identified code quality issues:
+- TextArea uses legacy theme API
+- 150 lines of dead code in TextArea
+- Unused `enabled`/`visible` fields in BaseWidget
+
+## Approach: Pragmatic Balance (Modified)
+
+**Decision**: Extract 3 full widgets + 1 helper function
+
+| Component | Implementation | Rationale |
+|-----------|---------------|-----------|
+| **TabBar** | Full Widget | Requested, reusable for tabs |
+| **ScrollableList** | Full Widget | High reuse (dropdowns, menus) |
+| **Grid** | Full Widget | High reuse (icon grids, palettes) |
+| **ColorSwatch** | Helper function | Only 4 lines, widget overhead not justified |
+
+## Implementation Phases
+
+### Phase 1: Code Quality Fixes (Low Risk)
+
+**1.1 Fix TextArea legacy theme API** (`textarea.go:31-43`)
+
+Before:
+```go
+bg := tm.GetColor("ui", "text_bg", tcell.ColorBlack)
+fg := tm.GetColor("ui", "text_fg", tcell.ColorWhite)
+```
+
+After:
+```go
+bg := tm.GetSemanticColor("bg.surface")
+fg := tm.GetSemanticColor("text.primary")
+```
+
+**1.2 Remove dead code** (`textarea.go:172-321`)
+
+Delete the ~150 lines of commented-out `HandleKeyOld` function.
+
+**1.3 Remove unused BaseWidget fields** (`core/widget.go`)
+
+Remove `enabled` and `visible` fields from BaseWidget struct (lines 30-31). These are defined but never used by any widget.
+
+### Phase 2: Create New Widgets
+
+#### 2.1 TabBar Widget (`widgets/tabbar.go`)
+
+**Purpose**: Horizontal tab navigation with keyboard and mouse support.
+
+**API**:
+```go
+type TabItem struct {
+    Label string
+    ID    string  // Optional identifier
+}
+
+type TabBar struct {
+    core.BaseWidget
+    Tabs       []TabItem
+    ActiveIdx  int
+    OnChange   func(int)  // Called when tab selection changes
+    inv        func(core.Rect)
+}
+
+// Constructor
+func NewTabBar(x, y, w int, tabs []TabItem) *TabBar
+
+// Widget interface
+func (tb *TabBar) Draw(p *core.Painter)
+func (tb *TabBar) HandleKey(ev *tcell.EventKey) bool  // Left/Right, 1-9
+func (tb *TabBar) HandleMouse(ev *tcell.EventMouse) bool
+func (tb *TabBar) SetInvalidator(fn func(core.Rect))
+
+// Public API
+func (tb *TabBar) SetActive(idx int)
+func (tb *TabBar) ActiveTab() TabItem
+```
+
+**Key Handling**:
+- Left/Right arrows: Navigate between tabs
+- Number keys 1-9: Jump to tab by index
+- Returns true if handled, false to let parent handle
+
+**Visual Behavior**:
+- Active tab: Reverse video (+ bold when TabBar is focused)
+- Inactive tabs: Dim when focused, normal otherwise
+- Optional focus marker '►' at left edge
+
+**Estimated Lines**: ~150
+
+---
+
+#### 2.2 ScrollableList Widget (`widgets/scrollablelist.go`)
+
+**Purpose**: Vertical scrollable list with item selection.
+
+**API**:
+```go
+type ListItem struct {
+    Text  string
+    Value interface{}  // Optional data payload
+}
+
+type ScrollableList struct {
+    core.BaseWidget
+    Items       []ListItem
+    SelectedIdx int
+    OnChange    func(int)  // Called when selection changes
+
+    // Custom rendering (optional)
+    RenderItem func(p *core.Painter, rect core.Rect, item ListItem, selected bool)
+
+    inv func(core.Rect)
+}
+
+// Constructor
+func NewScrollableList(x, y, w, h int) *ScrollableList
+
+// Widget interface
+func (sl *ScrollableList) Draw(p *core.Painter)
+func (sl *ScrollableList) HandleKey(ev *tcell.EventKey) bool
+func (sl *ScrollableList) HandleMouse(ev *tcell.EventMouse) bool
+func (sl *ScrollableList) SetInvalidator(fn func(core.Rect))
+
+// Public API
+func (sl *ScrollableList) SetItems(items []ListItem)
+func (sl *ScrollableList) SetSelected(idx int)
+func (sl *ScrollableList) SelectedItem() *ListItem
+func (sl *ScrollableList) Clear()
+```
+
+**Key Handling**:
+- Up/Down: Navigate items
+- Home/End: Jump to first/last
+- PgUp/PgDn: Page navigation
+- Returns false when at boundary (let parent handle Tab)
+
+**Visual Behavior**:
+- Selected item: Reverse video
+- Scroll indicators: ▲ (top), ▼ (bottom) when content overflows
+- Centers selected item in viewport when navigating
+
+**Estimated Lines**: ~200
+
+---
+
+#### 2.3 Grid Widget (`widgets/grid.go`)
+
+**Purpose**: 2D grid layout with cell selection and navigation.
+
+**API**:
+```go
+type GridItem struct {
+    Text  string
+    Value interface{}  // Optional data payload
+}
+
+type Grid struct {
+    core.BaseWidget
+    Items        []GridItem
+    SelectedIdx  int
+    MinCellWidth int  // Minimum cell width (for column calculation)
+    MaxCols      int  // Maximum columns (0 = unlimited)
+    OnChange     func(int)  // Called when selection changes
+
+    // Custom rendering (optional)
+    RenderCell func(p *core.Painter, rect core.Rect, item GridItem, selected bool)
+
+    // Internal state
+    cols int
+    inv  func(core.Rect)
+}
+
+// Constructor
+func NewGrid(x, y, w, h int) *Grid
+
+// Widget interface
+func (g *Grid) Draw(p *core.Painter)
+func (g *Grid) HandleKey(ev *tcell.EventKey) bool
+func (g *Grid) HandleMouse(ev *tcell.EventMouse) bool
+func (g *Grid) SetInvalidator(fn func(core.Rect))
+
+// Public API
+func (g *Grid) SetItems(items []GridItem)
+func (g *Grid) SetSelected(idx int)
+func (g *Grid) SelectedItem() *GridItem
+func (g *Grid) Columns() int  // Returns calculated column count
+```
+
+**Key Handling**:
+- Arrow keys: 2D navigation
+- Tab: Left-to-right, top-to-bottom sequential navigation
+- Home/End: First/last item
+
+**Layout Algorithm**:
+1. Find longest item text
+2. Calculate cell width: max(MinCellWidth, longestText + padding)
+3. Calculate columns: min(availableWidth / cellWidth, MaxCols)
+4. Distribute remaining width evenly
+
+**Estimated Lines**: ~250
+
+---
+
+#### 2.4 ColorSwatch Helper (`widgets/colorpicker/helpers.go`)
+
+**Purpose**: Render color preview in consistent format.
+
+**API**:
+```go
+// DrawColorSwatch renders [██] with the given color
+func DrawColorSwatch(p *core.Painter, x, y int, color tcell.Color, bracketStyle tcell.Style)
+
+// DrawColorSwatchWithLabel renders [█A] where A is the label on background
+func DrawColorSwatchWithLabel(p *core.Painter, x, y int, color, bgColor tcell.Color, label rune, bracketStyle tcell.Style)
+```
+
+**Usage**:
+```go
+// In SemanticPicker
+DrawColorSwatch(p, x, y, selectedColor, baseStyle)
+p.DrawText(x+5, y, colorName, style)
+
+// In ColorPicker collapsed view
+DrawColorSwatchWithLabel(p, x, y, result.Color, globalBg, 'A', style)
+```
+
+**Estimated Lines**: ~40
+
+### Phase 3: Integrate Widgets into ColorPicker
+
+#### 3.1 Refactor SemanticPicker (`colorpicker/semantic.go`)
+
+**Before**: Manual scroll offset calculation, manual item rendering (~113 lines)
+
+**After**:
+```go
+type SemanticPicker struct {
+    list *ScrollableList
+    semanticNames []string
+}
+
+func NewSemanticPicker() *SemanticPicker {
+    sp := &SemanticPicker{
+        semanticNames: []string{"accent", "bg.base", ...},
+    }
+
+    items := make([]ListItem, len(sp.semanticNames))
+    for i, name := range sp.semanticNames {
+        items[i] = ListItem{Text: name, Value: name}
+    }
+
+    sp.list = NewScrollableList(0, 0, 28, 10)
+    sp.list.SetItems(items)
+    sp.list.RenderItem = sp.renderColorItem
+
+    return sp
+}
+
+func (sp *SemanticPicker) renderColorItem(p *core.Painter, rect core.Rect, item ListItem, selected bool) {
+    name := item.Text
+    color := theme.Get().GetSemanticColor(name)
+    style := baseStyle
+    if selected {
+        style = style.Reverse(true)
+    }
+    DrawColorSwatch(p, rect.X, rect.Y, color, style)
+    p.DrawText(rect.X+5, rect.Y, name, style)
+}
+```
+
+**Estimated change**: -60 lines removed, +30 lines added
+
+---
+
+#### 3.2 Refactor PalettePicker (`colorpicker/palette.go`)
+
+**Before**: Manual column calculation, manual grid rendering (~134 lines)
+
+**After**:
+```go
+type PalettePicker struct {
+    grid *Grid
+    paletteNames []string
+}
+
+func NewPalettePicker() *PalettePicker {
+    pp := &PalettePicker{
+        paletteNames: []string{"rosewater", "flamingo", ...},
+    }
+
+    items := make([]GridItem, len(pp.paletteNames))
+    for i, name := range pp.paletteNames {
+        items[i] = GridItem{Text: name, Value: name}
+    }
+
+    pp.grid = NewGrid(0, 0, 40, 12)
+    pp.grid.MinCellWidth = 15
+    pp.grid.MaxCols = 3
+    pp.grid.SetItems(items)
+    pp.grid.RenderCell = pp.renderColorCell
+
+    return pp
+}
+
+func (pp *PalettePicker) renderColorCell(p *core.Painter, rect core.Rect, item GridItem, selected bool) {
+    name := item.Text
+    color := theme.ResolveColorName(name)
+    style := baseStyle
+    if selected {
+        style = style.Reverse(true)
+    }
+    DrawColorSwatch(p, rect.X, rect.Y, color, style)
+    p.DrawText(rect.X+5, rect.Y, name, style)
+}
+```
+
+**Estimated change**: -100 lines removed, +40 lines added
+
+---
+
+#### 3.3 Refactor ColorPicker (`colorpicker.go`)
+
+**Before**: Manual tab bar rendering (lines 318-347), manual tab navigation
+
+**After**:
+```go
+type ColorPicker struct {
+    core.BaseWidget
+    config      ColorPickerConfig
+    expanded    bool
+    currentMode ColorPickerMode
+    result      ColorPickerResult
+    focus       focusArea
+
+    // NEW: Use TabBar widget
+    tabBar     *TabBar
+
+    modes      map[ColorPickerMode]colorpicker.ModePicker
+    modeOrder  []ColorPickerMode
+    activeMode colorpicker.ModePicker
+    OnChange   func(ColorPickerResult)
+    inv        func(core.Rect)
+}
+
+func NewColorPicker(x, y int, config ColorPickerConfig) *ColorPicker {
+    cp := &ColorPicker{...}
+
+    // Build tabs from enabled modes
+    tabs := []TabItem{}
+    for _, mode := range cp.modeOrder {
+        tabs = append(tabs, TabItem{Label: mode.String(), ID: string(mode)})
+    }
+
+    cp.tabBar = NewTabBar(0, 0, 30, tabs)
+    cp.tabBar.OnChange = func(idx int) {
+        cp.selectMode(cp.modeOrder[idx])
+    }
+
+    return cp
+}
+
+func (cp *ColorPicker) drawExpanded(painter *core.Painter) {
+    // ...border drawing...
+
+    // Position and draw TabBar on top border
+    cp.tabBar.SetPosition(cp.Rect.X + 2, cp.Rect.Y)
+    cp.tabBar.Resize(cp.Rect.W - 4, 1)
+    if cp.focus == focusTabBar {
+        cp.tabBar.Focus()
+    } else {
+        cp.tabBar.Blur()
+    }
+    cp.tabBar.Draw(painter)
+
+    // ...mode content drawing...
+}
+```
+
+**Estimated change**: -80 lines removed, +40 lines added
+
+### Phase 4: Testing & Validation
+
+1. **Unit Tests** for new widgets:
+   - `widgets/tabbar_test.go` (~100 lines)
+   - `widgets/scrollablelist_test.go` (~150 lines)
+   - `widgets/grid_test.go` (~150 lines)
+
+2. **Integration Tests**:
+   - Ensure ColorPicker still works identically
+   - Test keyboard navigation through all modes
+   - Test mouse interaction
+
+3. **Manual Testing**:
+   - Run ColorPicker demo
+   - Verify tab switching
+   - Verify list/grid selection
+   - Verify modal behavior
+
+## File Changes Summary
+
+### New Files (7)
+| File | Lines | Purpose |
+|------|-------|---------|
+| `widgets/tabbar.go` | ~150 | TabBar widget |
+| `widgets/tabbar_test.go` | ~100 | TabBar tests |
+| `widgets/scrollablelist.go` | ~200 | ScrollableList widget |
+| `widgets/scrollablelist_test.go` | ~150 | ScrollableList tests |
+| `widgets/grid.go` | ~250 | Grid widget |
+| `widgets/grid_test.go` | ~150 | Grid tests |
+| `widgets/colorpicker/helpers.go` | ~40 | ColorSwatch helpers |
+
+### Modified Files (5)
+| File | Changes |
+|------|---------|
+| `core/widget.go` | Remove `enabled`, `visible` fields |
+| `widgets/textarea.go` | Fix theme API, remove dead code |
+| `widgets/colorpicker.go` | Use TabBar widget |
+| `widgets/colorpicker/semantic.go` | Use ScrollableList |
+| `widgets/colorpicker/palette.go` | Use Grid |
+
+### Totals
+- **New code**: ~1040 lines (widgets + tests)
+- **Removed code**: ~390 lines (dead code + refactored logic)
+- **Net change**: +650 lines
+
+## Success Criteria
+
+1. All existing tests pass (`make test`)
+2. ColorPicker functionality unchanged
+3. New widgets work standalone
+4. Code is more DRY (no duplicated scroll/grid logic)
+5. Theme API is consistent across all widgets
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking ColorPicker | Implement one phase at a time, test after each |
+| Over-abstraction | Helper pattern for ColorSwatch instead of full widget |
+| Merge conflicts | Work on feature branch, keep commits small |
+
+## Timeline
+
+Estimated effort: 6-8 hours
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1: Code Quality | 30 min |
+| Phase 2: Create Widgets | 3-4 hours |
+| Phase 3: Integration | 2-3 hours |
+| Phase 4: Testing | 1 hour |
+
+## Checklist
+
+### Phase 1: Code Quality
+- [ ] Fix TextArea legacy theme API
+- [ ] Remove dead code from TextArea
+- [ ] Remove unused BaseWidget fields
+- [ ] Run tests, verify no breakage
+
+### Phase 2: Create Widgets
+- [ ] Create TabBar widget
+- [ ] Create TabBar tests
+- [ ] Create ScrollableList widget
+- [ ] Create ScrollableList tests
+- [ ] Create Grid widget
+- [ ] Create Grid tests
+- [ ] Create ColorSwatch helper
+
+### Phase 3: Integration
+- [ ] Refactor SemanticPicker
+- [ ] Refactor PalettePicker
+- [ ] Refactor ColorPicker
+- [ ] Test ColorPicker thoroughly
+
+### Phase 4: Validation
+- [ ] Run `make test`
+- [ ] Manual test ColorPicker
+- [ ] Update TEXELUI_PLAN.md status

--- a/texelui/core/widget.go
+++ b/texelui/core/widget.go
@@ -27,8 +27,6 @@ type ZIndexer interface {
 type BaseWidget struct {
 	Rect      Rect
 	focused   bool
-	enabled   bool
-	visible   bool
 	focusable bool
 	zIndex    int // z-ordering: higher values draw on top
 	// Optional focus styling: if enabled, widgets may use FocusedStyle when focused.

--- a/texelui/primitives/grid.go
+++ b/texelui/primitives/grid.go
@@ -1,0 +1,365 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texelui/primitives/grid.go
+// Summary: 2D grid widget with cell selection and keyboard/mouse navigation.
+
+package primitives
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"texelation/texel/theme"
+	"texelation/texelui/core"
+)
+
+// GridItem represents a single cell in a Grid.
+type GridItem struct {
+	Text  string
+	Value interface{} // Optional data payload
+}
+
+// GridCellRenderer is a custom rendering function for grid cells.
+// If nil, the default rendering is used (text with selection highlight).
+type GridCellRenderer func(p *core.Painter, rect core.Rect, item GridItem, selected bool)
+
+// Grid is a 2D grid widget with cell selection and navigation.
+// It dynamically calculates the number of columns based on available width
+// and supports 2D keyboard navigation, Tab sequential navigation, and mouse clicks.
+type Grid struct {
+	core.BaseWidget
+	Items        []GridItem
+	SelectedIdx  int
+	MinCellWidth int // Minimum width per cell (used for column calculation)
+	MaxCols      int // Maximum number of columns (0 = unlimited)
+	OnChange     func(int) // Called when selection changes
+
+	// Custom rendering (optional)
+	RenderCell GridCellRenderer
+
+	// Internal state (computed during Draw)
+	cols      int
+	cellWidth int
+	inv       func(core.Rect)
+}
+
+// NewGrid creates a new grid at the specified position and size.
+func NewGrid(x, y, w, h int) *Grid {
+	g := &Grid{
+		Items:        []GridItem{},
+		SelectedIdx:  0,
+		MinCellWidth: 10,
+		MaxCols:      0, // Unlimited
+		cols:         1,
+	}
+
+	g.SetPosition(x, y)
+	g.Resize(w, h)
+	g.SetFocusable(true)
+
+	// Configure focus style from theme
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	g.SetFocusedStyle(tcell.StyleDefault.Foreground(fg).Background(bg), true)
+
+	return g
+}
+
+// SetInvalidator allows the UI manager to inject a dirty-region invalidator.
+func (g *Grid) SetInvalidator(fn func(core.Rect)) {
+	g.inv = fn
+}
+
+// SetItems replaces the grid items.
+func (g *Grid) SetItems(items []GridItem) {
+	g.Items = items
+	// Clamp selection to valid range
+	if g.SelectedIdx >= len(items) {
+		g.SelectedIdx = len(items) - 1
+	}
+	if g.SelectedIdx < 0 {
+		g.SelectedIdx = 0
+	}
+	g.invalidate()
+}
+
+// SetSelected changes the selected cell by index.
+func (g *Grid) SetSelected(idx int) {
+	if idx < 0 || idx >= len(g.Items) {
+		return
+	}
+	if idx == g.SelectedIdx {
+		return
+	}
+	g.SelectedIdx = idx
+	g.invalidate()
+	if g.OnChange != nil {
+		g.OnChange(idx)
+	}
+}
+
+// SelectedItem returns the currently selected item, or nil if none.
+func (g *Grid) SelectedItem() *GridItem {
+	if g.SelectedIdx >= 0 && g.SelectedIdx < len(g.Items) {
+		return &g.Items[g.SelectedIdx]
+	}
+	return nil
+}
+
+// Columns returns the calculated number of columns.
+func (g *Grid) Columns() int {
+	return g.cols
+}
+
+// calculateLayout computes grid layout based on available width.
+func (g *Grid) calculateLayout() {
+	if g.Rect.W <= 0 || len(g.Items) == 0 {
+		g.cols = 1
+		g.cellWidth = g.Rect.W
+		return
+	}
+
+	// Find longest item text
+	maxTextLen := 0
+	for _, item := range g.Items {
+		if len(item.Text) > maxTextLen {
+			maxTextLen = len(item.Text)
+		}
+	}
+
+	// Calculate cell width (at least MinCellWidth, at least longest text + padding)
+	cellWidth := g.MinCellWidth
+	if maxTextLen+2 > cellWidth { // +2 for minimal padding
+		cellWidth = maxTextLen + 2
+	}
+
+	// Calculate number of columns
+	cols := g.Rect.W / cellWidth
+	if cols < 1 {
+		cols = 1
+	}
+	if g.MaxCols > 0 && cols > g.MaxCols {
+		cols = g.MaxCols
+	}
+
+	// Recalculate cell width to use available space evenly
+	cellWidth = g.Rect.W / cols
+
+	g.cols = cols
+	g.cellWidth = cellWidth
+}
+
+// Draw renders the grid.
+func (g *Grid) Draw(painter *core.Painter) {
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	baseStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
+
+	// Fill background
+	painter.Fill(g.Rect, ' ', baseStyle)
+
+	if len(g.Items) == 0 {
+		return
+	}
+
+	// Calculate layout
+	g.calculateLayout()
+
+	// Draw items in grid
+	col := 0
+	x := g.Rect.X
+	y := g.Rect.Y
+
+	for i, item := range g.Items {
+		if y >= g.Rect.Y+g.Rect.H {
+			break // No more rows available
+		}
+
+		selected := i == g.SelectedIdx
+
+		cellRect := core.Rect{
+			X: x,
+			Y: y,
+			W: g.cellWidth,
+			H: 1,
+		}
+
+		if g.RenderCell != nil {
+			// Custom rendering
+			g.RenderCell(painter, cellRect, item, selected)
+		} else {
+			// Default rendering
+			g.drawDefaultCell(painter, cellRect, item, selected, baseStyle)
+		}
+
+		col++
+		if col >= g.cols {
+			col = 0
+			x = g.Rect.X
+			y++
+		} else {
+			x += g.cellWidth
+		}
+	}
+}
+
+// drawDefaultCell renders a grid cell with default styling.
+func (g *Grid) drawDefaultCell(painter *core.Painter, rect core.Rect, item GridItem, selected bool, baseStyle tcell.Style) {
+	style := baseStyle
+	if selected {
+		style = style.Reverse(true)
+	}
+
+	// Fill cell background
+	painter.Fill(rect, ' ', style)
+
+	// Draw text (truncate if needed)
+	text := item.Text
+	maxLen := rect.W
+	if len(text) > maxLen && maxLen > 0 {
+		text = text[:maxLen]
+	}
+
+	painter.DrawText(rect.X, rect.Y, text, style)
+}
+
+// HandleKey processes keyboard input for grid navigation.
+func (g *Grid) HandleKey(ev *tcell.EventKey) bool {
+	if len(g.Items) == 0 {
+		return false
+	}
+
+	// Ensure layout is calculated
+	if g.cols < 1 {
+		g.cols = 1
+	}
+
+	currentRow := g.SelectedIdx / g.cols
+	currentCol := g.SelectedIdx % g.cols
+	totalRows := (len(g.Items) + g.cols - 1) / g.cols
+
+	switch ev.Key() {
+	case tcell.KeyUp:
+		if currentRow > 0 {
+			newIdx := g.SelectedIdx - g.cols
+			if newIdx >= 0 {
+				g.SetSelected(newIdx)
+				return true
+			}
+		}
+		return false
+
+	case tcell.KeyDown:
+		if currentRow < totalRows-1 {
+			newIdx := g.SelectedIdx + g.cols
+			if newIdx >= len(g.Items) {
+				// Move to last item if going down from partial last row
+				newIdx = len(g.Items) - 1
+			}
+			if newIdx != g.SelectedIdx {
+				g.SetSelected(newIdx)
+				return true
+			}
+		}
+		return false
+
+	case tcell.KeyLeft:
+		if currentCol > 0 {
+			g.SetSelected(g.SelectedIdx - 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyRight:
+		if currentCol < g.cols-1 && g.SelectedIdx < len(g.Items)-1 {
+			g.SetSelected(g.SelectedIdx + 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyHome:
+		if g.SelectedIdx != 0 {
+			g.SetSelected(0)
+			return true
+		}
+		return false
+
+	case tcell.KeyEnd:
+		lastIdx := len(g.Items) - 1
+		if g.SelectedIdx != lastIdx {
+			g.SetSelected(lastIdx)
+			return true
+		}
+		return false
+
+	case tcell.KeyTab:
+		// Tab: left-to-right, top-to-bottom sequential navigation
+		if ev.Modifiers()&tcell.ModShift != 0 {
+			// Shift+Tab: go backwards
+			if g.SelectedIdx > 0 {
+				g.SetSelected(g.SelectedIdx - 1)
+				return true
+			}
+		} else {
+			// Tab: go forwards
+			if g.SelectedIdx < len(g.Items)-1 {
+				g.SetSelected(g.SelectedIdx + 1)
+				return true
+			}
+		}
+		// At boundary, let parent handle
+		return false
+	}
+
+	return false
+}
+
+// HandleMouse processes mouse input for cell selection.
+func (g *Grid) HandleMouse(ev *tcell.EventMouse) bool {
+	if len(g.Items) == 0 {
+		return false
+	}
+
+	x, y := ev.Position()
+	if !g.HitTest(x, y) {
+		return false
+	}
+
+	if ev.Buttons() != tcell.Button1 {
+		return false
+	}
+
+	// Ensure layout is calculated
+	if g.cols < 1 || g.cellWidth < 1 {
+		g.calculateLayout()
+	}
+
+	// Calculate which cell was clicked
+	relX := x - g.Rect.X
+	relY := y - g.Rect.Y
+
+	clickedCol := relX / g.cellWidth
+	if clickedCol >= g.cols {
+		clickedCol = g.cols - 1
+	}
+
+	clickedRow := relY
+	clickedIdx := clickedRow*g.cols + clickedCol
+
+	if clickedIdx >= 0 && clickedIdx < len(g.Items) {
+		if clickedIdx != g.SelectedIdx {
+			g.SetSelected(clickedIdx)
+		}
+		return true
+	}
+
+	return false
+}
+
+// invalidate marks the widget as needing redraw.
+func (g *Grid) invalidate() {
+	if g.inv != nil {
+		g.inv(g.Rect)
+	}
+}

--- a/texelui/primitives/grid_test.go
+++ b/texelui/primitives/grid_test.go
@@ -1,0 +1,383 @@
+package primitives
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestGrid_NewGrid(t *testing.T) {
+	g := NewGrid(5, 10, 40, 8)
+
+	x, y := g.Position()
+	if x != 5 || y != 10 {
+		t.Errorf("expected position (5,10), got (%d,%d)", x, y)
+	}
+
+	w, h := g.Size()
+	if w != 40 || h != 8 {
+		t.Errorf("expected size (40,8), got (%d,%d)", w, h)
+	}
+
+	if g.SelectedIdx != 0 {
+		t.Errorf("expected initial SelectedIdx 0, got %d", g.SelectedIdx)
+	}
+
+	if !g.Focusable() {
+		t.Error("expected Grid to be focusable")
+	}
+
+	if g.MinCellWidth != 10 {
+		t.Errorf("expected default MinCellWidth 10, got %d", g.MinCellWidth)
+	}
+}
+
+func TestGrid_SetItems(t *testing.T) {
+	g := NewGrid(0, 0, 40, 8)
+
+	items := []GridItem{
+		{Text: "Item 1", Value: 1},
+		{Text: "Item 2", Value: 2},
+		{Text: "Item 3", Value: 3},
+	}
+
+	g.SetItems(items)
+
+	if len(g.Items) != 3 {
+		t.Errorf("expected 3 items, got %d", len(g.Items))
+	}
+
+	if g.SelectedIdx != 0 {
+		t.Errorf("expected SelectedIdx 0, got %d", g.SelectedIdx)
+	}
+}
+
+func TestGrid_SetItems_ClampsSelection(t *testing.T) {
+	g := NewGrid(0, 0, 40, 8)
+
+	// Set initial items
+	g.SetItems([]GridItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+	g.SetSelected(2)
+
+	// Replace with fewer items
+	g.SetItems([]GridItem{
+		{Text: "X"},
+	})
+
+	if g.SelectedIdx != 0 {
+		t.Errorf("expected SelectedIdx clamped to 0, got %d", g.SelectedIdx)
+	}
+}
+
+func TestGrid_SetSelected(t *testing.T) {
+	g := NewGrid(0, 0, 40, 8)
+	g.SetItems([]GridItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+
+	callCount := 0
+	lastIdx := -1
+	g.OnChange = func(idx int) {
+		callCount++
+		lastIdx = idx
+	}
+
+	// Set to valid index
+	g.SetSelected(1)
+	if g.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx 1, got %d", g.SelectedIdx)
+	}
+	if callCount != 1 || lastIdx != 1 {
+		t.Errorf("expected OnChange called once with idx 1, got callCount=%d lastIdx=%d", callCount, lastIdx)
+	}
+
+	// Set to same index (should not trigger callback)
+	g.SetSelected(1)
+	if callCount != 1 {
+		t.Errorf("expected no additional OnChange call, got callCount=%d", callCount)
+	}
+
+	// Set to invalid index (negative)
+	g.SetSelected(-1)
+	if g.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx to remain 1 after invalid set, got %d", g.SelectedIdx)
+	}
+
+	// Set to invalid index (too large)
+	g.SetSelected(10)
+	if g.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx to remain 1 after invalid set, got %d", g.SelectedIdx)
+	}
+}
+
+func TestGrid_SelectedItem(t *testing.T) {
+	g := NewGrid(0, 0, 40, 8)
+
+	// Empty grid
+	if g.SelectedItem() != nil {
+		t.Error("expected nil for empty grid")
+	}
+
+	g.SetItems([]GridItem{
+		{Text: "First", Value: 100},
+		{Text: "Second", Value: 200},
+	})
+
+	item := g.SelectedItem()
+	if item == nil {
+		t.Fatal("expected non-nil item")
+	}
+	if item.Text != "First" || item.Value != 100 {
+		t.Errorf("expected First item, got %+v", item)
+	}
+
+	g.SetSelected(1)
+	item = g.SelectedItem()
+	if item.Text != "Second" || item.Value != 200 {
+		t.Errorf("expected Second item, got %+v", item)
+	}
+}
+
+func TestGrid_ColumnCalculation(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.MinCellWidth = 10
+
+	g.SetItems([]GridItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+		{Text: "D"},
+		{Text: "E"},
+		{Text: "F"},
+	})
+
+	// Force layout calculation by calling calculateLayout
+	g.calculateLayout()
+
+	// Width 30 / MinCellWidth 10 = 3 columns
+	if g.Columns() != 3 {
+		t.Errorf("expected 3 columns, got %d", g.Columns())
+	}
+}
+
+func TestGrid_MaxCols(t *testing.T) {
+	g := NewGrid(0, 0, 100, 8)
+	g.MinCellWidth = 10
+	g.MaxCols = 2 // Limit to 2 columns
+
+	g.SetItems([]GridItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+
+	g.calculateLayout()
+
+	if g.Columns() != 2 {
+		t.Errorf("expected 2 columns (MaxCols), got %d", g.Columns())
+	}
+}
+
+func TestGrid_HandleKey_LeftRight(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.MinCellWidth = 10 // 3 columns
+	g.SetItems([]GridItem{
+		{Text: "A"}, {Text: "B"}, {Text: "C"},
+		{Text: "D"}, {Text: "E"}, {Text: "F"},
+	})
+	g.calculateLayout()
+
+	// Start at A (idx 0, col 0)
+
+	// Right to B
+	ev := tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone)
+	handled := g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 1 {
+		t.Errorf("expected Right to idx 1, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Right to C
+	handled = g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 2 {
+		t.Errorf("expected Right to idx 2, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Right at end of row (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Right at end of row to not handle")
+	}
+
+	// Left back to B
+	ev = tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone)
+	handled = g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 1 {
+		t.Errorf("expected Left to idx 1, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Left to A
+	handled = g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 0 {
+		t.Errorf("expected Left to idx 0, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Left at start of row (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Left at start of row to not handle")
+	}
+}
+
+func TestGrid_HandleKey_UpDown(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.MinCellWidth = 10 // 3 columns
+	g.SetItems([]GridItem{
+		{Text: "A"}, {Text: "B"}, {Text: "C"},
+		{Text: "D"}, {Text: "E"}, {Text: "F"},
+	})
+	g.calculateLayout()
+
+	// Start at A (idx 0, row 0)
+	g.SetSelected(1) // Start at B (idx 1)
+
+	// Down to E (idx 4)
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	handled := g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 4 {
+		t.Errorf("expected Down to idx 4, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Down at bottom row (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Down at bottom row to not handle")
+	}
+
+	// Up back to B (idx 1)
+	ev = tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone)
+	handled = g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 1 {
+		t.Errorf("expected Up to idx 1, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Up at top row (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Up at top row to not handle")
+	}
+}
+
+func TestGrid_HandleKey_HomeEnd(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.SetItems([]GridItem{
+		{Text: "A"}, {Text: "B"}, {Text: "C"},
+		{Text: "D"}, {Text: "E"}, {Text: "F"},
+	})
+	g.SetSelected(3) // Start in middle
+
+	// End
+	ev := tcell.NewEventKey(tcell.KeyEnd, 0, tcell.ModNone)
+	handled := g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 5 {
+		t.Errorf("expected End to go to last item, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// End when already at end (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected End at end to not handle")
+	}
+
+	// Home
+	ev = tcell.NewEventKey(tcell.KeyHome, 0, tcell.ModNone)
+	handled = g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 0 {
+		t.Errorf("expected Home to go to first item, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+
+	// Home when already at beginning (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Home at beginning to not handle")
+	}
+}
+
+func TestGrid_HandleKey_Tab(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.MinCellWidth = 10 // 3 columns
+	g.SetItems([]GridItem{
+		{Text: "A"}, {Text: "B"}, {Text: "C"},
+		{Text: "D"}, {Text: "E"}, {Text: "F"},
+	})
+
+	// Tab forward through all items
+	ev := tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone)
+	for expected := 1; expected <= 5; expected++ {
+		handled := g.HandleKey(ev)
+		if !handled || g.SelectedIdx != expected {
+			t.Errorf("expected Tab to idx %d, got handled=%v idx=%d", expected, handled, g.SelectedIdx)
+		}
+	}
+
+	// Tab at end (should not handle)
+	handled := g.HandleKey(ev)
+	if handled {
+		t.Error("expected Tab at end to not handle")
+	}
+
+	// Shift+Tab backwards
+	ev = tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModShift)
+	for expected := 4; expected >= 0; expected-- {
+		handled := g.HandleKey(ev)
+		if !handled || g.SelectedIdx != expected {
+			t.Errorf("expected Shift+Tab to idx %d, got handled=%v idx=%d", expected, handled, g.SelectedIdx)
+		}
+	}
+
+	// Shift+Tab at beginning (should not handle)
+	handled = g.HandleKey(ev)
+	if handled {
+		t.Error("expected Shift+Tab at beginning to not handle")
+	}
+}
+
+func TestGrid_HandleKey_PartialLastRow(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+	g.MinCellWidth = 10 // 3 columns
+	g.SetItems([]GridItem{
+		{Text: "A"}, {Text: "B"}, {Text: "C"},
+		{Text: "D"}, {Text: "E"}, // Only 2 items in last row
+	})
+	g.calculateLayout()
+
+	// Start at C (idx 2)
+	g.SetSelected(2)
+
+	// Down should go to E (idx 4, last item) even though column 2 doesn't exist in last row
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	handled := g.HandleKey(ev)
+	if !handled || g.SelectedIdx != 4 {
+		t.Errorf("expected Down to clamp to last item, got handled=%v idx=%d", handled, g.SelectedIdx)
+	}
+}
+
+func TestGrid_EmptyGrid(t *testing.T) {
+	g := NewGrid(0, 0, 30, 8)
+
+	// HandleKey should return false for empty grid
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	if g.HandleKey(ev) {
+		t.Error("expected HandleKey to return false for empty grid")
+	}
+
+	// SelectedItem should return nil
+	if g.SelectedItem() != nil {
+		t.Error("expected SelectedItem to return nil for empty grid")
+	}
+}

--- a/texelui/primitives/scrollablelist.go
+++ b/texelui/primitives/scrollablelist.go
@@ -1,0 +1,345 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texelui/primitives/scrollablelist.go
+// Summary: Vertical scrollable list widget with item selection.
+
+package primitives
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"texelation/texel/theme"
+	"texelation/texelui/core"
+)
+
+// ListItem represents a single item in a ScrollableList.
+type ListItem struct {
+	Text  string
+	Value interface{} // Optional data payload
+}
+
+// ListItemRenderer is a custom rendering function for list items.
+// If nil, the default rendering is used (text with selection highlight).
+type ListItemRenderer func(p *core.Painter, rect core.Rect, item ListItem, selected bool)
+
+// ScrollableList is a vertical scrollable list widget with item selection.
+// It supports keyboard navigation (Up/Down/Home/End/PgUp/PgDn), mouse clicks,
+// and scroll wheel.
+type ScrollableList struct {
+	core.BaseWidget
+	Items       []ListItem
+	SelectedIdx int
+	OnChange    func(int) // Called when selection changes
+
+	// Custom rendering (optional)
+	RenderItem ListItemRenderer
+
+	// Show scroll indicators when content overflows
+	ShowScrollIndicators bool
+
+	// Internal state
+	scrollOffset int
+	inv          func(core.Rect)
+}
+
+// NewScrollableList creates a new scrollable list at the specified position and size.
+func NewScrollableList(x, y, w, h int) *ScrollableList {
+	sl := &ScrollableList{
+		Items:                []ListItem{},
+		SelectedIdx:          0,
+		ShowScrollIndicators: true,
+		scrollOffset:         0,
+	}
+
+	sl.SetPosition(x, y)
+	sl.Resize(w, h)
+	sl.SetFocusable(true)
+
+	// Configure focus style from theme
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	sl.SetFocusedStyle(tcell.StyleDefault.Foreground(fg).Background(bg), true)
+
+	return sl
+}
+
+// SetInvalidator allows the UI manager to inject a dirty-region invalidator.
+func (sl *ScrollableList) SetInvalidator(fn func(core.Rect)) {
+	sl.inv = fn
+}
+
+// SetItems replaces the list items.
+func (sl *ScrollableList) SetItems(items []ListItem) {
+	sl.Items = items
+	// Clamp selection to valid range
+	if sl.SelectedIdx >= len(items) {
+		sl.SelectedIdx = len(items) - 1
+	}
+	if sl.SelectedIdx < 0 {
+		sl.SelectedIdx = 0
+	}
+	sl.ensureSelectedVisible()
+	sl.invalidate()
+}
+
+// SetSelected changes the selected item by index.
+func (sl *ScrollableList) SetSelected(idx int) {
+	if idx < 0 || idx >= len(sl.Items) {
+		return
+	}
+	if idx == sl.SelectedIdx {
+		return
+	}
+	sl.SelectedIdx = idx
+	sl.ensureSelectedVisible()
+	sl.invalidate()
+	if sl.OnChange != nil {
+		sl.OnChange(idx)
+	}
+}
+
+// SelectedItem returns the currently selected item, or nil if none.
+func (sl *ScrollableList) SelectedItem() *ListItem {
+	if sl.SelectedIdx >= 0 && sl.SelectedIdx < len(sl.Items) {
+		return &sl.Items[sl.SelectedIdx]
+	}
+	return nil
+}
+
+// Clear removes all items from the list.
+func (sl *ScrollableList) Clear() {
+	sl.Items = []ListItem{}
+	sl.SelectedIdx = 0
+	sl.scrollOffset = 0
+	sl.invalidate()
+}
+
+// ensureSelectedVisible adjusts scroll offset to keep selected item visible.
+// Centers the selected item when possible.
+func (sl *ScrollableList) ensureSelectedVisible() {
+	if len(sl.Items) == 0 || sl.Rect.H <= 0 {
+		sl.scrollOffset = 0
+		return
+	}
+
+	viewportH := sl.Rect.H
+
+	// Center selected item in viewport
+	targetOffset := sl.SelectedIdx - viewportH/2
+	if targetOffset < 0 {
+		targetOffset = 0
+	}
+
+	maxOffset := len(sl.Items) - viewportH
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if targetOffset > maxOffset {
+		targetOffset = maxOffset
+	}
+
+	sl.scrollOffset = targetOffset
+}
+
+// Draw renders the scrollable list.
+func (sl *ScrollableList) Draw(painter *core.Painter) {
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	baseStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
+
+	// Fill background
+	painter.Fill(sl.Rect, ' ', baseStyle)
+
+	if len(sl.Items) == 0 {
+		return
+	}
+
+	viewportH := sl.Rect.H
+
+	// Draw visible items
+	y := sl.Rect.Y
+	for i := sl.scrollOffset; i < len(sl.Items) && y < sl.Rect.Y+viewportH; i++ {
+		item := sl.Items[i]
+		selected := i == sl.SelectedIdx
+
+		itemRect := core.Rect{
+			X: sl.Rect.X,
+			Y: y,
+			W: sl.Rect.W,
+			H: 1,
+		}
+
+		if sl.RenderItem != nil {
+			// Custom rendering
+			sl.RenderItem(painter, itemRect, item, selected)
+		} else {
+			// Default rendering
+			sl.drawDefaultItem(painter, itemRect, item, selected, baseStyle)
+		}
+
+		y++
+	}
+
+	// Draw scroll indicators if enabled
+	if sl.ShowScrollIndicators {
+		sl.drawScrollIndicators(painter, baseStyle)
+	}
+}
+
+// drawDefaultItem renders a list item with default styling.
+func (sl *ScrollableList) drawDefaultItem(painter *core.Painter, rect core.Rect, item ListItem, selected bool, baseStyle tcell.Style) {
+	style := baseStyle
+	if selected {
+		style = style.Reverse(true)
+	}
+
+	// Fill item background
+	painter.Fill(rect, ' ', style)
+
+	// Draw text (truncate if needed)
+	text := item.Text
+	maxLen := rect.W
+	if len(text) > maxLen && maxLen > 0 {
+		text = text[:maxLen]
+	}
+
+	painter.DrawText(rect.X, rect.Y, text, style)
+}
+
+// drawScrollIndicators draws ▲ and ▼ when content is scrollable.
+func (sl *ScrollableList) drawScrollIndicators(painter *core.Painter, baseStyle tcell.Style) {
+	viewportH := sl.Rect.H
+	indicatorX := sl.Rect.X + sl.Rect.W - 1
+
+	// Show ▲ if there's content above
+	if sl.scrollOffset > 0 {
+		painter.SetCell(indicatorX, sl.Rect.Y, '▲', baseStyle)
+	}
+
+	// Show ▼ if there's content below
+	if sl.scrollOffset+viewportH < len(sl.Items) {
+		painter.SetCell(indicatorX, sl.Rect.Y+viewportH-1, '▼', baseStyle)
+	}
+}
+
+// HandleKey processes keyboard input for list navigation.
+func (sl *ScrollableList) HandleKey(ev *tcell.EventKey) bool {
+	if len(sl.Items) == 0 {
+		return false
+	}
+
+	switch ev.Key() {
+	case tcell.KeyUp:
+		if sl.SelectedIdx > 0 {
+			sl.SetSelected(sl.SelectedIdx - 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyDown:
+		if sl.SelectedIdx < len(sl.Items)-1 {
+			sl.SetSelected(sl.SelectedIdx + 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyHome:
+		if sl.SelectedIdx != 0 {
+			sl.SetSelected(0)
+			return true
+		}
+		return false
+
+	case tcell.KeyEnd:
+		lastIdx := len(sl.Items) - 1
+		if sl.SelectedIdx != lastIdx {
+			sl.SetSelected(lastIdx)
+			return true
+		}
+		return false
+
+	case tcell.KeyPgUp:
+		pageSize := sl.Rect.H
+		if pageSize < 1 {
+			pageSize = 1
+		}
+		newIdx := sl.SelectedIdx - pageSize
+		if newIdx < 0 {
+			newIdx = 0
+		}
+		if newIdx != sl.SelectedIdx {
+			sl.SetSelected(newIdx)
+			return true
+		}
+		return false
+
+	case tcell.KeyPgDn:
+		pageSize := sl.Rect.H
+		if pageSize < 1 {
+			pageSize = 1
+		}
+		newIdx := sl.SelectedIdx + pageSize
+		if newIdx >= len(sl.Items) {
+			newIdx = len(sl.Items) - 1
+		}
+		if newIdx != sl.SelectedIdx {
+			sl.SetSelected(newIdx)
+			return true
+		}
+		return false
+	}
+
+	return false
+}
+
+// HandleMouse processes mouse input for item selection and scrolling.
+func (sl *ScrollableList) HandleMouse(ev *tcell.EventMouse) bool {
+	if len(sl.Items) == 0 {
+		return false
+	}
+
+	x, y := ev.Position()
+	if !sl.HitTest(x, y) {
+		return false
+	}
+
+	buttons := ev.Buttons()
+
+	// Handle scroll wheel
+	if buttons&tcell.WheelUp != 0 {
+		if sl.SelectedIdx > 0 {
+			sl.SetSelected(sl.SelectedIdx - 1)
+		}
+		return true
+	}
+	if buttons&tcell.WheelDown != 0 {
+		if sl.SelectedIdx < len(sl.Items)-1 {
+			sl.SetSelected(sl.SelectedIdx + 1)
+		}
+		return true
+	}
+
+	// Handle click
+	if buttons == tcell.Button1 {
+		relY := y - sl.Rect.Y
+		clickedIdx := sl.scrollOffset + relY
+
+		if clickedIdx >= 0 && clickedIdx < len(sl.Items) {
+			if clickedIdx != sl.SelectedIdx {
+				sl.SetSelected(clickedIdx)
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+// invalidate marks the widget as needing redraw.
+func (sl *ScrollableList) invalidate() {
+	if sl.inv != nil {
+		sl.inv(sl.Rect)
+	}
+}

--- a/texelui/primitives/scrollablelist_test.go
+++ b/texelui/primitives/scrollablelist_test.go
@@ -1,0 +1,336 @@
+package primitives
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestScrollableList_NewScrollableList(t *testing.T) {
+	sl := NewScrollableList(5, 10, 30, 10)
+
+	x, y := sl.Position()
+	if x != 5 || y != 10 {
+		t.Errorf("expected position (5,10), got (%d,%d)", x, y)
+	}
+
+	w, h := sl.Size()
+	if w != 30 || h != 10 {
+		t.Errorf("expected size (30,10), got (%d,%d)", w, h)
+	}
+
+	if sl.SelectedIdx != 0 {
+		t.Errorf("expected initial SelectedIdx 0, got %d", sl.SelectedIdx)
+	}
+
+	if !sl.Focusable() {
+		t.Error("expected ScrollableList to be focusable")
+	}
+
+	if !sl.ShowScrollIndicators {
+		t.Error("expected ShowScrollIndicators to be true by default")
+	}
+}
+
+func TestScrollableList_SetItems(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+
+	items := []ListItem{
+		{Text: "Item 1", Value: 1},
+		{Text: "Item 2", Value: 2},
+		{Text: "Item 3", Value: 3},
+	}
+
+	sl.SetItems(items)
+
+	if len(sl.Items) != 3 {
+		t.Errorf("expected 3 items, got %d", len(sl.Items))
+	}
+
+	if sl.SelectedIdx != 0 {
+		t.Errorf("expected SelectedIdx 0, got %d", sl.SelectedIdx)
+	}
+}
+
+func TestScrollableList_SetItems_ClampsSelection(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+
+	// Set initial items
+	sl.SetItems([]ListItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+	sl.SetSelected(2)
+
+	// Replace with fewer items
+	sl.SetItems([]ListItem{
+		{Text: "X"},
+	})
+
+	if sl.SelectedIdx != 0 {
+		t.Errorf("expected SelectedIdx clamped to 0, got %d", sl.SelectedIdx)
+	}
+}
+
+func TestScrollableList_SetSelected(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+	sl.SetItems([]ListItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+
+	callCount := 0
+	lastIdx := -1
+	sl.OnChange = func(idx int) {
+		callCount++
+		lastIdx = idx
+	}
+
+	// Set to valid index
+	sl.SetSelected(1)
+	if sl.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx 1, got %d", sl.SelectedIdx)
+	}
+	if callCount != 1 || lastIdx != 1 {
+		t.Errorf("expected OnChange called once with idx 1, got callCount=%d lastIdx=%d", callCount, lastIdx)
+	}
+
+	// Set to same index (should not trigger callback)
+	sl.SetSelected(1)
+	if callCount != 1 {
+		t.Errorf("expected no additional OnChange call, got callCount=%d", callCount)
+	}
+
+	// Set to invalid index (negative)
+	sl.SetSelected(-1)
+	if sl.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx to remain 1 after invalid set, got %d", sl.SelectedIdx)
+	}
+
+	// Set to invalid index (too large)
+	sl.SetSelected(10)
+	if sl.SelectedIdx != 1 {
+		t.Errorf("expected SelectedIdx to remain 1 after invalid set, got %d", sl.SelectedIdx)
+	}
+}
+
+func TestScrollableList_SelectedItem(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+
+	// Empty list
+	if sl.SelectedItem() != nil {
+		t.Error("expected nil for empty list")
+	}
+
+	sl.SetItems([]ListItem{
+		{Text: "First", Value: 100},
+		{Text: "Second", Value: 200},
+	})
+
+	item := sl.SelectedItem()
+	if item == nil {
+		t.Fatal("expected non-nil item")
+	}
+	if item.Text != "First" || item.Value != 100 {
+		t.Errorf("expected First item, got %+v", item)
+	}
+
+	sl.SetSelected(1)
+	item = sl.SelectedItem()
+	if item.Text != "Second" || item.Value != 200 {
+		t.Errorf("expected Second item, got %+v", item)
+	}
+}
+
+func TestScrollableList_Clear(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+	sl.SetItems([]ListItem{
+		{Text: "A"},
+		{Text: "B"},
+	})
+	sl.SetSelected(1)
+
+	sl.Clear()
+
+	if len(sl.Items) != 0 {
+		t.Errorf("expected 0 items after clear, got %d", len(sl.Items))
+	}
+	if sl.SelectedIdx != 0 {
+		t.Errorf("expected SelectedIdx 0 after clear, got %d", sl.SelectedIdx)
+	}
+}
+
+func TestScrollableList_HandleKey_UpDown(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+	sl.SetItems([]ListItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+	})
+
+	// Down arrow
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	handled := sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 1 {
+		t.Errorf("expected Down to move to idx 1, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Down again
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 2 {
+		t.Errorf("expected Down to move to idx 2, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Down at end (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled || sl.SelectedIdx != 2 {
+		t.Errorf("expected Down at end to not handle, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Up arrow
+	ev = tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone)
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 1 {
+		t.Errorf("expected Up to move to idx 1, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Up to beginning
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 0 {
+		t.Errorf("expected Up to move to idx 0, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Up at beginning (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled || sl.SelectedIdx != 0 {
+		t.Errorf("expected Up at beginning to not handle, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+}
+
+func TestScrollableList_HandleKey_HomeEnd(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+	sl.SetItems([]ListItem{
+		{Text: "A"},
+		{Text: "B"},
+		{Text: "C"},
+		{Text: "D"},
+	})
+	sl.SetSelected(2)
+
+	// End key
+	ev := tcell.NewEventKey(tcell.KeyEnd, 0, tcell.ModNone)
+	handled := sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 3 {
+		t.Errorf("expected End to go to last item, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// End when already at end (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled {
+		t.Error("expected End at end to not handle")
+	}
+
+	// Home key
+	ev = tcell.NewEventKey(tcell.KeyHome, 0, tcell.ModNone)
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 0 {
+		t.Errorf("expected Home to go to first item, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Home when already at beginning (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled {
+		t.Error("expected Home at beginning to not handle")
+	}
+}
+
+func TestScrollableList_HandleKey_PgUpPgDn(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5) // Height 5 = page size
+	items := make([]ListItem, 20)
+	for i := range items {
+		items[i] = ListItem{Text: string(rune('A' + i))}
+	}
+	sl.SetItems(items)
+	sl.SetSelected(10) // Start in middle
+
+	// PgDn
+	ev := tcell.NewEventKey(tcell.KeyPgDn, 0, tcell.ModNone)
+	handled := sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 15 {
+		t.Errorf("expected PgDn to move +5, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// PgDn again (should clamp to end)
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 19 {
+		t.Errorf("expected PgDn to clamp to end, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// PgDn at end (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled {
+		t.Error("expected PgDn at end to not handle")
+	}
+
+	// PgUp
+	ev = tcell.NewEventKey(tcell.KeyPgUp, 0, tcell.ModNone)
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 14 {
+		t.Errorf("expected PgUp to move -5, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// Multiple PgUp to beginning
+	sl.SetSelected(3)
+	handled = sl.HandleKey(ev)
+	if !handled || sl.SelectedIdx != 0 {
+		t.Errorf("expected PgUp to clamp to 0, got handled=%v idx=%d", handled, sl.SelectedIdx)
+	}
+
+	// PgUp at beginning (should not handle)
+	handled = sl.HandleKey(ev)
+	if handled {
+		t.Error("expected PgUp at beginning to not handle")
+	}
+}
+
+func TestScrollableList_EmptyList(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 5)
+
+	// HandleKey should return false for empty list
+	ev := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	if sl.HandleKey(ev) {
+		t.Error("expected HandleKey to return false for empty list")
+	}
+
+	// SelectedItem should return nil
+	if sl.SelectedItem() != nil {
+		t.Error("expected SelectedItem to return nil for empty list")
+	}
+}
+
+func TestScrollableList_ScrollOffset(t *testing.T) {
+	sl := NewScrollableList(0, 0, 20, 3) // Only 3 visible items
+	items := make([]ListItem, 10)
+	for i := range items {
+		items[i] = ListItem{Text: string(rune('A' + i))}
+	}
+	sl.SetItems(items)
+
+	// Initial selection should have offset 0
+	// (selected item 0 should be centered or at top)
+
+	// Select item 5 (should scroll to center it)
+	sl.SetSelected(5)
+
+	// The scroll offset should position item 5 visible
+	// With height 3 and selected 5, offset should center it around 5-1=4
+	// (viewport shows items 4, 5, 6)
+
+	// We can't directly test scrollOffset since it's private,
+	// but we can verify behavior through selection and rendering
+	if sl.SelectedIdx != 5 {
+		t.Errorf("expected selection 5, got %d", sl.SelectedIdx)
+	}
+}

--- a/texelui/primitives/tabbar.go
+++ b/texelui/primitives/tabbar.go
@@ -1,0 +1,241 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texelui/primitives/tabbar.go
+// Summary: Horizontal tab bar widget with keyboard and mouse navigation.
+
+package primitives
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"texelation/texel/theme"
+	"texelation/texelui/core"
+)
+
+// TabItem represents a single tab in a TabBar.
+type TabItem struct {
+	Label string
+	ID    string // Optional identifier for the tab
+}
+
+// TabBar is a horizontal tab navigation widget.
+// It displays tabs and handles keyboard (Left/Right, number keys) and mouse navigation.
+type TabBar struct {
+	core.BaseWidget
+	Tabs      []TabItem
+	ActiveIdx int
+	OnChange  func(int) // Called when active tab changes
+
+	// Styling
+	ShowFocusMarker bool // Show '►' marker when focused (default true)
+
+	inv func(core.Rect)
+}
+
+// NewTabBar creates a new tab bar at the specified position.
+// Width determines the available space for tabs. Height is always 1.
+func NewTabBar(x, y, w int, tabs []TabItem) *TabBar {
+	tb := &TabBar{
+		Tabs:            tabs,
+		ActiveIdx:       0,
+		ShowFocusMarker: true,
+	}
+
+	tb.SetPosition(x, y)
+	tb.Resize(w, 1)
+	tb.SetFocusable(true)
+
+	// Configure focus style from theme
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	tb.SetFocusedStyle(tcell.StyleDefault.Foreground(fg).Background(bg), true)
+
+	return tb
+}
+
+// SetInvalidator allows the UI manager to inject a dirty-region invalidator.
+func (tb *TabBar) SetInvalidator(fn func(core.Rect)) {
+	tb.inv = fn
+}
+
+// SetActive changes the active tab by index.
+func (tb *TabBar) SetActive(idx int) {
+	if idx < 0 || idx >= len(tb.Tabs) {
+		return
+	}
+	if idx == tb.ActiveIdx {
+		return
+	}
+	tb.ActiveIdx = idx
+	tb.invalidate()
+	if tb.OnChange != nil {
+		tb.OnChange(idx)
+	}
+}
+
+// ActiveTab returns the currently active tab item.
+func (tb *TabBar) ActiveTab() TabItem {
+	if tb.ActiveIdx >= 0 && tb.ActiveIdx < len(tb.Tabs) {
+		return tb.Tabs[tb.ActiveIdx]
+	}
+	return TabItem{}
+}
+
+// Draw renders the tab bar.
+func (tb *TabBar) Draw(painter *core.Painter) {
+	if len(tb.Tabs) == 0 {
+		return
+	}
+
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	baseStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
+
+	focused := tb.IsFocused()
+	x := tb.Rect.X
+	y := tb.Rect.Y
+
+	// Draw focus marker if focused and enabled
+	if focused && tb.ShowFocusMarker {
+		painter.SetCell(x, y, '►', baseStyle.Bold(true))
+		x++
+	}
+
+	// Draw each tab
+	for i, tab := range tb.Tabs {
+		tabLabel := " " + tab.Label + " "
+		isActive := i == tb.ActiveIdx
+
+		tabStyle := baseStyle
+		if isActive {
+			if focused {
+				// Active tab with focus: bold + reverse
+				tabStyle = tabStyle.Reverse(true).Bold(true)
+			} else {
+				// Active tab without focus: just reverse
+				tabStyle = tabStyle.Reverse(true)
+			}
+		} else if focused {
+			// Inactive tabs when focused: dim
+			tabStyle = tabStyle.Dim(true)
+		}
+
+		// Draw tab label
+		for _, ch := range tabLabel {
+			if x >= tb.Rect.X+tb.Rect.W {
+				break
+			}
+			painter.SetCell(x, y, ch, tabStyle)
+			x++
+		}
+
+		// Add spacing between tabs (unless at end)
+		if i < len(tb.Tabs)-1 && x < tb.Rect.X+tb.Rect.W {
+			painter.SetCell(x, y, ' ', baseStyle)
+			x++
+		}
+	}
+}
+
+// HandleKey processes keyboard input for tab navigation.
+// Returns true if the key was handled.
+func (tb *TabBar) HandleKey(ev *tcell.EventKey) bool {
+	if len(tb.Tabs) == 0 {
+		return false
+	}
+
+	switch ev.Key() {
+	case tcell.KeyLeft:
+		if tb.ActiveIdx > 0 {
+			tb.SetActive(tb.ActiveIdx - 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyRight:
+		if tb.ActiveIdx < len(tb.Tabs)-1 {
+			tb.SetActive(tb.ActiveIdx + 1)
+			return true
+		}
+		return false
+
+	case tcell.KeyHome:
+		if tb.ActiveIdx != 0 {
+			tb.SetActive(0)
+			return true
+		}
+		return false
+
+	case tcell.KeyEnd:
+		lastIdx := len(tb.Tabs) - 1
+		if tb.ActiveIdx != lastIdx {
+			tb.SetActive(lastIdx)
+			return true
+		}
+		return false
+
+	case tcell.KeyRune:
+		// Number keys 1-9 for direct tab selection
+		r := ev.Rune()
+		if r >= '1' && r <= '9' {
+			idx := int(r - '1')
+			if idx < len(tb.Tabs) && idx != tb.ActiveIdx {
+				tb.SetActive(idx)
+				return true
+			}
+		}
+		return false
+	}
+
+	return false
+}
+
+// HandleMouse processes mouse input for tab selection.
+func (tb *TabBar) HandleMouse(ev *tcell.EventMouse) bool {
+	if len(tb.Tabs) == 0 {
+		return false
+	}
+
+	x, y := ev.Position()
+	if !tb.HitTest(x, y) {
+		return false
+	}
+
+	if ev.Buttons() != tcell.Button1 {
+		return false
+	}
+
+	// Calculate which tab was clicked
+	tabX := tb.Rect.X
+	focused := tb.IsFocused()
+
+	// Account for focus marker
+	if focused && tb.ShowFocusMarker {
+		tabX++
+	}
+
+	for i, tab := range tb.Tabs {
+		tabLabel := " " + tab.Label + " "
+		tabWidth := len(tabLabel)
+
+		if x >= tabX && x < tabX+tabWidth {
+			if i != tb.ActiveIdx {
+				tb.SetActive(i)
+			}
+			return true
+		}
+
+		tabX += tabWidth + 1 // +1 for spacing
+	}
+
+	return true
+}
+
+// invalidate marks the widget as needing redraw.
+func (tb *TabBar) invalidate() {
+	if tb.inv != nil {
+		tb.inv(tb.Rect)
+	}
+}

--- a/texelui/primitives/tabbar_test.go
+++ b/texelui/primitives/tabbar_test.go
@@ -1,0 +1,238 @@
+package primitives
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestTabBar_NewTabBar(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "Tab1", ID: "1"},
+		{Label: "Tab2", ID: "2"},
+		{Label: "Tab3", ID: "3"},
+	}
+
+	tb := NewTabBar(5, 10, 40, tabs)
+
+	if len(tb.Tabs) != 3 {
+		t.Errorf("expected 3 tabs, got %d", len(tb.Tabs))
+	}
+
+	x, y := tb.Position()
+	if x != 5 || y != 10 {
+		t.Errorf("expected position (5,10), got (%d,%d)", x, y)
+	}
+
+	w, h := tb.Size()
+	if w != 40 || h != 1 {
+		t.Errorf("expected size (40,1), got (%d,%d)", w, h)
+	}
+
+	if tb.ActiveIdx != 0 {
+		t.Errorf("expected initial ActiveIdx 0, got %d", tb.ActiveIdx)
+	}
+
+	if !tb.Focusable() {
+		t.Error("expected TabBar to be focusable")
+	}
+}
+
+func TestTabBar_SetActive(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "C"},
+	}
+	tb := NewTabBar(0, 0, 30, tabs)
+
+	callCount := 0
+	lastIdx := -1
+	tb.OnChange = func(idx int) {
+		callCount++
+		lastIdx = idx
+	}
+
+	// Set to valid index
+	tb.SetActive(1)
+	if tb.ActiveIdx != 1 {
+		t.Errorf("expected ActiveIdx 1, got %d", tb.ActiveIdx)
+	}
+	if callCount != 1 || lastIdx != 1 {
+		t.Errorf("expected OnChange called once with idx 1, got callCount=%d lastIdx=%d", callCount, lastIdx)
+	}
+
+	// Set to same index (should not trigger callback)
+	tb.SetActive(1)
+	if callCount != 1 {
+		t.Errorf("expected no additional OnChange call, got callCount=%d", callCount)
+	}
+
+	// Set to invalid index (negative)
+	tb.SetActive(-1)
+	if tb.ActiveIdx != 1 {
+		t.Errorf("expected ActiveIdx to remain 1 after invalid set, got %d", tb.ActiveIdx)
+	}
+
+	// Set to invalid index (too large)
+	tb.SetActive(10)
+	if tb.ActiveIdx != 1 {
+		t.Errorf("expected ActiveIdx to remain 1 after invalid set, got %d", tb.ActiveIdx)
+	}
+}
+
+func TestTabBar_ActiveTab(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "First", ID: "first"},
+		{Label: "Second", ID: "second"},
+	}
+	tb := NewTabBar(0, 0, 30, tabs)
+
+	active := tb.ActiveTab()
+	if active.Label != "First" || active.ID != "first" {
+		t.Errorf("expected first tab, got %+v", active)
+	}
+
+	tb.SetActive(1)
+	active = tb.ActiveTab()
+	if active.Label != "Second" || active.ID != "second" {
+		t.Errorf("expected second tab, got %+v", active)
+	}
+}
+
+func TestTabBar_HandleKey_LeftRight(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "C"},
+	}
+	tb := NewTabBar(0, 0, 30, tabs)
+
+	// Right arrow
+	ev := tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone)
+	handled := tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 1 {
+		t.Errorf("expected Right to move to idx 1, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Right again
+	handled = tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 2 {
+		t.Errorf("expected Right to move to idx 2, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Right at end (should not handle - at boundary)
+	handled = tb.HandleKey(ev)
+	if handled || tb.ActiveIdx != 2 {
+		t.Errorf("expected Right at end to not handle, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Left arrow
+	ev = tcell.NewEventKey(tcell.KeyLeft, 0, tcell.ModNone)
+	handled = tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 1 {
+		t.Errorf("expected Left to move to idx 1, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Left to beginning
+	handled = tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 0 {
+		t.Errorf("expected Left to move to idx 0, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Left at beginning (should not handle - at boundary)
+	handled = tb.HandleKey(ev)
+	if handled || tb.ActiveIdx != 0 {
+		t.Errorf("expected Left at beginning to not handle, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+}
+
+func TestTabBar_HandleKey_HomeEnd(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "A"},
+		{Label: "B"},
+		{Label: "C"},
+		{Label: "D"},
+	}
+	tb := NewTabBar(0, 0, 40, tabs)
+	tb.SetActive(2) // Start in middle
+
+	// End key
+	ev := tcell.NewEventKey(tcell.KeyEnd, 0, tcell.ModNone)
+	handled := tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 3 {
+		t.Errorf("expected End to go to last tab, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// End when already at end (should not handle)
+	handled = tb.HandleKey(ev)
+	if handled {
+		t.Error("expected End at end to not handle")
+	}
+
+	// Home key
+	ev = tcell.NewEventKey(tcell.KeyHome, 0, tcell.ModNone)
+	handled = tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 0 {
+		t.Errorf("expected Home to go to first tab, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Home when already at beginning (should not handle)
+	handled = tb.HandleKey(ev)
+	if handled {
+		t.Error("expected Home at beginning to not handle")
+	}
+}
+
+func TestTabBar_HandleKey_NumberKeys(t *testing.T) {
+	tabs := []TabItem{
+		{Label: "One"},
+		{Label: "Two"},
+		{Label: "Three"},
+	}
+	tb := NewTabBar(0, 0, 40, tabs)
+
+	// Press '2' to select second tab
+	ev := tcell.NewEventKey(tcell.KeyRune, '2', tcell.ModNone)
+	handled := tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 1 {
+		t.Errorf("expected '2' to select idx 1, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Press '1' to select first tab
+	ev = tcell.NewEventKey(tcell.KeyRune, '1', tcell.ModNone)
+	handled = tb.HandleKey(ev)
+	if !handled || tb.ActiveIdx != 0 {
+		t.Errorf("expected '1' to select idx 0, got handled=%v idx=%d", handled, tb.ActiveIdx)
+	}
+
+	// Press '9' (out of range - should not handle)
+	ev = tcell.NewEventKey(tcell.KeyRune, '9', tcell.ModNone)
+	handled = tb.HandleKey(ev)
+	if handled {
+		t.Error("expected '9' to not handle for 3-tab bar")
+	}
+
+	// Press same number as current (should not handle)
+	ev = tcell.NewEventKey(tcell.KeyRune, '1', tcell.ModNone)
+	handled = tb.HandleKey(ev)
+	if handled {
+		t.Error("expected pressing current tab number to not handle")
+	}
+}
+
+func TestTabBar_EmptyTabs(t *testing.T) {
+	tb := NewTabBar(0, 0, 30, []TabItem{})
+
+	// HandleKey should return false for empty tabs
+	ev := tcell.NewEventKey(tcell.KeyRight, 0, tcell.ModNone)
+	if tb.HandleKey(ev) {
+		t.Error("expected HandleKey to return false for empty tabs")
+	}
+
+	// ActiveTab should return empty item
+	active := tb.ActiveTab()
+	if active.Label != "" || active.ID != "" {
+		t.Errorf("expected empty tab, got %+v", active)
+	}
+}

--- a/texelui/widgets/colorpicker/helpers.go
+++ b/texelui/widgets/colorpicker/helpers.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texelui/widgets/colorpicker/helpers.go
+// Summary: Helper functions for color rendering.
+
+package colorpicker
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"texelation/texelui/core"
+)
+
+// DrawColorSwatch renders a color swatch in the format [██]
+// where the two blocks show the color.
+// Returns the width of the rendered swatch (4 characters).
+func DrawColorSwatch(p *core.Painter, x, y int, color tcell.Color, bracketStyle tcell.Style) int {
+	_, bg, _ := bracketStyle.Decompose()
+	p.SetCell(x, y, '[', bracketStyle)
+	p.SetCell(x+1, y, '█', tcell.StyleDefault.Foreground(color).Background(bg))
+	p.SetCell(x+2, y, '█', tcell.StyleDefault.Foreground(color).Background(bg))
+	p.SetCell(x+3, y, ']', bracketStyle)
+	return 4
+}
+
+// DrawColorSwatchWithLabel renders a color swatch in the format [█L]
+// where the first block shows the color as foreground on background,
+// and L is a label character shown with the color as foreground on bgColor.
+// This is useful for showing contrast/readability of the color.
+// Returns the width of the rendered swatch (4 characters).
+func DrawColorSwatchWithLabel(p *core.Painter, x, y int, color, bgColor tcell.Color, label rune, bracketStyle tcell.Style) int {
+	_, bg, _ := bracketStyle.Decompose()
+	p.SetCell(x, y, '[', bracketStyle)
+	p.SetCell(x+1, y, ' ', tcell.StyleDefault.Background(color))
+	p.SetCell(x+2, y, label, tcell.StyleDefault.Foreground(color).Background(bgColor))
+	p.SetCell(x+3, y, ']', bracketStyle)
+	_ = bg // bg is used by bracket style
+	return 4
+}
+
+// DrawColorSwatchSingle renders a compact 1-block color swatch [█]
+// Returns the width of the rendered swatch (3 characters).
+func DrawColorSwatchSingle(p *core.Painter, x, y int, color tcell.Color, bracketStyle tcell.Style) int {
+	_, bg, _ := bracketStyle.Decompose()
+	p.SetCell(x, y, '[', bracketStyle)
+	p.SetCell(x+1, y, '█', tcell.StyleDefault.Foreground(color).Background(bg))
+	p.SetCell(x+2, y, ']', bracketStyle)
+	return 3
+}

--- a/texelui/widgets/colorpicker/palette.go
+++ b/texelui/widgets/colorpicker/palette.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // File: texelui/widgets/colorpicker/palette.go
-// Summary: Palette color selection mode.
+// Summary: Palette color selection mode using Grid widget.
 
 package colorpicker
 
@@ -10,18 +10,19 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"texelation/texel/theme"
 	"texelation/texelui/core"
+	"texelation/texelui/primitives"
 )
 
 // PalettePicker allows selection from the current color palette.
+// It uses a Grid internally for 2D navigation and rendering.
 type PalettePicker struct {
 	paletteNames []string
-	selectedIdx  int
-	cols         int // Number of columns in grid (updated by Draw based on available width)
+	grid         *primitives.Grid
 }
 
 // NewPalettePicker creates a palette color picker.
 func NewPalettePicker() *PalettePicker {
-	return &PalettePicker{
+	pp := &PalettePicker{
 		paletteNames: []string{
 			// Standard Catppuccin palette colors
 			"rosewater",
@@ -51,21 +52,9 @@ func NewPalettePicker() *PalettePicker {
 			"mantle",
 			"crust",
 		},
-		selectedIdx: 0,
-		cols:        3,
 	}
-}
 
-func (pp *PalettePicker) Draw(painter *core.Painter, rect core.Rect) {
-	tm := theme.Get()
-	fg := tm.GetSemanticColor("text.primary")
-	bg := tm.GetSemanticColor("bg.surface")
-	baseStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
-
-	// Fill background
-	painter.Fill(rect, ' ', baseStyle)
-
-	// Find longest name to calculate cell width
+	// Find longest name to calculate proper cell width
 	maxNameLen := 0
 	for _, name := range pp.paletteNames {
 		if len(name) > maxNameLen {
@@ -73,163 +62,84 @@ func (pp *PalettePicker) Draw(painter *core.Painter, rect core.Rect) {
 		}
 	}
 
-	// Cell width: [██] + space + name + padding
-	// = 4 (brackets+blocks) + 1 (space) + maxNameLen + 1 (padding between columns)
-	minCellWidth := 6 + maxNameLen
-
-	// Calculate how many columns fit in available width
-	cols := rect.W / minCellWidth
-	if cols < 1 {
-		cols = 1
-	}
-	if cols > 3 {
-		cols = 3 // Max 3 columns
-	}
-
-	// Store for navigation
-	pp.cols = cols
-
-	// Recalculate cell width to use available space evenly
-	cellWidth := rect.W / cols
-
-	x := rect.X
-	y := rect.Y
-	col := 0
-
+	// Create grid items
+	items := make([]primitives.GridItem, len(pp.paletteNames))
 	for i, name := range pp.paletteNames {
-		if y >= rect.Y+rect.H {
-			break
-		}
-
-		color := theme.ResolveColorName(name)
-
-		style := baseStyle
-		if i == pp.selectedIdx {
-			style = style.Reverse(true)
-		}
-
-		// Draw: [██] name
-		cx := x
-		painter.SetCell(cx, y, '[', style)
-		cx++
-		painter.SetCell(cx, y, '█', tcell.StyleDefault.Foreground(color).Background(bg))
-		cx++
-		painter.SetCell(cx, y, '█', tcell.StyleDefault.Foreground(color).Background(bg))
-		cx++
-		painter.SetCell(cx, y, ']', style)
-		cx += 2
-
-		// Draw full name (no truncation needed with proper sizing)
-		painter.DrawText(cx, y, name, style)
-
-		col++
-		if col >= cols {
-			col = 0
-			x = rect.X
-			y++
-		} else {
-			x += cellWidth
-		}
+		items[i] = primitives.GridItem{Text: name, Value: name}
 	}
+
+	// Create grid with appropriate sizing
+	// Cell width: [██] + space + name + padding = 4 + 1 + maxNameLen + 1 = 6 + maxNameLen
+	pp.grid = primitives.NewGrid(0, 0, 40, 10)
+	pp.grid.MinCellWidth = 6 + maxNameLen
+	pp.grid.MaxCols = 3
+	pp.grid.SetItems(items)
+	pp.grid.RenderCell = pp.renderColorCell
+
+	return pp
+}
+
+// renderColorCell renders a palette color cell with swatch and name.
+func (pp *PalettePicker) renderColorCell(p *core.Painter, rect core.Rect, item primitives.GridItem, selected bool) {
+	tm := theme.Get()
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	baseStyle := tcell.StyleDefault.Foreground(fg).Background(bg)
+
+	style := baseStyle
+	if selected {
+		style = style.Reverse(true)
+	}
+
+	// Fill cell background
+	p.Fill(rect, ' ', style)
+
+	name := item.Text
+	color := theme.ResolveColorName(name)
+
+	// Draw: [██] name
+	x := rect.X
+	DrawColorSwatch(p, x, rect.Y, color, style)
+	x += 5 // swatch width (4) + space (1)
+
+	// Truncate name if needed
+	displayName := name
+	maxLen := rect.W - 6
+	if len(displayName) > maxLen && maxLen > 0 {
+		displayName = displayName[:maxLen]
+	}
+	p.DrawText(x, rect.Y, displayName, style)
+}
+
+func (pp *PalettePicker) Draw(painter *core.Painter, rect core.Rect) {
+	// Update grid position and size to match provided rect
+	pp.grid.SetPosition(rect.X, rect.Y)
+	pp.grid.Resize(rect.W, rect.H)
+
+	// Delegate to grid
+	pp.grid.Draw(painter)
 }
 
 func (pp *PalettePicker) HandleKey(ev *tcell.EventKey) bool {
-	cols := pp.cols
-	if cols < 1 {
-		cols = 1
-	}
-	rows := (len(pp.paletteNames) + cols - 1) / cols
-	currentRow := pp.selectedIdx / cols
-	currentCol := pp.selectedIdx % cols
-
-	switch ev.Key() {
-	case tcell.KeyUp:
-		if currentRow > 0 {
-			pp.selectedIdx -= cols
-		}
-		return true
-	case tcell.KeyDown:
-		if currentRow < rows-1 {
-			newIdx := pp.selectedIdx + cols
-			if newIdx < len(pp.paletteNames) {
-				pp.selectedIdx = newIdx
-			} else {
-				// Move to last item if going down from partial last row
-				pp.selectedIdx = len(pp.paletteNames) - 1
-			}
-		}
-		return true
-	case tcell.KeyLeft:
-		if currentCol > 0 {
-			pp.selectedIdx--
-		}
-		return true
-	case tcell.KeyRight:
-		if currentCol < cols-1 && pp.selectedIdx < len(pp.paletteNames)-1 {
-			pp.selectedIdx++
-		}
-		return true
-	case tcell.KeyHome:
-		pp.selectedIdx = 0
-		return true
-	case tcell.KeyEnd:
-		pp.selectedIdx = len(pp.paletteNames) - 1
-		return true
-	case tcell.KeyTab:
-		// Tab: left-to-right, then top-to-bottom
-		if ev.Modifiers()&tcell.ModShift != 0 {
-			// Shift+Tab: go backwards
-			if pp.selectedIdx > 0 {
-				pp.selectedIdx--
-				return true
-			}
-		} else {
-			// Tab: go forwards
-			if pp.selectedIdx < len(pp.paletteNames)-1 {
-				pp.selectedIdx++
-				return true
-			}
-		}
-		// At boundary, let parent handle
-		return false
-	}
-	return false
+	return pp.grid.HandleKey(ev)
 }
 
 func (pp *PalettePicker) HandleMouse(ev *tcell.EventMouse, rect core.Rect) bool {
-	x, y := ev.Position()
-	if x < rect.X || y < rect.Y || x >= rect.X+rect.W || y >= rect.Y+rect.H {
-		return false
-	}
+	// Update grid position and size to match provided rect
+	pp.grid.SetPosition(rect.X, rect.Y)
+	pp.grid.Resize(rect.W, rect.H)
 
-	if ev.Buttons() == tcell.Button1 {
-		cols := pp.cols
-		if cols < 1 {
-			cols = 1
-		}
-		cellWidth := rect.W / cols
-
-		relX := x - rect.X
-		relY := y - rect.Y
-
-		clickedCol := relX / cellWidth
-		if clickedCol >= cols {
-			clickedCol = cols - 1
-		}
-		clickedRow := relY
-		clickedIdx := clickedRow*cols + clickedCol
-
-		if clickedIdx >= 0 && clickedIdx < len(pp.paletteNames) {
-			pp.selectedIdx = clickedIdx
-			return true
-		}
-	}
-
-	return false
+	return pp.grid.HandleMouse(ev)
 }
 
 func (pp *PalettePicker) GetResult() PickerResult {
-	name := pp.paletteNames[pp.selectedIdx]
+	item := pp.grid.SelectedItem()
+	if item == nil {
+		// Fallback to first item
+		name := pp.paletteNames[0]
+		return MakeResult(theme.ResolveColorName(name), "@"+name)
+	}
+	name := item.Text
 	color := theme.ResolveColorName(name)
 	// Prefix with @ to indicate palette color
 	return MakeResult(color, "@"+name)
@@ -258,7 +168,7 @@ func (pp *PalettePicker) SetColor(color tcell.Color) {
 	// Try to find matching palette color
 	for i, name := range pp.paletteNames {
 		if theme.ResolveColorName(name) == color {
-			pp.selectedIdx = i
+			pp.grid.SetSelected(i)
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

- Add new `texelui/primitives` package with reusable UI components:
  - **ScrollableList**: vertical list with scrolling and custom item rendering
  - **Grid**: 2D grid with dynamic columns and custom cell rendering  
  - **TabBar**: horizontal tab navigation with keyboard/mouse support
- Refactor ColorPicker to use primitives internally
- Fix code quality issues in TextArea and BaseWidget

## Test plan

- [x] All existing tests pass (`make test`)
- [x] New primitives have comprehensive test coverage (33 tests)
- [x] ColorPicker demo builds and works correctly
- [x] Manual testing of ColorPicker modes (Semantic, Palette, OKLCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)