### PR TITLE
Add ResizeSplit flag to LogicalLine, persist Wrapped/Wide

### DIFF
--- a/apps/texelterm/parser/logical_line.go
+++ b/apps/texelterm/parser/logical_line.go
@@ -32,6 +32,12 @@ type LogicalLine struct {
 	// Synthetic indicates a transformer-inserted line that is hidden
 	// in the original (non-overlay) view.
 	Synthetic bool
+
+	// ResizeSplit indicates this line was created by memoryBufferResize
+	// splitting a long logical line into width-sized chunks. Used by
+	// rejoinResizeSplitChain to identify resize-created chains without
+	// confusing them with natural auto-wrap chains.
+	ResizeSplit bool
 }
 
 // NewLogicalLine creates a new empty logical line.
@@ -108,6 +114,7 @@ func (l *LogicalLine) Clone() *LogicalLine {
 	clone := NewLogicalLineFromCells(l.Cells)
 	clone.FixedWidth = l.FixedWidth
 	clone.Synthetic = l.Synthetic
+	clone.ResizeSplit = l.ResizeSplit
 	clone.OverlayWidth = l.OverlayWidth
 	if l.Overlay != nil {
 		clone.Overlay = make([]Cell, len(l.Overlay))

--- a/apps/texelterm/parser/logical_line_persistence.go
+++ b/apps/texelterm/parser/logical_line_persistence.go
@@ -64,13 +64,16 @@ func WriteLogicalLines(path string, lines []*LogicalLine) error {
 // writeLogicalLine writes a single logical line in v2 format.
 // Format: [flags:1][cell_count:4][cells...][overlay_width:4][overlay_count:4][overlay_cells...]
 func writeLogicalLine(w io.Writer, line *LogicalLine, cellBuf []byte) error {
-	// Flags byte: bit 0 = has overlay, bit 1 = synthetic
+	// Flags byte: bit 0 = has overlay, bit 1 = synthetic, bit 2 = resize-split
 	var flags byte
 	if line.Overlay != nil {
 		flags |= 0x01
 	}
 	if line.Synthetic {
 		flags |= 0x02
+	}
+	if line.ResizeSplit {
+		flags |= 0x04
 	}
 	if _, err := w.Write([]byte{flags}); err != nil {
 		return err
@@ -227,8 +230,9 @@ func readLogicalLine(r io.Reader, cellBuf []byte, version int) (*LogicalLine, er
 	}
 
 	line := &LogicalLine{
-		Cells:     cells,
-		Synthetic: flags&0x02 != 0,
+		Cells:       cells,
+		Synthetic:   flags&0x02 != 0,
+		ResizeSplit: flags&0x04 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/logical_line_persistence_test.go
+++ b/apps/texelterm/parser/logical_line_persistence_test.go
@@ -400,5 +400,40 @@ func TestLogicalLinePersistence_OverlayRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLogicalLinePersistence_ResizeSplitRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	histFile := filepath.Join(tmpDir, "test.lhist")
+
+	lines := []*LogicalLine{
+		{Cells: makeCells("normal line"), ResizeSplit: false},
+		{Cells: makeCells("split chunk"), ResizeSplit: true},
+		{Cells: makeCells("synth+split"), Synthetic: true, ResizeSplit: true},
+	}
+
+	if err := WriteLogicalLines(histFile, lines); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	loaded, err := LoadLogicalLines(histFile)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(loaded))
+	}
+
+	if loaded[0].ResizeSplit {
+		t.Error("line 0 should not be ResizeSplit")
+	}
+	if !loaded[1].ResizeSplit {
+		t.Error("line 1 should be ResizeSplit")
+	}
+	if !loaded[2].ResizeSplit || !loaded[2].Synthetic {
+		t.Errorf("line 2: ResizeSplit=%v (want true), Synthetic=%v (want true)",
+			loaded[2].ResizeSplit, loaded[2].Synthetic)
+	}
+}
+
 // Note: TestScrollbackHistory_SaveAndLoad was removed as part of DisplayBuffer cleanup.
 // The ScrollbackHistory type has been replaced by MemoryBuffer.

--- a/apps/texelterm/parser/memory_buffer.go
+++ b/apps/texelterm/parser/memory_buffer.go
@@ -516,6 +516,7 @@ func (mb *MemoryBuffer) setLineLocked(globalIdx int64, line *LogicalLine) bool {
 			existing.OverlayWidth = 0
 		}
 		existing.Synthetic = line.Synthetic
+		existing.ResizeSplit = line.ResizeSplit
 	}
 
 	return true

--- a/apps/texelterm/parser/page.go
+++ b/apps/texelterm/parser/page.go
@@ -84,8 +84,15 @@ func encodeCell(cell Cell, buf []byte) {
 	buf[9] = byte(cell.BG.Mode)
 	binary.LittleEndian.PutUint32(buf[10:14], encodeColorValue(cell.BG))
 
-	// Attributes (2 bytes)
-	binary.LittleEndian.PutUint16(buf[14:16], uint16(cell.Attr))
+	// Attributes (2 bytes) - bits 0-4: Attr, bit 5: Wrapped, bit 6: Wide
+	attrBits := uint16(cell.Attr)
+	if cell.Wrapped {
+		attrBits |= 1 << 5
+	}
+	if cell.Wide {
+		attrBits |= 1 << 6
+	}
+	binary.LittleEndian.PutUint16(buf[14:16], attrBits)
 }
 
 // decodeCell reads a Cell from the buffer.
@@ -103,8 +110,11 @@ func decodeCell(buf []byte) Cell {
 	bgMode := ColorMode(buf[9])
 	cell.BG = decodeColorFromValue(bgMode, binary.LittleEndian.Uint32(buf[10:14]))
 
-	// Attributes
-	cell.Attr = Attribute(binary.LittleEndian.Uint16(buf[14:16]))
+	// Attributes - bits 0-4: Attr, bit 5: Wrapped, bit 6: Wide
+	attrBits := binary.LittleEndian.Uint16(buf[14:16])
+	cell.Attr = Attribute(attrBits & 0x1F)
+	cell.Wrapped = attrBits&(1<<5) != 0
+	cell.Wide = attrBits&(1<<6) != 0
 
 	return cell
 }
@@ -571,6 +581,9 @@ func encodeLineData(line *LogicalLine) []byte {
 	if line.Synthetic {
 		flags |= 0x02
 	}
+	if line.ResizeSplit {
+		flags |= 0x04
+	}
 
 	cellCount := uint32(len(line.Cells))
 	size := 1 + 4 + 4 + int(cellCount)*PageCellSize
@@ -663,7 +676,7 @@ func decodeLineDataV2(data []byte) (*LogicalLine, error) {
 	}
 
 	flags := data[0]
-	if flags & ^byte(0x03) != 0 {
+	if flags & ^byte(0x07) != 0 {
 		return nil, fmt.Errorf("invalid v2 flags: 0x%02x", flags)
 	}
 
@@ -686,9 +699,10 @@ func decodeLineDataV2(data []byte) (*LogicalLine, error) {
 	}
 
 	line := &LogicalLine{
-		Cells:      cells,
-		FixedWidth: int(fixedWidth),
-		Synthetic:  flags&0x02 != 0,
+		Cells:       cells,
+		FixedWidth:  int(fixedWidth),
+		Synthetic:   flags&0x02 != 0,
+		ResizeSplit: flags&0x04 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/page_store_test.go
+++ b/apps/texelterm/parser/page_store_test.go
@@ -970,3 +970,147 @@ func TestPageStore_UpdateLine_NonExistent(t *testing.T) {
 		t.Error("UpdateLine should fail for non-existent index")
 	}
 }
+
+// --- Cell Wrapped/Wide Round-Trip Tests ---
+
+func TestCellEncoding_WrappedWideRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		cell    Cell
+		wantW   bool
+		wantWd  bool
+		wantA   Attribute
+	}{
+		{
+			name:  "wrapped only",
+			cell:  Cell{Rune: 'A', Wrapped: true},
+			wantW: true, wantA: 0,
+		},
+		{
+			name:   "wide only",
+			cell:   Cell{Rune: '漢', Wide: true},
+			wantWd: true, wantA: 0,
+		},
+		{
+			name:   "wrapped + wide + attrs",
+			cell:   Cell{Rune: 'X', Attr: AttrBold | AttrDim, Wrapped: true, Wide: true},
+			wantW:  true, wantWd: true, wantA: AttrBold | AttrDim,
+		},
+		{
+			name:  "attrs only, no wrapped/wide",
+			cell:  Cell{Rune: 'Y', Attr: AttrUnderline | AttrReverse},
+			wantA: AttrUnderline | AttrReverse,
+		},
+		{
+			name: "zero cell",
+			cell: Cell{},
+		},
+	}
+
+	buf := make([]byte, PageCellSize)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encodeCell(tt.cell, buf)
+			got := decodeCell(buf)
+			if got.Wrapped != tt.wantW {
+				t.Errorf("Wrapped: got %v, want %v", got.Wrapped, tt.wantW)
+			}
+			if got.Wide != tt.wantWd {
+				t.Errorf("Wide: got %v, want %v", got.Wide, tt.wantWd)
+			}
+			if got.Attr != tt.wantA {
+				t.Errorf("Attr: got %v, want %v", got.Attr, tt.wantA)
+			}
+			if got.Rune != tt.cell.Rune {
+				t.Errorf("Rune: got %c, want %c", got.Rune, tt.cell.Rune)
+			}
+		})
+	}
+}
+
+func TestCellEncoding_BackwardCompat(t *testing.T) {
+	// Old format: bits 5-6 of attr are 0 → Wrapped=false, Wide=false
+	buf := make([]byte, PageCellSize)
+	cell := Cell{Rune: 'Z', Attr: AttrBold | AttrItalic}
+	// Simulate old encoder that writes raw Attr without packing Wrapped/Wide
+	encodeCell(cell, buf)
+	got := decodeCell(buf)
+	if got.Wrapped || got.Wide {
+		t.Errorf("Old format should have Wrapped=false, Wide=false, got Wrapped=%v, Wide=%v",
+			got.Wrapped, got.Wide)
+	}
+	if got.Attr != (AttrBold | AttrItalic) {
+		t.Errorf("Attr should be bold|italic, got %v", got.Attr)
+	}
+}
+
+// --- ResizeSplit Line Encoding Round-Trip Tests ---
+
+func TestLineEncoding_ResizeSplitRoundTrip(t *testing.T) {
+	line := &LogicalLine{
+		Cells:       []Cell{{Rune: 'A'}, {Rune: 'B'}},
+		ResizeSplit: true,
+	}
+	data := encodeLineData(line)
+	got, err := decodeLineData(data)
+	if err != nil {
+		t.Fatalf("decodeLineData: %v", err)
+	}
+	if !got.ResizeSplit {
+		t.Error("ResizeSplit should be true after round-trip")
+	}
+	if got.Synthetic {
+		t.Error("Synthetic should be false")
+	}
+}
+
+func TestLineEncoding_ResizeSplitBackwardCompat(t *testing.T) {
+	// Line without ResizeSplit → bit 2 is 0
+	line := &LogicalLine{
+		Cells:     []Cell{{Rune: 'X'}},
+		Synthetic: true,
+	}
+	data := encodeLineData(line)
+	got, err := decodeLineData(data)
+	if err != nil {
+		t.Fatalf("decodeLineData: %v", err)
+	}
+	if got.ResizeSplit {
+		t.Error("ResizeSplit should be false when not set")
+	}
+	if !got.Synthetic {
+		t.Error("Synthetic should be true")
+	}
+}
+
+func TestPage_ResizeSplitRoundTrip(t *testing.T) {
+	page := NewPage(1, 0)
+	now := time.Now()
+
+	line := &LogicalLine{
+		Cells:       []Cell{{Rune: 'H'}, {Rune: 'i', Wrapped: true}},
+		ResizeSplit: true,
+	}
+	page.AddLine(line, now, 0)
+
+	var buf bytes.Buffer
+	if _, err := page.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	page2 := &Page{}
+	if _, err := page2.ReadFrom(&buf); err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+
+	if len(page2.Lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(page2.Lines))
+	}
+	got := page2.Lines[0]
+	if !got.ResizeSplit {
+		t.Error("ResizeSplit should survive page round-trip")
+	}
+	if !got.Cells[1].Wrapped {
+		t.Error("Wrapped should survive page round-trip")
+	}
+}

