### PR TITLE
feat(sparse): add Store — sparse globalIdx-keyed cell storage (step 1 of 7)

### DIFF
--- a/apps/texelterm/parser/sparse/doc.go
+++ b/apps/texelterm/parser/sparse/doc.go
@@ -1,0 +1,8 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Package sparse provides a globalIdx-keyed sparse cell store and the
+// three-cursor write/view model that replaces texelterm's dense MemoryBuffer.
+//
+// See docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md.
+package sparse

--- a/apps/texelterm/parser/sparse/doc.go
+++ b/apps/texelterm/parser/sparse/doc.go
@@ -1,8 +1,9 @@
 // Copyright © 2026 Texelation contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-// Package sparse provides a globalIdx-keyed sparse cell store and the
-// three-cursor write/view model that replaces texelterm's dense MemoryBuffer.
+// Package sparse provides a globalIdx-keyed sparse cell store for texelterm.
+// Subsequent types in this package add the write-window and view-window
+// cursors that replace the dense MemoryBuffer.
 //
 // See docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md.
 package sparse

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -1,0 +1,55 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"sync"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// storeLine is the wrapper around a row of cells in the sparse Store.
+// A missing map entry represents "no content at this globalIdx" — reads of
+// missing globalIdxs return blank cells.
+type storeLine struct {
+	cells []parser.Cell
+}
+
+// Store is a sparse, globalIdx-keyed cell storage.
+//
+// A cell at globalIdx X is just a cell at globalIdx X. There is no viewport
+// concept, no cursor, no scrollback/viewport distinction. Reads of unwritten
+// globalIdxs return blank cells. Writes at arbitrary globalIdxs are allowed.
+//
+// Store is safe for concurrent use.
+type Store struct {
+	mu         sync.RWMutex
+	width      int
+	lines      map[int64]*storeLine
+	contentEnd int64 // highest globalIdx ever written; -1 means empty
+}
+
+// NewStore creates an empty Store for a terminal of the given column width.
+func NewStore(width int) *Store {
+	return &Store{
+		width:      width,
+		lines:      make(map[int64]*storeLine),
+		contentEnd: -1,
+	}
+}
+
+// Width returns the column width the Store was created with.
+func (s *Store) Width() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.width
+}
+
+// Max returns the highest globalIdx ever written. Returns -1 if the Store
+// has never been written to.
+func (s *Store) Max() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.contentEnd
+}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -126,3 +126,17 @@ func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
 		s.contentEnd = globalIdx
 	}
 }
+
+// ClearRange removes every line in the closed interval [lo, hi]. Lines
+// outside the interval are untouched. contentEnd is not decreased — a
+// cleared range still counts as "ever been written" for the high-water mark.
+func (s *Store) ClearRange(lo, hi int64) {
+	if lo > hi {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := lo; k <= hi; k++ {
+		delete(s.lines, k)
+	}
+}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -40,9 +40,8 @@ func NewStore(width int) *Store {
 }
 
 // Width returns the column width the Store was created with.
+// width is set in NewStore and never mutated, so no lock is needed.
 func (s *Store) Width() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	return s.width
 }
 
@@ -84,9 +83,14 @@ func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
 		s.lines[globalIdx] = line
 	}
 	if col >= len(line.cells) {
-		newCells := make([]parser.Cell, col+1)
-		copy(newCells, line.cells)
-		line.cells = newCells
+		needed := col + 1
+		newCap := cap(line.cells) * 2
+		if newCap < needed {
+			newCap = needed
+		}
+		grown := make([]parser.Cell, needed, newCap)
+		copy(grown, line.cells)
+		line.cells = grown
 	}
 	line.cells[col] = cell
 	if globalIdx > s.contentEnd {
@@ -136,6 +140,9 @@ func (s *Store) ClearRange(lo, hi int64) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Iterate the interval directly. This is O(hi-lo+1) rather than O(len(lines)),
+	// which is efficient when the range is dense. If callers need to evict large
+	// sparse ranges, prefer iterating s.lines keys instead.
 	for k := lo; k <= hi; k++ {
 		delete(s.lines, k)
 	}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -93,3 +93,36 @@ func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
 		s.contentEnd = globalIdx
 	}
 }
+
+// GetLine returns a copy of the cells at globalIdx. Returns nil if the
+// globalIdx has never been written to. The returned slice is safe to mutate
+// — it does not alias Store internal state.
+func (s *Store) GetLine(globalIdx int64) []parser.Cell {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return nil
+	}
+	out := make([]parser.Cell, len(line.cells))
+	copy(out, line.cells)
+	return out
+}
+
+// SetLine replaces the cells at globalIdx with a copy of cells. Any existing
+// content at that globalIdx is overwritten in full. To preserve alignment
+// with column 0, callers must pass cells starting at column 0.
+func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.cells = make([]parser.Cell, len(cells))
+	copy(line.cells, cells)
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -53,3 +53,43 @@ func (s *Store) Max() int64 {
 	defer s.mu.RUnlock()
 	return s.contentEnd
 }
