### PR TITLE
Auto-install and version-check shell integration scripts

### DIFF
--- a/apps/texelterm/shell/bash.sh
+++ b/apps/texelterm/shell/bash.sh
@@ -1,0 +1,73 @@
+# TEXEL_SHELL_INTEGRATION_VERSION=9
+# Texelterm Shell Integration for Bash
+# Automatically loaded by texelterm - do not modify
+#
+# This integration provides:
+# - OSC 133 shell integration (prompt/command tracking)
+# - Environment capture for shell restart persistence
+# - Per-terminal history isolation
+# - OSC 7 CWD reporting for session restore
+#
+# Environment files (~/.texel-env-$TEXEL_PANE_ID) persist across shell/server restarts.
+# Each pane has its own environment file, stable across process restarts.
+
+# Per-terminal history file (isolated by pane ID)
+if [[ -n "$TEXEL_PANE_ID" ]]; then
+    export HISTFILE="$HOME/.texel-history-$TEXEL_PANE_ID"
+fi
+
+# Enable history append mode (never overwrite)
+shopt -s histappend
+
+# Track if this is the first prompt (to avoid capturing environment on startup)
+_TEXEL_PROMPT_COUNT=0
+
+# Send debug marker to confirm integration loaded
+printf '\033]133;D;999\007' 2>/dev/null
+
+# OSC 133 Shell Integration with file-based environment capture
+_texel_prompt_command() {
+    local ret=$?
+    # Send command end marker (but skip on first prompt)
+    if (( _TEXEL_PROMPT_COUNT > 0 )); then
+        printf '\033]133;D;%s\007' "$ret"
+
+        # Append new history to file immediately (prevents loss on crash)
+        history -a
+
+        # Save environment to file for shell/server restart persistence
+        # Use >| to force overwrite (bypasses noclobber)
+        # Pane-ID-based file persists across shell restarts and server restarts
+        if [[ -n "$TEXEL_PANE_ID" ]]; then
+            {
+                env
+                echo "__TEXEL_CWD=$PWD"
+            } >| ~/.texel-env-$TEXEL_PANE_ID
+        fi
+    fi
+    # Increment prompt counter
+    (( _TEXEL_PROMPT_COUNT++ ))
+
+    # OSC 7 - Report current working directory for session restore
+    printf '\033]7;file://%s%s\007' "$(hostname)" "$PWD"
+
+    # Send prompt start marker
+    printf '\033]133;A\007'
+}
+
+# Setup PROMPT_COMMAND
+if [[ -z "$PROMPT_COMMAND" ]]; then
+    PROMPT_COMMAND='_texel_prompt_command'
+elif [[ "$PROMPT_COMMAND" != *"_texel_prompt_command"* ]]; then
+    PROMPT_COMMAND="_texel_prompt_command;$PROMPT_COMMAND"
+fi
+
+# Embed Prompt End (OSC 133;B) into PS1
+if [[ "$PS1" != *"\033]133;B"* ]]; then
+    PS1="$PS1\[\033]133;B\007\]"
+fi
+
+# PS0: Embed command text in OSC 133;C
+if [[ "$PS0" != *"\033]133;C"* ]]; then
+    PS0='\033]133;C;$(HISTTIMEFORMAT="" history 1 | sed "s/^[ ]*[0-9]*[ ]*//")\'$'\007'
+fi

