### PR TITLE
Add crypt screen-scramble effect (Ctrl+R)

### DIFF
--- a/internal/effects/config.go
+++ b/internal/effects/config.go
@@ -143,6 +143,8 @@ func ParseTrigger(name string) (EffectTriggerType, bool) {
 		return TriggerWorkspaceZoom, true
 	case "workspace.theme":
 		return TriggerWorkspaceTheme, true
+	case "crypt.toggle":
+		return TriggerCryptToggle, true
 	case "clipboard.changed":
 		return TriggerClipboardChanged, true
 	case "clock.tick":
@@ -172,6 +174,7 @@ func TriggerNames() []string {
 		"workspace.layout",
 		"workspace.zoom",
 		"workspace.theme",
+		"crypt.toggle",
 		"clipboard.changed",
 		"clock.tick",
 		"session.state",

--- a/internal/effects/crypt.go
+++ b/internal/effects/crypt.go
@@ -1,0 +1,60 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/effects/crypt.go
+// Summary: Implements crypt screen-scramble effect for the client effect subsystem.
+// Usage: Replaces alphanumeric characters with random block characters while preserving styles.
+
+package effects
+
+import (
+	"math/rand"
+	"time"
+	"unicode"
+
+	"github.com/framegrace/texelation/client"
+)
+
+// Braille patterns U+2801..U+28FF (skip U+2800 blank).
+const brailleBase = 0x2801
+const brailleCount = 0x28FF - brailleBase + 1
+
+type cryptEffect struct {
+	active bool
+}
+
+func (e *cryptEffect) ID() string { return "crypt" }
+
+func (e *cryptEffect) Active() bool { return e.active }
+
+func (e *cryptEffect) Update(now time.Time) {}
+
+func (e *cryptEffect) HandleTrigger(trigger EffectTrigger) {
+	if trigger.Type != TriggerCryptToggle {
+		return
+	}
+	e.active = !e.active
+}
+
+func (e *cryptEffect) ApplyWorkspace(buffer [][]client.Cell) {
+	if !e.active {
+		return
+	}
+	for y := range buffer {
+		row := buffer[y]
+		for x := range row {
+			ch := row[x].Ch
+			if unicode.IsLetter(ch) || unicode.IsDigit(ch) {
+				row[x].Ch = rune(brailleBase + rand.Intn(brailleCount))
+			}
+		}
+	}
+}
+
+func (e *cryptEffect) ApplyPane(pane *client.PaneState, buffer [][]client.Cell) {}
+
+func init() {
+	Register("crypt", func(cfg EffectConfig) (Effect, error) {
+		return &cryptEffect{}, nil
+	})
+}

--- a/internal/effects/events.go
+++ b/internal/effects/events.go
@@ -71,6 +71,8 @@ const (
 	TriggerWorkspaceZoom
 	TriggerWorkspaceTheme
 
+	TriggerCryptToggle
+
 	TriggerClipboardChanged
 	TriggerClockTick
 	TriggerSessionState

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -154,6 +154,10 @@ func (s *clientState) applyEffectConfig() {
 		}
 		manager.RegisterBinding(effects.Binding{Effect: eff, Target: binding.Target, Event: binding.Event})
 	}
+	// Always register the crypt (screen lock) effect regardless of theme bindings.
+	if cryptEff, err := effects.CreateEffect("crypt", nil); err == nil {
+		manager.RegisterBinding(effects.Binding{Effect: cryptEff, Target: effects.TargetWorkspace, Event: effects.TriggerCryptToggle})
+	}
 	if s.renderCh != nil {
 		manager.AttachRenderChannel(s.renderCh)
 	}

--- a/internal/runtime/client/input_handler.go
+++ b/internal/runtime/client/input_handler.go
@@ -34,6 +34,16 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 			consumePasteKey(state, ev)
 			return true
 		}
+		if ev.Key() == tcell.KeyCtrlR {
+			if state.effects != nil {
+				state.effects.HandleTrigger(effects.EffectTrigger{
+					Type:      effects.TriggerCryptToggle,
+					Timestamp: time.Now(),
+				})
+			}
+			render(state, screen)
+			return true
+		}
 		if state.controlMode && ev.Modifiers() == 0 {
 			r := ev.Rune()
 			if r == 'q' || r == 'Q' {


### PR DESCRIPTION
## Summary
- New `crypt` effect that replaces alphanumeric characters with random braille patterns (U+2801–U+28FF) while preserving all cell styles
- Toggled via **Ctrl+R** directly (no control mode needed)
- Always registered in the effect manager regardless of theme bindings, so it works as a future screen lock visual

## Test plan
- [x] Press Ctrl+R — all alphanumeric chars become random braille noise, colors/attributes preserved
- [x] Press Ctrl+R again — normal display restores
- [x] Verify no FPS impact when effect is inactive
- [x] `go build ./...` and `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)