### PR TITLE
Fix normal screen mismatch after resize during alt screen

### DIFF
--- a/apps/texelterm/parser/alt_screen_test.go
+++ b/apps/texelterm/parser/alt_screen_test.go
@@ -339,6 +339,109 @@ func TestScrollRegionDetailedState(t *testing.T) {
 	}
 }
 
+// TestAltScreenResizeThenExit verifies that resizing the terminal while in alt screen
+// correctly updates the normal screen memory buffer so that exiting alt screen produces
+// a grid with the correct dimensions and cursor position.
+func TestAltScreenResizeThenExit(t *testing.T) {
+	v := NewVTerm(80, 24, WithMemoryBuffer())
+	p := NewParser(v)
+
+	// Write some content on normal screen
+	for i := 0; i < 15; i++ {
+		for _, ch := range "output line\r\n" {
+			p.Parse(ch)
+		}
+	}
+	// Cursor should be around row 15
+	_, curYBefore := v.Cursor()
+	t.Logf("Before alt screen: cursor at row %d", curYBefore)
+
+	// Enter alt screen
+	for _, ch := range "\x1b[?1049h" {
+		p.Parse(ch)
+	}
+	if !v.InAltScreen() {
+		t.Fatal("Should be in alt screen")
+	}
+
+	// Write some alt screen content
+	for _, ch := range "Alt screen app running...\r\n" {
+		p.Parse(ch)
+	}
+
+	// Resize while in alt screen (grow from 24 to 35 rows)
+	v.Resize(80, 35)
+
+	// Exit alt screen
+	for _, ch := range "\x1b[?1049l" {
+		p.Parse(ch)
+	}
+	if v.InAltScreen() {
+		t.Fatal("Should not be in alt screen")
+	}
+
+	// Grid must have the new height
+	grid := v.Grid()
+	if len(grid) != 35 {
+		t.Errorf("Grid rows: got %d, want 35", len(grid))
+	}
+	// Each row must have the correct width
+	for i, row := range grid {
+		if len(row) != 80 {
+			t.Errorf("Grid row %d width: got %d, want 80", i, len(row))
+			break
+		}
+	}
+
+	// Cursor must be within the new dimensions
+	cx, cy := v.Cursor()
+	if cy < 0 || cy >= 35 {
+		t.Errorf("Cursor Y out of bounds: got %d, want 0-%d", cy, 34)
+	}
+	if cx < 0 || cx >= 80 {
+		t.Errorf("Cursor X out of bounds: got %d, want 0-79", cx)
+	}
+}
+
+// TestAltScreenResizeShrinkThenExit verifies shrinking during alt screen also works.
+func TestAltScreenResizeShrinkThenExit(t *testing.T) {
+	v := NewVTerm(80, 30, WithMemoryBuffer())
+	p := NewParser(v)
+
+	// Write enough content to fill the screen
+	for i := 0; i < 25; i++ {
+		for _, ch := range "output line\r\n" {
+			p.Parse(ch)
+		}
+	}
+
+	// Enter alt screen
+	for _, ch := range "\x1b[?1049h" {
+		p.Parse(ch)
+	}
+
+	// Resize: shrink from 30 to 20 rows
+	v.Resize(80, 20)
+
+	// Exit alt screen
+	for _, ch := range "\x1b[?1049l" {
+		p.Parse(ch)
+	}
+
+	grid := v.Grid()
+	if len(grid) != 20 {
+		t.Errorf("Grid rows: got %d, want 20", len(grid))
+	}
+
+	cx, cy := v.Cursor()
+	if cy < 0 || cy >= 20 {
+		t.Errorf("Cursor Y out of bounds: got %d, want 0-%d", cy, 19)
+	}
+	if cx < 0 || cx >= 80 {
+		t.Errorf("Cursor X out of bounds: got %d, want 0-79", cx)
+	}
+}
+
 // Helper to convert grid line to string for debugging
 func gridLineToString(cells []Cell) string {
 	if cells == nil {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -1386,6 +1386,10 @@ func (v *VTerm) Resize(width, height int) {
 	v.height = height
 
 	if v.inAltScreen {
+		// Save alt-screen cursor before any resize operations
+		altCursorX, altCursorY := v.cursorX, v.cursorY
+
+		// Resize alt buffer
 		newAltBuffer := make([][]Cell, v.height)
 		for i := range newAltBuffer {
 			newAltBuffer[i] = make([]Cell, v.width)
@@ -1395,7 +1399,21 @@ func (v *VTerm) Resize(width, height int) {
 			}
 		}
 		v.altBuffer = newAltBuffer
-		v.SetCursorPos(v.cursorY, v.cursorX) // Re-clamp cursor
+
+		// Also resize the normal screen memory buffer so that when we exit
+		// alt screen, liveEdgeBase and viewport dimensions are consistent.
+		// Temporarily swap in the saved main cursor so memoryBufferResize
+		// adjusts it correctly for the new dimensions.
+		if v.IsMemoryBufferEnabled() {
+			v.cursorX, v.cursorY = v.savedMainCursorX, v.savedMainCursorY
+			v.memoryBufferResize(width, height)
+			v.savedMainCursorX = v.cursorX
+			v.savedMainCursorY = v.cursorY
+		}
+
+		// Restore alt-screen cursor, clamped to new alt buffer size
+		v.cursorX, v.cursorY = altCursorX, altCursorY
+		v.SetCursorPos(v.cursorY, v.cursorX)
 	} else {
 		// Use MemoryBuffer/ViewportWindow resize
 		v.memoryBufferResize(width, height)


### PR DESCRIPTION
## Summary
- When resizing a pane while an alt-screen app (neovim, htop) was running, exiting the app left the normal screen with stale viewport dimensions and cursor position — content overlaid pane borders and required a manual resize to fix
- Root cause: `VTerm.Resize()` only resized `altBuffer` when `inAltScreen == true`, never calling `memoryBufferResize()` for the normal screen
- Fix: also call `memoryBufferResize()` in the alt-screen branch, with the saved main cursor temporarily swapped in so it gets adjusted for the new dimensions

## Test plan
- [x] `TestAltScreenResizeThenExit` — grow from 24→35 rows during alt screen, verify grid dimensions and cursor on exit
- [x] `TestAltScreenResizeShrinkThenExit` — shrink from 30→20 rows during alt screen, same verification
- [x] All existing alt screen tests pass
- [x] Full `go test ./apps/texelterm/...` passes
- [x] Manual: open neovim in a pane, resize pane, exit neovim — prompt should be correctly positioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)