--- a/apps/texelterm/shell/embed.go
+++ b/apps/texelterm/shell/embed.go
@@ -1,0 +1,128 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Package shell embeds canonical shell integration scripts and installs/updates
+// them in the user's config directory. Each script carries a version comment;
+// on every shell launch the installed version is compared against the embedded
+// version and overwritten if outdated or missing.
+package shell
+
+import (
+	"bufio"
+	"embed"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+//go:embed bash.sh zsh.sh fish.fish
+var scripts embed.FS
+
+// CurrentVersion is the version stamped into the embedded scripts.
+// Bump this (and the comment in each .sh/.fish file) whenever the
+// scripts change in a way that requires re-installation.
+const CurrentVersion = 9
+
+// scriptFiles maps installed filenames to their embedded source names.
+var scriptFiles = []string{"bash.sh", "zsh.sh", "fish.fish"}
+
+// EnsureInstalled checks each script in configDir, writes or updates if
+// missing or version < CurrentVersion. Generates bash-wrapper.sh dynamically.
+func EnsureInstalled(configDir string) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("shell: create config dir: %w", err)
+	}
+
+	for _, name := range scriptFiles {
+		dst := filepath.Join(configDir, name)
+		if needsUpdate(dst) {
+			data, err := scripts.ReadFile(name)
+			if err != nil {
+				return fmt.Errorf("shell: read embedded %s: %w", name, err)
+			}
+			if err := os.WriteFile(dst, data, 0644); err != nil {
+				return fmt.Errorf("shell: write %s: %w", dst, err)
+			}
+			log.Printf("[SHELL] Installed %s (version %d)", dst, CurrentVersion)
+		}
+	}
+
+	// Generate bash-wrapper.sh dynamically (contains home-dir path)
+	if err := generateBashWrapper(configDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// needsUpdate returns true if the installed script is missing or has a
+// version older than CurrentVersion.
+func needsUpdate(path string) bool {
+	v, err := installedVersion(path)
+	if err != nil {
+		return true // missing or unreadable
+	}
+	return v < CurrentVersion
+}
+
+// installedVersion reads the first line of path and extracts the
+// TEXEL_SHELL_INTEGRATION_VERSION value. Returns 0 and an error if
+// the file is missing, unreadable, or lacks a version comment.
+func installedVersion(path string) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return 0, fmt.Errorf("empty file")
+	}
+	return parseVersionLine(scanner.Text())
+}
+
+// parseVersionLine extracts the version number from a line like:
+//
+//	# TEXEL_SHELL_INTEGRATION_VERSION=9
+func parseVersionLine(line string) (int, error) {
+	const prefix = "TEXEL_SHELL_INTEGRATION_VERSION="
+	idx := strings.Index(line, prefix)
+	if idx < 0 {
+		return 0, fmt.Errorf("no version marker")
+	}
+	numStr := strings.TrimSpace(line[idx+len(prefix):])
+	v, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("bad version number %q: %w", numStr, err)
+	}
+	return v, nil
+}
+
+// generateBashWrapper writes bash-wrapper.sh which sources the integration
+// script followed by the user's .bashrc. The path is derived from configDir
+// rather than hardcoded to a specific home directory.
+func generateBashWrapper(configDir string) error {
+	integrationPath := filepath.Join(configDir, "bash.sh")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("shell: detect home dir: %w", err)
+	}
+	bashrc := filepath.Join(homeDir, ".bashrc")
+
+	content := fmt.Sprintf(`#!/bin/bash
+# Texelterm shell integration wrapper (auto-generated, do not edit)
+# Loads integration first, then user's bashrc
+[[ -f %s ]] && source %s
+[[ -f %s ]] && source %s
+`, integrationPath, integrationPath, bashrc, bashrc)
+
+	wrapperPath := filepath.Join(configDir, "bash-wrapper.sh")
+	if err := os.WriteFile(wrapperPath, []byte(content), 0755); err != nil {
+		return fmt.Errorf("shell: write bash-wrapper.sh: %w", err)
+	}
+	return nil
+}

