### PR TITLE
Fix pane decorator pill click routing

### DIFF
--- a/texel/desktop_input.go
+++ b/texel/desktop_input.go
@@ -164,8 +164,11 @@ func (d *DesktopEngine) processMouseEvent(x, y int, buttons tcell.ButtonMask, mo
 		}
 	}
 
-	// Handle workspace border resize first
-	if d.activeWorkspace != nil {
+	// Handle workspace border resize first — but skip it if the cursor
+	// is inside a pane decorator pill's hover zone. Otherwise clicks on
+	// pills that sit on a shared split border would be intercepted as
+	// resize grabs instead of firing the pill action.
+	if d.activeWorkspace != nil && !d.pointInAnyPaneDecoratorZone(x, y) {
 		if d.activeWorkspace.handleMouseResize(x, y, buttons, prevButtons) {
 			return
 		}
@@ -219,6 +222,36 @@ func (d *DesktopEngine) routeClickToStatusPane(x, y int, buttons, prevButtons tc
 		}
 	}
 	return false
+}
+
+// pointInAnyPaneDecoratorZone reports whether (x, y) falls inside any
+// pane's decorator pill hover zone in the active workspace. Used by
+// the mouse dispatcher to give pill interactions priority over border
+// resize — a pill drawn on a shared split border would otherwise be
+// intercepted by the resize grab.
+func (d *DesktopEngine) pointInAnyPaneDecoratorZone(x, y int) bool {
+	ws := d.activeWorkspace
+	if ws == nil || ws.tree == nil {
+		return false
+	}
+	if d.zoomedPane != nil && d.zoomedPane.Pane != nil {
+		p := d.zoomedPane.Pane
+		if p.decorator != nil && p.decorator.HoverZoneContains(x, y, p.absX0, p.absX1, p.absY0) {
+			return true
+		}
+		return false
+	}
+	found := false
+	ws.tree.Traverse(func(node *Node) {
+		if found || node == nil || node.Pane == nil {
+			return
+		}
+		p := node.Pane
+		if p.decorator != nil && p.decorator.HoverZoneContains(x, y, p.absX0, p.absX1, p.absY0) {
+			found = true
+		}
+	})
+	return found
 }
 
 func (d *DesktopEngine) paneAtCoordinates(x, y int) *pane {

--- a/texel/pane_decorator.go
+++ b/texel/pane_decorator.go
@@ -395,6 +395,29 @@ func (d *PaneDecorator) HandleMouse(absX, absY int, buttons tcell.ButtonMask, bo
 	return "", true
 }
 
+// HoverZoneContains reports whether the given absolute screen point
+// would trigger pill interaction (hover-expand or click). The zone is
+// the expanded-width rect along the pane's top border, so the check
+// holds regardless of the pill's current collapsed/expanded state.
+//
+// Used by the mouse dispatch path to give the pill priority over
+// border-resize handling — clicks inside this zone should run the pill
+// action, not start a resize drag on the shared border.
+func (d *PaneDecorator) HoverZoneContains(absX, absY int, borderX0, borderX1, borderY int) bool {
+	if d == nil || !d.HasActions() {
+		return false
+	}
+	if absY != borderY {
+		return false
+	}
+	expandedW := d.expandedWidth()
+	pillX := borderX1 - expandedW - 1
+	if pillX < borderX0+1 {
+		pillX = borderX0 + 1
+	}
+	return absX >= pillX && absX < pillX+expandedW
+}
+
 // expandedWidth returns the pill width as if it were expanded.
 // Used by HandleMouse to determine the hover zone regardless of current state.
 func (d *PaneDecorator) expandedWidth() int {

--- a/texel/pane_input.go
+++ b/texel/pane_input.go
@@ -66,9 +66,13 @@ func (p *pane) handlePaste(data []byte) {
 
 // handleMouse forwards a mouse event to the pane's app with local coordinates.
 func (p *pane) handleMouse(x, y int, buttons tcell.ButtonMask, modifiers tcell.ModMask) {
-	// Check decorator pill on the top border. Only interactive on the active pane.
-	// Always forward mouse position so the pill can collapse when leaving its zone.
-	if p.decorator != nil && p.decorator.HasActions() && p.IsActive {
+	// Check decorator pill on the top border. The pill is interactive on
+	// any pane — gating this on p.IsActive meant clicks on an inactive
+	// pane's pill fell through to the normal pane mouse path, which
+	// activated the pane (firing the pane.active flash effect) instead
+	// of running the pill action. The pane still activates via
+	// activatePaneAt in processMouseEvent, but now the action runs too.
+	if p.decorator != nil && p.decorator.HasActions() {
 		help, consumed := p.decorator.HandleMouse(x, y, buttons, p.absX0, p.absX1, p.absY0)
 		if consumed {
 			if help != "" && p.screen != nil && p.screen.desktop != nil {


### PR DESCRIPTION
## Summary

Two bugs combined to make the decorator pill unclickable on common layouts:

### Bug 1 — active-pane gate swallowed the action
\`pane_input.handleMouse\` only dispatched to \`decorator.HandleMouse\` when \`p.IsActive\` was true. Clicking a pill on a non-focused pane fell through to the normal pane mouse path, which activated the pane (firing the \`pane.active\` flash effect) but never ran the pill action. The pane still activates via \`activatePaneAt\` in \`processMouseEvent\`, so removing the gate lets the action AND the focus-change both run on a single click.

### Bug 2 — border-resize stole clicks on shared splits
\`desktop_input.processMouseEvent\` called \`handleMouseResize\` before \`pane.handleMouse\`. A pill drawn on a pane's top border that is **shared** with another pane (e.g. the bottom pane of a horizontal split) sits exactly on a resize handle, so the resize grab intercepted the click — visible as both adjacent panes' borders flashing white during mouse-down with no action fired.

Fix: skip border-resize handling when the cursor is inside any pane's decorator pill hover zone. Normal split borders still drag freely; only the small rectangle where the pill sits is reserved for the pill.

## Implementation

- \`PaneDecorator.HoverZoneContains\` (new, exported): encapsulates the expanded hover-rect geometry so the desktop mouse dispatcher can ask "is this coordinate a pill zone" without duplicating the pillX math from \`HandleMouse\`.
- \`DesktopEngine.pointInAnyPaneDecoratorZone\`: walks the active workspace tree (or the zoomed pane, if one is active) and checks each pane's decorator zone. Called from \`processMouseEvent\` before \`handleMouseResize\`.
- \`pane.handleMouse\`: drops the \`p.IsActive\` check on the decorator dispatch.

## Test plan

- [x] \`make test\` — full suite green
- [x] Manual: 3-pane workspace, bottom-right pane (top border shared with pane above):
  - Before: clicking pills flashed both adjacent pane borders white with no action
  - After: pill actions fire correctly, pane activates, no spurious flash
- [x] Dragging the shared border outside the pill zone still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)