### PR TITLE
Fix reset-state, relocate env files, remove --from-scratch, guard nil UIManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ texelation --reset-state       # Delete all state and start fresh (with confirma
 # Advanced options
 texelation --client-only       # Connect without starting/checking server
 texelation --socket PATH       # Use custom socket path
-texelation --from-scratch      # Start fresh, ignore saved snapshot
 texelation --default-app NAME  # Set default app for new panes
 texelation --verbose-logs      # Enable detailed server logging
 texelation --reconnect         # Resume previous session explicitly
@@ -205,9 +204,9 @@ restart is required. You can also reload theme and config with
 
 ## Sessions & Persistence
 
-- **Snapshots**: Server saves state to `~/.texelation/snapshot.json`. Use `--from-scratch` to start fresh.
+- **Snapshots**: Server saves state to `~/.texelation/snapshot.json`. Use `--reset-state` to delete all state and start fresh.
 - **Reconnect**: Client automatically resumes sessions. Restart the client anytime without losing state.
-- **Environment**: Shell environment and CWD persist via `~/.texel-env-<pane-id>` files.
+- **Environment**: Shell environment and CWD persist via `~/.texelation/scrollback/<pane-id>.env` files.
 
 ## Project Layout
 

--- a/apps/texelterm/shell/bash.sh
+++ b/apps/texelterm/shell/bash.sh
@@ -1,4 +1,4 @@
-# TEXEL_SHELL_INTEGRATION_VERSION=9
+# TEXEL_SHELL_INTEGRATION_VERSION=10
 # Texelterm Shell Integration for Bash
 # Automatically loaded by texelterm - do not modify
 #
@@ -8,12 +8,18 @@
 # - Per-terminal history isolation
 # - OSC 7 CWD reporting for session restore
 #
-# Environment files (~/.texel-env-$TEXEL_PANE_ID) persist across shell/server restarts.
-# Each pane has its own environment file, stable across process restarts.
+# Per-pane state lives under ~/.texelation/scrollback/<pane-id>.*
+# This keeps env, history, and scrollback together and lets --reset-state nuke everything.
 
 # Per-terminal history file (isolated by pane ID)
 if [[ -n "$TEXEL_PANE_ID" ]]; then
-    export HISTFILE="$HOME/.texel-history-$TEXEL_PANE_ID"
+    _TEXEL_PANE_DIR="$HOME/.texelation/scrollback"
+    [[ -d "$_TEXEL_PANE_DIR" ]] || mkdir -p "$_TEXEL_PANE_DIR"
+    export HISTFILE="$_TEXEL_PANE_DIR/$TEXEL_PANE_ID.bash_history"
+    # Migrate legacy history file if it exists and new one doesn't
+    if [[ ! -f "$HISTFILE" && -f "$HOME/.texel-history-$TEXEL_PANE_ID" ]]; then
+        mv "$HOME/.texel-history-$TEXEL_PANE_ID" "$HISTFILE"
+    fi
 fi
 
 # Enable history append mode (never overwrite)
@@ -42,7 +48,7 @@ _texel_prompt_command() {
             {
                 env
                 echo "__TEXEL_CWD=$PWD"
-            } >| ~/.texel-env-$TEXEL_PANE_ID
+            } >| "$_TEXEL_PANE_DIR/$TEXEL_PANE_ID.env"
         fi
     fi
     # Increment prompt counter

--- a/apps/texelterm/shell/embed.go
+++ b/apps/texelterm/shell/embed.go
@@ -24,7 +24,7 @@ var scripts embed.FS
 // CurrentVersion is the version stamped into the embedded scripts.
 // Bump this (and the comment in each .sh/.fish file) whenever the
 // scripts change in a way that requires re-installation.
-const CurrentVersion = 9
+const CurrentVersion = 10
 
 // scriptFiles maps installed filenames to their embedded source names.
 var scriptFiles = []string{"bash.sh", "zsh.sh", "fish.fish"}

