### PR TITLE
Fix ColorPicker freeze in floating panel and improve config editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ build-apps: ## Build ALL app binaries into bin/
 	$(GO_ENV) go build -o $(BIN_DIR)/app-runner ./cmd/app-runner
 	$(GO_ENV) go build -o $(BIN_DIR)/texel-stress ./cmd/texel-stress
 	$(GO_ENV) go build -o $(BIN_DIR)/texelui-demo ./cmd/texelui-demo
+	$(GO_ENV) go build -o $(BIN_DIR)/config-editor ./cmd/config-editor
 	$(GO_ENV) go build -o $(BIN_DIR)/texel-server $(SERVER_PKG)
 	$(GO_ENV) go build -o $(BIN_DIR)/texel-client $(CLIENT_PKG)
 	$(GO_ENV) go build -o $(BIN_DIR)/texelation ./cmd/texelation

--- a/texelui/adapter/texel_app.go
+++ b/texelui/adapter/texel_app.go
@@ -24,7 +24,9 @@ func NewUIApp(title string, ui *core.UIManager) *UIApp {
 	if ui == nil {
 		ui = core.NewUIManager()
 	}
-	return &UIApp{title: title, ui: ui, stopCh: make(chan struct{})}
+	app := &UIApp{title: title, ui: ui, stopCh: make(chan struct{})}
+	app.EnableStatusBar() // Enable status bar by default
+	return app
 }
 
 func (a *UIApp) Run() error { <-a.stopCh; return nil }
@@ -81,6 +83,11 @@ func (a *UIApp) StatusBar() *widgets.StatusBar {
 	return nil
 }
 