--- a/apps/texelterm/shell/embed_test.go
+++ b/apps/texelterm/shell/embed_test.go
@@ -1,0 +1,225 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseVersionLine(t *testing.T) {
+	tests := []struct {
+		line    string
+		want    int
+		wantErr bool
+	}{
+		{"# TEXEL_SHELL_INTEGRATION_VERSION=9", 9, false},
+		{"# TEXEL_SHELL_INTEGRATION_VERSION=1", 1, false},
+		{"# TEXEL_SHELL_INTEGRATION_VERSION=42", 42, false},
+		{"# Texelterm Shell Integration for Bash", 0, true},
+		{"", 0, true},
+		{"# TEXEL_SHELL_INTEGRATION_VERSION=abc", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := parseVersionLine(tt.line)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseVersionLine(%q) error = %v, wantErr %v", tt.line, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseVersionLine(%q) = %d, want %d", tt.line, got, tt.want)
+		}
+	}
+}
+
+func TestEnsureInstalled_FreshDir(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "shell-integration")
+
+	t.Setenv("HOME", dir) // bash-wrapper.sh uses UserHomeDir
+
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	// All scripts should exist
+	for _, name := range []string{"bash.sh", "zsh.sh", "fish.fish", "bash-wrapper.sh"} {
+		path := filepath.Join(configDir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	// Verify version in each script
+	for _, name := range scriptFiles {
+		path := filepath.Join(configDir, name)
+		v, err := installedVersion(path)
+		if err != nil {
+			t.Errorf("installedVersion(%s): %v", name, err)
+			continue
+		}
+		if v != CurrentVersion {
+			t.Errorf("%s version = %d, want %d", name, v, CurrentVersion)
+		}
+	}
+}
+
+func TestEnsureInstalled_UpdatesOldVersion(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "shell-integration")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+
+	// Write an old-version bash.sh
+	old := "# TEXEL_SHELL_INTEGRATION_VERSION=7\n# old content\n"
+	if err := os.WriteFile(filepath.Join(configDir, "bash.sh"), []byte(old), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	// bash.sh should be updated to CurrentVersion
+	v, err := installedVersion(filepath.Join(configDir, "bash.sh"))
+	if err != nil {
+		t.Fatalf("installedVersion: %v", err)
+	}
+	if v != CurrentVersion {
+		t.Errorf("bash.sh version = %d after update, want %d", v, CurrentVersion)
+	}
+
+	// Content should contain OSC 7
+	data, _ := os.ReadFile(filepath.Join(configDir, "bash.sh"))
+	if !strings.Contains(string(data), "OSC 7") {
+		t.Error("updated bash.sh missing OSC 7 comment")
+	}
+}
+
+func TestEnsureInstalled_NoDowngrade(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "shell-integration")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", dir)
+
+	// Write a future-version bash.sh
+	future := "# TEXEL_SHELL_INTEGRATION_VERSION=99\n# future content\n"
+	futurePath := filepath.Join(configDir, "bash.sh")
+	if err := os.WriteFile(futurePath, []byte(future), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	// bash.sh should NOT be overwritten
+	data, _ := os.ReadFile(futurePath)
+	if !strings.Contains(string(data), "future content") {
+		t.Error("bash.sh was downgraded from future version")
+	}
+}
+
+func TestEnsureInstalled_BashWrapperUsesHomeDir(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "shell-integration")
+
+	t.Setenv("HOME", dir)
+
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(configDir, "bash-wrapper.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	// Should reference the correct config dir, not a hardcoded path
+	if !strings.Contains(content, configDir) {
+		t.Errorf("bash-wrapper.sh doesn't reference configDir %s", configDir)
+	}
+
+	// Should reference bashrc in the home dir
+	bashrc := filepath.Join(dir, ".bashrc")
+	if !strings.Contains(content, bashrc) {
+		t.Errorf("bash-wrapper.sh doesn't reference %s", bashrc)
+	}
+
+	// Should be executable
+	info, _ := os.Stat(filepath.Join(configDir, "bash-wrapper.sh"))
+	if info.Mode()&0111 == 0 {
+		t.Error("bash-wrapper.sh is not executable")
+	}
+}
+
+func TestNeedsUpdate_MissingFile(t *testing.T) {
+	if !needsUpdate("/nonexistent/path/script.sh") {
+		t.Error("needsUpdate should return true for missing file")
+	}
+}
+
+func TestNeedsUpdate_NoVersionMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sh")
+	os.WriteFile(path, []byte("#!/bin/bash\necho hello\n"), 0644)
+
+	if !needsUpdate(path) {
+		t.Error("needsUpdate should return true for file without version marker")
+	}
+}
+
+func TestEmbeddedScriptsHaveVersionMarker(t *testing.T) {
+	for _, name := range scriptFiles {
+		data, err := scripts.ReadFile(name)
+		if err != nil {
+			t.Fatalf("embedded %s: %v", name, err)
+		}
+		lines := strings.SplitN(string(data), "\n", 2)
+		v, err := parseVersionLine(lines[0])
+		if err != nil {
+			t.Errorf("embedded %s: no version on line 1: %v", name, err)
+			continue
+		}
+		if v != CurrentVersion {
+			t.Errorf("embedded %s version = %d, want %d", name, v, CurrentVersion)
+		}
+	}
+}
+
+func TestEnsureInstalled_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "shell-integration")
+	t.Setenv("HOME", dir)
+
+	// First install
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("first EnsureInstalled: %v", err)
+	}
+
+	// Record mod times
+	modTimes := make(map[string]int64)
+	for _, name := range scriptFiles {
+		info, _ := os.Stat(filepath.Join(configDir, name))
+		modTimes[name] = info.ModTime().UnixNano()
+	}
+
+	// Second install — scripts already at CurrentVersion, should not rewrite
+	if err := EnsureInstalled(configDir); err != nil {
+		t.Fatalf("second EnsureInstalled: %v", err)
+	}
+
+	for _, name := range scriptFiles {
+		info, _ := os.Stat(filepath.Join(configDir, name))
+		if info.ModTime().UnixNano() != modTimes[name] {
+			t.Errorf("%s was rewritten on idempotent call", name)
+		}
+	}
+}

