### PR TITLE
Fix refresh notifier goroutine leak

### DIFF
--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -145,13 +145,14 @@ type DesktopEngine struct {
 
 // FloatingPanel represents an app floating above the workspace.
 type FloatingPanel struct {
-	app      App
-	pipeline RenderPipeline // For events and rendering (from PipelineProvider)
-	x, y     int
-	width    int
-	height   int
-	modal    bool
-	id       [16]byte
+	app         App
+	pipeline    RenderPipeline // For events and rendering (from PipelineProvider)
+	x, y        int
+	width       int
+	height      int
+	modal       bool
+	id          [16]byte
+	stopRefresh func() // stops the refresh notifier goroutine
 }
 
 func newFloatingPanelID(app App) [16]byte {
@@ -593,7 +594,12 @@ func (d *DesktopEngine) SwitchToWorkspace(id int) {
 	}
 
 	for _, sp := range d.statusPanes {
-		sp.app.SetRefreshNotifier(d.makeRefreshNotifier())
+		if sp.stopRefresh != nil {
+			sp.stopRefresh()
+		}
+		notifier, stop := d.makeRefreshNotifier()
+		sp.stopRefresh = stop
+		sp.app.SetRefreshNotifier(notifier)
 	}
 	d.recalculateLayout()
 	d.broadcastStateUpdate()
@@ -992,7 +998,8 @@ func (d *DesktopEngine) SendRefresh() {
 // makeRefreshNotifier creates a channel suitable for App.SetRefreshNotifier
 // that forwards to the desktop event loop. Use this for status panes and
 // floating panels that don't have a per-pane refresh forwarder.
-func (d *DesktopEngine) makeRefreshNotifier() chan<- bool {
+// The returned stop function closes the channel and terminates the goroutine.
+func (d *DesktopEngine) makeRefreshNotifier() (chan<- bool, func()) {
 	ch := make(chan bool, 1)
 	go func() {
 		for {
@@ -1007,7 +1014,7 @@ func (d *DesktopEngine) makeRefreshNotifier() chan<- bool {
 			}
 		}
 	}()
-	return ch
+	return ch, func() { close(ch) }
 }
 
 // Barrier blocks until the event loop has processed all previously-queued events.

--- a/texel/desktop_overlays.go
+++ b/texel/desktop_overlays.go
@@ -38,7 +38,8 @@ func (d *DesktopEngine) ShowFloatingPanel(app App, x, y, w, h int) {
 	}
 
 	// Wire refresh notifier to pipeline (or app as fallback)
-	notifier := d.makeRefreshNotifier()
+	notifier, stop := d.makeRefreshNotifier()
+	panel.stopRefresh = stop
 	if panel.pipeline != nil {
 		panel.pipeline.SetRefreshNotifier(notifier)
 	} else {
@@ -87,6 +88,9 @@ func (d *DesktopEngine) CloseFloatingPanel(panel *FloatingPanel) {
 	}
 
 	if found {
+		if panel.stopRefresh != nil {
+			panel.stopRefresh()
+		}
 		d.appLifecycle.StopApp(panel.app)
 		d.recalculateLayout()
 		d.broadcastTreeChanged()

--- a/texel/desktop_status.go
+++ b/texel/desktop_status.go
@@ -18,10 +18,11 @@ const (
 
 // StatusPane is a special pane with absolute sizing, placed on one side of the screen.
 type StatusPane struct {
-	app  App
-	side Side
-	size int // rows for Top/Bottom, cols for Left/Right
-	id   [16]byte
+	app         App
+	side        Side
+	size        int // rows for Top/Bottom, cols for Left/Right
+	id          [16]byte
+	stopRefresh func() // stops the refresh notifier goroutine
 }
 
 // AddStatusPane adds a new status pane to the desktop.
@@ -38,7 +39,9 @@ func (d *DesktopEngine) AddStatusPane(app App, side Side, size int) {
 		d.Subscribe(listener)
 	}
 
-	app.SetRefreshNotifier(d.makeRefreshNotifier())
+	notifier, stop := d.makeRefreshNotifier()
+	sp.stopRefresh = stop
+	app.SetRefreshNotifier(notifier)
 
 	d.appLifecycle.StartApp(app, nil)
 	d.recalculateLayout()


### PR DESCRIPTION
## Summary
- `makeRefreshNotifier()` now returns a stop function alongside the channel
- `FloatingPanel` and `StatusPane` store the stop func and call it on removal or re-wiring
- Fixes goroutine leak when closing floating panels or switching workspaces

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./texel/ ./internal/runtime/server/` passes
- [ ] Manual: open/close launcher repeatedly, confirm no goroutine growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)