--- a/apps/texelterm/shell/fish.fish
+++ b/apps/texelterm/shell/fish.fish
@@ -1,4 +1,4 @@
-# TEXEL_SHELL_INTEGRATION_VERSION=9
+# TEXEL_SHELL_INTEGRATION_VERSION=10
 # Texelterm Shell Integration for Fish
 # Automatically loaded by texelterm - do not modify
 #

--- a/apps/texelterm/shell/zsh.sh
+++ b/apps/texelterm/shell/zsh.sh
@@ -1,4 +1,4 @@
-# TEXEL_SHELL_INTEGRATION_VERSION=9
+# TEXEL_SHELL_INTEGRATION_VERSION=10
 # Texelterm Shell Integration for Zsh
 # Automatically loaded by texelterm - do not modify
 #

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -1432,8 +1432,18 @@ func (a *TexelTerm) runShell() error {
 func (a *TexelTerm) loadShellEnvironment(paneID string) (env []string, cwd string) {
 	if paneID != "" {
 		if homeDir, err := os.UserHomeDir(); err == nil {
-			envFile := filepath.Join(homeDir, fmt.Sprintf(".texel-env-%s", paneID))
-			if data, err := os.ReadFile(envFile); err == nil {
+			// New location: ~/.texelation/scrollback/<pane-id>.env
+			envFile := filepath.Join(homeDir, ".texelation", "scrollback", paneID+".env")
+			data, err := os.ReadFile(envFile)
+			if err != nil {
+				// Fallback to legacy location: ~/.texel-env-<pane-id>
+				legacyFile := filepath.Join(homeDir, fmt.Sprintf(".texel-env-%s", paneID))
+				data, err = os.ReadFile(legacyFile)
+				if err == nil {
+					envFile = legacyFile
+				}
+			}
+			if err == nil {
 				lines := strings.Split(string(data), "\n")
 				for _, line := range lines {
 					if line == "" {
@@ -1452,7 +1462,7 @@ func (a *TexelTerm) loadShellEnvironment(paneID string) (env []string, cwd strin
 				}
 				log.Printf("Loaded environment from %s: %d variables", envFile, len(env))
 			} else {
-				log.Printf("Could not read env file %s: %v (normal on first run)", envFile, err)
+				log.Printf("Could not read env file (normal on first run)")
 			}
 		}
 	}

--- a/cmd/texelation/lifecycle/daemon.go
+++ b/cmd/texelation/lifecycle/daemon.go
@@ -43,13 +43,12 @@ func (s DaemonState) String() string {
 
 // ServerOptions configures server daemon startup
 type ServerOptions struct {
-	SocketPath    string
-	SnapshotPath  string
-	FromScratch   bool
-	DefaultApp    string
-	VerboseLogs   bool
-	LogFilePath   string // Daemon stdout/stderr destination
-	Title         string
+	SocketPath   string
+	SnapshotPath string
+	DefaultApp   string
+	VerboseLogs  bool
+	LogFilePath  string // Daemon stdout/stderr destination
+	Title        string
 }
 
 // DaemonManager handles server process lifecycle
@@ -132,9 +131,6 @@ func (d *standardDaemonManager) Start(ctx context.Context, opts ServerOptions) e
 	}
 	if opts.SnapshotPath != "" {
 		args = append(args, "--snapshot", opts.SnapshotPath)
-	}
-	if opts.FromScratch {
-		args = append(args, "--from-scratch")
 	}
 	if opts.DefaultApp != "" {
 		args = append(args, "--default-app", opts.DefaultApp)

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -47,7 +47,6 @@ func run() error {
 
 	// Server flags
 	snapshotPath := fs.String("snapshot", "", "Path to persist pane snapshots (default: ~/.texelation/snapshot.json)")
-	fromScratch := fs.Bool("from-scratch", false, "Start from scratch, ignoring any saved snapshot")
 	defaultApp := fs.String("default-app", "", "Default app for new panes")
 	verboseLogs := fs.Bool("verbose-logs", false, "Enable verbose server logging")
 	title := fs.String("title", "Texel Server", "Title for the main pane")
@@ -101,7 +100,6 @@ func run() error {
 		return handleServerOnly(lifecycle.ServerOptions{
 			SocketPath:   *socketPath,
 			SnapshotPath: *snapshotPath,
-			FromScratch:  *fromScratch,
 			DefaultApp:   *defaultApp,
 			VerboseLogs:  *verboseLogs,
 			LogFilePath:  paths.ServerLogPath,
@@ -120,7 +118,6 @@ func run() error {
 		return handleUnifiedMode(ctx, paths, lifecycle.ServerOptions{
 			SocketPath:   *socketPath,
 			SnapshotPath: *snapshotPath,
-			FromScratch:  *fromScratch,
 			DefaultApp:   *defaultApp,
 			VerboseLogs:  *verboseLogs,
 			LogFilePath:  paths.ServerLogPath,
@@ -195,9 +192,6 @@ func handleServerOnly(opts lifecycle.ServerOptions) error {
 	if opts.SnapshotPath != "" {
 		args = append(args, "--snapshot", opts.SnapshotPath)
 	}
-	if opts.FromScratch {
-		args = append(args, "--from-scratch")
-	}
 	if opts.DefaultApp != "" {
 		args = append(args, "--default-app", opts.DefaultApp)
 	}
@@ -267,10 +261,25 @@ func handleStopServer(ctx context.Context, paths *Paths, socketPath string) erro
 }
 
 func handleResetState(ctx context.Context, paths *Paths, socketPath string) error {
-	fmt.Println("WARNING: This will delete all saved state:")
-	fmt.Printf("  - %s (snapshot)\n", paths.SnapshotPath)
-	fmt.Printf("  - %s (PID file)\n", paths.PIDPath)
-	fmt.Printf("  - %s (server logs)\n", paths.ServerLogPath)
+	// Enumerate what will be deleted
+	fmt.Println("WARNING: This will delete ALL saved state:")
+	fmt.Printf("  - %s/ (scrollback, search indices, env, history, storage, logs, snapshot)\n", paths.ConfigDir)
+
+	// Find legacy env/history files still in ~/
+	homeDir, _ := os.UserHomeDir()
+	var legacyFiles []string
+	if homeDir != "" {
+		envMatches, _ := filepath.Glob(filepath.Join(homeDir, ".texel-env-*"))
+		histMatches, _ := filepath.Glob(filepath.Join(homeDir, ".texel-history-*"))
+		legacyFiles = append(envMatches, histMatches...)
+	}
+	if len(legacyFiles) > 0 {
+		fmt.Printf("  - ~/%s, ~/%s (%d legacy pane files)\n", ".texel-env-*", ".texel-history-*", len(legacyFiles))
+	}
+
+	fmt.Printf("  - %s (socket)\n", socketPath)
+	fmt.Println()
+	fmt.Println("User configuration (~/.config/texelation/) will NOT be deleted.")
 	fmt.Println()
 	fmt.Print("Type 'yes' to confirm: ")
 
@@ -297,19 +306,37 @@ func handleResetState(ctx context.Context, paths *Paths, socketPath string) erro
 		_ = daemon.Stop(ctx) // Best effort
 	}
 
-	// Remove state files
 	removed := 0
-	if err := os.Remove(paths.SnapshotPath); err == nil {
-		removed++
-	}
-	if err := os.Remove(paths.PIDPath); err == nil {
-		removed++
-	}
-	if err := os.Remove(paths.ServerLogPath); err == nil {
+
+	// Remove the entire state directory (~/.texelation/)
+	// This covers: scrollback/*.hist3, scrollback/*.index.db, storage/,
+	// texelbrowse/, snapshot.json, server.log, texelation.pid
+	if err := os.RemoveAll(paths.ConfigDir); err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: failed to remove %s: %v\n", paths.ConfigDir, err)
+	} else {
+		fmt.Printf("  removed %s/\n", paths.ConfigDir)
 		removed++
 	}
 
-	fmt.Printf("State reset complete (%d files removed)\n", removed)
+	// Remove legacy per-pane files (~/.texel-env-*, ~/.texel-history-*)
+	for _, f := range legacyFiles {
+		if err := os.Remove(f); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: failed to remove %s: %v\n", f, err)
+		} else {
+			removed++
+		}
+	}
+	if len(legacyFiles) > 0 {
+		fmt.Printf("  removed %d legacy pane files\n", len(legacyFiles))
+	}
+
+	// Remove socket file
+	if err := os.Remove(socketPath); err == nil {
+		fmt.Printf("  removed %s\n", socketPath)
+		removed++
+	}
+
+	fmt.Printf("\nState reset complete (%d items removed)\n", removed)
 	return nil
 }
 

--- a/texel/pane.go
+++ b/texel/pane.go
@@ -467,9 +467,11 @@ func (p *pane) injectGraphicsProvider(factory func(paneID [16]byte) GraphicsProv
 		return
 	}
 	if ua, ok := p.app.(interface{ UI() *texelcore.UIManager }); ok {
-		gp := factory(p.id)
-		if gp != nil {
-			ua.UI().SetGraphicsProvider(gp)
+		if mgr := ua.UI(); mgr != nil {
+			gp := factory(p.id)
+			if gp != nil {
+				mgr.SetGraphicsProvider(gp)
+			}
 		}
 	}
 }

--- a/texel/pane_render.go
+++ b/texel/pane_render.go
@@ -107,8 +107,10 @@ func (p *pane) renderBuffer(applyEffects bool) [][]Cell {
 	// graphicsProvider.Reset() → app.Render() → Flush() cycle.
 	if p.app != nil {
 		if ua, ok := p.app.(interface{ UI() *texelcore.UIManager }); ok {
-			if gp := ua.UI().GraphicsProvider(); gp != nil {
-				gp.Reset()
+			if mgr := ua.UI(); mgr != nil {
+				if gp := mgr.GraphicsProvider(); gp != nil {
+					gp.Reset()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **Comprehensive `--reset-state`**: Now removes the entire `~/.texelation/` directory (scrollback, search indices, storage, logs, snapshot, PID file), legacy `~/.texel-env-*` and `~/.texel-history-*` files, and the socket file. User config in `~/.config/texelation/` is explicitly preserved.
- **Relocate per-pane env/history files**: Moved from scattered `~/.texel-env-<id>` and `~/.texel-history-<id>` in home directory into `~/.texelation/scrollback/<id>.env` and `<id>.bash_history`, co-located with existing scrollback data. Includes automatic legacy migration and fallback reads. Shell integration version bumped 9 → 10.
- **Remove `--from-scratch`**: Redundant with `--reset-state`. Removed flag, `ServerOptions.FromScratch`, and all forwarding logic from the `texelation` command.
- **Fix nil UIManager panic**: `toggleApp.UI()` returns nil for apps like texelterm that don't implement `UIManager`. Added nil guards in `pane.go:injectGraphicsProvider` and `pane_render.go:renderBuffer` to prevent crash on fresh start without snapshot.

## Test plan

- [ ] Run `texelation --reset-state` and verify it removes all state under `~/.texelation/` and legacy env/history files
- [ ] Start texelation fresh, verify texelterm launches without panic
- [ ] Verify shell env/history files are created under `~/.texelation/scrollback/` (not in `~/`)
- [ ] Verify legacy env/history files are migrated on first shell start
- [ ] Confirm `--from-scratch` flag is no longer accepted
- [ ] Run `make test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)