### PR TITLE
Fix StatusBar deadlock in config editor standalone mode

### DIFF
--- a/apps/configeditor/configeditor.go
+++ b/apps/configeditor/configeditor.go
@@ -84,7 +84,6 @@ type targetPanel struct {
 	core.BaseWidget
 	Style    tcell.Style
 	header   *widgets.Label
-	status   *widgets.Label
 	saveBtn  *widgets.Button
 	resetBtn *widgets.Button
 	tabs     *widgets.TabLayout
@@ -98,7 +97,6 @@ func newTargetPanel(title string, showActions bool) *targetPanel {
 	panel := &targetPanel{
 		Style:  tcell.StyleDefault.Background(bg).Foreground(fg),
 		header: widgets.NewLabel(0, 0, 0, 1, title),
-		status: widgets.NewLabel(0, 0, 0, 1, ""),
 	}
 	if showActions {
 		panel.saveBtn = widgets.NewButton(0, 0, 0, 1, "Save")
@@ -116,9 +114,6 @@ func (p *targetPanel) SetInvalidator(fn func(core.Rect)) {
 	p.inv = fn
 	if p.header != nil {
 		p.header.SetInvalidator(fn)
-	}
-	if p.status != nil {
-		p.status.SetInvalidator(fn)
 	}
 	if p.saveBtn != nil {
 		p.saveBtn.SetInvalidator(fn)
@@ -146,19 +141,6 @@ func (p *targetPanel) Draw(painter *core.Painter) {
 	if p.tabs != nil {
 		p.tabs.Draw(painter)
 	}
-	if p.status != nil {
-		p.status.Draw(painter)
-	}
-}
-
-func (p *targetPanel) setStatus(text string) {
-	if p.status == nil {
-		return
-	}
-	p.status.Text = text
-	if p.inv != nil {
-		p.inv(p.status.Rect)
-	}
 }
 
 func (p *targetPanel) Resize(w, h int) {
@@ -170,9 +152,9 @@ func (p *targetPanel) layout() {
 	left := p.Rect.X + 2
 	right := p.Rect.X + p.Rect.W - 2
 	headerY := p.Rect.Y
-	statusY := p.Rect.Y + p.Rect.H - 1
 	contentY := p.Rect.Y + 2
-	contentH := p.Rect.H - 3
+	// Content now uses full remaining height (no status row at bottom)
+	contentH := p.Rect.H - 2
 	if contentH < 1 {
 		contentH = 1
 	}
@@ -200,10 +182,6 @@ func (p *targetPanel) layout() {
 		p.tabs.SetPosition(p.Rect.X, contentY)
 		p.tabs.Resize(p.Rect.W, contentH)
 	}
-	if p.status != nil {
-		p.status.SetPosition(left, statusY)
-		p.status.Resize(maxInt(10, p.Rect.W-4), 1)
-	}
 }
 
 func (p *targetPanel) VisitChildren(f func(core.Widget)) {
@@ -218,9 +196,6 @@ func (p *targetPanel) VisitChildren(f func(core.Widget)) {
 	}
 	if p.tabs != nil {
 		f(p.tabs)
-	}
-	if p.status != nil {
-		f(p.status)
 	}
 }
 
@@ -317,6 +292,7 @@ type ConfigEditor struct {
 	controlBus    texel.ControlBus
 	autoApply     bool
 	singleTarget  bool
+	statusBar     *widgets.StatusBar // Cached to avoid lock during callbacks
 }
 
 // New creates a config editor app.
@@ -327,13 +303,15 @@ func New(reg *registry.Registry) texel.App {
 // NewWithTarget creates a config editor app with an optional default target.
 func NewWithTarget(reg *registry.Registry, target string) texel.App {
 	ui := core.NewUIManager()
+	uiApp := adapter.NewUIApp("Config Editor", ui)
 	editor := &ConfigEditor{
-		UIApp:         adapter.NewUIApp("Config Editor", ui),
+		UIApp:         uiApp,
 		registry:      reg,
 		defaultTarget: target,
 		controlBus:    texel.NewControlBus(),
 		autoApply:     true,
 		singleTarget:  target != "" && target != "system",
+		statusBar:     uiApp.StatusBar(), // Cache before any locks are held
 	}
 	editor.buildTargets()
 	editor.buildUI()
@@ -506,18 +484,18 @@ func (e *ConfigEditor) buildTargetPanel(target *configTarget) *targetPanel {
 	if panel.saveBtn != nil {
 		panel.saveBtn.OnClick = func() {
 			if err := e.saveTarget(target); err != nil {
-				panel.setStatus(fmt.Sprintf("Save failed: %v", err))
+				e.showError(fmt.Sprintf("Save failed: %v", err))
 			} else {
-				panel.setStatus("Saved.")
+				e.showSuccess("Saved.")
 			}
 		}
 	}
 	if panel.resetBtn != nil {
 		panel.resetBtn.OnClick = func() {
 			if err := e.reloadTarget(target); err != nil {
-				panel.setStatus(fmt.Sprintf("Reload failed: %v", err))
+				e.showError(fmt.Sprintf("Reload failed: %v", err))
 			} else {
-				panel.setStatus("Reloaded.")
+				e.showSuccess("Reloaded.")
 			}
 		}
 	}
@@ -708,16 +686,30 @@ func (e *ConfigEditor) applyTargetConfig(target *configTarget, kind applyKind) {
 		err = config.SaveApp(target.name)
 	}
 
-	if target.panel != nil {
-		if err != nil {
-			target.panel.setStatus(fmt.Sprintf("Apply failed: %v", err))
-		} else {
-			target.panel.setStatus("Saved.")
-		}
+	if err != nil {
+		e.showError(fmt.Sprintf("Apply failed: %v", err))
+	} else {
+		e.showSuccess("Saved.")
 	}
 
 	if err == nil {
 		e.emitApply(kind, target)
+	}
+}
+
+// showSuccess displays a success message in the global StatusBar.
+// Uses cached StatusBar reference to avoid acquiring UIManager.mu during callbacks.
+func (e *ConfigEditor) showSuccess(msg string) {
+	if e.statusBar != nil {
+		e.statusBar.ShowSuccess(msg)
+	}
+}
+
+// showError displays an error message in the global StatusBar.
+// Uses cached StatusBar reference to avoid acquiring UIManager.mu during callbacks.
+func (e *ConfigEditor) showError(msg string) {
+	if e.statusBar != nil {
+		e.statusBar.ShowError(msg)
 	}
 }
 

--- a/apps/configeditor/statusbar_integration_test.go
+++ b/apps/configeditor/statusbar_integration_test.go
@@ -1,0 +1,329 @@
+package configeditor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"texelation/texel/theme"
+	"texelation/texelui/core"
+	"texelation/texelui/widgets"
+)
+
+// TestConfigEditorStatusBarFreeze reproduces the freeze that occurs when
+// StatusBar.ShowSuccess is called from the config editor's applyTargetConfig.
+func TestConfigEditorStatusBarFreeze(t *testing.T) {
+	// Set up temp config dir
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_ = theme.Reload()
+
+	// Create the config editor (this sets up the StatusBar)
+	app := New(nil)
+	editor := app.(*ConfigEditor)
+
+	// Resize to initialize layout
+	editor.Resize(80, 24)
+
+	// Set up a refresh notifier (like standalone runner does)
+	refreshCh := make(chan bool, 1)
+	editor.SetRefreshNotifier(refreshCh)
+
+	// Drain refresh channel in background (like standalone runner does)
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	// Simulate the flow: HandleKey triggers a change which calls showSuccess
+	done := make(chan struct{})
+	go func() {
+		// Call showSuccess directly (simulating what happens during a change)
+		editor.showSuccess("Test message")
+
+		// Then render (like standalone runner does after HandleKey)
+		editor.Render()
+
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good - no freeze
+	case <-time.After(2 * time.Second):
+		t.Fatal("showSuccess + Render blocked - StatusBar freeze detected")
+	}
+
+	// Also test the full HandleKey -> showSuccess flow
+	done2 := make(chan struct{})
+	go func() {
+		// Simulate pressing a key that would trigger a change
+		ev := tcell.NewEventKey(tcell.KeyRune, 'x', 0)
+		editor.HandleKey(ev)
+		editor.Render()
+		close(done2)
+	}()
+
+	select {
+	case <-done2:
+		// Good
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleKey + Render blocked")
+	}
+
+	// Clean up
+	close(stopDrain)
+	editor.Stop()
+}
+
+// TestConfigEditorApplyWithStatusBar tests the full apply flow with StatusBar messages.
+func TestConfigEditorApplyWithStatusBar(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	_ = theme.Reload()
+
+	app := New(nil)
+	editor := app.(*ConfigEditor)
+	editor.Resize(80, 24)
+
+	refreshCh := make(chan bool, 1)
+	editor.SetRefreshNotifier(refreshCh)
+
+	// Drain in background
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	// Get the system target
+	var target *configTarget
+	for _, tgt := range editor.targets {
+		if tgt.kind == targetSystem {
+			target = tgt
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("No system target found")
+	}
+
+	// Test applyTargetConfig which should call showSuccess
+	done := make(chan struct{})
+	go func() {
+		editor.applyTargetConfig(target, applySystem)
+		editor.Render()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good
+	case <-time.After(2 * time.Second):
+		t.Fatal("applyTargetConfig blocked - StatusBar freeze")
+	}
+
+	close(stopDrain)
+	editor.Stop()
+}
+
+// TestColorPickerWithStatusBar tests that ColorPicker OnChange calling StatusBar
+// doesn't cause a freeze.
+func TestColorPickerWithStatusBar(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	// Create and set up StatusBar
+	sb := widgets.NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	// Create a ColorPicker that calls StatusBar on change
+	cp := widgets.NewColorPicker(10, 10, widgets.ColorPickerConfig{
+		EnableSemantic: true,
+		EnablePalette:  true,
+		EnableOKLCH:    true,
+		Label:          "Test",
+	})
+	cp.SetValue("#ff0000")
+	cp.OnChange = func(result widgets.ColorPickerResult) {
+		// This is what the config editor does
+		sb.ShowSuccess("Color changed to: " + result.Source)
+	}
+
+	ui.AddWidget(cp)
+	ui.Focus(cp)
+
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Drain refresh channel
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	// Expand the ColorPicker and navigate with Tab to get to content
+	cp.Expand()
+
+	// Press Tab a few times to get into content area, then Enter
+	done := make(chan struct{})
+	go func() {
+		// Tab to move through tab bar to content
+		for i := 0; i < 5; i++ {
+			ev := tcell.NewEventKey(tcell.KeyTab, 0, 0)
+			ui.HandleKey(ev)
+		}
+		// Press Enter to select
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+		ui.HandleKey(ev)
+		ui.Render()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good - no freeze
+	case <-time.After(2 * time.Second):
+		t.Fatal("ColorPicker Enter with StatusBar.ShowSuccess blocked - freeze detected")
+	}
+
+	sb.Stop()
+	close(stopDrain)
+}
+
+// TestStatusBarAfterHandleKey tests the realistic flow where Render is called
+// AFTER HandleKey returns, like the standalone runner does.
+func TestStatusBarAfterHandleKey(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	sb := widgets.NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	// Create a button that shows a message in OnClick
+	btn := widgets.NewButton(10, 10, 20, 1, "Test")
+	btn.OnClick = func() {
+		// This is what happens in the config editor
+		sb.ShowSuccess("Clicked!")
+		// NOTE: We do NOT call Render here - that would be a bug.
+		// The standalone runner calls draw() AFTER HandleKey returns.
+	}
+
+	ui.AddWidget(btn)
+	ui.Focus(btn)
+
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Drain refresh channel (simulates the goroutine in runner.go)
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	// This is the realistic flow from standalone runner:
+	// 1. HandleKey (triggers OnClick which calls ShowSuccess)
+	// 2. After HandleKey returns, call Render
+	done := make(chan struct{})
+	go func() {
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+		ui.HandleKey(ev) // This triggers OnClick -> ShowSuccess
+		ui.Render()      // This is called AFTER HandleKey returns
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good - this is the expected flow
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleKey + Render (sequential) blocked - unexpected freeze")
+	}
+
+	sb.Stop()
+	close(stopDrain)
+}
+
+// TestStatusBarGetterDuringCallback tests that calling UIManager.StatusBar()
+// from within a callback during HandleKey would cause a deadlock if not handled.
+// This test verifies the config editor's cached StatusBar approach works.
+func TestStatusBarGetterDuringCallback(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	sb := widgets.NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	// This is the DANGEROUS pattern that caused the original freeze:
+	// Calling ui.StatusBar() from within a callback would try to acquire u.mu
+	// while HandleKey already holds it (non-reentrant mutex = deadlock).
+	//
+	// The fix is to cache the StatusBar reference at initialization, which
+	// is what ConfigEditor now does.
+	//
+	// This test verifies the pattern works with a cached reference.
+	cachedSB := sb // Use the concrete *StatusBar directly (same as ConfigEditor caches)
+
+	btn := widgets.NewButton(10, 10, 20, 1, "Test")
+	btn.OnClick = func() {
+		// Use cached reference instead of calling ui.StatusBar()
+		if cachedSB != nil {
+			cachedSB.ShowSuccess("Clicked!")
+		}
+	}
+
+	ui.AddWidget(btn)
+	ui.Focus(btn)
+
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+		ui.HandleKey(ev)
+		ui.Render()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good - cached reference pattern works
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cached StatusBar reference pattern blocked - unexpected freeze")
+	}
+
+	sb.Stop()
+	close(stopDrain)
+}

--- a/texelui/widgets/statusbar.go
+++ b/texelui/widgets/statusbar.go
@@ -75,7 +75,8 @@ func (s *StatusBar) Start() {
 		s.mu.Unlock()
 		return // Already started
 	}
-	s.ticker = time.NewTicker(100 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	s.ticker = ticker
 	s.mu.Unlock()
 
 	go func() {
@@ -83,7 +84,7 @@ func (s *StatusBar) Start() {
 			select {
 			case <-s.stopCh:
 				return
-			case <-s.ticker.C:
+			case <-ticker.C:
 				if s.expireMessages() {
 					s.invalidate()
 				}

--- a/texelui/widgets/statusbar_test.go
+++ b/texelui/widgets/statusbar_test.go
@@ -1,0 +1,201 @@
+package widgets
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"texelation/texelui/core"
+)
+
+// TestStatusBarShowMessageDuringHandleKey reproduces the freeze that occurs
+// when StatusBar.ShowSuccess is called from within a widget's OnChange callback
+// during HandleKey processing.
+func TestStatusBarShowMessageDuringHandleKey(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	// Create and set up StatusBar
+	sb := NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	// Create a button that calls StatusBar.ShowSuccess when clicked
+	btn := NewButton(10, 10, 20, 1, "Test")
+	btn.OnClick = func() {
+		// This simulates what happens when a widget's OnChange calls showSuccess
+		sb.ShowSuccess("Success!")
+	}
+
+	ui.AddWidget(btn)
+	ui.Focus(btn)
+
+	// Set up a refresh notifier (like the standalone runner does)
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Simulate pressing Enter on the button - this should trigger OnClick
+	// which calls StatusBar.ShowSuccess
+	done := make(chan struct{})
+	go func() {
+		ev := tcell.NewEventKey(tcell.KeyEnter, 0, 0)
+		ui.HandleKey(ev)
+		close(done)
+	}()
+
+	// Wait for completion with timeout
+	select {
+	case <-done:
+		// Good - HandleKey completed without blocking
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleKey blocked - potential deadlock in StatusBar.ShowSuccess during HandleKey")
+	}
+
+	// Clean up
+	sb.Stop()
+}
+
+// TestStatusBarShowMessageFromCallback tests calling ShowSuccess from a callback
+// that's triggered during key handling, similar to how config editor uses it.
+func TestStatusBarShowMessageFromCallback(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	// Create and set up StatusBar
+	sb := NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	// Create an input that calls StatusBar.ShowSuccess on change
+	input := NewInput(10, 10, 30)
+	input.OnChange = func(text string) {
+		sb.ShowSuccess("Changed to: " + text)
+	}
+
+	ui.AddWidget(input)
+	ui.Focus(input)
+
+	// Set up a refresh notifier
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Simulate typing a character - this should trigger OnChange
+	done := make(chan struct{})
+	go func() {
+		ev := tcell.NewEventKey(tcell.KeyRune, 'a', 0)
+		ui.HandleKey(ev)
+		close(done)
+	}()
+
+	// Wait for completion with timeout
+	select {
+	case <-done:
+		// Good - HandleKey completed
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleKey blocked - deadlock when calling StatusBar.ShowSuccess from OnChange")
+	}
+
+	// Verify the message was added
+	if len(sb.messages) == 0 {
+		t.Error("Expected message to be added to StatusBar")
+	}
+
+	// Clean up
+	sb.Stop()
+}
+
+// TestStatusBarTickerDuringHandleKey tests that the StatusBar ticker doesn't
+// cause issues when HandleKey is in progress.
+func TestStatusBarTickerDuringHandleKey(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	// Create and set up StatusBar with a short message that will expire
+	sb := NewStatusBar(0, 22, 80)
+	sb.DefaultMessageDuration = 50 * time.Millisecond // Very short duration
+	ui.SetStatusBar(sb)
+
+	// Add a message that will expire soon
+	sb.ShowMessage("Expiring soon")
+
+	// Create a simple focusable widget
+	btn := NewButton(10, 10, 20, 1, "Test")
+	ui.AddWidget(btn)
+	ui.Focus(btn)
+
+	// Set up a refresh notifier
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Drain refresh channel in background
+	stopDrain := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-refreshCh:
+			case <-stopDrain:
+				return
+			}
+		}
+	}()
+
+	// Simulate multiple key events while the ticker might be expiring messages
+	for i := 0; i < 20; i++ {
+		done := make(chan struct{})
+		go func() {
+			ev := tcell.NewEventKey(tcell.KeyRune, 'x', 0)
+			ui.HandleKey(ev)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Good
+		case <-time.After(1 * time.Second):
+			t.Fatalf("HandleKey blocked on iteration %d", i)
+		}
+
+		// Small delay to let ticker potentially fire
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Clean up - stop StatusBar first, then stop draining
+	sb.Stop()
+	close(stopDrain)
+}
+
+// TestStatusBarRenderDuringShowMessage tests that calling Render while
+// ShowMessage is in progress doesn't cause a deadlock.
+func TestStatusBarRenderDuringShowMessage(t *testing.T) {
+	ui := core.NewUIManager()
+	ui.Resize(80, 24)
+
+	sb := NewStatusBar(0, 22, 80)
+	ui.SetStatusBar(sb)
+
+	btn := NewButton(10, 10, 20, 1, "Test")
+	ui.AddWidget(btn)
+	ui.Focus(btn)
+
+	refreshCh := make(chan bool, 1)
+	ui.SetRefreshNotifier(refreshCh)
+
+	// Simulate the standalone runner pattern: render after each event
+	for i := 0; i < 10; i++ {
+		done := make(chan struct{})
+		go func() {
+			// Show a message (like config editor does)
+			sb.ShowSuccess("Saved.")
+			// Then render (like standalone runner does after HandleKey)
+			ui.Render()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Good
+		case <-time.After(2 * time.Second):
+			t.Fatalf("ShowSuccess + Render blocked on iteration %d", i)
+		}
+	}
+
+	sb.Stop()
+}


### PR DESCRIPTION
## Summary

- Fix deadlock when calling `showSuccess`/`showError` from button callbacks in standalone config editor
- Root cause: `UIManager.StatusBar()` acquires `u.mu`, which is already held by `HandleKey` (Go's mutex is non-reentrant)
- Solution: Cache the StatusBar reference in ConfigEditor at initialization instead of calling `StatusBar()` during callbacks
- Also fixes a race condition in `StatusBar.Start()` where the ticker goroutine could access `s.ticker` after `Stop()` set it to nil

## Test plan

- [x] New tests added: `TestConfigEditorStatusBarFreeze`, `TestConfigEditorApplyWithStatusBar`, `TestColorPickerWithStatusBar`, `TestStatusBarAfterHandleKey`, `TestStatusBarGetterDuringCallback`
- [x] New StatusBar widget tests: `TestStatusBarShowMessageDuringHandleKey`, `TestStatusBarShowMessageFromCallback`, `TestStatusBarTickerDuringHandleKey`, `TestStatusBarRenderDuringShowMessage`
- [x] All tests pass
- [x] Manual test: Run standalone config editor and verify no freeze when clicking Save/Reset buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)