--- a/apps/texelterm/parser/vterm_memory_buffer.go
+++ b/apps/texelterm/parser/vterm_memory_buffer.go
@@ -1129,25 +1129,6 @@ func (v *VTerm) memoryBufferAtLiveEdge() bool {
 
 // --- Resize ---
 
-// findChainStart walks backward from lineIdx to find the first line in a
-// wrap chain. A line belongs to the chain if the previous line's last cell
-// has Wrapped set and the previous line is a normal (non-synthetic,
-// non-overlay, non-fixed-width) line.
-func findChainStart(mb *MemoryBuffer, lineIdx, globalOffset int64) int64 {
-	chainStart := lineIdx
-	for chainStart > globalOffset {
-		prev := mb.GetLine(chainStart - 1)
-		if prev == nil || prev.Synthetic || prev.Overlay != nil || prev.FixedWidth > 0 {
-			break
-		}
-		if len(prev.Cells) == 0 || !prev.Cells[len(prev.Cells)-1].Wrapped {
-			break
-		}
-		chainStart--
-	}
-	return chainStart
-}
-
 // combineAndCollapseChain combines all cells in the wrap chain from chainStart
 // to chainEnd into a single logical line, clears the Wrapped flag on the last
 // cell, and deletes the extra lines. Returns the combined cells.
@@ -1206,30 +1187,46 @@ func (v *VTerm) assertCursorConsistency(label string, cursorGlobalLine int64) {
 	}
 }
 
