### PR TITLE
Fix CSI parser: colon subparams and intermediate byte guard

### DIFF
--- a/apps/texelterm/esctest/helpers.go
+++ b/apps/texelterm/esctest/helpers.go
@@ -568,6 +568,12 @@ func SGR(d *Driver, params ...int) {
 	d.WriteRaw(fmt.Sprintf("%s[%sm", ESC, paramStr))
 }
 
+// SGRRaw sends a raw SGR sequence string, allowing colon-separated subparameters.
+// Example: SGRRaw(d, "4:3") sends CSI 4:3 m (curly underline).
+func SGRRaw(d *Driver, seq string) {
+	d.WriteRaw(fmt.Sprintf("%s[%sm", ESC, seq))
+}
+
 // SGR constants for common attributes
 const (
 	SGR_RESET          = 0

--- a/apps/texelterm/esctest/sgr_test.go
+++ b/apps/texelterm/esctest/sgr_test.go
@@ -300,3 +300,69 @@ func Test_SGR_ResetDoesNotAffectColors(t *testing.T) {
 	AssertCellForegroundColor(t, d, NewPoint(1, 1), parser.DefaultFG, "SGR 0 should reset foreground")
 	AssertCellBackgroundColor(t, d, NewPoint(1, 1), parser.DefaultBG, "SGR 0 should reset background")
 }
+
+// Test_SGR_CurlyUnderlineDoesNotSetItalic tests that colon-separated underline
+// subparameters (e.g., 4:3 for curly underline) do not leak into italic.
+// This was a real bug: the parser treated ':' like ';', so 4:3 was parsed as
+// SGR 4 (underline) + SGR 3 (italic).
+func Test_SGR_CurlyUnderlineDoesNotSetItalic(t *testing.T) {
+	d := NewDriver(80, 24)
+
+	// Send curly underline (4:3) - should set underline, NOT italic
+	SGRRaw(d, "4:3")
+	d.WriteRaw("a")
+
+	AssertCellHasAttribute(t, d, NewPoint(1, 1), parser.AttrUnderline, "4:3 should set underline")
+	AssertCellDoesNotHaveAttribute(t, d, NewPoint(1, 1), parser.AttrItalic, "4:3 should NOT set italic")
+}
+
+// Test_SGR_ColonUnderlineNone tests that 4:0 clears underline.
+func Test_SGR_ColonUnderlineNone(t *testing.T) {
+	d := NewDriver(80, 24)
+
+	SGR(d, SGR_UNDERLINE) // Enable underline
+	SGRRaw(d, "4:0")      // Disable via subparam
+	d.WriteRaw("a")
+
+	AssertCellDoesNotHaveAttribute(t, d, NewPoint(1, 1), parser.AttrUnderline, "4:0 should clear underline")
+}
+
+// Test_SGR_ColonRGBForeground tests colon-separated RGB color (38:2:r:g:b).
+func Test_SGR_ColonRGBForeground(t *testing.T) {
+	d := NewDriver(80, 24)
+
+	// Send RGB foreground via colon syntax: 38:2:255:128:0
+	SGRRaw(d, "38:2:255:128:0")
+	d.WriteRaw("O")
+
+	expectedOrange := parser.Color{Mode: parser.ColorModeRGB, R: 255, G: 128, B: 0}
+	AssertCellForegroundColor(t, d, NewPoint(1, 1), expectedOrange, "Colon RGB should set foreground")
+}
+
+// Test_SGR_Colon256Foreground tests colon-separated 256-color (38:5:idx).
+func Test_SGR_Colon256Foreground(t *testing.T) {
+	d := NewDriver(80, 24)
+
+	SGRRaw(d, "38:5:196")
+	d.WriteRaw("R")
+
+	expectedRed := parser.Color{Mode: parser.ColorMode256, Value: 196}
+	AssertCellForegroundColor(t, d, NewPoint(1, 1), expectedRed, "Colon 256-color should set foreground")
+}
+
+// Test_SGR_MixedColonSemicolon tests sequences mixing colon and semicolon separators.
+// Example: "\e[1;4:3;38:2:255:0:0m" = bold + curly underline + red RGB foreground
+func Test_SGR_MixedColonSemicolon(t *testing.T) {
+	d := NewDriver(80, 24)
+
+	// bold ; curly-underline ; RGB red foreground
+	SGRRaw(d, "1;4:3;38:2:255:0:0")
+	d.WriteRaw("X")
+
+	AssertCellHasAttribute(t, d, NewPoint(1, 1), parser.AttrBold, "Should be bold")
+	AssertCellHasAttribute(t, d, NewPoint(1, 1), parser.AttrUnderline, "Should be underlined")
+	AssertCellDoesNotHaveAttribute(t, d, NewPoint(1, 1), parser.AttrItalic, "Should NOT be italic")
+
+	expectedRed := parser.Color{Mode: parser.ColorModeRGB, R: 255, G: 0, B: 0}
+	AssertCellForegroundColor(t, d, NewPoint(1, 1), expectedRed, "Should have RGB red foreground")
+}

--- a/apps/texelterm/parser/parser.go
+++ b/apps/texelterm/parser/parser.go
@@ -31,7 +31,8 @@ const (
 type Parser struct {
 	state        State
 	vterm        *VTerm
-	params       []int
+	params       [][]int // Each element is a group of colon-separated subparams
+	currentGroup []int   // Current colon-separated group being built
 	currentParam int
 	private      bool
 	oscBuffer    []rune
@@ -41,11 +42,12 @@ type Parser struct {
 
 func NewParser(v *VTerm) *Parser {
 	return &Parser{
-		state:     StateGround,
-		vterm:     v,
-		params:    make([]int, 0, 16),
-		oscBuffer: make([]rune, 0, 128),
-		dcsBuffer: make([]rune, 0, 128),
+		state:        StateGround,
+		vterm:        v,
+		params:       make([][]int, 0, 16),
+		currentGroup: make([]int, 0, 4),
+		oscBuffer:    make([]rune, 0, 128),
+		dcsBuffer:    make([]rune, 0, 128),
 	}
 }
 
@@ -86,6 +88,7 @@ func (p *Parser) Parse(r rune) {
 		case '[':
 			p.state = StateCSI
 			p.params = p.params[:0]
+			p.currentGroup = p.currentGroup[:0]
 			p.currentParam = 0
 			p.private = false
 			p.intermediate = 0 // Reset intermediate byte
@@ -147,10 +150,16 @@ func (p *Parser) Parse(r rune) {
 		switch {
 		case r >= '0' && r <= '9':
 			p.currentParam = p.currentParam*10 + int(r-'0')
-		case r == ';', r == ':':
-			// Both semicolon and colon are valid parameter separators.
-			// Colon is used for SGR subparameters (ITU T.416) like 38:2:r:g:b
-			p.params = append(p.params, p.currentParam)
+		case r == ':':
+			// Colon separates subparameters within a single parameter group
+			// (ITU T.416) e.g., 4:3 = underline style curly, 38:2:r:g:b = RGB color
+			p.currentGroup = append(p.currentGroup, p.currentParam)
+			p.currentParam = 0
+		case r == ';':
+			// Semicolon separates top-level parameters
+			p.currentGroup = append(p.currentGroup, p.currentParam)
+			p.params = append(p.params, p.currentGroup)
+			p.currentGroup = make([]int, 0, 4)
 			p.currentParam = 0
 		case r == '?':
 			// '?' is the DEC private parameter marker (e.g., CSI ? 6 h for DECSET)
@@ -166,9 +175,11 @@ func (p *Parser) Parse(r rune) {
 			// Includes '!', '\'',' etc.
 			p.intermediate = r
 		case r >= '@' && r <= '~':
-			p.params = append(p.params, p.currentParam)
+			p.currentGroup = append(p.currentGroup, p.currentParam)
+			p.params = append(p.params, p.currentGroup)
 			p.vterm.ProcessCSI(r, p.params, p.intermediate, p.private)
 			p.state = StateGround
+			p.currentGroup = make([]int, 0, 4)
 			p.private = false // Reset for next CSI
 		}
 	case StateOSC:

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -810,11 +810,25 @@ func (v *VTerm) SoftReset() {
 
 // --- Core CSI Dispatch ---
 
+// flattenParams extracts the first (main) value from each parameter group,
+// discarding colon-separated subparameters. Used by CSI handlers that don't
+// need subparameter awareness (everything except SGR).
+func flattenParams(params [][]int) []int {
+	flat := make([]int, len(params))
+	for i, group := range params {
+		if len(group) > 0 {
+			flat[i] = group[0]
+		}
+	}
+	return flat
+}
+
 // ProcessCSI interprets a parsed CSI sequence and calls the appropriate handler.
-func (v *VTerm) ProcessCSI(command rune, params []int, intermediate rune, private bool) {
+func (v *VTerm) ProcessCSI(command rune, params [][]int, intermediate rune, private bool) {
+	flat := flattenParams(params)
 	param := func(i int, defaultVal int) int {
-		if i < len(params) && params[i] != 0 {
-			return params[i]
+		if i < len(flat) && flat[i] != 0 {
+			return flat[i]
 		}
 		return defaultVal
 	}
@@ -864,22 +878,39 @@ func (v *VTerm) ProcessCSI(command rune, params []int, intermediate rune, privat
 	// Handle mode setting/resetting (SM/RM for ANSI modes, DECSET/DECRESET for DEC private modes)
 	if command == 'h' || command == 'l' {
 		if private {
-			v.processPrivateCSI(command, params)
+			v.processPrivateCSI(command, flat)
 		} else {
-			v.processANSIMode(command, params)
+			v.processANSIMode(command, flat)
 		}
+		return
+	}
+
+	// All commands below are plain CSI sequences (no intermediate byte).
+	// Sequences with intermediate bytes (CSI > Ps X, CSI $ Ps X, etc.) are
+	// handled above or silently ignored. Without this guard, extended sequences
+	// like CSI > 4 ; 2 m (XTMODKEYS) would be misrouted to handlers like SGR.
+	//
+	// TODO: Implement the following extended CSI sequences:
+	//   CSI > Ps m       — XTMODKEYS: set modifier key encoding level
+	//   CSI > Ps u       — Kitty keyboard protocol: push mode
+	//   CSI < u          — Kitty keyboard protocol: pop mode
+	//   CSI = Ps u       — Kitty keyboard protocol: query mode
+	//   CSI > q          — XTVERSION: report terminal name and version
+	//   CSI > Ps S       — XTSMGRAPHICS: query/set graphics capabilities
+	//   CSI > Ps n       — DECDSR (extended): device status reports
+	if intermediate != 0 {
 		return
 	}
 
 	switch command {
 	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'f', 'd', '`', 'a', 'e':
-		v.handleCursorMovement(command, params)
+		v.handleCursorMovement(command, flat)
 	case 'I': // CHT - Cursor Horizontal Tab
 		v.TabForward(param(0, 1))
 	case 'Z': // CBT - Cursor Backward Tab
 		v.TabBackward(param(0, 1))
 	case 'J', 'K', 'P', 'X', 'b':
-		v.handleErase(command, params)
+		v.handleErase(command, flat)
 	case '@':
 		v.InsertCharacters(param(0, 1))
 	case 'L':
@@ -901,7 +932,7 @@ func (v *VTerm) ProcessCSI(command rune, params []int, intermediate rune, privat
 			v.scrollRegion(-param(0, 1), v.marginTop, v.marginBottom)
 		}
 	case 'm':
-		v.handleSGR(params)
+		v.handleSGR(params) // SGR receives full [][]int for subparam awareness
 	case 'n': // DSR - Device Status Report
 		if param(0, 0) == 6 { // Report Cursor Position
 			response := fmt.Sprintf("\x1b[%d;%dR", v.cursorY+1, v.cursorX+1)
@@ -921,14 +952,7 @@ func (v *VTerm) ProcessCSI(command rune, params []int, intermediate rune, privat
 			v.SaveCursor()
 		}
 	case 'u':
-		// CSI u without intermediate = DECRC (Restore Cursor)
-		// CSI > Ps u = Extended keyboard protocol (push mode) - ignore
-		// CSI < u = Extended keyboard protocol (pop mode) - ignore
-		// CSI = Ps u = Extended keyboard protocol (query mode) - ignore
-		if intermediate == 0 {
-			v.RestoreCursor()
-		}
-		// Extended keyboard protocol sequences are silently ignored
+		v.RestoreCursor()
 	case 'c': // DA - Primary Device Attributes
 		// Response: CSI ? Ps ; Ps ; ... c
 		// Ps values:

--- a/apps/texelterm/parser/vterm_appearance.go
+++ b/apps/texelterm/parser/vterm_appearance.go
@@ -68,13 +68,24 @@ func (v *VTerm) ClearVisibleScreen() {
 
 // handleSGR processes SGR (Select Graphic Rendition) escape sequences.
 // Handles text attributes (bold, underline, reverse) and colors (standard, 256-color, RGB).
-func (v *VTerm) handleSGR(params []int) {
-	i := 0
+// params is [][]int where each element is a colon-separated group of subparameters.
+// For example, "\e[1;4:3;38:2:255:0:0m" produces:
+//
+//	[[1], [4,3], [38,2,255,0,0]]
+//
+// This correctly distinguishes semicolons (top-level separators) from colons (subparameters).
+func (v *VTerm) handleSGR(params [][]int) {
 	if len(params) == 0 {
-		params = []int{0}
+		params = [][]int{{0}}
 	}
+	i := 0
 	for i < len(params) {
-		p := params[i]
+		group := params[i]
+		if len(group) == 0 {
+			i++
+			continue
+		}
+		p := group[0]
 		switch {
 		case p == 0:
 			v.ResetAttributes()
@@ -85,7 +96,14 @@ func (v *VTerm) handleSGR(params []int) {
 		case p == 3:
 			v.SetAttribute(AttrItalic)
 		case p == 4:
-			v.SetAttribute(AttrUnderline)
+			// SGR 4 = underline. Subparam selects style: 4:0=none, 4:1=single,
+			// 4:2=double, 4:3=curly, 4:4=dotted, 4:5=dashed.
+			// Without subparam (plain SGR 4), default is single underline.
+			if len(group) > 1 && group[1] == 0 {
+				v.ClearAttribute(AttrUnderline) // 4:0 = no underline
+			} else {
+				v.SetAttribute(AttrUnderline) // 4 or 4:1-5 = underline on
+			}
 		case p == 7:
 			v.SetAttribute(AttrReverse)
 		case p == 22:
@@ -105,30 +123,12 @@ func (v *VTerm) handleSGR(params []int) {
 		case p == 49:
 			v.currentBG = v.defaultBG
 		case p == 38: // Set extended foreground color
-			if i+2 < len(params) && params[i+1] == 5 { // 256-color palette
-				idx := uint8(params[i+2])
-				if idx < 8 {
-					v.currentFG = Color{Mode: ColorModeStandard, Value: idx}
-				} else {
-					v.currentFG = Color{Mode: ColorMode256, Value: idx}
-				}
-				i += 2
-			} else if i+4 < len(params) && params[i+1] == 2 { // RGB true-color
-				v.currentFG = Color{Mode: ColorModeRGB, R: uint8(params[i+2]), G: uint8(params[i+3]), B: uint8(params[i+4])}
-				i += 4
+			if v.parseExtendedColor(group, params, i, &v.currentFG, &i) {
+				// i already advanced by parseExtendedColor
 			}
 		case p == 48: // Set extended background color
-			if i+2 < len(params) && params[i+1] == 5 { // 256-color palette
-				idx := uint8(params[i+2])
-				if idx < 8 {
-					v.currentBG = Color{Mode: ColorModeStandard, Value: idx}
-				} else {
-					v.currentBG = Color{Mode: ColorMode256, Value: idx}
-				}
-				i += 2
-			} else if i+4 < len(params) && params[i+1] == 2 { // RGB true-color
-				v.currentBG = Color{Mode: ColorModeRGB, R: uint8(params[i+2]), G: uint8(params[i+3]), B: uint8(params[i+4])}
-				i += 4
+			if v.parseExtendedColor(group, params, i, &v.currentBG, &i) {
+				// i already advanced by parseExtendedColor
 			}
 		case p >= 90 && p <= 97: // Bright foreground
 			v.currentFG = Color{Mode: ColorModeStandard, Value: uint8(p - 90 + 8)}
@@ -137,6 +137,56 @@ func (v *VTerm) handleSGR(params []int) {
 		}
 		i++
 	}
+}
+
+// parseExtendedColor handles extended color sequences for both colon and semicolon forms:
+//   - Colon form (ITU T.416): 38:5:idx or 38:2:r:g:b (all in one group)
+//   - Semicolon form (legacy): 38;5;idx or 38;2;r;g;b (spread across groups)
+//
+// Returns true if a color was parsed. Advances *idx past consumed groups for semicolon form.
+func (v *VTerm) parseExtendedColor(group []int, params [][]int, idx int, target *Color, outIdx *int) bool {
+	// Colon form: everything is in a single group, e.g. [38,5,196] or [38,2,255,0,0]
+	if len(group) >= 3 && group[1] == 5 {
+		val := uint8(group[2])
+		if val < 8 {
+			*target = Color{Mode: ColorModeStandard, Value: val}
+		} else {
+			*target = Color{Mode: ColorMode256, Value: val}
+		}
+		return true
+	}
+	if len(group) >= 5 && group[1] == 2 {
+		*target = Color{Mode: ColorModeRGB, R: uint8(group[2]), G: uint8(group[3]), B: uint8(group[4])}
+		return true
+	}
+
+	// Semicolon form: values are in subsequent groups, e.g. [38],[5],[196]
+	if idx+2 < len(params) && len(params[idx+1]) > 0 && params[idx+1][0] == 5 && len(params[idx+2]) > 0 {
+		val := uint8(params[idx+2][0])
+		if val < 8 {
+			*target = Color{Mode: ColorModeStandard, Value: val}
+		} else {
+			*target = Color{Mode: ColorMode256, Value: val}
+		}
+		*outIdx = idx + 2
+		return true
+	}
+	if idx+4 < len(params) && len(params[idx+1]) > 0 && params[idx+1][0] == 2 {
+		r, g, b := uint8(0), uint8(0), uint8(0)
+		if len(params[idx+2]) > 0 {
+			r = uint8(params[idx+2][0])
+		}
+		if len(params[idx+3]) > 0 {
+			g = uint8(params[idx+3][0])
+		}
+		if len(params[idx+4]) > 0 {
+			b = uint8(params[idx+4][0])
+		}
+		*target = Color{Mode: ColorModeRGB, R: r, G: g, B: b}
+		*outIdx = idx + 4
+		return true
+	}
+	return false
 }
 
 // SetAttribute sets a text attribute (bold, underline, reverse).


### PR DESCRIPTION
## Summary

- **Distinguish `:` and `;` in CSI parser**: Per ITU T.416, colons delimit subparameters within a group (e.g., `4:3` = curly underline style) while semicolons separate top-level parameters. Previously both were treated as flat separators, causing sequences like `4:3` to be parsed as SGR 4 (underline) + SGR 3 (italic). Changed `params` from `[]int` to `[][]int` so SGR handlers can access subparameter groups. Non-SGR handlers use `flattenParams()` for backward compatibility.
- **Guard CSI dispatch against intermediate bytes**: Extended sequences like `CSI > 4 ; 2 m` (XTMODKEYS) were falling through to the `'m'` case and being misinterpreted as SGR 4 (underline) + SGR 2 (dim). This was the **root cause** of persistent underline when running Claude Code inside texelterm. Added an `intermediate != 0` early return after handlers that legitimately use intermediate bytes (DECSTR, DECRQM, DECIC, DECDC, DA2, SM/RM).
- **Added TODO** for implementing extended CSI sequences: XTMODKEYS, Kitty keyboard protocol, XTVERSION, XTSMGRAPHICS, extended DECDSR.

### Root cause analysis

Claude Code sends `CSI > 4 ; 2 m` at startup to configure xterm key modifier reporting (XTMODKEYS). The `>` was stored as an intermediate byte, but the `case 'm'` dispatch didn't check for it, so the sequence was routed to `handleSGR` which interpreted `4` as "underline on" and `2` as "dim". The underline was never cleared because Claude Code only sends `CSI > 4 m` (XTMODKEYS reset) on exit — which was also misrouted as SGR 4 (underline on again). A full SGR 0 reset on exit finally cleared it.

## Test plan

- [x] `go test ./apps/texelterm/parser/` — all pass
- [x] `go test ./apps/texelterm/esctest/` — all pass, including 5 new tests:
  - `Test_SGR_CurlyUnderlineDoesNotSetItalic` — `4:3` sets underline, not italic
  - `Test_SGR_ColonUnderlineNone` — `4:0` clears underline
  - `Test_SGR_ColonRGBForeground` — `38:2:r:g:b` colon form
  - `Test_SGR_Colon256Foreground` — `38:5:idx` colon form
  - `Test_SGR_MixedColonSemicolon` — mixed `1;4:3;38:2:255:0:0`
- [x] Manual test: Claude Code inside texelterm no longer shows persistent underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)