### PR TITLE
feat(sparse): add ViewWindow with autoFollow and Rule 6/7 (step 3 of 7)

### DIFF
--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -98,3 +98,33 @@ func (v *ViewWindow) ScrollUp(n int) {
 		v.viewBottom = minBottom
 	}
 }
+
+// ScrollDown moves viewBottom down by n lines toward the live edge. writeBottom
+// is the current WriteWindow bottom; ScrollDown will not move past it. If
+// viewBottom reaches writeBottom, autoFollow is automatically re-engaged.
+func (v *ViewWindow) ScrollDown(n int, writeBottom int64) {
+	if n <= 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.viewBottom += int64(n)
+	if v.viewBottom >= writeBottom {
+		v.viewBottom = writeBottom
+		v.autoFollow = true
+	}
+}
+
+// ScrollToBottom snaps viewBottom to writeBottom and re-engages autoFollow.
+func (v *ViewWindow) ScrollToBottom(writeBottom int64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.viewBottom = writeBottom
+	v.autoFollow = true
+}
+
+// OnInput is called when the user types or clicks in the pane. Re-engages
+// autoFollow at the current writeBottom.
+func (v *ViewWindow) OnInput(writeBottom int64) {
+	v.ScrollToBottom(writeBottom)
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -59,3 +59,42 @@ func (v *ViewWindow) VisibleRange() (top, bottom int64) {
 	defer v.mu.Unlock()
 	return v.viewBottom - int64(v.height) + 1, v.viewBottom
 }
+
+// OnWriteBottomChanged is called by the WriteWindow observer wiring when the
+// bottom of the write window moves. If autoFollow is true, viewBottom is
+// updated to match.
+func (v *ViewWindow) OnWriteBottomChanged(newBottom int64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.autoFollow {
+		v.viewBottom = newBottom
+	}
+}
+
+// OnWriteTopChanged is called when the WriteWindow retreats its top on grow.
+// If autoFollow is true, viewBottom snaps to the new writeBottom (caller
+// passes the new writeBottom directly, NOT writeTop).
+func (v *ViewWindow) OnWriteTopChanged(newBottom int64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.autoFollow {
+		v.viewBottom = newBottom
+	}
+}
+
+// ScrollUp detaches from the live edge and moves viewBottom up by n lines.
+// viewBottom is clamped to at least height-1 (can't show negative globalIdxs
+// as the view bottom).
+func (v *ViewWindow) ScrollUp(n int) {
+	if n <= 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoFollow = false
+	v.viewBottom -= int64(n)
+	minBottom := int64(v.height - 1)
+	if v.viewBottom < minBottom {
+		v.viewBottom = minBottom
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -128,3 +128,28 @@ func (v *ViewWindow) ScrollToBottom(writeBottom int64) {
 func (v *ViewWindow) OnInput(writeBottom int64) {
 	v.ScrollToBottom(writeBottom)
 }
+
+// Resize applies Rule 6 from the design spec.
+//
+// If autoFollow is true, viewBottom is snapped to newWriteBottom so the view
+// follows the (possibly moved) write window.
+//
+// If autoFollow is false, viewBottom is unchanged. viewTop is simply derived
+// from the new height, which may reveal or hide rows above viewBottom.
+func (v *ViewWindow) Resize(newWidth, newHeight int, newWriteBottom int64) {
+	if newWidth <= 0 || newHeight <= 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.width = newWidth
+	v.height = newHeight
+	if v.autoFollow {
+		v.viewBottom = newWriteBottom
+	}
+	// Enforce viewBottom >= height - 1.
+	minBottom := int64(v.height - 1)
+	if v.viewBottom < minBottom {
+		v.viewBottom = minBottom
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -1,0 +1,61 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import "sync"
+
+// ViewWindow is the user-facing portion of a sparse terminal. It owns the
+// viewBottom anchor and the autoFollow flag, and it responds to write-window
+// events when following.
+//
+// ViewWindow does not read from the Store directly — it only tracks the
+// coordinate pair (viewTop, viewBottom) for the caller to project.
+// ViewWindow is safe for concurrent use.
+type ViewWindow struct {
+	mu         sync.Mutex
+	width      int
+	height     int
+	viewBottom int64
+	autoFollow bool
+}
+
+// NewViewWindow creates a ViewWindow in autoFollow mode. viewBottom starts
+// at height-1 so a fresh terminal projects rows [0, height-1].
+func NewViewWindow(width, height int) *ViewWindow {
+	return &ViewWindow{
+		width:      width,
+		height:     height,
+		viewBottom: int64(height - 1),
+		autoFollow: true,
+	}
+}
+
+// Width returns the current column width.
+func (v *ViewWindow) Width() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.width
+}
+
+// Height returns the current row height.
+func (v *ViewWindow) Height() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.height
+}
+
+// IsFollowing reports whether the view is tracking the write window.
+func (v *ViewWindow) IsFollowing() bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.autoFollow
+}
+
+// VisibleRange returns the (top, bottom) globalIdx pair that the caller
+// should project from the Store.
+func (v *ViewWindow) VisibleRange() (top, bottom int64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.viewBottom - int64(v.height) + 1, v.viewBottom
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -60,25 +60,27 @@ func (v *ViewWindow) VisibleRange() (top, bottom int64) {
 	return v.viewBottom - int64(v.height) + 1, v.viewBottom
 }
 
-// OnWriteBottomChanged is called by the WriteWindow observer wiring when the
-// bottom of the write window moves. If autoFollow is true, viewBottom is
-// updated to match.
-func (v *ViewWindow) OnWriteBottomChanged(newBottom int64) {
+// OnWriteBottomChanged is called when the bottom of the write window moves.
+// newWriteBottom is the new WriteWindow.WriteBottom() value. If autoFollow
+// is true, viewBottom is updated to match.
+func (v *ViewWindow) OnWriteBottomChanged(newWriteBottom int64) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if v.autoFollow {
-		v.viewBottom = newBottom
+		v.viewBottom = newWriteBottom
 	}
 }
 
-// OnWriteTopChanged is called when the WriteWindow retreats its top on grow.
-// If autoFollow is true, viewBottom snaps to the new writeBottom (caller
-// passes the new writeBottom directly, NOT writeTop).
-func (v *ViewWindow) OnWriteTopChanged(newBottom int64) {
+// OnWriteTopChanged is called when the WriteWindow retreats its top on grow
+// (i.e. the write window expands upward). Despite the name referring to the
+// top, callers must pass newWriteBottom — the new WriteWindow.WriteBottom()
+// value — because that is what viewBottom tracks. Both events update the
+// same anchor. If autoFollow is true, viewBottom is updated to match.
+func (v *ViewWindow) OnWriteTopChanged(newWriteBottom int64) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if v.autoFollow {
-		v.viewBottom = newBottom
+		v.viewBottom = newWriteBottom
 	}
 }
 

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -85,3 +85,30 @@ func TestViewWindow_OnInputReattaches(t *testing.T) {
 		t.Error("OnInput should re-engage autoFollow")
 	}
 }
+
+func TestViewWindow_ResizeWhileFollowing(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.Resize(80, 30, 115) // new size, new writeBottom (grew by 15)
+	_, bottom := vw.VisibleRange()
+	if bottom != 115 {
+		t.Errorf("follow-resize: viewBottom = %d, want 115", bottom)
+	}
+	if got := vw.Height(); got != 30 {
+		t.Errorf("Height = %d, want 30", got)
+	}
+}
+
+func TestViewWindow_ResizeWhileScrolledBack(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.ScrollUp(30) // viewBottom = 70, autoFollow off
+	vw.Resize(80, 30, 100)  // grow height; writeBottom unchanged
+	_, bottom := vw.VisibleRange()
+	if bottom != 70 {
+		t.Errorf("frozen view: viewBottom = %d, want 70 (anchored)", bottom)
+	}
+	if got := vw.Height(); got != 30 {
+		t.Errorf("Height = %d, want 30", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -102,13 +102,29 @@ func TestViewWindow_ResizeWhileFollowing(t *testing.T) {
 func TestViewWindow_ResizeWhileScrolledBack(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(30) // viewBottom = 70, autoFollow off
-	vw.Resize(80, 30, 100)  // grow height; writeBottom unchanged
+	vw.ScrollUp(30)        // viewBottom = 70, autoFollow off
+	vw.Resize(80, 30, 100) // grow height; writeBottom unchanged
 	_, bottom := vw.VisibleRange()
 	if bottom != 70 {
 		t.Errorf("frozen view: viewBottom = %d, want 70 (anchored)", bottom)
 	}
 	if got := vw.Height(); got != 30 {
 		t.Errorf("Height = %d, want 30", got)
+	}
+}
+
+func TestViewWindow_OnWriteTopChangedFollows(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteTopChanged(50) // called when grow retreats writeTop
+	_, bottom := vw.VisibleRange()
+	if bottom != 50 {
+		t.Errorf("OnWriteTopChanged while following: viewBottom = %d, want 50", bottom)
+	}
+	// Detach and verify it does not follow.
+	vw.ScrollUp(5)
+	vw.OnWriteTopChanged(100)
+	_, bottom = vw.VisibleRange()
+	if bottom != 45 {
+		t.Errorf("OnWriteTopChanged while frozen: viewBottom = %d, want 45", bottom)
 	}
 }

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -26,3 +26,26 @@ func TestViewWindow_VisibleRangeInitially(t *testing.T) {
 		t.Errorf("fresh viewTop = %d, want 0", top)
 	}
 }
+
+func TestViewWindow_FollowsWriteBottom(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	_, bottom := vw.VisibleRange()
+	if bottom != 100 {
+		t.Errorf("autoFollow: viewBottom = %d, want 100", bottom)
+	}
+}
+
+func TestViewWindow_DoesNotFollowWhenScrolledBack(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.ScrollUp(10) // detaches from live edge
+	if vw.IsFollowing() {
+		t.Error("after ScrollUp, should not be following")
+	}
+	vw.OnWriteBottomChanged(200)
+	_, bottom := vw.VisibleRange()
+	if bottom != 90 {
+		t.Errorf("frozen viewBottom = %d, want 90 (unchanged)", bottom)
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -49,3 +49,39 @@ func TestViewWindow_DoesNotFollowWhenScrolledBack(t *testing.T) {
 		t.Errorf("frozen viewBottom = %d, want 90 (unchanged)", bottom)
 	}
 }
+
+func TestViewWindow_ScrollDownClampedToWriteBottom(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.ScrollUp(30)
+	vw.ScrollDown(100, 100) // n, writeBottom
+	_, bottom := vw.VisibleRange()
+	if bottom != 100 {
+		t.Errorf("ScrollDown clamped at writeBottom: viewBottom = %d, want 100", bottom)
+	}
+}
+
+func TestViewWindow_ScrollToBottomReattaches(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.ScrollUp(50)
+	vw.ScrollToBottom(100)
+
+	if !vw.IsFollowing() {
+		t.Error("ScrollToBottom should re-engage autoFollow")
+	}
+	_, bottom := vw.VisibleRange()
+	if bottom != 100 {
+		t.Errorf("viewBottom = %d, want 100", bottom)
+	}
+}
+
+func TestViewWindow_OnInputReattaches(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	vw.OnWriteBottomChanged(100)
+	vw.ScrollUp(50)
+	vw.OnInput(100)
+	if !vw.IsFollowing() {
+		t.Error("OnInput should re-engage autoFollow")
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -1,0 +1,28 @@
+package sparse
+
+import "testing"
+
+func TestViewWindow_NewFollowing(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	if !vw.IsFollowing() {
+		t.Error("new ViewWindow should be in autoFollow mode")
+	}
+	if got := vw.Height(); got != 24 {
+		t.Errorf("Height = %d, want 24", got)
+	}
+	if got := vw.Width(); got != 80 {
+		t.Errorf("Width = %d, want 80", got)
+	}
+}
+
+func TestViewWindow_VisibleRangeInitially(t *testing.T) {
+	vw := NewViewWindow(80, 24)
+	top, bottom := vw.VisibleRange()
+	// Fresh ViewWindow pretends writeBottom is height-1 until told otherwise.
+	if bottom != 23 {
+		t.Errorf("fresh viewBottom = %d, want 23", bottom)
+	}
+	if top != 0 {
+		t.Errorf("fresh viewTop = %d, want 0", top)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `apps/texelterm/parser/sparse/view_window.go` — the user-scroll side of the sparse terminal. This is Step 3 of 7.

`ViewWindow` owns `viewBottom` and `autoFollow`. It has no reference to `Store` or `WriteWindow` — `writeBottom` is passed in as a parameter on scroll/resize calls, keeping the types fully decoupled.

### Key behaviours

- **autoFollow** (Rule 4): when true, `viewBottom` tracks `writeBottom` on every `OnWriteBottomChanged`/`OnWriteTopChanged` call
- **ScrollUp**: detaches from live edge (`autoFollow=false`), freezes `viewBottom`
- **ScrollDown**: clamps at `writeBottom`; re-engages `autoFollow` if it reaches the bottom
- **OnInput / ScrollToBottom**: re-engages `autoFollow` immediately
- **Resize** (Rule 6): if following, snaps `viewBottom` to new `writeBottom`; if frozen, preserves `viewBottom` anchor

### Note on `OnWriteTopChanged`
Called when the write window retreats its top on grow. Despite the name referring to the top, callers pass the new `writeBottom` — that is what `viewBottom` tracks. Both events update the same anchor.

## Test plan

- [ ] `go test -race ./apps/texelterm/parser/sparse/...` — 36 tests pass

## Context

Design spec: `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`
Depends on: #174 (Step 2 — `sparse.WriteWindow`, already merged)

Next: Step 4 will add `sparse.Terminal` — thin composition of Store + WriteWindow + ViewWindow with `Grid()` projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)