-// rejoinCursorWrapChain undoes wrap chain splits created by previous resizes.
-// When memoryBufferResize decreases the width, it splits the cursor's logical
-// line into multiple logical lines connected by Wrapped flags. If the width
-// then changes again, BuildRange may rejoin these lines differently, changing
-// the physical row count without adjusting cursorY. By rejoining the chain
-// back into a single logical line before each resize, we ensure the resize
-// always starts from a clean state.
-func (v *VTerm) rejoinCursorWrapChain() {
+// rejoinResizeSplitChain undoes width-split chains created by previous resizes.
+// Unlike the old rejoinCursorWrapChain which used Wrapped cell flags (confusing
+// resize splits with natural auto-wraps), this uses the ResizeSplit flag on
+// LogicalLine to precisely identify resize-created chains.
+func (v *VTerm) rejoinResizeSplitChain() {
 	mb := v.memBufState.memBuf
 	cursorGlobal := v.memBufState.liveEdgeBase + int64(v.cursorY)
-	globalOffset := mb.GlobalOffset()
 
-	// Walk backward from cursor's line to find the start of any wrap chain.
-	chainStart := findChainStart(mb, cursorGlobal, globalOffset)
+	// Find a resize-split line: either the cursor's line or the previous one
+	// (cursor-past-chain case when absoluteCol % width == 0).
+	var anchor int64
+	cursorLine := mb.GetLine(cursorGlobal)
+	if cursorLine != nil && cursorLine.ResizeSplit {
+		anchor = cursorGlobal
+	} else if cursorGlobal > mb.GlobalOffset() {
+		prevLine := mb.GetLine(cursorGlobal - 1)
+		if prevLine != nil && prevLine.ResizeSplit {
+			anchor = cursorGlobal - 1
+		} else {
+			return // no resize-split chain near cursor
+		}
+	} else {
+		return
+	}
 
-	// Walk forward from cursor to find the end of the chain.
-	// The chain continues while the current line's last cell has Wrapped set.
-	chainEnd := cursorGlobal
-	for {
-		line := mb.GetLine(chainEnd)
-		if line == nil || line.Synthetic || line.Overlay != nil || line.FixedWidth > 0 {
+	// Walk backward to chain start (first ResizeSplit line).
+	chainStart := anchor
+	for chainStart > mb.GlobalOffset() {
+		prev := mb.GetLine(chainStart - 1)
+		if prev == nil || !prev.ResizeSplit {
 			break
 		}
-		if len(line.Cells) == 0 || !line.Cells[len(line.Cells)-1].Wrapped {
+		chainStart--
+	}
+
+	// Walk forward to chain end (last ResizeSplit line).
+	chainEnd := anchor
+	for {
+		next := mb.GetLine(chainEnd + 1)
+		if next == nil || !next.ResizeSplit {
 			break
 		}
 		chainEnd++
@@ -1237,79 +1234,53 @@ func (v *VTerm) rejoinCursorWrapChain() {
 
 	chainLen := int(chainEnd - chainStart + 1)
 	if chainLen <= 1 {
-		// Cursor is not in a multi-line chain. Check if there's a chain
-		// immediately before the cursor. This happens when a previous resize
-		// split put the cursor past the chain end (absoluteCol % width == 0).
-		v.rejoinPreCursorWrapChain()
+		// Single line — just clear ResizeSplit and return.
+		if line := mb.GetLine(chainStart); line != nil {
+			line.ResizeSplit = false
+		}
 		return
 	}
 
 	// Compute absolute cursor column within the chain.
 	absCol := 0
-	for i := chainStart; i < cursorGlobal; i++ {
-		line := mb.GetLine(i)
-		if line != nil {
-			absCol += len(line.Cells)
+	cursorPastChain := cursorGlobal > chainEnd
+	if cursorPastChain {
+		// Cursor is past chain (cursor-past-chain case).
+		for i := chainStart; i <= chainEnd; i++ {
+			if line := mb.GetLine(i); line != nil {
+				absCol += len(line.Cells)
+			}
 		}
+	} else {
+		for i := chainStart; i < cursorGlobal; i++ {
+			if line := mb.GetLine(i); line != nil {
+				absCol += len(line.Cells)
+			}
+		}
+		absCol += v.cursorX
 	}
-	absCol += v.cursorX
 
 	// Combine all chain lines into one and delete extras.
 	combineAndCollapseChain(mb, chainStart, chainEnd)
+
+	// Clear ResizeSplit on the combined line.
+	if firstLine := mb.GetLine(chainStart); firstLine != nil {
+		firstLine.ResizeSplit = false
+	}
 
 	// Adjust cursor position.
-	rowsRemoved := int(cursorGlobal - chainStart)
-	v.cursorY -= rowsRemoved
-	v.cursorX = absCol
-
-	v.logMemBufDebug("[RESIZE] Rejoin wrap chain: chainStart=%d, chainEnd=%d, chainLen=%d, absCol=%d, cursorY=%d",
-		chainStart, chainEnd, chainLen, absCol, v.cursorY)
-}
-
-// rejoinPreCursorWrapChain handles the case where the cursor is immediately
-// past a wrap chain (not inside it). This occurs when a resize split puts
-// cursorX at 0 on the line after the chain (absoluteCol % width == 0).
-// It finds the chain, combines it into one line, deletes the extras, and
-// moves the cursor onto the combined line at the end of the content.
-func (v *VTerm) rejoinPreCursorWrapChain() {
-	mb := v.memBufState.memBuf
-	cursorGlobal := v.memBufState.liveEdgeBase + int64(v.cursorY)
-	globalOffset := mb.GlobalOffset()
-
-	if cursorGlobal <= globalOffset {
-		return
+	if cursorPastChain {
+		// Cursor was past chain — shift up by deleted lines.
+		linesRemoved := chainLen - 1
+		v.cursorY -= linesRemoved
+	} else {
+		rowsRemoved := int(cursorGlobal - chainStart)
+		v.cursorY -= rowsRemoved
+		v.cursorX = absCol
 	}
 
-	// The line before the cursor must be the END of a chain (NOT Wrapped).
-	prevLine := mb.GetLine(cursorGlobal - 1)
-	if prevLine == nil || prevLine.Synthetic || prevLine.Overlay != nil || prevLine.FixedWidth > 0 {
-		return
-	}
-	if len(prevLine.Cells) > 0 && prevLine.Cells[len(prevLine.Cells)-1].Wrapped {
-		return // Still a chain middle — the main rejoin should have caught this.
-	}
-
-	// Walk backward from prevLine to find the chain start.
-	chainEnd := cursorGlobal - 1
-	chainStart := findChainStart(mb, chainEnd, globalOffset)
-
-	preChainLen := int(chainEnd - chainStart + 1)
-	if preChainLen <= 1 {
-		return // No multi-line chain before cursor
-	}
-
-	// Combine all chain lines into one and delete extras.
-	combineAndCollapseChain(mb, chainStart, chainEnd)
-
-	// Shift cursor up by the number of deleted lines. The cursor stays on
-	// its own line (which shifted up), NOT on the combined chain line.
-	// The combined line will be visually wrapped by the renderer at the new
-	// width — no explicit re-split is needed.
-	linesRemoved := preChainLen - 1
-	v.cursorY -= linesRemoved
-
-	v.logMemBufDebug("[RESIZE] Rejoin pre-cursor chain: chainStart=%d, chainEnd=%d, len=%d, linesRemoved=%d, cursorY=%d",
-		chainStart, chainEnd, preChainLen, linesRemoved, v.cursorY)
+	v.logMemBufDebug("[RESIZE] Rejoin resize-split chain: chainStart=%d, chainEnd=%d, chainLen=%d, absCol=%d, cursorPastChain=%v, cursorY=%d",
+		chainStart, chainEnd, chainLen, absCol, cursorPastChain, v.cursorY)
 }
 
 // memoryBufferResize handles terminal resize.
@@ -1329,17 +1300,11 @@ func (v *VTerm) memoryBufferResize(width, height int) {
 	oldHeight := v.memBufState.viewport.Height()
 	mb := v.memBufState.memBuf
 
-	// Rejoin any wrap chain around the cursor before computing positions.
-	// Previous resize width-decrease splits create wrap chains (multiple
-	// logical lines with Wrapped flags). When the width changes again,
-	// BuildRange may rejoin these chains, changing the physical line count
-	// without cursorY being adjusted. By rejoining first, we start each
-	// resize from a clean state: one logical line per original content line.
-	//
-	// ORDERING: rejoinCursorWrapChain mutates the MemoryBuffer via
-	// DeleteLine/InsertLine and must run before viewport.Resize (below)
-	// which rebuilds the PhysicalLineIndex from the buffer's contents.
-	v.rejoinCursorWrapChain()
+	// Rejoin any resize-split chain around the cursor before computing positions.
+	// Previous resize width-decrease splits create chains (multiple logical
+	// lines with ResizeSplit=true). When the width changes again, we rejoin
+	// them to start from a clean state: one logical line per original content.
+	v.rejoinResizeSplitChain()
 
 	// Calculate cursor's global line before resize
 	cursorGlobalLine := v.memBufState.liveEdgeBase + int64(v.cursorY)
@@ -1351,7 +1316,7 @@ func (v *VTerm) memoryBufferResize(width, height int) {
 
 	// When the cursor column exceeds the new width, split the cursor's logical
 	// line into a wrapped chain so that cursorY/cursorX correctly address the
-	// content. This triggers on width decrease, or after rejoinCursorWrapChain
+	// content. This triggers on width decrease, or after rejoinResizeSplitChain
 	// restores cursorX to the absolute column in the combined line.
 	if width > 0 && v.cursorX >= width {
 		line := mb.GetLine(cursorGlobalLine)
@@ -1368,6 +1333,7 @@ func (v *VTerm) memoryBufferResize(width, height int) {
 				copy(firstChunk, cells[:width])
 				firstChunk[width-1].Wrapped = true
 				line.Cells = firstChunk
+				line.ResizeSplit = true
 
 				// Insert remaining chunks as new wrapped logical lines.
 				for i := 1; i < numChunks; i++ {
@@ -1381,7 +1347,7 @@ func (v *VTerm) memoryBufferResize(width, height int) {
 
 					insertIdx := cursorGlobalLine + int64(i)
 					mb.InsertLine(insertIdx)
-					mb.SetLine(insertIdx, &LogicalLine{Cells: chunk})
+					mb.SetLine(insertIdx, &LogicalLine{Cells: chunk, ResizeSplit: true})
 				}
 
 				// Adjust cursor to the correct split segment.

--- a/apps/texelterm/parser/vterm_memory_buffer_test.go
+++ b/apps/texelterm/parser/vterm_memory_buffer_test.go
@@ -5898,3 +5898,133 @@ func TestResizeWidth_TwoLinePrompt_CharByCharExpand(t *testing.T) {
 		}
 	}
 }
+
+// --- ResizeSplit Tests ---
+
+// TestResizeSplit_FlagSetOnChunks verifies that width-split creates chunks
+// with ResizeSplit=true, and that rejoining clears it.
+func TestResizeSplit_FlagSetOnChunks(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	v := NewVTerm(40, 24, WithMemoryBuffer())
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Write a 30-char line
+	parseString(p, "ABCDEFGHIJ0123456789abcdefghij")
+
+	// Resize narrow: 30 chars at width 10 → 3 chunks
+	v.Resize(10, 24)
+	mb := v.memBufState.memBuf
+
+	// All 3 chunks should have ResizeSplit=true
+	for i := mb.GlobalOffset(); i < mb.GlobalEnd(); i++ {
+		line := mb.GetLine(i)
+		if line != nil && len(line.Cells) > 0 {
+			if !line.ResizeSplit {
+				t.Errorf("Line %d should have ResizeSplit=true after width-split", i)
+			}
+		}
+	}
+
+	// Resize back: should rejoin and clear ResizeSplit
+	v.Resize(40, 24)
+	line0 := mb.GetLine(mb.GlobalOffset())
+	if line0 == nil {
+		t.Fatal("line 0 nil after rejoin")
+	}
+	if line0.ResizeSplit {
+		t.Error("ResizeSplit should be false after rejoin")
+	}
+	if len(line0.Cells) != 30 {
+		t.Errorf("Combined line should have 30 cells, got %d", len(line0.Cells))
+	}
+}
+
+// TestResizeSplit_NaturalWrapNotRejoined verifies that natural auto-wrap
+// chains (created by the shell, not by resize) are NOT rejoined.
+func TestResizeSplit_NaturalWrapNotRejoined(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	width, height := 10, 24
+	v := NewVTerm(width, height, WithMemoryBuffer())
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Write more than 10 chars → natural wrap at width 10
+	// "HelloWorld" fills exactly 10, then "!!" wraps to next line
+	parseString(p, "HelloWorld!!")
+
+	mb := v.memBufState.memBuf
+
+	// The cursor's line and the wrapped line should NOT have ResizeSplit
+	for i := mb.GlobalOffset(); i < mb.GlobalEnd(); i++ {
+		line := mb.GetLine(i)
+		if line != nil && line.ResizeSplit {
+			t.Errorf("Line %d should NOT have ResizeSplit (natural wrap, not resize)", i)
+		}
+	}
+
+	// Resize wider → natural wraps should be preserved (not rejoined)
+	v.Resize(40, height)
+
+	// The natural wrap chain should still be two separate logical lines
+	lineCount := 0
+	for i := mb.GlobalOffset(); i < mb.GlobalEnd(); i++ {
+		line := mb.GetLine(i)
+		if line != nil && len(line.Cells) > 0 {
+			lineCount++
+		}
+	}
+	if lineCount < 2 {
+		t.Errorf("Natural wrap should still be 2 lines after resize, got %d", lineCount)
+	}
+}
+
+// TestResizeSplit_CursorPastChain tests the cursor-past-chain case:
+// when absoluteCol % width == 0, cursor ends up on the line AFTER the chain.
+func TestResizeSplit_CursorPastChain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	v := NewVTerm(40, 24, WithMemoryBuffer())
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Write exactly 20 chars → at width 10, absoluteCol=20, 20%10==0
+	// Cursor ends up on line after chain (cursorX=0)
+	parseString(p, "01234567890123456789")
+
+	v.Resize(10, 24)
+
+	// cursorX should be 0 (20 % 10 == 0), cursorY should be 2 (20 / 10 == 2)
+	if v.cursorX != 0 {
+		t.Errorf("After split: cursorX=%d, want 0", v.cursorX)
+	}
+
+	// Now resize back to 40 — should rejoin via cursor-past-chain detection
+	v.Resize(40, 24)
+
+	mb := v.memBufState.memBuf
+	line0 := mb.GetLine(mb.GlobalOffset())
+	if line0 == nil {
+		t.Fatal("line 0 nil after rejoin")
+	}
+	if len(line0.Cells) != 20 {
+		t.Errorf("Combined line should have 20 cells, got %d", len(line0.Cells))
+	}
+	if line0.ResizeSplit {
+		t.Error("ResizeSplit should be cleared after rejoin")
+	}
+
+	// Cursor should be on the line AFTER the combined content (shifted up).
+	// The chain was lines 0-1, cursor was on line 2. After collapsing
+	// chain to line 0 and deleting line 1, cursor shifts to line 1.
+	// The content is on line 0 (row 0 in grid).
+	grid := v.Grid()
+	row0 := cellsToString(grid[0])
+	if !strings.Contains(row0, "01234567890123456789") {
+		t.Errorf("Grid row 0 should contain the full content, got %q", row0)
+	}
+	// Cursor should be one row below content
+	if v.cursorY != 1 {
+		t.Errorf("cursorY should be 1 (past combined line), got %d", v.cursorY)
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add `ResizeSplit bool` to `LogicalLine` to explicitly tag lines created by `memoryBufferResize` width-split, replacing the ambiguous `Wrapped` cell flag approach
- Replace `rejoinCursorWrapChain` + `rejoinPreCursorWrapChain` with unified `rejoinResizeSplitChain` that uses the new flag — natural auto-wrap chains are no longer confused with resize splits
- Fix latent persistence bug: pack `Wrapped` and `Wide` cell bools into spare Attr bits 5-6 in `page.go` cell encoding (backward compatible)
- Add `ResizeSplit` as flags bit 2 in both `page.go` and `logical_line_persistence.go` line encoding (backward compatible)
- Fix `MemoryBuffer.setLineLocked` to propagate `ResizeSplit` field

## Test plan
- [x] All existing resize tests pass (12 tests)
- [x] New `TestCellEncoding_WrappedWideRoundTrip` — cell serialization round-trip with Wrapped/Wide
- [x] New `TestCellEncoding_BackwardCompat` — old format reads correctly
- [x] New `TestLineEncoding_ResizeSplitRoundTrip` — page line encoding round-trip
- [x] New `TestPage_ResizeSplitRoundTrip` — full page write/read with ResizeSplit+Wrapped
- [x] New `TestLogicalLinePersistence_ResizeSplitRoundTrip` — logical line persistence
- [x] New `TestResizeSplit_FlagSetOnChunks` — flag set on split, cleared on rejoin
- [x] New `TestResizeSplit_NaturalWrapNotRejoined` — natural wraps preserved across resize
- [x] New `TestResizeSplit_CursorPastChain` — cursor-past-chain adjustment
- [x] Race detection clean (`go test -race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)