### PR TITLE
Fix snapshot updates on app replacement

### DIFF
--- a/texel/pane.go
+++ b/texel/pane.go
@@ -383,6 +383,8 @@ func (p *pane) doReplaceWithApp(name string, config map[string]interface{}) {
 
 	// Broadcast state update so the desktop knows about the change
 	p.screen.desktop.broadcastStateUpdate()
+	// App identity changed; broadcast tree change so snapshots persist the new app type.
+	p.screen.desktop.broadcastTreeChanged()
 
 	// Force a refresh of the workspace to ensure the new app is rendered
 	if p.screen != nil {


### PR DESCRIPTION
## Summary
- broadcast workspace tree change after replacing a pane app so snapshots include new app type
- tighten snapshot test to assert replaced app_type persists
- fixes launcher replacement not persisting across server restart

## Testing
- go test ./internal/runtime/server -run TestSnapshotSavedOnReplaceWithApp -count=1