### PR TITLE
Fix auto-wrap reflow on terminal output

### DIFF
--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -245,10 +245,16 @@ func (v *VTerm) writeCharWithWrapping(r rune) {
 	} else {
 		// Main screen wrapping logic
 		if v.wrapEnabled && newX > rightEdge {
-			// Set wrapNext instead of wrapping immediately
-			// This allows CR or LF to clear the flag without creating extra lines
-			v.wrapNext = true
-			v.SetCursorPos(v.cursorY, rightEdge)
+			if v.IsMemoryBufferEnabled() {
+				// Memory buffer: let cursorX advance past terminal width.
+				// The LogicalLine extends naturally, and WrapToWidth() handles display.
+				v.cursorX = newX
+			} else {
+				// Set wrapNext instead of wrapping immediately
+				// This allows CR or LF to clear the flag without creating extra lines
+				v.wrapNext = true
+				v.SetCursorPos(v.cursorY, rightEdge)
+			}
 		} else if newX <= rightEdge {
 			v.SetCursorPos(v.cursorY, newX)
 			// Sync prevCursor with new cursor position so delta-based sync doesn't see false movement.


### PR DESCRIPTION
## Summary
- Let cursorX advance past terminal width during auto-wrap so LogicalLine extends naturally — WrapToWidth() already handles display wrapping and resize reflow
- Fix WAL metadata sync after checkpoint, gap line notification, viewport flush on close, and EnsureLine off-by-1 on history reload

## Test plan
- [x] `TestAutoWrap_GridRendering` — wrapped content displays correctly across rows
- [x] `TestAutoWrap_ResizeReflow` — content reflows to fewer rows when terminal widens
- [x] `TestVTerm_ScrollStatePersistence` — no regression on persistence reload
- [x] Full parser test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)