### PR TITLE
Add TabPanel widget with simple AddTab API

### DIFF
--- a/apps/configeditor/configeditor.go
+++ b/apps/configeditor/configeditor.go
@@ -22,7 +22,6 @@ import (
 	"texelation/texel/theme"
 	"texelation/texelui/adapter"
 	"texelation/texelui/core"
-	"texelation/texelui/primitives"
 	"texelation/texelui/scroll"
 	"texelation/texelui/widgets"
 )
@@ -46,20 +45,20 @@ type configTarget struct {
 	values         config.Config
 	themeValues    config.Config
 	themeOverrides config.Config
-	content        *targetContent    // Wrapper with header label + sections
-	sections       *widgets.TabLayout
+	content        *targetContent   // Wrapper with header label + sections
+	sections       *widgets.TabPanel
 	bindings       []*fieldBinding
 }
 
-// targetContent wraps a header label and sections TabLayout for each target.
+// targetContent wraps a header label and sections TabPanel for each target.
 // Embeds Pane for focus/key/mouse handling, just adds layout on resize.
 type targetContent struct {
 	*widgets.Pane
 	header   *widgets.Label
-	sections *widgets.TabLayout
+	sections *widgets.TabPanel
 }
 
-func newTargetContent(title string, sections *widgets.TabLayout) *targetContent {
+func newTargetContent(title string, sections *widgets.TabPanel) *targetContent {
 	pane := widgets.NewPane(0, 0, 1, 1, tcell.StyleDefault)
 	header := widgets.NewLabel(0, 0, 1, 1, title)
 	pane.AddChild(header)
@@ -118,7 +117,7 @@ type ConfigEditor struct {
 	*adapter.UIApp
 	registry      *registry.Registry
 	targets       []*configTarget
-	rootTabs      *widgets.TabLayout
+	rootTabs      *widgets.TabPanel
 	activeWidget  core.Widget        // Currently displayed widget (rootTabs or single target.sections)
 	defaultTarget string
 	controlBus    texel.ControlBus
@@ -249,18 +248,14 @@ func (e *ConfigEditor) Resize(cols, rows int) {
 	}
 }
 
-func (e *ConfigEditor) buildTabs() *widgets.TabLayout {
-	tabs := make([]primitives.TabItem, 0, len(e.targets))
+func (e *ConfigEditor) buildTabs() *widgets.TabPanel {
+	panel := widgets.NewTabPanel()
 	for _, target := range e.targets {
-		tabs = append(tabs, primitives.TabItem{Label: target.label, ID: target.name})
-	}
-	tabLayout := widgets.NewTabLayout(0, 0, 1, 1, tabs)
-	for idx, target := range e.targets {
 		target.sections = e.buildSections(target)
 		target.content = newTargetContent(target.label+" Configuration", target.sections)
-		tabLayout.SetTabContent(idx, target.content)
+		panel.AddTabWithID(target.label, target.name, target.content)
 	}
-	return tabLayout
+	return panel
 }
 
 func (e *ConfigEditor) selectTarget(name string) {
@@ -326,47 +321,40 @@ func (e *ConfigEditor) targetByName(name string) *configTarget {
 	return nil
 }
 
-func (e *ConfigEditor) buildSections(target *configTarget) *widgets.TabLayout {
+func (e *ConfigEditor) buildSections(target *configTarget) *widgets.TabPanel {
 	switch target.kind {
 	case targetSystem:
 		return e.buildSystemSections(target)
 	case targetApp:
 		return e.buildAppSections(target)
 	default:
-		return widgets.NewTabLayout(0, 0, 1, 1, nil)
+		return widgets.NewTabPanel()
 	}
 }
 
-func (e *ConfigEditor) buildSystemSections(target *configTarget) *widgets.TabLayout {
-	tabItems := []primitives.TabItem{
-		{Label: "General", ID: "general"},
-		{Label: "Layout Transitions", ID: "layout_transitions"},
-		{Label: "Effects", ID: "effects"},
-		{Label: "Theme", ID: "theme"},
-		{Label: "TexelUI Theme", ID: "texelui_theme"},
-	}
-	tabs := widgets.NewTabLayout(0, 0, 1, 1, tabItems)
+func (e *ConfigEditor) buildSystemSections(target *configTarget) *widgets.TabPanel {
+	panel := widgets.NewTabPanel()
 	target.bindings = nil
 
 	generalValues := generalValues(target.values)
-	tabs.SetTabContent(0, e.buildSectionPane(target, target.values, "", generalValues, false, applySystem))
+	panel.AddTab("General", e.buildSectionPane(target, target.values, "", generalValues, false, applySystem))
 
 	layoutValues := sectionValues(target.values, "layout_transitions")
-	tabs.SetTabContent(1, e.buildSectionPane(target, target.values, "layout_transitions", layoutValues, false, applySystem))
+	panel.AddTab("Layout Transitions", e.buildSectionPane(target, target.values, "layout_transitions", layoutValues, false, applySystem))
 
 	effectsValues := sectionValues(target.values, "effects")
-	tabs.SetTabContent(2, e.buildEffectsSection(target, effectsValues))
+	panel.AddTab("Effects", e.buildEffectsSection(target, effectsValues))
 
 	themePane := e.buildGroupedThemePane(target, target.themeValues, systemThemeSections, true)
-	tabs.SetTabContent(3, themePane)
+	panel.AddTab("Theme", themePane)
 
 	uiValues := sectionValues(target.themeValues, "ui")
-	tabs.SetTabContent(4, e.buildSectionPane(target, target.themeValues, "ui", uiValues, true, applyTheme))
+	panel.AddTab("TexelUI Theme", e.buildSectionPane(target, target.themeValues, "ui", uiValues, true, applyTheme))
 
-	return tabs
+	return panel
 }
 
-func (e *ConfigEditor) buildAppSections(target *configTarget) *widgets.TabLayout {
+func (e *ConfigEditor) buildAppSections(target *configTarget) *widgets.TabPanel {
 	sections := splitSections(target.values)
 	delete(sections, "theme_overrides")
 	if len(sections) == 0 {
@@ -378,7 +366,8 @@ func (e *ConfigEditor) buildAppSections(target *configTarget) *widgets.TabLayout
 	}
 	sort.Strings(sectionKeys)
 
-	tabItems := make([]primitives.TabItem, 0, len(sectionKeys)+1)
+	panel := widgets.NewTabPanel()
+	target.bindings = nil
 	for _, key := range sectionKeys {
 		label := key
 		if key == "" {
@@ -386,19 +375,12 @@ func (e *ConfigEditor) buildAppSections(target *configTarget) *widgets.TabLayout
 		} else {
 			label = humanLabel(key)
 		}
-		tabItems = append(tabItems, primitives.TabItem{Label: label, ID: key})
-	}
-	tabItems = append(tabItems, primitives.TabItem{Label: "Theme", ID: "theme"})
-
-	tabs := widgets.NewTabLayout(0, 0, 1, 1, tabItems)
-	target.bindings = nil
-	for idx, key := range sectionKeys {
 		pane := e.buildSectionPane(target, target.values, key, sections[key], false, applyApp)
-		tabs.SetTabContent(idx, pane)
+		panel.AddTab(label, pane)
 	}
 	themePane := e.buildAppThemePane(target)
-	tabs.SetTabContent(len(sectionKeys), themePane)
-	return tabs
+	panel.AddTab("Theme", themePane)
+	return panel
 }
 
 func (e *ConfigEditor) buildSectionPane(target *configTarget, cfg config.Config, sectionKey string, values map[string]interface{}, forceColor bool, apply applyKind) core.Widget {

--- a/texelui/widgets/tabpanel.go
+++ b/texelui/widgets/tabpanel.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texelui/widgets/tabpanel.go
+// Summary: High-level tab container with simple AddTab API.
+
+package widgets
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"texelation/texelui/core"
+	"texelation/texelui/primitives"
+)
+
+// TabPanel is a high-level tab container that combines a tab bar with switchable
+// content panels. Unlike TabLayout which requires pre-defining tabs, TabPanel
+// lets you add tabs dynamically with a simple API:
+//
+//	panel := widgets.NewTabPanel(0, 0, 80, 24)
+//	panel.AddTab("General", generalPane)
+//	panel.AddTab("Advanced", advancedPane)
+type TabPanel struct {
+	*TabLayout
+	tabs []primitives.TabItem
+}
+
+// NewTabPanel creates a new empty tab panel.
+// Position and size default to 0,0,1,1 and should be set via SetPosition/Resize
+// when the panel is added to a layout.
+func NewTabPanel() *TabPanel {
+	tp := &TabPanel{
+		TabLayout: NewTabLayout(0, 0, 1, 1, nil),
+		tabs:      make([]primitives.TabItem, 0),
+	}
+	return tp
+}
+
+// AddTab adds a new tab with the given name and content widget.
+// Returns the index of the added tab.
+func (tp *TabPanel) AddTab(name string, content core.Widget) int {
+	idx := len(tp.tabs)
+	tp.tabs = append(tp.tabs, primitives.TabItem{Label: name, ID: name})
+
+	// Rebuild the tab bar with new tabs
+	tp.rebuildTabBar()
+
+	// Set the content for the new tab
+	tp.TabLayout.SetTabContent(idx, content)
+
+	return idx
+}
+
+// AddTabWithID adds a new tab with the given name, ID and content widget.
+// Returns the index of the added tab.
+func (tp *TabPanel) AddTabWithID(name, id string, content core.Widget) int {
+	idx := len(tp.tabs)
+	tp.tabs = append(tp.tabs, primitives.TabItem{Label: name, ID: id})
+
+	// Rebuild the tab bar with new tabs
+	tp.rebuildTabBar()
+
+	// Set the content for the new tab
+	tp.TabLayout.SetTabContent(idx, content)
+
+	return idx
+}
+
+// TabCount returns the number of tabs.
+func (tp *TabPanel) TabCount() int {
+	return len(tp.tabs)
+}
+
+// RemoveTab removes the tab at the given index.
+func (tp *TabPanel) RemoveTab(idx int) {
+	if idx < 0 || idx >= len(tp.tabs) {
+		return
+	}
+
+	// Remove from tabs slice
+	tp.tabs = append(tp.tabs[:idx], tp.tabs[idx+1:]...)
+
+	// Rebuild the tab bar
+	tp.rebuildTabBar()
+}
+
+// ClearTabs removes all tabs.
+func (tp *TabPanel) ClearTabs() {
+	tp.tabs = tp.tabs[:0]
+	tp.rebuildTabBar()
+}
+
+// rebuildTabBar recreates the internal TabLayout with current tabs.
+func (tp *TabPanel) rebuildTabBar() {
+	// Save current state
+	activeIdx := tp.TabLayout.ActiveIndex()
+	inv := tp.TabLayout.inv
+	trapsFocus := tp.TabLayout.TrapsFocus()
+	rect := tp.TabLayout.Rect
+
+	// Collect existing content widgets
+	oldChildren := tp.TabLayout.children
+
+	// Create new TabLayout with updated tabs
+	tp.TabLayout = NewTabLayout(rect.X, rect.Y, rect.W, rect.H, tp.tabs)
+	tp.TabLayout.SetTrapsFocus(trapsFocus)
+	if inv != nil {
+		tp.TabLayout.SetInvalidator(inv)
+	}
+
+	// Re-assign content widgets that still exist
+	for i := 0; i < len(tp.tabs) && i < len(oldChildren); i++ {
+		if oldChildren[i] != nil {
+			tp.TabLayout.SetTabContent(i, oldChildren[i])
+		}
+	}
+
+	// Restore active index if still valid
+	if activeIdx >= 0 && activeIdx < len(tp.tabs) {
+		tp.TabLayout.SetActive(activeIdx)
+	} else if len(tp.tabs) > 0 {
+		tp.TabLayout.SetActive(0)
+	}
+}
+
+// SetTabContent updates the content widget for a specific tab.
+// This is a convenience method that delegates to the underlying TabLayout.
+func (tp *TabPanel) SetTabContent(idx int, content core.Widget) {
+	tp.TabLayout.SetTabContent(idx, content)
+}
+
+// OnTabChange sets a callback that's called when the active tab changes.
+func (tp *TabPanel) OnTabChange(fn func(idx int)) {
+	tp.TabLayout.tabBar.OnChange = func(idx int) {
+		tp.TabLayout.invalidate()
+		if fn != nil {
+			fn(idx)
+		}
+	}
+}
+
+// HandleKey processes keyboard input.
+func (tp *TabPanel) HandleKey(ev *tcell.EventKey) bool {
+	return tp.TabLayout.HandleKey(ev)
+}
+
+// HandleMouse processes mouse input.
+func (tp *TabPanel) HandleMouse(ev *tcell.EventMouse) bool {
+	return tp.TabLayout.HandleMouse(ev)
+}


### PR DESCRIPTION
## Summary
Add a new `TabPanel` widget that wraps `TabLayout` with a simpler, more intuitive API for adding tabs dynamically.

**Before:**
```go
tabItems := []primitives.TabItem{
    {Label: "General", ID: "general"},
    {Label: "Advanced", ID: "advanced"},
}
tabs := widgets.NewTabLayout(0, 0, 1, 1, tabItems)
tabs.SetTabContent(0, generalPane)
tabs.SetTabContent(1, advancedPane)
```

**After:**
```go
panel := widgets.NewTabPanel()  // No position/size args needed
panel.AddTab("General", generalPane)
panel.AddTab("Advanced", advancedPane)
```

Changes:
- Add `texelui/widgets/tabpanel.go` with:
  - `NewTabPanel()` - simple constructor with no position/size args
  - `AddTab(name, content)` / `AddTabWithID(name, id, content)`
  - `RemoveTab(idx)` / `ClearTabs()`
  - `OnTabChange(fn)` callback
- Refactor config editor to use `TabPanel`, eliminating the need to import `primitives`

## Test plan
- [x] All config editor tests pass
- [x] All widgets tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)