### PR TITLE
feat(sparse): add Terminal composition + shrink-drag regression test (step 4 of 7)

### DIFF
--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -92,3 +92,27 @@ func (t *Terminal) ScrollToBottom() { t.view.ScrollToBottom(t.write.WriteBottom(
 
 // OnInput re-engages autoFollow after a user keystroke or click.
 func (t *Terminal) OnInput() { t.view.OnInput(t.write.WriteBottom()) }
+
+// Grid builds a dense height x width grid from the current view range by
+// reading the Store. Unwritten cells and short lines are blank-padded.
+//
+// The returned slice is owned by the caller and safe to mutate.
+func (t *Terminal) Grid() [][]parser.Cell {
+	width := t.write.Width()
+	height := t.write.Height()
+	top, _ := t.view.VisibleRange()
+
+	grid := make([][]parser.Cell, height)
+	for y := 0; y < height; y++ {
+		row := make([]parser.Cell, width)
+		gi := top + int64(y)
+		if gi >= 0 {
+			line := t.store.GetLine(gi)
+			for x := 0; x < width && x < len(line); x++ {
+				row[x] = line[x]
+			}
+		}
+		grid[y] = row
+	}
+	return grid
+}

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -93,6 +93,23 @@ func (t *Terminal) ScrollToBottom() { t.view.ScrollToBottom(t.write.WriteBottom(
 // OnInput re-engages autoFollow after a user keystroke or click.
 func (t *Terminal) OnInput() { t.view.OnInput(t.write.WriteBottom()) }
 
+// EraseDisplay clears every cell in the current write window. This is
+// the sparse equivalent of ESC[2J on the main screen.
+func (t *Terminal) EraseDisplay() {
+	t.write.EraseDisplay()
+}
+
+// EraseLine clears the cells of the line at the cursor's current globalIdx.
+// This is the sparse equivalent of ESC[2K.
+func (t *Terminal) EraseLine() {
+	t.write.EraseLine()
+}
+
+// ReadLine returns a copy of the cells at globalIdx. Returns nil for gaps.
+func (t *Terminal) ReadLine(globalIdx int64) []parser.Cell {
+	return t.store.GetLine(globalIdx)
+}
+
 // Grid builds a dense height x width grid from the current view range by
 // reading the Store. Unwritten cells and short lines are blank-padded.
 //

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -72,3 +72,23 @@ func (t *Terminal) WriteBottom() int64 { return t.write.WriteBottom() }
 
 // VisibleRange returns the (top, bottom) globalIdx pair of the current view.
 func (t *Terminal) VisibleRange() (top, bottom int64) { return t.view.VisibleRange() }
+
+// Resize resizes both the write and view windows. WriteWindow applies
+// Rule 5 first; ViewWindow then applies Rule 6 observing the (possibly
+// moved) writeBottom.
+func (t *Terminal) Resize(newWidth, newHeight int) {
+	t.write.Resize(newWidth, newHeight)
+	t.view.Resize(newWidth, newHeight, t.write.WriteBottom())
+}
+
+// ScrollUp scrolls the view back by n lines and disengages autoFollow.
+func (t *Terminal) ScrollUp(n int) { t.view.ScrollUp(n) }
+
+// ScrollDown scrolls the view forward by n lines toward the live edge.
+func (t *Terminal) ScrollDown(n int) { t.view.ScrollDown(n, t.write.WriteBottom()) }
+
+// ScrollToBottom snaps the view to the live edge and re-engages autoFollow.
+func (t *Terminal) ScrollToBottom() { t.view.ScrollToBottom(t.write.WriteBottom()) }
+
+// OnInput re-engages autoFollow after a user keystroke or click.
+func (t *Terminal) OnInput() { t.view.OnInput(t.write.WriteBottom()) }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -114,6 +114,11 @@ func (t *Terminal) ReadLine(globalIdx int64) []parser.Cell {
 // reading the Store. Unwritten cells and short lines are blank-padded.
 //
 // The returned slice is owned by the caller and safe to mutate.
+//
+// Grid acquires each underlying lock separately and does not hold a single
+// consistent snapshot. A concurrent Resize may cause the returned grid to
+// reflect a transient mix of old and new dimensions; the next call will be
+// consistent.
 func (t *Terminal) Grid() [][]parser.Cell {
 	width := t.write.Width()
 	height := t.write.Height()

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -3,6 +3,8 @@
 
 package sparse
 
+import "github.com/framegrace/texelation/apps/texelterm/parser"
+
 // Terminal is a thin composition of Store, WriteWindow, and ViewWindow. It
 // exposes the API that VTerm's main-screen path calls into.
 //
@@ -36,3 +38,37 @@ func (t *Terminal) IsFollowing() bool { return t.view.IsFollowing() }
 // ContentEnd returns the highest globalIdx ever written, or -1 if nothing
 // has been written yet.
 func (t *Terminal) ContentEnd() int64 { return t.store.Max() }
+
+// WriteCell writes one cell and notifies the ViewWindow of any writeBottom
+// change so auto-follow stays coherent.
+func (t *Terminal) WriteCell(cell parser.Cell) {
+	t.write.WriteCell(cell)
+	t.view.OnWriteBottomChanged(t.write.WriteBottom())
+}
+
+// Newline advances the cursor (scrolling at bottom) and notifies the view.
+func (t *Terminal) Newline() {
+	t.write.Newline()
+	t.view.OnWriteBottomChanged(t.write.WriteBottom())
+}
+
+// CarriageReturn resets cursor column to 0.
+func (t *Terminal) CarriageReturn() { t.write.CarriageReturn() }
+
+// SetCursor places the cursor at row, col (viewport-relative to writeTop).
+func (t *Terminal) SetCursor(row, col int) { t.write.SetCursor(row, col) }
+
+// Cursor returns the cursor (globalIdx, col) pair.
+func (t *Terminal) Cursor() (globalIdx int64, col int) { return t.write.Cursor() }
+
+// CursorRow returns the cursor row relative to writeTop.
+func (t *Terminal) CursorRow() int { return t.write.CursorRow() }
+
+// WriteTop returns the top globalIdx of the write window.
+func (t *Terminal) WriteTop() int64 { return t.write.WriteTop() }
+
+// WriteBottom returns the bottom globalIdx of the write window.
+func (t *Terminal) WriteBottom() int64 { return t.write.WriteBottom() }
+
+// VisibleRange returns the (top, bottom) globalIdx pair of the current view.
+func (t *Terminal) VisibleRange() (top, bottom int64) { return t.view.VisibleRange() }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -1,0 +1,38 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+// Terminal is a thin composition of Store, WriteWindow, and ViewWindow. It
+// exposes the API that VTerm's main-screen path calls into.
+//
+// Construction is eager: all three underlying types are created up-front so
+// that no method has to lazy-init anything. This keeps the locking strategy
+// simple — reads never upgrade to writes.
+type Terminal struct {
+	store *Store
+	write *WriteWindow
+	view  *ViewWindow
+}
+
+// NewTerminal creates a Terminal with the given dimensions. ViewWindow starts
+// in autoFollow mode with viewBottom = height - 1.
+func NewTerminal(width, height int) *Terminal {
+	store := NewStore(width)
+	write := NewWriteWindow(store, width, height)
+	view := NewViewWindow(width, height)
+	return &Terminal{store: store, write: write, view: view}
+}
+
+// Width returns the terminal width.
+func (t *Terminal) Width() int { return t.write.Width() }
+
+// Height returns the terminal height.
+func (t *Terminal) Height() int { return t.write.Height() }
+
+// IsFollowing reports whether the view is auto-following the write window.
+func (t *Terminal) IsFollowing() bool { return t.view.IsFollowing() }
+
+// ContentEnd returns the highest globalIdx ever written, or -1 if nothing
+// has been written yet.
+func (t *Terminal) ContentEnd() int64 { return t.store.Max() }

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -142,3 +142,79 @@ func TestTerminal_GridReflectsScrollback(t *testing.T) {
 		t.Errorf("grid[2][0] = %q, want blank (row 3, unwritten)", grid[2][0].Rune)
 	}
 }
+
+// TestTerminal_ShrinkDragDoesNotDuplicateTextContent simulates claude-like
+// behavior: each shrink step, "redraw" the UI at the new size with a text
+// marker on row 1. Afterward, verify the text marker appears exactly once in
+// the store.
+func TestTerminal_ShrinkDragDoesNotDuplicateTextContent(t *testing.T) {
+	tm := NewTerminal(80, 40)
+	marker := "Claude Code"
+
+	// Initial draw: border on row 0, marker on row 1, cursor parked at
+	// row 37 (input box bottom).
+	drawUI := func(h int) {
+		// Border row 0.
+		tm.SetCursor(0, 0)
+		for _, r := range "┌──────────────┐" {
+			tm.WriteCell(parser.Cell{Rune: r})
+		}
+		// Text row 1.
+		tm.SetCursor(1, 0)
+		for _, r := range marker {
+			tm.WriteCell(parser.Cell{Rune: r})
+		}
+		// Cursor parked at last-row (input box).
+		tm.SetCursor(h-2, 5)
+	}
+
+	drawUI(40)
+
+	// Shrink-drag from 40 -> 20.
+	for h := 39; h >= 20; h-- {
+		tm.Resize(80, h)
+		// Clear the old window and redraw at new size.
+		// (In real life, the TUI does this via ESC[2J or scroll region.)
+		top := tm.WriteTop()
+		bottom := tm.WriteBottom()
+		tm.EraseDisplay() // new helper — see below
+		_ = top
+		_ = bottom
+		drawUI(h)
+	}
+
+	// Count occurrences of the marker across the entire store, from globalIdx 0
+	// up to ContentEnd.
+	count := 0
+	end := tm.ContentEnd()
+	for gi := int64(0); gi <= end; gi++ {
+		line := tm.ReadLine(gi)
+		if containsRunes(line, []rune(marker)) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("marker %q appears %d times in store; want 1", marker, count)
+	}
+}
+
+// containsRunes reports whether row contains the full sequence needle as a
+// contiguous run of Rune fields.
+func containsRunes(row []parser.Cell, needle []rune) bool {
+	if len(needle) == 0 || len(row) < len(needle) {
+		return false
+	}
+	for start := 0; start+len(needle) <= len(row); start++ {
+		match := true
+		for j, r := range needle {
+			if row[start+j].Rune != r {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -25,3 +25,30 @@ func TestTerminal_NewInitialState(t *testing.T) {
 	}
 	_ = parser.Cell{}
 }
+
+func TestTerminal_WriteCellAdvancesFollowingView(t *testing.T) {
+	tm := NewTerminal(10, 5)
+	tm.WriteCell(parser.Cell{Rune: 'h'})
+	tm.Newline()
+	// Cursor should be on row 1 now.
+	gi, col := tm.Cursor()
+	if gi != 1 || col != 0 {
+		t.Errorf("after Newline, Cursor = (%d,%d), want (1,0)", gi, col)
+	}
+	// Because we're following, viewBottom should track writeBottom.
+	_, vbottom := tm.VisibleRange()
+	if vbottom != 4 {
+		t.Errorf("viewBottom = %d, want 4 (writeBottom)", vbottom)
+	}
+}
+
+func TestTerminal_NewlineAtBottomScrollsAndViewFollows(t *testing.T) {
+	tm := NewTerminal(10, 3)
+	tm.SetCursor(2, 0)
+	tm.Newline()
+	// writeTop advanced, writeBottom = 3, following view snaps.
+	_, vbottom := tm.VisibleRange()
+	if vbottom != 3 {
+		t.Errorf("viewBottom = %d, want 3", vbottom)
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -83,7 +83,7 @@ func TestTerminal_ResizeFrozenViewStaysPut(t *testing.T) {
 	tm.ScrollUp(20)
 	_, beforeBottom := tm.VisibleRange()
 
-	tm.Resize(80, 30) // grow
+	tm.Resize(80, 30) // shrink; frozen view must not move (Rule 6)
 
 	_, afterBottom := tm.VisibleRange()
 	if afterBottom != beforeBottom {
@@ -174,11 +174,7 @@ func TestTerminal_ShrinkDragDoesNotDuplicateTextContent(t *testing.T) {
 		tm.Resize(80, h)
 		// Clear the old window and redraw at new size.
 		// (In real life, the TUI does this via ESC[2J or scroll region.)
-		top := tm.WriteTop()
-		bottom := tm.WriteBottom()
-		tm.EraseDisplay() // new helper — see below
-		_ = top
-		_ = bottom
+		tm.EraseDisplay()
 		drawUI(h)
 	}
 

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -91,3 +91,54 @@ func TestTerminal_ResizeFrozenViewStaysPut(t *testing.T) {
 		t.Errorf("frozen view moved: %d -> %d", beforeBottom, afterBottom)
 	}
 }
+
+func TestTerminal_GridReturnsHeightXWidth(t *testing.T) {
+	tm := NewTerminal(10, 5)
+	tm.WriteCell(parser.Cell{Rune: 'A'})
+	tm.WriteCell(parser.Cell{Rune: 'B'})
+
+	grid := tm.Grid()
+	if len(grid) != 5 {
+		t.Fatalf("grid rows = %d, want 5", len(grid))
+	}
+	for y, row := range grid {
+		if len(row) != 10 {
+			t.Errorf("row %d width = %d, want 10", y, len(row))
+		}
+	}
+	if grid[0][0].Rune != 'A' {
+		t.Errorf("grid[0][0] = %q, want A", grid[0][0].Rune)
+	}
+	if grid[0][1].Rune != 'B' {
+		t.Errorf("grid[0][1] = %q, want B", grid[0][1].Rune)
+	}
+	// Unwritten cells are blank.
+	if grid[0][5].Rune != 0 {
+		t.Errorf("grid[0][5] = %q, want blank", grid[0][5].Rune)
+	}
+	if grid[4][0].Rune != 0 {
+		t.Errorf("grid[4][0] = %q, want blank (unwritten row)", grid[4][0].Rune)
+	}
+}
+
+func TestTerminal_GridReflectsScrollback(t *testing.T) {
+	tm := NewTerminal(10, 3)
+	// Fill rows 0,1,2 then scroll down — writeTop=1, writeBottom=3.
+	tm.WriteCell(parser.Cell{Rune: 'A'})
+	tm.Newline()
+	tm.WriteCell(parser.Cell{Rune: 'B'})
+	tm.Newline()
+	tm.WriteCell(parser.Cell{Rune: 'C'})
+	tm.Newline() // scrolls
+	// Following view: viewBottom = 3, view covers [1,2,3]
+	grid := tm.Grid()
+	if grid[0][0].Rune != 'B' {
+		t.Errorf("grid[0][0] = %q, want B (row 1)", grid[0][0].Rune)
+	}
+	if grid[1][0].Rune != 'C' {
+		t.Errorf("grid[1][0] = %q, want C (row 2)", grid[1][0].Rune)
+	}
+	if grid[2][0].Rune != 0 {
+		t.Errorf("grid[2][0] = %q, want blank (row 3, unwritten)", grid[2][0].Rune)
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -52,3 +52,42 @@ func TestTerminal_NewlineAtBottomScrollsAndViewFollows(t *testing.T) {
 		t.Errorf("viewBottom = %d, want 3", vbottom)
 	}
 }
+
+func TestTerminal_ResizeShrinkShellCase(t *testing.T) {
+	tm := NewTerminal(80, 40)
+	// Fill 40 rows.
+	for i := 0; i < 40; i++ {
+		tm.WriteCell(parser.Cell{Rune: 'X'})
+		tm.Newline()
+	}
+	// cursor is now at row 40 of a scrolled window.
+	tm.SetCursor(39, 0)
+	tm.Resize(80, 20)
+
+	_, vbottom := tm.VisibleRange()
+	_, writeBottom := tm.WriteTop(), tm.WriteBottom()
+	if vbottom != writeBottom {
+		t.Errorf("following view: viewBottom = %d, writeBottom = %d", vbottom, writeBottom)
+	}
+	if got := tm.Height(); got != 20 {
+		t.Errorf("Height = %d, want 20", got)
+	}
+}
+
+func TestTerminal_ResizeFrozenViewStaysPut(t *testing.T) {
+	tm := NewTerminal(80, 40)
+	for i := 0; i < 80; i++ {
+		tm.WriteCell(parser.Cell{Rune: 'X'})
+		tm.Newline()
+	}
+	// Scroll back 20 rows.
+	tm.ScrollUp(20)
+	_, beforeBottom := tm.VisibleRange()
+
+	tm.Resize(80, 30) // grow
+
+	_, afterBottom := tm.VisibleRange()
+	if afterBottom != beforeBottom {
+		t.Errorf("frozen view moved: %d -> %d", beforeBottom, afterBottom)
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -23,7 +23,6 @@ func TestTerminal_NewInitialState(t *testing.T) {
 	if got := tm.ContentEnd(); got != -1 {
 		t.Errorf("fresh ContentEnd = %d, want -1", got)
 	}
-	_ = parser.Cell{}
 }
 
 func TestTerminal_WriteCellAdvancesFollowingView(t *testing.T) {

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -1,0 +1,27 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestTerminal_NewInitialState(t *testing.T) {
+	tm := NewTerminal(80, 24)
+	if got := tm.Width(); got != 80 {
+		t.Errorf("Width = %d, want 80", got)
+	}
+	if got := tm.Height(); got != 24 {
+		t.Errorf("Height = %d, want 24", got)
+	}
+	if !tm.IsFollowing() {
+		t.Error("new Terminal should follow writeBottom")
+	}
+	if got := tm.ContentEnd(); got != -1 {
+		t.Errorf("fresh ContentEnd = %d, want -1", got)
+	}
+	_ = parser.Cell{}
+}


### PR DESCRIPTION
## Summary

- Adds `sparse.Terminal` — a thin composition of `Store`, `WriteWindow`, and `ViewWindow` that exposes the API VTerm's main-screen path will call into
- All write, resize, scroll, and grid-projection methods delegate to the appropriate underlying type; `Newline` and `WriteCell` additionally notify `ViewWindow` to keep autoFollow coherent
- `Grid()` builds a dense `height×width` slice from the current view range, blank-padding unwritten cells

## Key test: `TestTerminal_ShrinkDragDoesNotDuplicateTextContent`

This is the unit-level proof that the sparse redesign fixes the target bug class. It simulates claude-code-like TUI behavior across a 40→20 row shrink drag — erasing and redrawing the UI at each step — and asserts the text marker appears **exactly once** in the store at the end. On the old MemoryBuffer model this would fail because `pendingRollback` heuristics caused the TUI's content to be duplicated in scrollback on every resize.

**Design spec:** `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`

## Test plan

- [x] `go test -race ./apps/texelterm/parser/sparse/...` — PASS (all 43 tests)
- [x] `gofmt -d` — no diff
- [x] Spec compliance review — APPROVED
- [x] Code quality review — APPROVED

🤖 Generated with [Claude Code](https://claude.ai/claude-code)