### PR TITLE
Enable rounded corners on panes

### DIFF
--- a/texel/pane.go
+++ b/texel/pane.go
@@ -63,9 +63,10 @@ type pane struct {
 // newPane creates a new, empty Pane. The App is attached later.
 func newPane(s *Workspace) *pane {
 	p := &pane{
-		screen:     s,
-		IsActive:   false,
-		IsResizing: false,
+		screen:         s,
+		IsActive:       false,
+		IsResizing:     false,
+		RoundedCorners: true,
 	}
 	if _, err := rand.Read(p.id[:]); err != nil {
 		sum := sha1.Sum([]byte(fmt.Sprintf("%p", p)))


### PR DESCRIPTION
## Summary
- Sets `RoundedCorners: true` in `newPane()` so all panes use rounded border corners by default

## Test plan
- [x] `go build ./...` clean
- [x] Visual: pane borders show rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)