--- a/apps/texelterm/shell/fish.fish
+++ b/apps/texelterm/shell/fish.fish
@@ -1,0 +1,40 @@
+# TEXEL_SHELL_INTEGRATION_VERSION=9
+# Texelterm Shell Integration for Fish
+# Automatically loaded by texelterm - do not modify
+#
+# This integration provides:
+# - OSC 133 shell integration (prompt/command tracking)
+# - Environment capture via DCS sequence
+# - OSC 7 CWD reporting for session restore
+
+function _texel_send_env
+    set -l env_base64 (env | base64 -w0)
+    printf '\033Ptexel-env;%s\033\\' "$env_base64"
+end
+
+function _texel_prompt_end --on-event fish_prompt
+    printf '\033]133;A\007'
+end
+
+function _texel_preexec --on-event fish_preexec
+    printf '\033]133;C;%s\007' "$argv"
+end
+
+function _texel_postexec --on-event fish_postexec
+    printf '\033]133;D;%s\007' "$status"
+    _texel_send_env
+
+    # OSC 7 - Report current working directory for session restore
+    printf '\033]7;file://%s%s\007' (hostname) "$PWD"
+end
+
+# Add OSC 133;B to prompt
+if not string match -q '*133;B*' -- "$fish_prompt"
+    function fish_prompt
+        printf '\033]133;B\007'
+        # Call original prompt
+        if functions -q __texel_original_fish_prompt
+            __texel_original_fish_prompt
+        end
+    end
+end

--- a/apps/texelterm/shell/zsh.sh
+++ b/apps/texelterm/shell/zsh.sh
@@ -1,0 +1,40 @@
+# TEXEL_SHELL_INTEGRATION_VERSION=9
+# Texelterm Shell Integration for Zsh
+# Automatically loaded by texelterm - do not modify
+#
+# This integration provides:
+# - OSC 133 shell integration (prompt/command tracking)
+# - Environment capture via DCS sequence
+# - OSC 7 CWD reporting for session restore
+
+# Function to send environment via DCS sequence
+_texel_send_env() {
+    local env_base64=$(env | base64 -w0)
+    printf '\033Ptexel-env;%s\033\\' "$env_base64"
+}
+
+# OSC 133 Shell Integration with Environment Capture
+_texel_precmd() {
+    local ret=$?
+    printf '\033]133;D;%s\007' "$ret"
+    _texel_send_env
+
+    # OSC 7 - Report current working directory for session restore
+    printf '\033]7;file://%s%s\007' "$(hostname)" "$PWD"
+
+    printf '\033]133;A\007'
+}
+
+_texel_preexec() {
+    printf '\033]133;C;%s\007' "$1"
+}
+
+# Hook into zsh's precmd/preexec system
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _texel_precmd
+add-zsh-hook preexec _texel_preexec
+
+# Add OSC 133;B to prompt
+if [[ "$PS1" != *"133;B"* ]]; then
+    PS1="$PS1%{\033]133;B\007%}"
+fi

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -26,6 +26,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/apps/texelterm/shell"
 	"github.com/framegrace/texelation/apps/texelterm/transformer"
 	"github.com/framegrace/texelation/config"
 
@@ -1366,20 +1367,9 @@ func (a *TexelTerm) getShellCommandSimpleIntegration(env []string) *exec.Cmd {
 	return exec.Command(parts[0], parts[1:]...)
 }
 
-// ensureShellIntegrationScripts creates shell integration scripts if they don't exist
+// ensureShellIntegrationScripts installs or updates shell integration scripts.
 func (a *TexelTerm) ensureShellIntegrationScripts(configDir string) error {
-	// Create directory if it doesn't exist
-	if err := os.MkdirAll(configDir, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
-	}
-
-	// We assume the scripts are already created in the config directory
-	// If not, they would need to be embedded in the binary or copied on first run
-	// For now, we just log and continue
-	log.Printf("Shell integration directory created: %s", configDir)
-	log.Printf("Please ensure integration scripts exist in this directory")
-
-	return nil
+	return shell.EnsureInstalled(configDir)
 }
 
 // StandalonePaneID is the fixed pane ID used for standalone texelterm.


### PR DESCRIPTION
## Summary

- Embed canonical shell integration scripts (bash, zsh, fish) in the binary via `//go:embed`
- On each shell launch, compare installed script version against embedded version and overwrite if missing or outdated (no downgrade)
- Add OSC 7 CWD reporting to all three shells, enabling PWD persistence across server restarts
- Generate `bash-wrapper.sh` dynamically using detected home dir instead of hardcoding

## Test plan

- [x] `go test ./apps/texelterm/shell/` — 8 tests covering version parsing, fresh install, upgrade, no-downgrade, idempotency, wrapper generation
- [x] `make test` — full suite passes
- [ ] Delete `~/.config/texelation/shell-integration/bash.sh` → run texelterm → verify recreated with V9 and OSC 7
- [ ] Verify existing V9 scripts are not rewritten on subsequent launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)