### PR TITLE
Simplify config editor by removing composite widget wrappers

### DIFF
--- a/texel/theme/theme.go
+++ b/texel/theme/theme.go
@@ -71,8 +71,6 @@ func GetLoadError() error {
 
 // Reload forces a re-read of the theme file and palette.
 func Reload() error {
-	log.Println("Theme: Reloading configuration...")
-	
 	// Re-create instance to clear old state
 	newInstance := make(Config)
 	if err := newInstance.Load(); err != nil {


### PR DESCRIPTION
## Summary
- Remove unnecessary `targetPanel` and `rootSwitcher` composite widgets that were thin wrappers around TabLayout
- Replace with simpler `targetContent` that embeds `*widgets.Pane` and only overrides `Resize()` for layout
- Remove log spam from `theme.Reload()` ("Theme: Reloading configuration...")

Net reduction: ~325 lines of boilerplate code.

## Test plan
- [x] All config editor tests pass
- [x] Verify config editor layout renders correctly
- [x] StatusBar integration tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)