+
+// Get returns the Cell at (globalIdx, col). Returns a zero-value Cell if the
+// globalIdx has never been written to or if col is outside the line's current
+// length.
+func (s *Store) Get(globalIdx int64, col int) parser.Cell {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return parser.Cell{}
+	}
+	if col < 0 || col >= len(line.cells) {
+		return parser.Cell{}
+	}
+	return line.cells[col]
+}
+
+// Set writes a single Cell at (globalIdx, col). The target line is
+// automatically extended to cover col if it did not already.
+func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
+	if col < 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	if col >= len(line.cells) {
+		newCells := make([]parser.Cell, col+1)
+		copy(newCells, line.cells)
+		line.cells = newCells
+	}
+	line.cells[col] = cell
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -146,3 +146,31 @@ func TestStore_ClearRangeKeepsContentEnd(t *testing.T) {
 		t.Errorf("Max() after ClearRange = %d, want 20 (contentEnd never decreases)", got)
 	}
 }
+
+func TestStore_ConcurrentReadersWriter(t *testing.T) {
+	s := NewStore(80)
+	const N = 200
+	done := make(chan struct{})
+
+	// One writer filling in lines.
+	go func() {
+		for i := int64(0); i < N; i++ {
+			s.SetLine(i, []parser.Cell{{Rune: 'x'}})
+		}
+		close(done)
+	}()
+
+	// Many readers hammering.
+	for r := 0; r < 8; r++ {
+		go func() {
+			for i := int64(0); i < N; i++ {
+				_ = s.Get(i, 0)
+				_ = s.GetLine(i)
+				_ = s.Max()
+				_ = s.Width()
+			}
+		}()
+	}
+
+	<-done
+}

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -19,3 +19,53 @@ func TestStore_NewStore(t *testing.T) {
 	}
 	_ = parser.Cell{} // Keep the import; used in later tests
 }
