### PR TITLE
feat(sparse): add WriteWindow with Rule 5 resize (step 2 of 7)

### DIFF
--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -1,0 +1,238 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"sync"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// WriteWindow is the TUI-facing portion of a sparse terminal. It owns the
+// cursor and the writeTop anchor, and it forwards writes to an underlying
+// Store.
+//
+// Applications issue cursor-relative writes: ESC[row;colH resolves to
+// (writeTop + row - 1, col - 1). The addressable area is the closed range
+// [writeTop, writeBottom], where writeBottom is derived as writeTop + height - 1.
+//
+// WriteWindow is safe for concurrent use. Callers that need to observe
+// window-move events should consult WriteTop/WriteBottom after each call.
+type WriteWindow struct {
+	mu     sync.Mutex
+	store  *Store
+	width  int
+	height int
+
+	writeTop        int64
+	cursorGlobalIdx int64
+	cursorCol       int
+}
+
+// NewWriteWindow creates a WriteWindow anchored at globalIdx 0 with the given
+// dimensions. The cursor starts at (writeTop, 0).
+func NewWriteWindow(store *Store, width, height int) *WriteWindow {
+	return &WriteWindow{
+		store:  store,
+		width:  width,
+		height: height,
+	}
+}
+
+// Width returns the current column width.
+func (w *WriteWindow) Width() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.width
+}
+
+// Height returns the current row height.
+func (w *WriteWindow) Height() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.height
+}
+
+// WriteTop returns the globalIdx of the top row of the write window.
+func (w *WriteWindow) WriteTop() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writeTop
+}
+
+// WriteBottom returns the globalIdx of the bottom row of the write window.
+func (w *WriteWindow) WriteBottom() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writeTop + int64(w.height) - 1
+}
+
+// Cursor returns the current cursor position as (globalIdx, col).
+func (w *WriteWindow) Cursor() (globalIdx int64, col int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.cursorGlobalIdx, w.cursorCol
+}
+
+// WriteCell writes one cell at the current cursor position and advances the
+// cursor column by one. This method does NOT handle line wrap — the caller
+// (typically the Parser layer) is responsible for wrap semantics.
+func (w *WriteWindow) WriteCell(cell parser.Cell) {
+	w.mu.Lock()
+	gi := w.cursorGlobalIdx
+	col := w.cursorCol
+	w.cursorCol++
+	w.mu.Unlock()
+
+	w.store.Set(gi, col, cell)
+}
+
+// CarriageReturn resets the cursor column to 0. The cursor globalIdx is
+// unchanged.
+func (w *WriteWindow) CarriageReturn() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.cursorCol = 0
+}
+
+// SetCursor places the cursor at row, col relative to the write window.
+// Rows are clamped to [0, height-1]; cols to [0, width-1].
+func (w *WriteWindow) SetCursor(row, col int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if row < 0 {
+		row = 0
+	}
+	if row >= w.height {
+		row = w.height - 1
+	}
+	if col < 0 {
+		col = 0
+	}
+	if col >= w.width {
+		col = w.width - 1
+	}
+	w.cursorGlobalIdx = w.writeTop + int64(row)
+	w.cursorCol = col
+}
+
+// CursorRow returns the cursor's row relative to the write window top.
+func (w *WriteWindow) CursorRow() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return int(w.cursorGlobalIdx - w.writeTop)
+}
+
+// Newline advances the cursor to the next row. If the cursor is already at
+// the bottom row of the write window, writeTop is advanced by 1 (classical
+// scroll-up). Cells at the old writeTop remain in the Store — they are now
+// "historical" simply because the window moved, not because they were copied.
+// The cursor column is reset to 0 (combined CR+LF semantics of LF in most
+// terminal modes; pure LF variants are handled by the parser, not here).
+func (w *WriteWindow) Newline() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	writeBottom := w.writeTop + int64(w.height) - 1
+	if w.cursorGlobalIdx >= writeBottom {
+		// At or below bottom — scroll up.
+		w.writeTop++
+		w.cursorGlobalIdx = w.writeTop + int64(w.height) - 1
+	} else {
+		w.cursorGlobalIdx++
+	}
+	w.cursorCol = 0
+}
+
+// Resize applies Rule 5 from the design spec.
+//
+// Grow: writeTop retreats by the grow delta, clamped at 0. No cells are
+// cleared. The new top rows of the window expose whatever is already stored
+// there (old scrollback, or blank if none).
+//
+// Shrink: cursor-minimum-advance — writeTop advances by the minimum amount
+// needed to keep the cursor inside the new write window. Cells below the
+// new writeBottom are cleared. Cells in [oldWriteTop, newWriteTop) stay in
+// the Store and become "above the window" (scrollback).
+//
+// Pure width changes (newHeight == height) apply only to width without
+// touching writeTop.
+func (w *WriteWindow) Resize(newWidth, newHeight int) {
+	if newWidth <= 0 || newHeight <= 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if newHeight > w.height {
+		w.resizeGrowLocked(newWidth, newHeight)
+	} else if newHeight < w.height {
+		w.resizeShrinkLocked(newWidth, newHeight)
+	}
+	w.width = newWidth
+	w.height = newHeight
+
+	// Keep cursor in bounds.
+	if w.cursorGlobalIdx < w.writeTop {
+		w.cursorGlobalIdx = w.writeTop
+	}
+	if bottom := w.writeTop + int64(w.height) - 1; w.cursorGlobalIdx > bottom {
+		w.cursorGlobalIdx = bottom
+	}
+	if w.cursorCol >= w.width {
+		w.cursorCol = w.width - 1
+	}
+}
+
+// resizeGrowLocked assumes w.mu is held.
+func (w *WriteWindow) resizeGrowLocked(newWidth, newHeight int) {
+	delta := int64(newHeight - w.height)
+	newTop := w.writeTop - delta
+	if newTop < 0 {
+		newTop = 0
+	}
+	w.writeTop = newTop
+}
+
+// resizeShrinkLocked implements Rule 5 shrink: cursor-minimum-advance.
+// Preconditions: w.mu held, newHeight < w.height.
+func (w *WriteWindow) resizeShrinkLocked(newWidth, newHeight int) {
+	oldWriteBottom := w.writeTop + int64(w.height) - 1
+	// Tentative newWriteBottom if writeTop didn't move.
+	tentativeBottom := w.writeTop + int64(newHeight) - 1
+
+	advance := int64(0)
+	if w.cursorGlobalIdx > tentativeBottom {
+		advance = w.cursorGlobalIdx - tentativeBottom
+	}
+	w.writeTop += advance
+	newWriteBottom := w.writeTop + int64(newHeight) - 1
+
+	// Cells [newWriteBottom+1, oldWriteBottom] are scratch space below the
+	// new window. Clear them.
+	if oldWriteBottom > newWriteBottom {
+		w.store.ClearRange(newWriteBottom+1, oldWriteBottom)
+	}
+
+	// Cells in [oldWriteTop, writeTop) (only when advance > 0) stay in the
+	// store. They are now "above the window" — scrollback. No action needed.
+	_ = newWidth
+}
+
+// EraseDisplay clears every cell in the current write window [writeTop,
+// writeBottom]. Cells outside the window are not touched.
+func (w *WriteWindow) EraseDisplay() {
+	w.mu.Lock()
+	top := w.writeTop
+	bottom := w.writeTop + int64(w.height) - 1
+	w.mu.Unlock()
+	w.store.ClearRange(top, bottom)
+}
+
+// EraseLine clears the line at the cursor's current globalIdx.
+func (w *WriteWindow) EraseLine() {
+	w.mu.Lock()
+	gi := w.cursorGlobalIdx
+	w.mu.Unlock()
+	w.store.ClearRange(gi, gi)
+}

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -165,9 +165,9 @@ func (w *WriteWindow) Resize(newWidth, newHeight int) {
 	defer w.mu.Unlock()
 
 	if newHeight > w.height {
-		w.resizeGrowLocked(newWidth, newHeight)
+		w.resizeGrowLocked(newHeight)
 	} else if newHeight < w.height {
-		w.resizeShrinkLocked(newWidth, newHeight)
+		w.resizeShrinkLocked(newHeight)
 	}
 	w.width = newWidth
 	w.height = newHeight
@@ -185,7 +185,7 @@ func (w *WriteWindow) Resize(newWidth, newHeight int) {
 }
 
 // resizeGrowLocked assumes w.mu is held.
-func (w *WriteWindow) resizeGrowLocked(newWidth, newHeight int) {
+func (w *WriteWindow) resizeGrowLocked(newHeight int) {
 	delta := int64(newHeight - w.height)
 	newTop := w.writeTop - delta
 	if newTop < 0 {
@@ -196,7 +196,7 @@ func (w *WriteWindow) resizeGrowLocked(newWidth, newHeight int) {
 
 // resizeShrinkLocked implements Rule 5 shrink: cursor-minimum-advance.
 // Preconditions: w.mu held, newHeight < w.height.
-func (w *WriteWindow) resizeShrinkLocked(newWidth, newHeight int) {
+func (w *WriteWindow) resizeShrinkLocked(newHeight int) {
 	oldWriteBottom := w.writeTop + int64(w.height) - 1
 	// Tentative newWriteBottom if writeTop didn't move.
 	tentativeBottom := w.writeTop + int64(newHeight) - 1
@@ -211,12 +211,16 @@ func (w *WriteWindow) resizeShrinkLocked(newWidth, newHeight int) {
 	// Cells [newWriteBottom+1, oldWriteBottom] are scratch space below the
 	// new window. Clear them.
 	if oldWriteBottom > newWriteBottom {
+		// ClearRange is called while w.mu is held (unlike WriteCell/EraseDisplay which
+		// release first). This is intentional: newWriteBottom is derived from the
+		// already-updated w.writeTop, so the mutation and the clear must be atomic
+		// with respect to w.mu. The call order (WriteWindow.mu → Store.mu) is safe
+		// per the design's acyclic lock acquisition rule.
 		w.store.ClearRange(newWriteBottom+1, oldWriteBottom)
 	}
 
 	// Cells in [oldWriteTop, writeTop) (only when advance > 0) stay in the
 	// store. They are now "above the window" — scrollback. No action needed.
-	_ = newWidth
 }
 
 // EraseDisplay clears every cell in the current write window [writeTop,

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -123,7 +123,7 @@ func TestWriteWindow_NewlinePreservesContent(t *testing.T) {
 	// window moves — that's the whole "scrollback is a windowing concept" principle.
 	store := NewStore(10)
 	ww := NewWriteWindow(store, 10, 3)
-	ww.WriteCell(parser.Cell{Rune: 'H'})  // row 0
+	ww.WriteCell(parser.Cell{Rune: 'H'}) // row 0
 	ww.SetCursor(2, 0)
 	ww.Newline() // scrolls
 

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -1,0 +1,26 @@
+package sparse
+
+import (
+	"testing"
+)
+
+func TestWriteWindow_NewInitialState(t *testing.T) {
+	store := NewStore(80)
+	ww := NewWriteWindow(store, 80, 24)
+	if got := ww.Width(); got != 80 {
+		t.Errorf("Width() = %d, want 80", got)
+	}
+	if got := ww.Height(); got != 24 {
+		t.Errorf("Height() = %d, want 24", got)
+	}
+	if got := ww.WriteTop(); got != 0 {
+		t.Errorf("WriteTop() = %d, want 0 (fresh WriteWindow)", got)
+	}
+	if got := ww.WriteBottom(); got != 23 {
+		t.Errorf("WriteBottom() = %d, want 23", got)
+	}
+	gi, col := ww.Cursor()
+	if gi != 0 || col != 0 {
+		t.Errorf("Cursor() = (%d,%d), want (0,0)", gi, col)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -249,3 +249,35 @@ func TestWriteWindow_ResizeShrinkPartialAdvance(t *testing.T) {
 		t.Errorf("CursorRow after partial advance = %d, want 19", got)
 	}
 }
+
+func TestWriteWindow_EraseDisplayClearsWindow(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	// Fill store [0..9] with content, window covers [0..4].
+	for i := int64(0); i < 10; i++ {
+		store.SetLine(i, []parser.Cell{{Rune: 'X'}})
+	}
+	ww.EraseDisplay()
+	// [0..4] cleared; [5..9] preserved.
+	for i := int64(0); i <= 4; i++ {
+		if got := store.GetLine(i); got != nil && len(got) > 0 && got[0].Rune != 0 {
+			t.Errorf("row %d should be cleared, got %v", i, got)
+		}
+	}
+	for i := int64(5); i <= 9; i++ {
+		if got := store.Get(i, 0).Rune; got != 'X' {
+			t.Errorf("row %d should be preserved, got %q", i, got)
+		}
+	}
+}
+
+func TestWriteWindow_EraseLineClearsCurrentRow(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	store.SetLine(2, []parser.Cell{{Rune: 'A'}, {Rune: 'B'}, {Rune: 'C'}})
+	ww.SetCursor(2, 0)
+	ww.EraseLine()
+	if got := store.GetLine(2); got != nil && len(got) > 0 && got[0].Rune != 0 {
+		t.Errorf("row 2 should be cleared, got %v", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -2,6 +2,8 @@ package sparse
 
 import (
 	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
 )
 
 func TestWriteWindow_NewInitialState(t *testing.T) {
@@ -22,5 +24,23 @@ func TestWriteWindow_NewInitialState(t *testing.T) {
 	gi, col := ww.Cursor()
 	if gi != 0 || col != 0 {
 		t.Errorf("Cursor() = (%d,%d), want (0,0)", gi, col)
+	}
+}
+
+func TestWriteWindow_WriteCellAdvancesCol(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.WriteCell(parser.Cell{Rune: 'h'})
+	ww.WriteCell(parser.Cell{Rune: 'i'})
+
+	gi, col := ww.Cursor()
+	if gi != 0 || col != 2 {
+		t.Errorf("Cursor() after 2 writes = (%d,%d), want (0,2)", gi, col)
+	}
+	if got := store.Get(0, 0).Rune; got != 'h' {
+		t.Errorf("store[0][0] = %q, want h", got)
+	}
+	if got := store.Get(0, 1).Rune; got != 'i' {
+		t.Errorf("store[0][1] = %q, want i", got)
 	}
 }

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -83,3 +83,51 @@ func TestWriteWindow_SetCursorClampsToWindow(t *testing.T) {
 		t.Errorf("col clamp: col = %d, want 9", col)
 	}
 }
+
+func TestWriteWindow_NewlineAdvancesCursor(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.WriteCell(parser.Cell{Rune: 'a'})
+	ww.Newline()
+
+	gi, col := ww.Cursor()
+	if gi != 1 || col != 0 {
+		t.Errorf("after Newline from row 0, Cursor() = (%d,%d), want (1,0)", gi, col)
+	}
+	if got := ww.WriteTop(); got != 0 {
+		t.Errorf("WriteTop() should not move; got %d", got)
+	}
+}
+
+func TestWriteWindow_NewlineAtBottomAdvancesWriteTop(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 3)
+	// Park cursor at last row.
+	ww.SetCursor(2, 0)
+	ww.Newline()
+
+	if got := ww.WriteTop(); got != 1 {
+		t.Errorf("WriteTop() after LF at bottom = %d, want 1 (scrolled up)", got)
+	}
+	if got := ww.WriteBottom(); got != 3 {
+		t.Errorf("WriteBottom() = %d, want 3", got)
+	}
+	gi, col := ww.Cursor()
+	if gi != 3 || col != 0 {
+		t.Errorf("Cursor() = (%d,%d), want (3,0)", gi, col)
+	}
+}
+
+func TestWriteWindow_NewlinePreservesContent(t *testing.T) {
+	// Content at oldWriteTop (row 0) must stay in the store even after the
+	// window moves — that's the whole "scrollback is a windowing concept" principle.
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 3)
+	ww.WriteCell(parser.Cell{Rune: 'H'})  // row 0
+	ww.SetCursor(2, 0)
+	ww.Newline() // scrolls
+
+	if got := store.Get(0, 0).Rune; got != 'H' {
+		t.Errorf("after scroll-up, store[0][0] = %q, want H (content survives)", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -44,3 +44,42 @@ func TestWriteWindow_WriteCellAdvancesCol(t *testing.T) {
 		t.Errorf("store[0][1] = %q, want i", got)
 	}
 }
+
+func TestWriteWindow_CarriageReturn(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.WriteCell(parser.Cell{Rune: 'h'})
+	ww.WriteCell(parser.Cell{Rune: 'i'})
+	ww.CarriageReturn()
+	gi, col := ww.Cursor()
+	if gi != 0 || col != 0 {
+		t.Errorf("after CR, Cursor() = (%d,%d), want (0,0)", gi, col)
+	}
+}
+
+func TestWriteWindow_SetCursorRelative(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 10)
+	ww.SetCursor(3, 7) // row 3, col 7
+	gi, col := ww.Cursor()
+	if gi != 3 || col != 7 {
+		t.Errorf("SetCursor(3,7): Cursor() = (%d,%d), want (3,7)", gi, col)
+	}
+	if got := ww.CursorRow(); got != 3 {
+		t.Errorf("CursorRow() = %d, want 3", got)
+	}
+}
+
+func TestWriteWindow_SetCursorClampsToWindow(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.SetCursor(100, 100) // way out of range
+	gi, col := ww.Cursor()
+	// Clamp row to [0, height-1] and col to [0, width-1].
+	if gi != 4 {
+		t.Errorf("row clamp: gi = %d, want 4", gi)
+	}
+	if col != 9 {
+		t.Errorf("col clamp: col = %d, want 9", col)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -131,3 +131,41 @@ func TestWriteWindow_NewlinePreservesContent(t *testing.T) {
 		t.Errorf("after scroll-up, store[0][0] = %q, want H (content survives)", got)
 	}
 }
+
+func TestWriteWindow_ResizeGrowRetreatsWriteTop(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	// Scroll down 10 times so writeTop is at 10.
+	for i := 0; i < 10; i++ {
+		ww.SetCursor(4, 0)
+		ww.Newline()
+	}
+	if got := ww.WriteTop(); got != 10 {
+		t.Fatalf("setup: WriteTop = %d, want 10", got)
+	}
+
+	// Grow from 5 to 8. writeTop should retreat by 3 to keep writeBottom pinned.
+	ww.Resize(10, 8)
+	if got := ww.WriteTop(); got != 7 {
+		t.Errorf("after grow 5->8, WriteTop = %d, want 7", got)
+	}
+	if got := ww.WriteBottom(); got != 14 {
+		t.Errorf("after grow, WriteBottom = %d, want 14 (unchanged)", got)
+	}
+	if got := ww.Height(); got != 8 {
+		t.Errorf("Height = %d, want 8", got)
+	}
+}
+
+func TestWriteWindow_ResizeGrowClampsAtZero(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	// writeTop = 0. Grow to 10 — shallow scrollback case.
+	ww.Resize(10, 10)
+	if got := ww.WriteTop(); got != 0 {
+		t.Errorf("after grow from 0, WriteTop = %d, want 0 (clamped)", got)
+	}
+	if got := ww.WriteBottom(); got != 9 {
+		t.Errorf("WriteBottom = %d, want 9 (extended past oldWriteBottom=4)", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -169,3 +169,83 @@ func TestWriteWindow_ResizeGrowClampsAtZero(t *testing.T) {
 		t.Errorf("WriteBottom = %d, want 9 (extended past oldWriteBottom=4)", got)
 	}
 }
+
+func TestWriteWindow_ResizeShrinkShellCase(t *testing.T) {
+	// Shell case: cursor at bottom row. Shrink should advance writeTop by
+	// exactly the shrink delta, keeping the cursor pinned at the new bottom.
+	store := NewStore(80)
+	ww := NewWriteWindow(store, 80, 40)
+	// Fill some content and park cursor at row 39 (bottom).
+	for i := 0; i < 40; i++ {
+		store.SetLine(int64(i), []parser.Cell{{Rune: 'L'}}) // row marker
+	}
+	ww.SetCursor(39, 5)
+
+	ww.Resize(80, 20)
+
+	if got := ww.WriteTop(); got != 20 {
+		t.Errorf("shell shrink 40->20: WriteTop = %d, want 20", got)
+	}
+	gi, col := ww.Cursor()
+	if gi != 39 || col != 5 {
+		t.Errorf("cursor moved: (%d,%d), want (39,5)", gi, col)
+	}
+	// Old top rows [0, 20) must still be in the store.
+	if got := store.Get(0, 0).Rune; got != 'L' {
+		t.Errorf("row 0 should survive in store: %q", got)
+	}
+	if got := store.Get(19, 0).Rune; got != 'L' {
+		t.Errorf("row 19 should survive in store: %q", got)
+	}
+}
+
+func TestWriteWindow_ResizeShrinkCursorNearTop(t *testing.T) {
+	// Full-screen TUI case: cursor at row 2. Shrink from 40 to 20 — cursor
+	// still fits. writeTop unchanged; bottom rows cleared.
+	store := NewStore(80)
+	ww := NewWriteWindow(store, 80, 40)
+	for i := 0; i < 40; i++ {
+		store.SetLine(int64(i), []parser.Cell{{Rune: 'L'}})
+	}
+	ww.SetCursor(2, 0)
+
+	ww.Resize(80, 20)
+
+	if got := ww.WriteTop(); got != 0 {
+		t.Errorf("top-cursor shrink: WriteTop = %d, want 0 (no advance)", got)
+	}
+	// Cells [20, 39] should be cleared from the store.
+	if got := store.GetLine(20); got != nil && len(got) > 0 && got[0].Rune != 0 {
+		t.Errorf("row 20 should be cleared, got %v", got)
+	}
+	if got := store.GetLine(39); got != nil && len(got) > 0 && got[0].Rune != 0 {
+		t.Errorf("row 39 should be cleared, got %v", got)
+	}
+	// Row 0 still there.
+	if got := store.Get(0, 0).Rune; got != 'L' {
+		t.Errorf("row 0 unchanged: %q", got)
+	}
+}
+
+func TestWriteWindow_ResizeShrinkPartialAdvance(t *testing.T) {
+	// Claude case: cursor at row 30 of h=40. Shrink to h=20 — cursor would
+	// otherwise be at row 30 of a 20-row window, outside. Advance should
+	// be exactly 11 (cursor.globalIdx=30 must fit in [newTop, newTop+19]).
+	store := NewStore(80)
+	ww := NewWriteWindow(store, 80, 40)
+	ww.SetCursor(30, 0)
+
+	ww.Resize(80, 20)
+
+	if got := ww.WriteTop(); got != 11 {
+		t.Errorf("partial-advance shrink: WriteTop = %d, want 11", got)
+	}
+	gi, _ := ww.Cursor()
+	if gi != 30 {
+		t.Errorf("cursor globalIdx moved: %d, want 30 (cursor is pinned)", gi)
+	}
+	// Cursor row within new window = 30 - 11 = 19 (bottom of new window).
+	if got := ww.CursorRow(); got != 19 {
+		t.Errorf("CursorRow after partial advance = %d, want 19", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `apps/texelterm/parser/sparse/write_window.go` — the write-side cursor model for texelterm's sparse terminal redesign. This is Step 2 of 7.

`WriteWindow` owns `writeTop`, `height`, `width`, and the cursor (`cursorGlobalIdx`, `cursorCol`). It forwards all cell writes to the underlying `Store` from Step 1.

### Key algorithm: Rule 5 resize

**Shrink** — cursor-minimum-advance:
`writeTop += max(0, cursor.globalIdx - (writeTop + newHeight - 1))`
Cells below the new `writeBottom` are cleared from the Store. Cells pushed above the window stay in the Store (they become scrollback). The cursor globalIdx is pinned — it never moves.

**Grow** — `writeBottom`-anchor:
`writeTop` retreats by the grow delta, clamped at 0. No cells are cleared.

Three shrink test cases cover the critical scenarios:
- **Shell case** — cursor at bottom row: `writeTop` advances by the full shrink delta
- **Cursor-near-top** — full-screen TUI with cursor at row 2: `writeTop` stays put, bottom rows cleared
- **Partial-advance (Claude case)** — cursor at row 30 of h=40, shrink to h=20: `writeTop` advances by exactly 11

This is the unit-level proof that the design eliminates the scrollback-pollution bug.

## Test plan

- [x] `go test -race ./apps/texelterm/parser/sparse/...` — 27 tests pass

## Context

Design spec: `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-11-sparse-viewport-write-window-split.md`
Depends on: #173 (Step 1 — `sparse.Store`, already merged)

Next: Step 3 will add `sparse.ViewWindow` (the user-scroll/autoFollow side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)