### PR TITLE
Fix empty scrollback gaps and preserve viewport on screen clear

### DIFF
--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -1253,6 +1253,28 @@ func (v *VTerm) OriginMode() bool    { return v.originMode }
 // InAltScreen returns true if the terminal is currently showing the alternate screen buffer.
 func (v *VTerm) InAltScreen() bool { return v.inAltScreen }
 
+// LiveEdgeBase returns the current liveEdgeBase (global line index of viewport row 0).
+func (v *VTerm) LiveEdgeBase() int64 {
+	if v.memBufState == nil {
+		return 0
+	}
+	return v.memBufState.liveEdgeBase
+}
+
+// MarginTop returns the current top scroll margin.
+func (v *VTerm) MarginTop() int { return v.marginTop }
+
+// MarginBottom returns the current bottom scroll margin.
+func (v *VTerm) MarginBottom() int { return v.marginBottom }
+
+// MemoryBuffer returns the underlying MemoryBuffer for diagnostic access.
+func (v *VTerm) MemoryBuffer() *MemoryBuffer {
+	if v.memBufState == nil {
+		return nil
+	}
+	return v.memBufState.memBuf
+}
+
 // GetAltBufferLine returns a copy of the specified line from the alternate screen buffer.
 // Returns nil if index is out of bounds or not in alt screen mode.
 func (v *VTerm) GetAltBufferLine(y int) []Cell {


### PR DESCRIPTION
## Summary
- **Empty scrollback gaps**: Scroll region scroll-ups now skip advancing `liveEdgeBase` when the scrolled-off line is empty, preventing blank gaps from TUI startup sequences
- **Viewport preserved on ED**: ESC[2J and ESC[H ESC[J push non-empty viewport content to scrollback before clearing (matching iTerm2/GNOME Terminal behavior), with leading/trailing empty rows compacted out
- **Persistence metadata**: `notifyMetadataChange()` now called when `liveEdgeBase` changes in scroll region ops; persistence covers all viewport lines

## Test plan
- [x] 10 new/updated tests covering scroll region scrollback, ED push-to-scrollback, and edge cases
- [x] Full parser test suite passes
- [x] Manual testing with Codex CLI — scrollback content preserved, no empty gaps
- [x] `TestCodexCaptureScrollback` replays real Codex capture and verifies gap reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)