### PR TITLE
Simplify widget constructors

### DIFF
--- a/apps/configeditor/configeditor.go
+++ b/apps/configeditor/configeditor.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gdamore/tcell/v2"
 	"texelation/config"
 	"texelation/internal/effects"
 	"texelation/registry"
@@ -59,8 +58,8 @@ type targetContent struct {
 }
 
 func newTargetContent(title string, sections *widgets.TabPanel) *targetContent {
-	pane := widgets.NewPane(0, 0, 1, 1, tcell.StyleDefault)
-	header := widgets.NewLabel(0, 0, 1, 1, title)
+	pane := widgets.NewPane()
+	header := widgets.NewLabel(title)
 	pane.AddChild(header)
 	pane.AddChild(sections)
 	return &targetContent{
@@ -432,7 +431,7 @@ func (e *ConfigEditor) buildEffectsSection(target *configTarget, values map[stri
 	options := effectOptions()
 
 	for _, event := range events {
-		label := widgets.NewLabel(0, 0, 0, 1, humanLabel(event))
+		label := widgets.NewLabel(humanLabel(event))
 		combo := widgets.NewComboBox(0, 0, 0, options, false)
 
 		selected := noneEffectLabel
@@ -570,7 +569,7 @@ func (e *ConfigEditor) buildAppThemePane(target *configTarget) core.Widget {
 		fields = overrideThemeFields(target.themeOverrides)
 	}
 	if len(fields) == 0 {
-		pane.AddRow(formRow{field: widgets.NewLabel(0, 0, 0, 1, "No theme settings for this app."), height: 1, fullWidth: true})
+		pane.AddRow(formRow{field: widgets.NewLabel("No theme settings for this app."), height: 1, fullWidth: true})
 		return wrapInScrollPane(pane)
 	}
 
@@ -617,7 +616,7 @@ func (e *ConfigEditor) buildAppThemePane(target *configTarget) core.Widget {
 				syncThemeOverrides(target)
 				e.applyTargetConfig(target, applyAppTheme)
 			}
-			pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, label), field: colorPicker, height: 1})
+			pane.AddRow(formRow{label: widgets.NewLabel(label), field: colorPicker, height: 1})
 		}
 		first = false
 	}
@@ -625,7 +624,7 @@ func (e *ConfigEditor) buildAppThemePane(target *configTarget) core.Widget {
 }
 
 func newSectionHeader(text string) *widgets.Label {
-	label := widgets.NewLabel(0, 0, 0, 1, text)
+	label := widgets.NewLabel(text)
 	label.Style = label.Style.Bold(true)
 	return label
 }
@@ -1067,15 +1066,10 @@ func maxInt(a, b int) int {
 
 // wrapInScrollPane wraps a formPane in a ScrollPane for scrollable content.
 func wrapInScrollPane(pane *formPane) *scrollableForm {
-	tm := theme.Get()
-	bg := tm.GetSemanticColor("bg.surface")
-	fg := tm.GetSemanticColor("text.primary")
-	style := tcell.StyleDefault.Background(bg).Foreground(fg)
-
 	contentH := pane.ContentHeight()
 	pane.Resize(80, contentH) // Initial reasonable width, will be updated on resize
 
-	sp := scroll.NewScrollPane(0, 0, 1, 1, style)
+	sp := scroll.NewScrollPane()
 	sp.SetChild(pane)
 	sp.SetContentHeight(contentH)
 

--- a/apps/configeditor/field_builder.go
+++ b/apps/configeditor/field_builder.go
@@ -102,12 +102,12 @@ func (fb *FieldBuilder) buildComboBox(fc FieldConfig, value string, pane *formPa
 		updateConfigValue(fb.cfg, fc.Section, fc.Key, val)
 		fb.onApply(fc.ApplyKind)
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), field: combo, height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), field: combo, height: 1})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldCombo, widget: combo}
 }
 
 func (fb *FieldBuilder) buildNumericInput(fc FieldConfig, value float64, pane *formPane) *fieldBinding {
-	input := widgets.NewInput(0, 0, 0)
+	input := widgets.NewInput()
 	input.Text = formatNumber(value)
 	dirty := false
 	input.OnChange = func(text string) {
@@ -122,12 +122,12 @@ func (fb *FieldBuilder) buildNumericInput(fc FieldConfig, value float64, pane *f
 			dirty = false
 		}
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), field: input, height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), field: input, height: 1})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldFloat, widget: input}
 }
 
 func (fb *FieldBuilder) buildIntInput(fc FieldConfig, value int, pane *formPane) *fieldBinding {
-	input := widgets.NewInput(0, 0, 0)
+	input := widgets.NewInput()
 	input.Text = strconv.Itoa(value)
 	dirty := false
 	input.OnChange = func(text string) {
@@ -142,7 +142,7 @@ func (fb *FieldBuilder) buildIntInput(fc FieldConfig, value int, pane *formPane)
 			dirty = false
 		}
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), field: input, height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), field: input, height: 1})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldInt, widget: input}
 }
 
@@ -158,12 +158,12 @@ func (fb *FieldBuilder) buildColorPicker(fc FieldConfig, value string, pane *for
 		updateConfigValue(fb.cfg, fc.Section, fc.Key, result.Source)
 		fb.onApply(fc.ApplyKind)
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), field: colorPicker, height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), field: colorPicker, height: 1})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldColor, widget: colorPicker}
 }
 
 func (fb *FieldBuilder) buildStringInput(fc FieldConfig, value string, pane *formPane) *fieldBinding {
-	input := widgets.NewInput(0, 0, 0)
+	input := widgets.NewInput()
 	input.Text = value
 	dirty := false
 	input.OnChange = func(text string) {
@@ -176,12 +176,13 @@ func (fb *FieldBuilder) buildStringInput(fc FieldConfig, value string, pane *for
 			dirty = false
 		}
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), field: input, height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), field: input, height: 1})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldString, widget: input}
 }
 
 func (fb *FieldBuilder) buildTextArea(fc FieldConfig, value interface{}, pane *formPane) *fieldBinding {
-	textarea := widgets.NewTextArea(0, 0, 0, 4)
+	textarea := widgets.NewTextArea()
+	textarea.Resize(0, 4)
 	textarea.SetText(formatJSON(value))
 	dirty := false
 	textarea.OnChange = func(text string) {
@@ -197,7 +198,7 @@ func (fb *FieldBuilder) buildTextArea(fc FieldConfig, value interface{}, pane *f
 			dirty = false
 		}
 	}
-	pane.AddRow(formRow{label: widgets.NewLabel(0, 0, 0, 1, fc.Label), height: 1})
+	pane.AddRow(formRow{label: widgets.NewLabel(fc.Label), height: 1})
 	pane.AddRow(formRow{field: textarea, height: 4, fullWidth: true})
 	return &fieldBinding{section: fc.Section, key: fc.Key, kind: fieldJSON, widget: textarea}
 }