+// DisableStatusBar removes and disables the status bar.
+func (a *UIApp) DisableStatusBar() {
+	a.ui.SetStatusBar(nil)
+}
+
 // NewWidgetShowcaseApp creates a tabbed demo showcasing all TexelUI widgets.
 // This is the unified demo that replaces individual demos.
 func NewWidgetShowcaseApp(title string) *UIApp {
@@ -97,8 +104,8 @@ func NewWidgetShowcaseApp(title string) *UIApp {
 
 	app := NewUIApp(title, ui)
 
-	// Enable status bar with key hints and messages
-	statusBar := app.EnableStatusBar()
+	// Get status bar (enabled by default in NewUIApp)
+	statusBar := app.StatusBar()
 
 	// === Inputs Tab (wrapped in ScrollPane for tall content) ===
 	inputsPane := createInputsTab()

--- a/texelui/core/widget.go
+++ b/texelui/core/widget.go
@@ -115,6 +115,14 @@ type Modal interface {
 	DismissModal()
 }
 
+// Expandable is an optional interface for widgets that can expand beyond their
+// normal layout size (e.g., dropdown menus, color pickers). When IsExpanded()
+// returns true, parent containers should skip resizing this widget and let it
+// manage its own size.
+type Expandable interface {
+	IsExpanded() bool
+}
+
 // FocusCycler is implemented by containers that manage focus cycling internally.
 // When Tab/Shift-Tab is pressed, the container cycles focus among its children.
 // Returns true if focus was cycled, false if exhausted (at boundary).

--- a/texelui/widgets/colorpicker.go
+++ b/texelui/widgets/colorpicker.go
@@ -301,6 +301,12 @@ func (cp *ColorPicker) DismissModal() {
 	cp.Collapse()
 }
 
+// IsExpanded returns true when the picker is expanded.
+// Implements core.Expandable interface.
+func (cp *ColorPicker) IsExpanded() bool {
+	return cp.expanded
+}
+
 // Draw renders the color picker.
 func (cp *ColorPicker) Draw(painter *core.Painter) {
 	if cp.expanded {

--- a/texelui/widgets/colorpicker_test.go
+++ b/texelui/widgets/colorpicker_test.go
@@ -1,0 +1,107 @@
+package widgets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+func TestColorPickerEnterWithOnChange(t *testing.T) {
+	cp := NewColorPicker(0, 0, ColorPickerConfig{
+		EnableSemantic: true,
+		EnablePalette:  true,
+		EnableOKLCH:    true,
+		Label:          "Test",
+	})
+	cp.SetValue("#ff0000")
+
+	// Set up an OnChange callback that simulates config editor behavior
+	callbackCalled := false
+	callbackBlocked := make(chan struct{})
+	cp.OnChange = func(result ColorPickerResult) {
+		callbackCalled = true
+		// Simulate some work (but don't block forever)
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-callbackBlocked:
+		}
+	}
+
+	// Expand the ColorPicker
+	cp.Expand()
+	if !cp.IsExpanded() {
+		t.Fatal("ColorPicker should be expanded after Expand()")
+	}
+	if !cp.IsModal() {
+		t.Fatal("ColorPicker should be modal when expanded")
+	}
+
+	// Move focus to content area (needed for Enter to commit)
+	cp.focus = focusContent
+
+	// Press Enter to select/commit - this should complete without blocking
+	done := make(chan struct{})
+	go func() {
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+		cp.HandleKey(ev)
+		close(done)
+	}()
+
+	// Wait for completion with timeout
+	select {
+	case <-done:
+		// Good - HandleKey completed
+	case <-time.After(1 * time.Second):
+		close(callbackBlocked) // unblock callback if stuck
+		t.Fatal("HandleKey blocked for too long - potential freeze issue")
+	}
+
+	// Verify the callback was called
+	if !callbackCalled {
+		t.Error("OnChange callback should have been called")
+	}
+
+	// Verify ColorPicker is now collapsed
+	if cp.IsExpanded() {
+		t.Error("ColorPicker should be collapsed after Enter")
+	}
+	if cp.IsModal() {
+		t.Error("ColorPicker should not be modal when collapsed")
+	}
+}
+
+func TestColorPickerEnterWithSlowOnChange(t *testing.T) {
+	cp := NewColorPicker(0, 0, ColorPickerConfig{
+		EnableSemantic: true,
+		EnablePalette:  true,
+	})
+	cp.SetValue("#ff0000")
+
+	// Set up an OnChange callback that takes some time
+	callbackDuration := 50 * time.Millisecond
+	cp.OnChange = func(result ColorPickerResult) {
+		time.Sleep(callbackDuration)
+	}
+
+	// Expand and focus content
+	cp.Expand()
+	cp.focus = focusContent
+
+	// Time the Enter key handling
+	start := time.Now()
+	ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+	cp.HandleKey(ev)
+	elapsed := time.Since(start)
+
+	// Should complete in a reasonable time (callback duration + some overhead)
+	maxExpected := callbackDuration + 100*time.Millisecond
+	if elapsed > maxExpected {
+		t.Errorf("HandleKey took too long: %v (expected < %v)", elapsed, maxExpected)
+	}
+
+	// Should be collapsed
+	if cp.IsExpanded() {
+		t.Error("ColorPicker should be collapsed after Enter")
+	}
+}


### PR DESCRIPTION
## Summary

- **Fixed UI freeze** when pressing Enter to select a color in the ColorPicker inside texelation's modal floating panel
- **Root cause**: The `OnChange` callback synchronously triggered the control bus, which eventually did synchronous network I/O (via `sendStateUpdate`) while holding the UIManager lock
- **Solution**: Make the control bus trigger asynchronous using a goroutine in `emitApply`

Additional improvements:
- Add ScrollPane wrapping for form panes to enable scrolling in config editor
- Implement `FocusCycler` interface for `rootSwitcher` and `targetPanel`
- Add `Expandable` interface check in `formPane.layout()` to skip resizing expanded widgets (like ColorPicker)
- Add modal widget tests for UIManager
- Add ColorPicker Enter handling tests

## Test plan

- [x] All existing tests pass (`make test`)
- [x] ColorPicker Enter handling tests pass
- [x] UIManager modal widget tests pass
- [x] Manual testing: ColorPicker works without freeze in texelation floating panel
- [x] Manual testing: Standalone config-editor still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)