### PR TITLE
Add random fade style for screensaver transitions

### DIFF
--- a/internal/effects/screensaver_fade.go
+++ b/internal/effects/screensaver_fade.go
@@ -44,9 +44,30 @@ func blenderForStyle(style string) fadeBlender {
 		return newSpiralBlender()
 	case "curtain":
 		return newCurtainBlender()
+	case "random":
+		return &randomBlender{}
 	default:
 		return &dissolveBlender{}
 	}
+}
+
+// randomBlender picks a random concrete blender on each Reset().
+type randomBlender struct {
+	inner fadeBlender
+}
+
+var concreteStyles = []string{"dissolve", "curtain", "spiral"}
+
+func (b *randomBlender) Reset() {
+	b.inner = blenderForStyle(concreteStyles[rand.Intn(len(concreteStyles))])
+	b.inner.Reset()
+}
+
+func (b *randomBlender) Blend(orig, dst [][]client.Cell, intensity float32) {
+	if b.inner == nil {
+		b.inner = blenderForStyle(concreteStyles[rand.Intn(len(concreteStyles))])
+	}
+	b.inner.Blend(orig, dst, intensity)
 }
 
 func NewScreensaverFade(inner Effect, fadeStyle string) Effect {


### PR DESCRIPTION
## Summary
- Adds `"random"` option for `fade_style` in screensaver config, matching the existing `"random"` support for effects
- Each screensaver activation picks a different transition style (dissolve, curtain, or spiral) via `randomBlender.Reset()`
- No config/parser changes needed — `ParseScreensaverConfig` already accepts any string for `fade_style`

## Config usage
```json
"screensaver": {
    "fade_style": "random"
}
```

## Test plan
- [x] `go build ./internal/effects/` compiles cleanly
- [x] `go test ./internal/effects/` passes
- [ ] Manual: set `"fade_style": "random"`, trigger screensaver multiple times, verify different transitions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)