+
+func TestStore_SetGetSingleCell(t *testing.T) {
+	s := NewStore(10)
+	cell := parser.Cell{Rune: 'A'}
+	s.Set(5, 3, cell)
+
+	got := s.Get(5, 3)
+	if got.Rune != 'A' {
+		t.Errorf("Get(5,3).Rune = %q, want %q", got.Rune, 'A')
+	}
+	if got := s.Max(); got != 5 {
+		t.Errorf("Max() after Set(5,*) = %d, want 5", got)
+	}
+}
+
+func TestStore_GetMissingReturnsBlank(t *testing.T) {
+	s := NewStore(10)
+	got := s.Get(0, 0)
+	if got.Rune != 0 {
+		t.Errorf("Get on empty Store returned rune %q, want 0", got.Rune)
+	}
+	got = s.Get(999, 7)
+	if got.Rune != 0 {
+		t.Errorf("Get(999,7) on empty Store returned rune %q, want 0", got.Rune)
+	}
+}
+
+func TestStore_SetExtendsBeyondExistingLine(t *testing.T) {
+	s := NewStore(80)
+	s.Set(0, 0, parser.Cell{Rune: 'X'})
+	s.Set(0, 40, parser.Cell{Rune: 'Y'})
+	if got := s.Get(0, 0).Rune; got != 'X' {
+		t.Errorf("Get(0,0) = %q, want X", got)
+	}
+	if got := s.Get(0, 40).Rune; got != 'Y' {
+		t.Errorf("Get(0,40) = %q, want Y", got)
+	}
+	if got := s.Get(0, 20).Rune; got != 0 {
+		t.Errorf("Get(0,20) = %q, want blank", got)
+	}
+}
+
+func TestStore_MaxNeverDecreases(t *testing.T) {
+	s := NewStore(10)
+	s.Set(10, 0, parser.Cell{Rune: 'A'})
+	s.Set(5, 0, parser.Cell{Rune: 'B'})
+	if got := s.Max(); got != 10 {
+		t.Errorf("Max() after writing higher then lower = %d, want 10", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -1,6 +1,7 @@
 package sparse
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
@@ -150,19 +151,22 @@ func TestStore_ClearRangeKeepsContentEnd(t *testing.T) {
 func TestStore_ConcurrentReadersWriter(t *testing.T) {
 	s := NewStore(80)
 	const N = 200
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 
 	// One writer filling in lines.
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for i := int64(0); i < N; i++ {
 			s.SetLine(i, []parser.Cell{{Rune: 'x'}})
 		}
-		close(done)
 	}()
 
 	// Many readers hammering.
 	for r := 0; r < 8; r++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			for i := int64(0); i < N; i++ {
 				_ = s.Get(i, 0)
 				_ = s.GetLine(i)
@@ -172,5 +176,5 @@ func TestStore_ConcurrentReadersWriter(t *testing.T) {
 		}()
 	}
 
-	<-done
+	wg.Wait()
 }

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -1,0 +1,21 @@
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestStore_NewStore(t *testing.T) {
+	s := NewStore(80)
+	if s == nil {
+		t.Fatal("NewStore returned nil")
+	}
+	if got := s.Width(); got != 80 {
+		t.Errorf("Width() = %d, want 80", got)
+	}
+	if got := s.Max(); got != -1 {
+		t.Errorf("Max() of empty store = %d, want -1", got)
+	}
+	_ = parser.Cell{} // Keep the import; used in later tests
+}

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -69,3 +69,52 @@ func TestStore_MaxNeverDecreases(t *testing.T) {
 		t.Errorf("Max() after writing higher then lower = %d, want 10", got)
 	}
 }
+
+func TestStore_SetLineGetLine(t *testing.T) {
+	s := NewStore(10)
+	line := []parser.Cell{
+		{Rune: 'h'}, {Rune: 'i'}, {Rune: '!'},
+	}
+	s.SetLine(3, line)
+
+	got := s.GetLine(3)
+	if len(got) != 3 {
+		t.Fatalf("GetLine(3) len = %d, want 3", len(got))
+	}
+	if got[0].Rune != 'h' || got[1].Rune != 'i' || got[2].Rune != '!' {
+		t.Errorf("GetLine(3) runes = %q,%q,%q; want h,i,!",
+			got[0].Rune, got[1].Rune, got[2].Rune)
+	}
+}
+
+func TestStore_SetLineOverwritesExistingCells(t *testing.T) {
+	s := NewStore(10)
+	s.Set(0, 5, parser.Cell{Rune: 'X'}) // existing cell at col 5
+	s.SetLine(0, []parser.Cell{{Rune: 'A'}, {Rune: 'B'}})
+
+	line := s.GetLine(0)
+	if len(line) != 2 {
+		t.Fatalf("GetLine(0) len = %d, want 2 (SetLine replaces, not merges)", len(line))
+	}
+}
+
+func TestStore_GetLineDoesNotAffectAdjacent(t *testing.T) {
+	s := NewStore(10)
+	s.SetLine(5, []parser.Cell{{Rune: 'X'}})
+	if got := s.GetLine(4); got != nil && len(got) != 0 {
+		t.Errorf("GetLine(4) = %v, want empty/nil", got)
+	}
+	if got := s.GetLine(6); got != nil && len(got) != 0 {
+		t.Errorf("GetLine(6) = %v, want empty/nil", got)
+	}
+}
+
+func TestStore_GetLineReturnsCopy(t *testing.T) {
+	s := NewStore(10)
+	s.SetLine(0, []parser.Cell{{Rune: 'A'}})
+	line := s.GetLine(0)
+	line[0].Rune = 'Z' // mutate returned slice
+	if got := s.Get(0, 0).Rune; got != 'A' {
+		t.Errorf("Store was mutated by caller: Get(0,0) = %q, want A", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -118,3 +118,31 @@ func TestStore_GetLineReturnsCopy(t *testing.T) {
 		t.Errorf("Store was mutated by caller: Get(0,0) = %q, want A", got)
 	}
 }
+
+func TestStore_ClearRangeRemovesOnlyTargets(t *testing.T) {
+	s := NewStore(10)
+	s.SetLine(0, []parser.Cell{{Rune: 'A'}})
+	s.SetLine(5, []parser.Cell{{Rune: 'B'}})
+	s.SetLine(10, []parser.Cell{{Rune: 'C'}})
+
+	s.ClearRange(3, 7) // inclusive range
+
+	if got := s.GetLine(0); got == nil || got[0].Rune != 'A' {
+		t.Errorf("line 0 should be preserved, got %v", got)
+	}
+	if got := s.GetLine(5); got != nil && len(got) > 0 && got[0].Rune != 0 {
+		t.Errorf("line 5 should be cleared, got %v", got)
+	}
+	if got := s.GetLine(10); got == nil || got[0].Rune != 'C' {
+		t.Errorf("line 10 should be preserved, got %v", got)
+	}
+}
+
+func TestStore_ClearRangeKeepsContentEnd(t *testing.T) {
+	s := NewStore(10)
+	s.SetLine(20, []parser.Cell{{Rune: 'X'}})
+	s.ClearRange(20, 20)
+	if got := s.Max(); got != 20 {
+		t.Errorf("Max() after ClearRange = %d, want 20 (contentEnd never decreases)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `apps/texelterm/parser/sparse/` — a new package that is Step 1 of 7 in the [sparse viewport + write-window split redesign](../blob/main/docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md).
- `sparse.Store`: a `map[int64]*storeLine`-backed cell store, protected by `sync.RWMutex`, with `Get`/`Set`/`GetLine`/`SetLine`/`ClearRange`. No viewport, cursor, or resize concept — pure storage CRUD.
- `contentEnd` is a monotonically non-decreasing high-water mark; `ClearRange` does not decrease it.
- `GetLine` returns a defensive copy; `Set` uses amortised-doubling slice growth.
- 12 tests, all passing with `-race`.

This is a pure addition — no existing code is touched.

## Test plan

- [ ] `go test -race ./apps/texelterm/parser/sparse/...` passes
- [ ] `gofmt -d ./apps/texelterm/parser/sparse/` produces no output

## Context

Implementation plan: `docs/superpowers/plans/2026-04-11-sparse-viewport-write-window-split.md`
Steps 2–5 (`WriteWindow`, `ViewWindow`, `Terminal`, persistence) will be opened as follow-on PRs once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)