### PR TITLE
Upgrade texelui to v0.8.0, migrate animation to shared package

### DIFF
--- a/apps/texelterm/history_navigator.go
+++ b/apps/texelterm/history_navigator.go
@@ -15,8 +15,9 @@ import (
 
 	texelcore "github.com/framegrace/texelui/core"
 
+	"github.com/framegrace/texelui/animation"
+
 	"github.com/framegrace/texelation/apps/texelterm/parser"
-	"github.com/framegrace/texelation/internal/effects"
 	"github.com/framegrace/texelation/internal/theming"
 	"github.com/framegrace/texelui/core"
 	"github.com/framegrace/texelui/theme"
@@ -106,7 +107,7 @@ type HistoryNavigator struct {
 	ScrollAnimMinTime   time.Duration // Min animation duration
 	ScrollAnimMaxTime   time.Duration // Max animation duration
 	ScrollAnimFrameRate int           // Frames per second
-	ScrollAnimEasing    effects.EasingFunc
+	ScrollAnimEasing    animation.EasingFunc
 
 	// Long jump edge animation config
 	ScrollAnimEdgeLines      int           // Lines to show at start/end edges (default: 5)
@@ -140,7 +141,7 @@ func NewHistoryNavigator(vterm *parser.VTerm, searchIndex *parser.SQLiteSearchIn
 		ScrollAnimMinTime:        defaultScrollAnimMinTime,
 		ScrollAnimMaxTime:        defaultScrollAnimMaxTime,
 		ScrollAnimFrameRate:      defaultScrollAnimFrameRate,
-		ScrollAnimEasing:         effects.EaseInOutCubic,
+		ScrollAnimEasing:         animation.EaseInOutCubic,
 		ScrollAnimEdgeLines:      defaultScrollAnimEdgeLines,
 		ScrollAnimEdgeStartDelay: defaultScrollAnimEdgeStartDelay,
 		ScrollAnimEdgeEndDelay:   defaultScrollAnimEdgeEndDelay,
@@ -883,7 +884,7 @@ func (h *HistoryNavigator) animateShortJump(startOffset, targetOffset, distance 
 	// Use configured easing function
 	easing := h.ScrollAnimEasing
 	if easing == nil {
-		easing = effects.EaseInOutCubic
+		easing = animation.EaseInOutCubic
 	}
 
 	// Animate in a goroutine
@@ -973,7 +974,7 @@ func (h *HistoryNavigator) animateLongJump(startOffset, targetOffset, distance i
 			// Use configured easing function
 			easing := h.ScrollAnimEasing
 			if easing == nil {
-				easing = effects.EaseInOutCubic
+				easing = animation.EaseInOutCubic
 			}
 
 			startTime := time.Now()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.3
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1
 	github.com/creack/pty v1.1.24
-	github.com/framegrace/texelui v0.7.0
+	github.com/framegrace/texelui v0.8.0
 	github.com/gdamore/tcell/v2 v2.13.8
 	github.com/go-enry/go-enry/v2 v2.9.4
 	github.com/mattn/go-runewidth v0.0.16

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/framegrace/texelui v0.7.0 h1:nagly9P7ljRgRsStasZfGp+h+21tTpsq0MxRUxSWHz4=
 github.com/framegrace/texelui v0.7.0/go.mod h1:6MlXF03E/QstYjj/XPzHiMrMW3ro8EyxuyWoWQNzTms=
+github.com/framegrace/texelui v0.8.0 h1:JTwuxnapblzgUKrx1zxztdVdB+6RNSBdlgVNz6dfopw=
+github.com/framegrace/texelui v0.8.0/go.mod h1:6MlXF03E/QstYjj/XPzHiMrMW3ro8EyxuyWoWQNzTms=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.8 h1:Mys/Kl5wfC/GcC5Cx4C2BIQH9dbnhnkPgS9/wF3RlfU=

--- a/internal/effects/timeline.go
+++ b/internal/effects/timeline.go
@@ -2,308 +2,38 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // File: internal/effects/timeline.go
-// Summary: Thread-safe animation timeline with configurable easing functions.
-// Usage: Simplifies effect implementation by handling all animation state automatically.
-// Notes: Supports per-key timelines with linear, smoothstep, and custom easing.
+// Summary: Re-exports animation primitives from texelui/animation.
+// The canonical implementation now lives in texelui. This file provides
+// backward-compatible aliases so existing effects code compiles unchanged.
 
 package effects
 
-import (
-	"sync"
-	"time"
-)
+import "github.com/framegrace/texelui/animation"
 
 // EasingFunc defines an easing function that maps progress [0,1] to eased value [0,1]
-type EasingFunc func(progress float32) float32
+type EasingFunc = animation.EasingFunc
 
-// Common easing functions
+// Common easing functions — re-exported from texelui/animation.
 var (
-	// EaseLinear - No easing, constant speed
-	EaseLinear EasingFunc = func(t float32) float32 { return t }
-
-	// EaseSmoothstep - Smooth S-curve (default, recommended for most animations)
-	// Accelerates at start, decelerates at end
-	EaseSmoothstep EasingFunc = func(t float32) float32 {
-		return t * t * (3.0 - 2.0*t)
-	}
-
-	// EaseSmootherstep - Even smoother S-curve with zero derivatives at 0 and 1
-	EaseSmootherstep EasingFunc = func(t float32) float32 {
-		return t * t * t * (t*(t*6.0-15.0) + 10.0)
-	}
-
-	// EaseInQuad - Quadratic ease-in (slow start, accelerating)
-	EaseInQuad EasingFunc = func(t float32) float32 {
-		return t * t
-	}
-
-	// EaseOutQuad - Quadratic ease-out (fast start, decelerating)
-	EaseOutQuad EasingFunc = func(t float32) float32 {
-		return t * (2.0 - t)
-	}
-
-	// EaseInOutQuad - Quadratic ease-in-out
-	EaseInOutQuad EasingFunc = func(t float32) float32 {
-		if t < 0.5 {
-			return 2.0 * t * t
-		}
-		return -1.0 + (4.0-2.0*t)*t
-	}
-
-	// EaseInCubic - Cubic ease-in (slower start)
-	EaseInCubic EasingFunc = func(t float32) float32 {
-		return t * t * t
-	}
-
-	// EaseOutCubic - Cubic ease-out
-	EaseOutCubic EasingFunc = func(t float32) float32 {
-		t1 := t - 1.0
-		return t1*t1*t1 + 1.0
-	}
-
-	// EaseInOutCubic - Cubic ease-in-out
-	EaseInOutCubic EasingFunc = func(t float32) float32 {
-		if t < 0.5 {
-			return 4.0 * t * t * t
-		}
-		t1 := 2.0*t - 2.0
-		return 1.0 + t1*t1*t1*0.5
-	}
+	EaseLinear       = animation.EaseLinear
+	EaseSmoothstep   = animation.EaseSmoothstep
+	EaseSmootherstep = animation.EaseSmootherstep
+	EaseInQuad       = animation.EaseInQuad
+	EaseOutQuad      = animation.EaseOutQuad
+	EaseInOutQuad    = animation.EaseInOutQuad
+	EaseInCubic      = animation.EaseInCubic
+	EaseOutCubic     = animation.EaseOutCubic
+	EaseInOutCubic   = animation.EaseInOutCubic
 )
 
-// AnimateOptions configures an animation transition
-type AnimateOptions struct {
-	Duration time.Duration // Animation duration (default: 0 = instant)
-	Easing   EasingFunc    // Easing function (default: EaseSmoothstep)
-}
+// AnimateOptions configures an animation transition.
+type AnimateOptions = animation.AnimateOptions
 
-// DefaultAnimateOptions returns options with smoothstep easing
-func DefaultAnimateOptions(duration time.Duration) AnimateOptions {
-	return AnimateOptions{
-		Duration: duration,
-		Easing:   EaseSmoothstep,
-	}
-}
+// DefaultAnimateOptions returns options with smoothstep easing.
+var DefaultAnimateOptions = animation.DefaultAnimateOptions
 
-// keyState tracks animation state for a single key
-type keyState struct {
-	current   float32
-	start     float32
-	target    float32
-	startTime time.Time
-	duration  time.Duration
-	easing    EasingFunc
-}
+// Timeline provides thread-safe, per-key animation timelines.
+type Timeline = animation.Timeline
 
-// Timeline provides thread-safe, per-key animation timelines with automatic state management
-type Timeline struct {
-	states         map[interface{}]*keyState
-	mu             sync.RWMutex
-	defaultEasing  EasingFunc
-	defaultInitial float32
-}
-
-// NewTimeline creates a new timeline manager
-// defaultInitial: initial value for uninitialized keys (typically 0.0)
-func NewTimeline(defaultInitial float32) *Timeline {
-	return &Timeline{
-		states:         make(map[interface{}]*keyState),
-		defaultEasing:  EaseSmoothstep,
-		defaultInitial: defaultInitial,
-	}
-}
-
-// AnimateTo starts or updates an animation for the given key
-// Returns the current animated value at this moment
-//
-// Minimal usage:
-//   value := timeline.AnimateTo(key, target, duration, now)
-//
-// With custom easing:
-//   value := timeline.AnimateToWithOptions(key, target, AnimateOptions{
-//       Duration: 300*time.Millisecond,
-//       Easing: EaseInOutCubic,
-//   }, now)
-func (tl *Timeline) AnimateTo(key interface{}, target float32, duration time.Duration, now time.Time) float32 {
-	return tl.AnimateToWithOptions(key, target, DefaultAnimateOptions(duration), now)
-}
-
-// AnimateToWithOptions starts an animation with custom easing function
-func (tl *Timeline) AnimateToWithOptions(key interface{}, target float32, opts AnimateOptions, now time.Time) float32 {
-	tl.mu.Lock()
-	defer tl.mu.Unlock()
-
-	state := tl.states[key]
-
-	if state == nil {
-		// Initialize new key
-		state = &keyState{
-			current:  tl.defaultInitial,
-			start:    tl.defaultInitial,
-			target:   target,
-			duration: opts.Duration,
-			easing:   opts.Easing,
-		}
-		if opts.Easing == nil {
-			state.easing = tl.defaultEasing
-		}
-		tl.states[key] = state
-
-		// If duration is zero, jump to target immediately
-		if opts.Duration <= 0 {
-			state.current = target
-			return target
-		}
-
-		state.startTime = now
-		return state.current
-	}
-
-	// Update existing animation
-	// First, compute current value to use as new start
-	current := tl.computeValue(state, now)
-
-	// Start new animation from current position
-	state.current = current
-	state.start = current
-	state.target = target
-	state.startTime = now
-	state.duration = opts.Duration
-	if opts.Easing != nil {
-		state.easing = opts.Easing
-	}
-
-	// If duration is zero or already at target, finish immediately
-	if opts.Duration <= 0 || current == target {
-		state.current = target
-		return target
-	}
-
-	return current
-}
-
-// Get returns the current animated value for a key
-// If the key hasn't been initialized, returns the default initial value
-func (tl *Timeline) Get(key interface{}, now time.Time) float32 {
-	tl.mu.RLock()
-	state := tl.states[key]
-	tl.mu.RUnlock()
-
-	if state == nil {
-		return tl.defaultInitial
-	}
-
-	tl.mu.Lock()
-	value := tl.computeValue(state, now)
-	state.current = value
-	tl.mu.Unlock()
-
-	return value
-}
-
-// GetCached returns the last computed value for a key without recomputing.
-// This is useful when called after Update() in the same frame to avoid redundant calculations.
-// If the key hasn't been initialized, returns the default initial value.
-func (tl *Timeline) GetCached(key interface{}) float32 {
-	tl.mu.RLock()
-	defer tl.mu.RUnlock()
-
-	state := tl.states[key]
-	if state == nil {
-		return tl.defaultInitial
-	}
-
-	return state.current
-}
-
-// IsAnimating returns true if the key is currently animating
-func (tl *Timeline) IsAnimating(key interface{}, now time.Time) bool {
-	tl.mu.RLock()
-	defer tl.mu.RUnlock()
-
-	state := tl.states[key]
-	if state == nil || state.duration <= 0 {
-		return false
-	}
-
-	elapsed := now.Sub(state.startTime)
-	return elapsed < state.duration && state.current != state.target
-}
-
-// HasActiveAnimations returns true if any key is currently animating
-// This method still exists for convenience but should be used sparingly.
-// Prefer checking specific keys with IsAnimating when possible for better performance.
-func (tl *Timeline) HasActiveAnimations() bool {
-	tl.mu.RLock()
-	defer tl.mu.RUnlock()
-
-	now := time.Now()
-	for _, state := range tl.states {
-		if state.duration > 0 && now.Sub(state.startTime) < state.duration {
-			if state.current != state.target {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// Update advances all animations to the given time
-// This is called by the effect manager on each frame
-func (tl *Timeline) Update(now time.Time) {
-	tl.mu.Lock()
-	defer tl.mu.Unlock()
-
-	for _, state := range tl.states {
-		state.current = tl.computeValue(state, now)
-	}
-}
-
-// Reset removes the timeline state for a key
-func (tl *Timeline) Reset(key interface{}) {
-	tl.mu.Lock()
-	defer tl.mu.Unlock()
-	delete(tl.states, key)
-}
-
-// Clear removes all timeline states
-func (tl *Timeline) Clear() {
-	tl.mu.Lock()
-	defer tl.mu.Unlock()
-	tl.states = make(map[interface{}]*keyState)
-}
-
-// computeValue calculates the current value for a state at the given time
-// Must be called with lock held
-func (tl *Timeline) computeValue(state *keyState, now time.Time) float32 {
-	if state.duration <= 0 {
-		return state.target
-	}
-
-	if now.Before(state.startTime) {
-		return state.start
-	}
-
-	elapsed := now.Sub(state.startTime)
-	if elapsed >= state.duration {
-		return state.target
-	}
-
-	// Calculate progress [0, 1]
-	progress := float32(elapsed) / float32(state.duration)
-	if progress < 0 {
-		progress = 0
-	} else if progress > 1 {
-		progress = 1
-	}
-
-	// Apply easing function
-	easing := state.easing
-	if easing == nil {
-		easing = tl.defaultEasing
-	}
-	easedProgress := easing(progress)
-
-	// Interpolate
-	return state.start + (state.target-state.start)*easedProgress
-}
+// NewTimeline creates a new timeline manager.
+var NewTimeline = animation.NewTimeline

--- a/texel/layout_transitions.go
+++ b/texel/layout_transitions.go
@@ -12,8 +12,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/framegrace/texelui/animation"
+
 	"github.com/framegrace/texelation/internal/debuglog"
-	"github.com/framegrace/texelation/internal/effects"
 )
 
 // LayoutTransitionConfig holds configuration for layout transitions from theme.json.
@@ -45,7 +46,7 @@ type LayoutTransitionManager struct {
 	enabled    bool
 	duration   time.Duration
 	easing     string
-	timeline   *effects.Timeline
+	timeline   *animation.Timeline
 	animating  map[*Node]*transitionState
 	desktop    *DesktopEngine
 	ticker     *time.Ticker
@@ -75,7 +76,7 @@ func NewLayoutTransitionManager(config LayoutTransitionConfig, desktop *DesktopE
 		enabled:   true,
 		duration:  duration,
 		easing:    easing,
-		timeline:  effects.NewTimeline(0.0),
+		timeline:  animation.NewTimeline(0.0),
 		animating: make(map[*Node]*transitionState),
 		desktop:   desktop,
 		stopCh:    make(chan struct{}),
@@ -343,7 +344,7 @@ func (m *LayoutTransitionManager) UpdateConfig(config LayoutTransitionConfig) {
 			m.stopCh = make(chan struct{})
 		}
 		if m.timeline == nil {
-			m.timeline = effects.NewTimeline(0.0)
+			m.timeline = animation.NewTimeline(0.0)
 		}
 		// Reset grace period when enabling
 		m.graceStart = time.Now()


### PR DESCRIPTION
## Summary

- Upgrade texelui dependency from v0.7.0 to v0.8.0 (dynamic colors, powerline tabs, arrow key navigation)
- Migrate `layout_transitions.go` and `history_navigator.go` to import `texelui/animation` directly instead of `internal/effects`
- Replace `internal/effects/timeline.go` (309 lines) with thin type aliases re-exporting from `texelui/animation` — effects system continues to work unchanged via aliases
- Net -303 lines of duplicated code

## Test plan
- [x] Full test suite passes
- [x] `make build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)