--- a/apps/configeditor/statusbar_integration_test.go
+++ b/apps/configeditor/statusbar_integration_test.go
@@ -216,7 +216,7 @@ func TestStatusBarAfterHandleKey(t *testing.T) {
 	ui.SetStatusBar(sb)
 
 	// Create a button that shows a message in OnClick
-	btn := widgets.NewButton(10, 10, 20, 1, "Test")
+	btn := widgets.NewButton("Test")
 	btn.OnClick = func() {
 		// This is what happens in the config editor
 		sb.ShowSuccess("Clicked!")
@@ -284,7 +284,7 @@ func TestStatusBarGetterDuringCallback(t *testing.T) {
 	// This test verifies the pattern works with a cached reference.
 	cachedSB := sb // Use the concrete *StatusBar directly (same as ConfigEditor caches)
 
-	btn := widgets.NewButton(10, 10, 20, 1, "Test")
+	btn := widgets.NewButton("Test")
 	btn.OnClick = func() {
 		// Use cached reference instead of calling ui.StatusBar()
 		if cachedSB != nil {

--- a/apps/launcher/launcher.go
+++ b/apps/launcher/launcher.go
@@ -165,9 +165,9 @@ func (l *Launcher) buildUI() {
 	// Add background pane
 	tm := theme.ForApp("launcher")
 	bgColor := tm.GetSemanticColor("bg.surface")
-	style := tcell.StyleDefault.Background(bgColor)
 
-	l.pane = widgets.NewPane(0, 0, 1, 1, style)
+	l.pane = widgets.NewPane()
+	l.pane.Style = tcell.StyleDefault.Background(bgColor)
 	ui.AddWidget(l.pane)
 
 	// Create labels for each app
@@ -180,7 +180,8 @@ func (l *Launcher) buildUI() {
 			text += fmt.Sprintf(" - %s", app.Manifest.Description)
 		}
 
-		label := widgets.NewLabel(2, 2+i, 0, 1, text)
+		label := widgets.NewLabel(text)
+		label.SetPosition(2, 2+i)
 		label.SetFocusable(true)
 		l.labels = append(l.labels, label)
 		ui.AddWidget(label)

--- a/texelui/adapter/texel_app.go
+++ b/texelui/adapter/texel_app.go
@@ -109,7 +109,8 @@ func NewWidgetShowcaseApp(title string) *UIApp {
 
 	// === Inputs Tab (wrapped in ScrollPane for tall content) ===
 	inputsPane := createInputsTab()
-	inputsScroll := scroll.NewScrollPane(0, 0, 80, 20, tcell.StyleDefault)
+	inputsScroll := scroll.NewScrollPane()
+	inputsScroll.Resize(80, 20)
 	inputsScroll.SetChild(inputsPane)
 	inputsScroll.SetContentHeight(30) // Form is taller than viewport
 	tabLayout.SetTabContent(0, inputsScroll)
@@ -140,31 +141,46 @@ func NewWidgetShowcaseApp(title string) *UIApp {
 // createInputsTab creates the Inputs tab content with Input, TextArea, ComboBox, ColorPicker.
 // This form is intentionally tall to demonstrate scrolling in the Inputs tab.
 func createInputsTab() *widgets.Pane {
-	pane := widgets.NewPane(0, 0, 80, 30, tcell.StyleDefault) // Tall pane for scrolling demo
+	pane := widgets.NewPane()
+	pane.Resize(80, 30) // Tall pane for scrolling demo
+
+	// Helper to position a label
+	posLabel := func(x, y int, text string) *widgets.Label {
+		l := widgets.NewLabel(text)
+		l.SetPosition(x, y)
+		return l
+	}
+	// Helper to position an input
+	posInput := func(x, y, w int) *widgets.Input {
+		i := widgets.NewInput()
+		i.SetPosition(x, y)
+		i.Resize(w, 1)
+		return i
+	}
 
 	// Input field
-	nameLabel := widgets.NewLabel(2, 1, 12, 1, "Name:")
-	nameInput := widgets.NewInput(14, 1, 30)
+	nameLabel := posLabel(2, 1, "Name:")
+	nameInput := posInput(14, 1, 30)
 	nameInput.Placeholder = "Enter your name"
 	pane.AddChild(nameLabel)
 	pane.AddChild(nameInput)
 
 	// Email field
-	emailLabel := widgets.NewLabel(2, 3, 12, 1, "Email:")
-	emailInput := widgets.NewInput(14, 3, 30)
+	emailLabel := posLabel(2, 3, "Email:")
+	emailInput := posInput(14, 3, 30)
 	emailInput.Placeholder = "user@example.com"
 	pane.AddChild(emailLabel)
 	pane.AddChild(emailInput)
 
 	// Phone field (new)
-	phoneLabel := widgets.NewLabel(2, 5, 12, 1, "Phone:")
-	phoneInput := widgets.NewInput(14, 5, 30)
+	phoneLabel := posLabel(2, 5, "Phone:")
+	phoneInput := posInput(14, 5, 30)
 	phoneInput.Placeholder = "+1 (555) 000-0000"
 	pane.AddChild(phoneLabel)
 	pane.AddChild(phoneInput)
 
 	// ComboBox (editable) - for country selection with autocomplete
-	countryLabel := widgets.NewLabel(2, 7, 12, 1, "Country:")
+	countryLabel := posLabel(2, 7, "Country:")
 	countries := []string{
 		"Argentina", "Australia", "Austria", "Belgium", "Brazil",
 		"Canada", "Chile", "China", "Denmark", "Egypt",
@@ -180,7 +196,7 @@ func createInputsTab() *widgets.Pane {
 	pane.AddChild(countryCombo)
 
 	// ComboBox (non-editable) - for priority selection
-	priorityLabel := widgets.NewLabel(2, 9, 12, 1, "Priority:")
+	priorityLabel := posLabel(2, 9, "Priority:")
 	priorities := []string{"Low", "Medium", "High", "Critical"}
 	priorityCombo := widgets.NewComboBox(14, 9, 20, priorities, false)
 	priorityCombo.SetValue("Medium")
@@ -188,15 +204,16 @@ func createInputsTab() *widgets.Pane {
 	pane.AddChild(priorityCombo)
 
 	// TextArea with internal ScrollPane - just set size, scrolling works automatically
-	notesLabel := widgets.NewLabel(2, 11, 12, 1, "Notes:")
+	notesLabel := posLabel(2, 11, "Notes:")
 	notesBorder := widgets.NewBorder(14, 11, 40, 5, tcell.StyleDefault)
-	notesArea := widgets.NewTextArea(0, 0, 38, 3) // Size matches border interior
+	notesArea := widgets.NewTextArea()
+	notesArea.Resize(38, 3) // Size matches border interior
 	notesBorder.SetChild(notesArea)
 	pane.AddChild(notesLabel)
 	pane.AddChild(notesBorder)
 
 	// ColorPicker
-	colorLabel := widgets.NewLabel(2, 17, 12, 1, "Color:")
+	colorLabel := posLabel(2, 17, "Color:")
 	colorPicker := widgets.NewColorPicker(14, 17, widgets.ColorPickerConfig{
 		EnableSemantic: true,
 		EnablePalette:  true,
@@ -208,26 +225,26 @@ func createInputsTab() *widgets.Pane {
 	pane.AddChild(colorPicker)
 
 	// Additional fields to make form taller (for scrolling demo)
-	website := widgets.NewLabel(2, 19, 12, 1, "Website:")
-	websiteInput := widgets.NewInput(14, 19, 30)
+	website := posLabel(2, 19, "Website:")
+	websiteInput := posInput(14, 19, 30)
 	websiteInput.Placeholder = "https://example.com"
 	pane.AddChild(website)
 	pane.AddChild(websiteInput)
 
-	company := widgets.NewLabel(2, 21, 12, 1, "Company:")
-	companyInput := widgets.NewInput(14, 21, 30)
+	company := posLabel(2, 21, "Company:")
+	companyInput := posInput(14, 21, 30)
 	companyInput.Placeholder = "Company name"
 	pane.AddChild(company)
 	pane.AddChild(companyInput)
 
-	department := widgets.NewLabel(2, 23, 12, 1, "Department:")
+	department := posLabel(2, 23, "Department:")
 	depts := []string{"Engineering", "Design", "Marketing", "Sales", "Support", "HR"}
 	deptCombo := widgets.NewComboBox(14, 23, 25, depts, false)
 	pane.AddChild(department)
 	pane.AddChild(deptCombo)
 
 	// Checkboxes for preferences
-	prefsLabel := widgets.NewLabel(2, 25, 20, 1, "Preferences:")
+	prefsLabel := posLabel(2, 25, "Preferences:")
 	check1 := widgets.NewCheckbox(2, 26, "Email notifications")
 	check2 := widgets.NewCheckbox(2, 27, "SMS notifications")
 	check3 := widgets.NewCheckbox(2, 28, "Newsletter subscription")
@@ -241,37 +258,52 @@ func createInputsTab() *widgets.Pane {
 
 // createLayoutsTab creates the Layouts tab content demonstrating VBox and HBox.
 func createLayoutsTab() *widgets.Pane {
-	pane := widgets.NewPane(0, 0, 80, 20, tcell.StyleDefault)
+	pane := widgets.NewPane()
+	pane.Resize(80, 20)
+
+	// Helper functions
+	posLabel := func(x, y int, text string) *widgets.Label {
+		l := widgets.NewLabel(text)
+		l.SetPosition(x, y)
+		return l
+	}
+	posButton := func(x, y int, text string) *widgets.Button {
+		b := widgets.NewButton(text)
+		b.SetPosition(x, y)
+		return b
+	}
 
 	// Title
-	title := widgets.NewLabel(2, 1, 40, 1, "Layout Managers Demo")
+	title := posLabel(2, 1, "Layout Managers Demo")
 
 	// VBox demonstration
-	vboxLabel := widgets.NewLabel(2, 3, 20, 1, "VBox (vertical):")
+	vboxLabel := posLabel(2, 3, "VBox (vertical):")
 	vboxBorder := widgets.NewBorder(2, 4, 25, 8, tcell.StyleDefault)
-	vboxPane := widgets.NewPane(0, 0, 23, 6, tcell.StyleDefault)
-	vboxBtn1 := widgets.NewButton(1, 1, 20, 1, "Button 1")
-	vboxBtn2 := widgets.NewButton(1, 2, 20, 1, "Button 2")
-	vboxBtn3 := widgets.NewButton(1, 3, 20, 1, "Button 3")
+	vboxPane := widgets.NewPane()
+	vboxPane.Resize(23, 6)
+	vboxBtn1 := posButton(1, 1, "Button 1")
+	vboxBtn2 := posButton(1, 2, "Button 2")
+	vboxBtn3 := posButton(1, 3, "Button 3")
 	vboxPane.AddChild(vboxBtn1)
 	vboxPane.AddChild(vboxBtn2)
 	vboxPane.AddChild(vboxBtn3)
 	vboxBorder.SetChild(vboxPane)
 
 	// HBox demonstration
-	hboxLabel := widgets.NewLabel(30, 3, 20, 1, "HBox (horizontal):")
+	hboxLabel := posLabel(30, 3, "HBox (horizontal):")
 	hboxBorder := widgets.NewBorder(30, 4, 40, 4, tcell.StyleDefault)
-	hboxPane := widgets.NewPane(0, 0, 38, 2, tcell.StyleDefault)
-	hboxBtn1 := widgets.NewButton(1, 0, 10, 1, "Left")
-	hboxBtn2 := widgets.NewButton(13, 0, 10, 1, "Center")
-	hboxBtn3 := widgets.NewButton(25, 0, 10, 1, "Right")
+	hboxPane := widgets.NewPane()
+	hboxPane.Resize(38, 2)
+	hboxBtn1 := posButton(1, 0, "Left")
+	hboxBtn2 := posButton(13, 0, "Center")
+	hboxBtn3 := posButton(25, 0, "Right")
 	hboxPane.AddChild(hboxBtn1)
 	hboxPane.AddChild(hboxBtn2)
 	hboxPane.AddChild(hboxBtn3)
 	hboxBorder.SetChild(hboxPane)
 
 	// Help text
-	helpLabel := widgets.NewLabel(2, 13, 60, 1, "Tab: navigate between buttons")
+	helpLabel := posLabel(2, 13, "Tab: navigate between buttons")
 
 	pane.AddChild(title)
 	pane.AddChild(vboxLabel)
@@ -290,25 +322,38 @@ func createWidgetsTab(ui *core.UIManager) *widgets.Pane {
 
 // createWidgetsTabWithStatusBar creates the Widgets tab content with optional status bar integration.
 func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.StatusBar) *widgets.Pane {
-	pane := widgets.NewPane(0, 0, 80, 20, tcell.StyleDefault)
+	pane := widgets.NewPane()
+	pane.Resize(80, 20)
+
+	// Helper functions
+	posLabel := func(x, y int, text string) *widgets.Label {
+		l := widgets.NewLabel(text)
+		l.SetPosition(x, y)
+		return l
+	}
+	posButton := func(x, y int, text string) *widgets.Button {
+		b := widgets.NewButton(text)
+		b.SetPosition(x, y)
+		return b
+	}
 
 	// Title
-	title := widgets.NewLabel(2, 1, 40, 1, "Basic Widgets Demo")
+	title := posLabel(2, 1, "Basic Widgets Demo")
 
 	// Labels with different alignments
-	labelTitle := widgets.NewLabel(2, 3, 20, 1, "Labels:")
-	leftLabel := widgets.NewLabel(2, 4, 20, 1, "Left aligned")
+	labelTitle := posLabel(2, 3, "Labels:")
+	leftLabel := posLabel(2, 4, "Left aligned")
 	leftLabel.Align = widgets.AlignLeft
-	centerLabel := widgets.NewLabel(2, 5, 20, 1, "Center aligned")
+	centerLabel := posLabel(2, 5, "Center aligned")
 	centerLabel.Align = widgets.AlignCenter
-	rightLabel := widgets.NewLabel(2, 6, 20, 1, "Right aligned")
+	rightLabel := posLabel(2, 6, "Right aligned")
 	rightLabel.Align = widgets.AlignRight
 
 	// Buttons
-	buttonTitle := widgets.NewLabel(30, 3, 20, 1, "Buttons:")
-	statusLabel := widgets.NewLabel(30, 8, 40, 1, "Click a button...")
+	buttonTitle := posLabel(30, 3, "Buttons:")
+	statusLabel := posLabel(30, 8, "Click a button...")
 
-	actionBtn := widgets.NewButton(30, 4, 15, 1, "Action")
+	actionBtn := posButton(30, 4, "Action")
 	actionBtn.OnClick = func() {
 		statusLabel.Text = "Action button clicked!"
 		if statusBar != nil {
@@ -316,7 +361,7 @@ func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.Status
 		}
 	}
 
-	toggleBtn := widgets.NewButton(30, 5, 15, 1, "Toggle")
+	toggleBtn := posButton(30, 5, "Toggle")
 	toggleBtn.OnClick = func() {
 		statusLabel.Text = "Toggle button clicked!"
 		if statusBar != nil {
@@ -324,7 +369,7 @@ func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.Status
 		}
 	}
 
-	errorBtn := widgets.NewButton(30, 6, 15, 1, "Error Demo")
+	errorBtn := posButton(30, 6, "Error Demo")
 	errorBtn.OnClick = func() {
 		statusLabel.Text = "Error demo clicked!"
 		if statusBar != nil {
@@ -333,7 +378,7 @@ func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.Status
 	}
 
 	// Checkboxes
-	checkTitle := widgets.NewLabel(2, 8, 20, 1, "Checkboxes:")
+	checkTitle := posLabel(2, 8, "Checkboxes:")
 	check1 := widgets.NewCheckbox(2, 9, "Option A")
 	check2 := widgets.NewCheckbox(2, 10, "Option B")
 	check3 := widgets.NewCheckbox(2, 11, "Option C (checked)")
@@ -360,7 +405,7 @@ func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.Status
 	}
 
 	// Help text - note that status bar shows key hints automatically
-	helpLabel := widgets.NewLabel(2, 14, 60, 1, "Key hints shown in status bar below")
+	helpLabel := posLabel(2, 14, "Key hints shown in status bar below")
 
 	pane.AddChild(title)
 	pane.AddChild(labelTitle)
@@ -384,19 +429,27 @@ func createWidgetsTabWithStatusBar(ui *core.UIManager, statusBar *widgets.Status
 // createScrollingTab creates the Scrolling tab demonstrating the ScrollPane widget.
 // Returns the ScrollPane directly so it receives key events properly.
 func createScrollingTab() core.Widget {
+	// Helper to position a label
+	posLabel := func(x, y int, text string) *widgets.Label {
+		l := widgets.NewLabel(text)
+		l.SetPosition(x, y)
+		return l
+	}
+
 	// Create content with title, scrollable area, and instructions
 	// Total height: 1 (title) + 1 (desc) + 1 (gap) + 50 (content) + 1 (gap) + 5 (instructions) = 59 rows
-	contentPane := widgets.NewPane(0, 0, 80, 59, tcell.StyleDefault)
+	contentPane := widgets.NewPane()
+	contentPane.Resize(80, 59)
 
 	// Title and description at top
-	title := widgets.NewLabel(2, 0, 40, 1, "ScrollPane Widget Demo")
-	desc := widgets.NewLabel(2, 1, 70, 1, "Scroll to see 50 rows of content. Use mouse wheel or PgUp/PgDn.")
+	title := posLabel(2, 0, "ScrollPane Widget Demo")
+	desc := posLabel(2, 1, "Scroll to see 50 rows of content. Use mouse wheel or PgUp/PgDn.")
 	contentPane.AddChild(title)
 	contentPane.AddChild(desc)
 
 	// 50 rows of scrollable content
 	for i := 0; i < 50; i++ {
-		label := widgets.NewLabel(4, 3+i, 70, 1, fmt.Sprintf("Row %02d - This is scrollable content that demonstrates the ScrollPane widget", i+1))
+		label := posLabel(4, 3+i, fmt.Sprintf("Row %02d - This is scrollable content that demonstrates the ScrollPane widget", i+1))
 		contentPane.AddChild(label)
 	}
 
@@ -409,12 +462,13 @@ func createScrollingTab() core.Widget {
 		"  Ctrl+End: Go to bottom",
 	}
 	for i, text := range instructions {
-		help := widgets.NewLabel(2, 54+i, 70, 1, text)
+		help := posLabel(2, 54+i, text)
 		contentPane.AddChild(help)
 	}
 
 	// Wrap everything in a ScrollPane
-	scrollPane := scroll.NewScrollPane(0, 0, 80, 20, tcell.StyleDefault)
+	scrollPane := scroll.NewScrollPane()
+	scrollPane.Resize(80, 20)
 	scrollPane.SetChild(contentPane)
 	scrollPane.SetContentHeight(59)
 

--- a/texelui/core/uimanager_test.go
+++ b/texelui/core/uimanager_test.go
@@ -11,10 +11,14 @@ func TestUIManagerRendersPaneAndTextArea(t *testing.T) {
 	ui := core.NewUIManager()
 	ui.Resize(20, 5)
 
-	pane := widgets.NewPane(0, 0, 20, 5, tcell.StyleDefault.Background(tcell.ColorBlack).Foreground(tcell.ColorWhite))
+	pane := widgets.NewPane()
+	pane.Resize(20, 5)
+	pane.Style = tcell.StyleDefault.Background(tcell.ColorBlack).Foreground(tcell.ColorWhite)
 	ui.AddWidget(pane)
 
-	ta := widgets.NewTextArea(1, 1, 18, 3)
+	ta := widgets.NewTextArea()
+	ta.SetPosition(1, 1)
+	ta.Resize(18, 3)
 	b := widgets.NewBorder(0, 0, 20, 5, tcell.StyleDefault.Foreground(tcell.ColorWhite))
 	b.SetChild(ta)
 	ui.AddWidget(b)
@@ -52,7 +56,8 @@ func TestUIManagerDirtyClipsRestrictDraw(t *testing.T) {
 	ui.Resize(10, 4)
 	// Border + TextArea child, ensure invalidator is propagated
 	b := widgets.NewBorder(0, 0, 10, 4, tcell.StyleDefault)
-	ta := widgets.NewTextArea(0, 0, 8, 2)
+	ta := widgets.NewTextArea()
+	ta.Resize(8, 2)
 	b.SetChild(ta)
 	ui.AddWidget(b)
 
@@ -72,7 +77,9 @@ func TestClickToFocusInnerWidget(t *testing.T) {
 	ui := core.NewUIManager()
 	ui.Resize(10, 4)
 	b := widgets.NewBorder(0, 0, 10, 4, tcell.StyleDefault)
-	ta := widgets.NewTextArea(1, 1, 8, 2)
+	ta := widgets.NewTextArea()
+	ta.SetPosition(1, 1)
+	ta.Resize(8, 2)
 	b.SetChild(ta)
 	ui.AddWidget(b)
 	// Click inside textarea at (1,1) (client origin)
@@ -125,14 +132,16 @@ func TestDualTextAreasClickFocusAndType(t *testing.T) {
     lb := widgets.NewBorder(0, 0, 10, 4, tcell.StyleDefault)
     // Make focus color identifiable for the test (left border green)
     lb.FocusedStyle = tcell.StyleDefault.Foreground(tcell.ColorGreen)
-    lta := widgets.NewTextArea(0, 0, 8, 2)
+    lta := widgets.NewTextArea()
+    lta.Resize(8, 2)
     lb.SetChild(lta)
     ui.AddWidget(lb)
 
     // Right border + TA
     rb := widgets.NewBorder(10, 0, 10, 4, tcell.StyleDefault)
     rb.FocusedStyle = tcell.StyleDefault.Foreground(tcell.ColorTeal)
-    rta := widgets.NewTextArea(0, 0, 8, 2)
+    rta := widgets.NewTextArea()
+    rta.Resize(8, 2)
     rb.SetChild(rta)
     ui.AddWidget(rb)
 
@@ -176,7 +185,8 @@ func TestDualTextAreasClickFocusAndType(t *testing.T) {
 func TestTextAreaReplaceModeOverwritesAndUnderlineCaret(t *testing.T) {
     ui := core.NewUIManager()
     ui.Resize(10, 1)
-    ta := widgets.NewTextArea(0, 0, 10, 1)
+    ta := widgets.NewTextArea()
+    ta.Resize(10, 1)
     ui.AddWidget(ta)
     ui.Focus(ta)
 

--- a/texelui/scroll/scrollpane.go
+++ b/texelui/scroll/scrollpane.go
@@ -34,25 +34,20 @@ type ScrollPane struct {
 	dragStartOffset int  // Scroll offset when drag started
 }
 
-// NewScrollPane creates a new scroll pane with the given dimensions and style.
-func NewScrollPane(x, y, w, h int, style tcell.Style) *ScrollPane {
+// NewScrollPane creates a new scroll pane.
+// Position defaults to 0,0 and size defaults to 1x1. Use SetPosition() and Resize() to configure.
+func NewScrollPane() *ScrollPane {
 	sp := &ScrollPane{
 		showIndicators: true,
 	}
-	sp.SetPosition(x, y)
-	sp.Resize(w, h)
+	sp.Resize(1, 1)
 	sp.SetFocusable(true) // ScrollPane must be focusable to receive key events
 
 	// Resolve default colors from theme
 	tm := theme.Get()
-	fg, bg, attr := style.Decompose()
-	if fg == tcell.ColorDefault {
-		fg = tm.GetSemanticColor("text.primary")
-	}
-	if bg == tcell.ColorDefault {
-		bg = tm.GetSemanticColor("bg.surface")
-	}
-	sp.Style = tcell.StyleDefault.Foreground(fg).Background(bg).Attributes(attr)
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	sp.Style = tcell.StyleDefault.Foreground(fg).Background(bg)
 
 	// Set up scrollbar with text.primary color for thumb
 	thumbStyle := tcell.StyleDefault.Foreground(fg).Background(bg)

--- a/texelui/scroll/scrollpane_test.go
+++ b/texelui/scroll/scrollpane_test.go
@@ -77,8 +77,25 @@ func (c *mockContainer) VisitChildren(f func(core.Widget)) {
 	}
 }
 
+// newTestScrollPane creates a ScrollPane for testing with the given size at position (0,0).
+func newTestScrollPane(w, h int) *ScrollPane {
+	sp := NewScrollPane()
+	sp.Resize(w, h)
+	return sp
+}
+
+// newTestScrollPaneAt creates a ScrollPane for testing with the given position and size.
+func newTestScrollPaneAt(x, y, w, h int) *ScrollPane {
+	sp := NewScrollPane()
+	sp.SetPosition(x, y)
+	sp.Resize(w, h)
+	return sp
+}
+
 func TestNewScrollPane(t *testing.T) {
-	sp := NewScrollPane(10, 5, 40, 20, tcell.StyleDefault)
+	sp := NewScrollPane()
+	sp.SetPosition(10, 5)
+	sp.Resize(40, 20)
 
 	x, y := sp.Position()
 	if x != 10 || y != 5 {
@@ -100,7 +117,7 @@ func TestNewScrollPane(t *testing.T) {
 }
 
 func TestScrollPane_SetChild(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 
 	// Set child that's taller than viewport
 	child := newMockWidget(0, 0, 40, 30, false)
@@ -120,7 +137,7 @@ func TestScrollPane_SetChild(t *testing.T) {
 }
 
 func TestScrollPane_SetContentHeight(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(50)
 
 	if sp.ContentHeight() != 50 {
@@ -134,7 +151,7 @@ func TestScrollPane_SetContentHeight(t *testing.T) {
 }
 
 func TestScrollPane_ScrollBy(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 
 	// Scroll down
@@ -163,7 +180,7 @@ func TestScrollPane_ScrollBy(t *testing.T) {
 }
 
 func TestScrollPane_ScrollTo(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 
 	// Scroll to row 50
@@ -182,7 +199,7 @@ func TestScrollPane_ScrollTo(t *testing.T) {
 }
 
 func TestScrollPane_ScrollToTopBottom(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 
 	sp.ScrollBy(50) // Scroll to middle
@@ -199,7 +216,7 @@ func TestScrollPane_ScrollToTopBottom(t *testing.T) {
 }
 
 func TestScrollPane_ScrollToCentered(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 
 	sp.ScrollToCentered(50)
@@ -259,7 +276,7 @@ func TestScrollPane_CanScroll(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sp := NewScrollPane(0, 0, 40, tt.viewportH, tcell.StyleDefault)
+			sp := newTestScrollPane(40, tt.viewportH)
 			sp.SetContentHeight(tt.contentH)
 			if tt.scrollTo > 0 {
 				sp.ScrollBy(tt.scrollTo)
@@ -279,7 +296,7 @@ func TestScrollPane_CanScroll(t *testing.T) {
 }
 
 func TestScrollPane_HandleKey_PageUpDown(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollBy(50) // Start in middle
 
@@ -303,7 +320,7 @@ func TestScrollPane_HandleKey_PageUpDown(t *testing.T) {
 }
 
 func TestScrollPane_HandleKey_CtrlHomeEnd(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollBy(50)
 
@@ -327,7 +344,7 @@ func TestScrollPane_HandleKey_CtrlHomeEnd(t *testing.T) {
 }
 
 func TestScrollPane_HandleMouse_Wheel(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollBy(50)
 
@@ -351,7 +368,7 @@ func TestScrollPane_HandleMouse_Wheel(t *testing.T) {
 }
 
 func TestScrollPane_HandleMouse_OutsideBounds(t *testing.T) {
-	sp := NewScrollPane(10, 10, 20, 10, tcell.StyleDefault)
+	sp := newTestScrollPaneAt(10, 10, 20, 10)
 	sp.SetContentHeight(100)
 
 	// Mouse event outside bounds
@@ -362,7 +379,7 @@ func TestScrollPane_HandleMouse_OutsideBounds(t *testing.T) {
 }
 
 func TestScrollPane_EnsureFocusedVisible(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 
 	// Create a container with focusable child at row 50
 	container := newMockContainer(0, 0, 40, 100)
@@ -384,7 +401,7 @@ func TestScrollPane_EnsureFocusedVisible(t *testing.T) {
 }
 
 func TestScrollPane_VisitChildren(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	child := newMockWidget(0, 0, 40, 30, false)
 	sp.SetChild(child)
 
@@ -402,7 +419,7 @@ func TestScrollPane_VisitChildren(t *testing.T) {
 }
 
 func TestScrollPane_VisitChildren_NoChild(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 
 	count := 0
 	sp.VisitChildren(func(w core.Widget) {
@@ -415,7 +432,7 @@ func TestScrollPane_VisitChildren_NoChild(t *testing.T) {
 }
 
 func TestScrollPane_WidgetAt(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	child := newMockWidget(5, 0, 30, 20, false)
 	sp.SetChild(child)
 
@@ -442,7 +459,7 @@ func TestScrollPane_Draw(t *testing.T) {
 	buf := createTestBuffer(50, 20)
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 50, H: 20})
 
-	sp := NewScrollPane(5, 2, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPaneAt(5, 2, 40, 10)
 	sp.SetContentHeight(30)
 	sp.ScrollBy(10) // Scroll down 10 rows
 
@@ -500,7 +517,7 @@ func TestScrollPane_Draw_NoIndicators(t *testing.T) {
 	buf := createTestBuffer(50, 20)
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 50, H: 20})
 
-	sp := NewScrollPane(5, 2, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPaneAt(5, 2, 40, 10)
 	sp.SetContentHeight(30)
 	sp.ScrollBy(10)
 	sp.ShowIndicators(false) // Disable indicators
@@ -541,7 +558,7 @@ func TestScrollPane_Draw_ArrowsNotOverwrittenByThumb(t *testing.T) {
 			buf := createTestBuffer(50, tc.viewportH+5)
 			painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 50, H: tc.viewportH + 5})
 
-			sp := NewScrollPane(5, 2, 40, tc.viewportH, tcell.StyleDefault)
+			sp := newTestScrollPaneAt(5, 2, 40, tc.viewportH)
 			sp.SetContentHeight(tc.contentHeight)
 			sp.ScrollBy(tc.scrollOffset)
 
@@ -574,7 +591,7 @@ func TestScrollPane_Draw_ScrollbarLayout(t *testing.T) {
 	buf := createTestBuffer(50, 15)
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 50, H: 15})
 
-	sp := NewScrollPane(5, 2, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPaneAt(5, 2, 40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollBy(45) // Middle position
 
@@ -636,7 +653,7 @@ func TestScrollPane_Draw_ThumbAtExtremes(t *testing.T) {
 			buf := createTestBuffer(50, 15)
 			painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 50, H: 15})
 
-			sp := NewScrollPane(5, 2, 40, 10, tcell.StyleDefault)
+			sp := newTestScrollPaneAt(5, 2, 40, 10)
 			sp.SetContentHeight(100) // viewport=10, content=100, maxOffset=90
 			sp.ScrollBy(tc.offset)
 
@@ -674,7 +691,7 @@ func TestScrollPane_Draw_ThumbAtExtremes(t *testing.T) {
 }
 
 func TestScrollPane_Invalidation(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 
 	invalidated := false
@@ -693,7 +710,7 @@ func TestScrollPane_Invalidation(t *testing.T) {
 }
 
 func TestScrollPane_ChildInvalidator(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 
 	invalidatorCalled := false
 	child := newMockWidget(0, 0, 40, 30, false)
@@ -713,7 +730,7 @@ func TestScrollPane_ChildInvalidator(t *testing.T) {
 }
 
 func TestScrollPane_Resize(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollBy(50)
 
@@ -738,7 +755,7 @@ func TestScrollPane_Resize(t *testing.T) {
 }
 
 func TestScrollPane_Resize_ClampOffset(t *testing.T) {
-	sp := NewScrollPane(0, 0, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(40, 10)
 	sp.SetContentHeight(100)
 	sp.ScrollToBottom() // offset = 90
 
@@ -764,7 +781,7 @@ func TestScrollPane_IntegrationDraw(t *testing.T) {
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 60, H: 30})
 
 	// ScrollPane at (10, 5) with size 40x10, content height 50
-	sp := NewScrollPane(10, 5, 40, 10, tcell.StyleDefault)
+	sp := newTestScrollPaneAt(10, 5, 40, 10)
 
 	// Create child widget that fills 40x50
 	child := &labelWidget{x: 10, y: 5, w: 40, h: 50}
@@ -831,7 +848,7 @@ func itoa(n int) string {
 
 // TestScrollPane_MouseScrollbarArrows verifies clicking arrows scrolls by 1 row.
 func TestScrollPane_MouseScrollbarArrows(t *testing.T) {
-	sp := NewScrollPane(0, 0, 20, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(20, 10)
 	child := newMockWidget(0, 0, 19, 100, false) // Content height 100
 	sp.SetChild(child)
 	sp.SetContentHeight(100)
@@ -866,7 +883,7 @@ func TestScrollPane_MouseScrollbarArrows(t *testing.T) {
 
 // TestScrollPane_MouseScrollbarTrack verifies clicking track scrolls by page.
 func TestScrollPane_MouseScrollbarTrack(t *testing.T) {
-	sp := NewScrollPane(0, 0, 20, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(20, 10)
 	child := newMockWidget(0, 0, 19, 100, false)
 	sp.SetChild(child)
 	sp.SetContentHeight(100)
@@ -901,7 +918,7 @@ func TestScrollPane_MouseScrollbarTrack(t *testing.T) {
 
 // TestScrollPane_MouseScrollbarThumbDrag verifies thumb drag scrolls proportionally.
 func TestScrollPane_MouseScrollbarThumbDrag(t *testing.T) {
-	sp := NewScrollPane(0, 0, 20, 10, tcell.StyleDefault)
+	sp := newTestScrollPane(20, 10)
 	child := newMockWidget(0, 0, 19, 100, false)
 	sp.SetChild(child)
 	sp.SetContentHeight(100)

--- a/texelui/widgets/button.go
+++ b/texelui/widgets/button.go
@@ -21,10 +21,10 @@ type Button struct {
 	inv func(core.Rect)
 }
 
-// NewButton creates a button at the specified position and size.
-// If w is 0, the button will size to fit the text plus padding.
-// If h is 0, the button will default to height 1.
-func NewButton(x, y, w, h int, text string) *Button {
+// NewButton creates a button with the given text.
+// Position defaults to 0,0 and size auto-fits text with padding.
+// Use SetPosition and Resize to adjust after adding to a layout.
+func NewButton(text string) *Button {
 	b := &Button{
 		Text: text,
 	}
@@ -40,17 +40,8 @@ func NewButton(x, y, w, h int, text string) *Button {
 	focusBg := tm.GetSemanticColor("border.focus")
 	b.SetFocusedStyle(tcell.StyleDefault.Foreground(focusFg).Background(focusBg), true)
 
-	b.SetPosition(x, y)
-
-	// Auto-size if dimensions are 0
-	if w == 0 {
-		// Add padding: [ Text ]
-		w = len(text) + 4
-	}
-	if h == 0 {
-		h = 1
-	}
-	b.Resize(w, h)
+	// Auto-size with padding: [ Text ]
+	b.Resize(len(text)+4, 1)
 
 	// Buttons are focusable by default
 	b.SetFocusable(true)

--- a/texelui/widgets/input.go
+++ b/texelui/widgets/input.go
@@ -35,8 +35,10 @@ type Input struct {
 	inv func(core.Rect)
 }
 
-// NewInput creates a single-line input field at the specified position and size.
-func NewInput(x, y, w int) *Input {
+// NewInput creates a single-line input field.
+// Position defaults to 0,0 and width to 20.
+// Use SetPosition and Resize to adjust after adding to a layout.
+func NewInput() *Input {
 	tm := theme.Get()
 	bg := tm.GetSemanticColor("bg.surface")
 	fg := tm.GetSemanticColor("text.primary")
@@ -50,11 +52,9 @@ func NewInput(x, y, w int) *Input {
 	}
 
 	// Configure focused style
-	// For now, keep same as default, or allow overrides via theme if needed
 	i.SetFocusedStyle(tcell.StyleDefault.Foreground(fg).Background(bg), true)
 
-	i.SetPosition(x, y)
-	i.Resize(w, 1) // Input is always single-line
+	i.Resize(20, 1) // Default width, always single-line
 	i.SetFocusable(true)
 
 	return i

--- a/texelui/widgets/label.go
+++ b/texelui/widgets/label.go
@@ -27,9 +27,10 @@ type Label struct {
 	inv func(core.Rect)
 }
 
-// NewLabel creates a label at the specified position and size.
-// If w or h are 0, the label will size to fit the text.
-func NewLabel(x, y, w, h int, text string) *Label {
+// NewLabel creates a label with the given text.
+// Position defaults to 0,0 and size auto-fits the text.
+// Use SetPosition and Resize to adjust after adding to a layout.
+func NewLabel(text string) *Label {
 	l := &Label{
 		Text:  text,
 		Align: AlignLeft,
@@ -41,16 +42,8 @@ func NewLabel(x, y, w, h int, text string) *Label {
 	bg := tm.GetSemanticColor("bg.surface")
 	l.Style = tcell.StyleDefault.Foreground(fg).Background(bg)
 
-	l.SetPosition(x, y)
-
-	// Auto-size if dimensions are 0
-	if w == 0 {
-		w = len(text)
-	}
-	if h == 0 {
-		h = 1
-	}
-	l.Resize(w, h)
+	// Auto-size to fit text
+	l.Resize(len(text), 1)
 
 	// Labels are not focusable by default
 	l.SetFocusable(false)

--- a/texelui/widgets/pane.go
+++ b/texelui/widgets/pane.go
@@ -21,29 +21,23 @@ type Pane struct {
 	lastFocusedIdx int  // Index of last focused child for focus restoration
 }
 
-func NewPane(x, y, w, h int, style tcell.Style) *Pane {
+// NewPane creates a pane container with theme default styling.
+// Position defaults to 0,0 and size to 1,1.
+// Use SetPosition and Resize to adjust after adding to a layout.
+func NewPane() *Pane {
 	p := &Pane{
 		lastFocusedIdx: -1, // No child focused yet
 	}
-	p.SetPosition(x, y)
-	p.Resize(w, h)
+	p.Resize(1, 1)
 
-	// Resolve default colors from theme
+	// Get default colors from theme
 	tm := theme.Get()
-	fg, bg, attr := style.Decompose()
-	if fg == tcell.ColorDefault {
-		fg = tm.GetSemanticColor("text.primary")
-	}
-	if bg == tcell.ColorDefault {
-		bg = tm.GetSemanticColor("bg.surface")
-	}
-	// Update style with resolved colors
-	p.Style = tcell.StyleDefault.Foreground(fg).Background(bg).Attributes(attr)
+	fg := tm.GetSemanticColor("text.primary")
+	bg := tm.GetSemanticColor("bg.surface")
+	p.Style = tcell.StyleDefault.Foreground(fg).Background(bg)
 
 	// Configure focus style
-	fbg := tm.GetSemanticColor("bg.surface")
-	ffg := tm.GetSemanticColor("text.primary")
-	p.SetFocusedStyle(tcell.StyleDefault.Background(fbg).Foreground(ffg), true)
+	p.SetFocusedStyle(tcell.StyleDefault.Background(bg).Foreground(fg), true)
 	return p
 }
 

--- a/texelui/widgets/statusbar_test.go
+++ b/texelui/widgets/statusbar_test.go
@@ -20,7 +20,8 @@ func TestStatusBarShowMessageDuringHandleKey(t *testing.T) {
 	ui.SetStatusBar(sb)
 
 	// Create a button that calls StatusBar.ShowSuccess when clicked
-	btn := NewButton(10, 10, 20, 1, "Test")
+	btn := NewButton("Test")
+	btn.SetPosition(10, 10)
 	btn.OnClick = func() {
 		// This simulates what happens when a widget's OnChange calls showSuccess
 		sb.ShowSuccess("Success!")
@@ -65,7 +66,9 @@ func TestStatusBarShowMessageFromCallback(t *testing.T) {
 	ui.SetStatusBar(sb)
 
 	// Create an input that calls StatusBar.ShowSuccess on change
-	input := NewInput(10, 10, 30)
+	input := NewInput()
+	input.SetPosition(10, 10)
+	input.Resize(30, 1)
 	input.OnChange = func(text string) {
 		sb.ShowSuccess("Changed to: " + text)
 	}
@@ -117,7 +120,8 @@ func TestStatusBarTickerDuringHandleKey(t *testing.T) {
 	sb.ShowMessage("Expiring soon")
 
 	// Create a simple focusable widget
-	btn := NewButton(10, 10, 20, 1, "Test")
+	btn := NewButton("Test")
+	btn.SetPosition(10, 10)
 	ui.AddWidget(btn)
 	ui.Focus(btn)
 
@@ -171,7 +175,8 @@ func TestStatusBarRenderDuringShowMessage(t *testing.T) {
 	sb := NewStatusBar(0, 22, 80)
 	ui.SetStatusBar(sb)
 
-	btn := NewButton(10, 10, 20, 1, "Test")
+	btn := NewButton("Test")
+	btn.SetPosition(10, 10)
 	ui.AddWidget(btn)
 	ui.Focus(btn)
 

--- a/texelui/widgets/tablayout_test.go
+++ b/texelui/widgets/tablayout_test.go
@@ -16,16 +16,22 @@ func TestTabLayout_FocusTraversal(t *testing.T) {
 	tl := NewTabLayout(0, 0, 80, 24, tabs)
 
 	// Create content for tab 1 with two focusable inputs
-	pane1 := NewPane(0, 0, 80, 20, tcell.StyleDefault)
-	input1 := NewInput(0, 0, 20)
-	input2 := NewInput(0, 1, 20)
+	pane1 := NewPane()
+	pane1.Resize(80, 20)
+	input1 := NewInput()
+	input1.Resize(20, 1)
+	input2 := NewInput()
+	input2.SetPosition(0, 1)
+	input2.Resize(20, 1)
 	pane1.AddChild(input1)
 	pane1.AddChild(input2)
 	tl.SetTabContent(0, pane1)
 
 	// Create content for tab 2
-	pane2 := NewPane(0, 0, 80, 20, tcell.StyleDefault)
-	input3 := NewInput(0, 0, 20)
+	pane2 := NewPane()
+	pane2.Resize(80, 20)
+	input3 := NewInput()
+	input3.Resize(20, 1)
 	pane2.AddChild(input3)
 	tl.SetTabContent(1, pane2)
 
@@ -189,9 +195,13 @@ func TestTabLayout_UIManagerTraversal(t *testing.T) {
 	}
 	tl := NewTabLayout(0, 0, 80, 24, tabs)
 
-	pane := NewPane(0, 0, 80, 20, tcell.StyleDefault)
-	input1 := NewInput(0, 0, 20)
-	input2 := NewInput(0, 1, 20)
+	pane := NewPane()
+	pane.Resize(80, 20)
+	input1 := NewInput()
+	input1.Resize(20, 1)
+	input2 := NewInput()
+	input2.SetPosition(0, 1)
+	input2.Resize(20, 1)
 	pane.AddChild(input1)
 	pane.AddChild(input2)
 	tl.SetTabContent(0, pane)
@@ -251,8 +261,10 @@ func TestTabLayout_TabBarAlwaysAccessible(t *testing.T) {
 	}
 	tl := NewTabLayout(0, 0, 80, 24, tabs)
 
-	pane := NewPane(0, 0, 80, 20, tcell.StyleDefault)
-	input := NewInput(0, 0, 20)
+	pane := NewPane()
+	pane.Resize(80, 20)
+	input := NewInput()
+	input.Resize(20, 1)
 	pane.AddChild(input)
 	tl.SetTabContent(0, pane)
 

--- a/texelui/widgets/textarea.go
+++ b/texelui/widgets/textarea.go
@@ -45,7 +45,9 @@ type textAreaContent struct {
 	Style  tcell.Style
 }
 
-func NewTextArea(x, y, w, h int) *TextArea {
+// NewTextArea creates a multi-line text input widget.
+// Position defaults to 0,0 and size defaults to 20x4. Use SetPosition() and Resize() to configure.
+func NewTextArea() *TextArea {
 	tm := theme.Get()
 	bg := tm.GetSemanticColor("bg.surface")
 	fg := tm.GetSemanticColor("text.primary")
@@ -65,14 +67,13 @@ func NewTextArea(x, y, w, h int) *TextArea {
 	ta.content.SetFocusable(false)
 
 	// Create internal scroll pane
-	ta.scrollPane = scroll.NewScrollPane(0, 0, w, h, ta.Style)
+	ta.scrollPane = scroll.NewScrollPane()
 	ta.scrollPane.SetChild(ta.content)
 	ta.scrollPane.SetFocusable(false) // TextArea handles focus
 
 	// Enable focused styling
 	ta.SetFocusedStyle(tcell.StyleDefault.Background(bg).Foreground(fg), true)
-	ta.SetPosition(x, y)
-	ta.Resize(w, h)
+	ta.Resize(20, 4) // Default size
 	ta.SetFocusable(true)
 
 	return ta

--- a/texelui/widgets/widgets_test.go
+++ b/texelui/widgets/widgets_test.go
@@ -17,8 +17,15 @@ func createTestBuffer(w, h int) [][]texel.Cell {
 	return buf
 }
 
+// newTestInput creates an Input for testing with the given width.
+func newTestInput(w int) *Input {
+	input := NewInput()
+	input.Resize(w, 1)
+	return input
+}
+
 func TestLabelCreation(t *testing.T) {
-	label := NewLabel(0, 0, 10, 1, "Test")
+	label := NewLabel("Test")
 	if label.Text != "Test" {
 		t.Errorf("expected text 'Test', got '%s'", label.Text)
 	}
@@ -30,7 +37,8 @@ func TestLabelCreation(t *testing.T) {
 
 func TestLabelDraw(t *testing.T) {
 	buf := createTestBuffer(20, 3)
-	label := NewLabel(0, 0, 10, 1, "Hello")
+	label := NewLabel("Hello")
+	label.Resize(10, 1)
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 20, H: 3})
 	label.Draw(painter)
 
@@ -50,7 +58,7 @@ func TestLabelDraw(t *testing.T) {
 
 func TestButtonCreation(t *testing.T) {
 	clicked := false
-	button := NewButton(0, 0, 10, 1, "Click")
+	button := NewButton("Click")
 	button.OnClick = func() {
 		clicked = true
 	}
@@ -70,7 +78,8 @@ func TestButtonCreation(t *testing.T) {
 
 func TestButtonDraw(t *testing.T) {
 	buf := createTestBuffer(20, 3)
-	button := NewButton(0, 0, 15, 1, "Test")
+	button := NewButton("Test")
+	button.Resize(15, 1)
 	painter := core.NewPainter(buf, core.Rect{X: 0, Y: 0, W: 20, H: 3})
 	button.Draw(painter)
 
@@ -89,7 +98,7 @@ func TestButtonDraw(t *testing.T) {
 }
 
 func TestInputCreation(t *testing.T) {
-	input := NewInput(0, 0, 20)
+	input := newTestInput(20)
 	if input.Text != "" {
 		t.Errorf("expected empty text, got '%s'", input.Text)
 	}
@@ -99,7 +108,7 @@ func TestInputCreation(t *testing.T) {
 }
 
 func TestInputTextEntry(t *testing.T) {
-	input := NewInput(0, 0, 20)
+	input := newTestInput(20)
 	input.SetFocusable(true)
 	input.Focus()
 
@@ -119,7 +128,7 @@ func TestInputTextEntry(t *testing.T) {
 }
 
 func TestInputBackspace(t *testing.T) {
-	input := NewInput(0, 0, 20)
+	input := newTestInput(20)
 	input.Text = "Test"
 	input.CaretPos = 4
 
@@ -136,7 +145,7 @@ func TestInputBackspace(t *testing.T) {
 }
 
 func TestInputNavigation(t *testing.T) {
-	input := NewInput(0, 0, 20)
+	input := newTestInput(20)
 	input.Text = "Hello"
 	input.CaretPos = 5
 
@@ -250,7 +259,7 @@ func TestCheckboxDraw(t *testing.T) {
 }
 
 func TestInputInsertReplaceMode(t *testing.T) {
-	input := NewInput(0, 0, 20)
+	input := newTestInput(20)
 	input.Text = "Hello"
 	input.CaretPos = 1
 


### PR DESCRIPTION
## Summary

- Simplify widget constructors to not require position/size parameters
- `NewLabel(text)`, `NewButton(text)`, `NewPane()`, `NewInput()`, `NewTextArea()`, `NewScrollPane()` now take minimal params
- Position and size can be set via `SetPosition()` and `Resize()` after creation
- This is cleaner for layout-managed widgets where position is handled automatically
- All widgets pick up theme colors by default

## Changed Widgets

| Widget | Old Constructor | New Constructor |
|--------|-----------------|-----------------|
| Label | `NewLabel(x, y, w, h, text)` | `NewLabel(text)` |
| Button | `NewButton(x, y, w, h, text)` | `NewButton(text)` |
| Pane | `NewPane(x, y, w, h, style)` | `NewPane()` |
| Input | `NewInput(x, y, w)` | `NewInput()` |
| TextArea | `NewTextArea(x, y, w, h)` | `NewTextArea()` |
| ScrollPane | `NewScrollPane(x, y, w, h, style)` | `NewScrollPane()` |

## Test plan

- [x] Build passes
- [x] All tests pass
- [x] Manual testing of widget showcase demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)