### PR TITLE
feat(sparse): Persistence adapter + MainScreenState (step 5 of 7)

### DIFF
--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -58,6 +58,35 @@ type ViewportState struct {
 	WorkingDir string `json:"working_dir"`
 }
 
+// MainScreenState stores the sparse-model main-screen state for session
+// restoration. Replaces ViewportState when the sparse redesign is active.
+// On load, if only a legacy ViewportState is present, it is discarded and
+// the terminal starts fresh (there is no clean translation between the two
+// models).
+type MainScreenState struct {
+	// WriteTop is the globalIdx of the top row of the write window.
+	WriteTop int64 `json:"write_top"`
+
+	// ContentEnd is the highest globalIdx ever written. -1 means empty.
+	ContentEnd int64 `json:"content_end"`
+
+	// CursorGlobalIdx is the absolute globalIdx where the cursor currently sits.
+	CursorGlobalIdx int64 `json:"cursor_global_idx"`
+
+	// CursorCol is the cursor column position (0-indexed).
+	CursorCol int `json:"cursor_col"`
+
+	// PromptStartLine is the global line index of the last shell prompt start.
+	// -1 means unknown.
+	PromptStartLine int64 `json:"prompt_start_line"`
+
+	// WorkingDir is the last known working directory from OSC 7.
+	WorkingDir string `json:"working_dir"`
+
+	// SavedAt is when the state was saved.
+	SavedAt time.Time `json:"saved_at"`
+}
+
 // PageStoreConfig holds configuration for the page store.
 type PageStoreConfig struct {
 	// BaseDir is the base directory for all history storage.

--- a/apps/texelterm/parser/page_store_main_screen_state_test.go
+++ b/apps/texelterm/parser/page_store_main_screen_state_test.go
@@ -1,0 +1,30 @@
+package parser
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMainScreenState_JSONRoundtrip(t *testing.T) {
+	s := MainScreenState{
+		WriteTop:        100,
+		ContentEnd:      150,
+		CursorGlobalIdx: 145,
+		CursorCol:       5,
+		PromptStartLine: 140,
+		WorkingDir:      "/home/user",
+		SavedAt:         time.Unix(1700000000, 0).UTC(),
+	}
+	b, err := json.Marshal(&s)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got MainScreenState
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != s {
+		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, s)
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence.go
+++ b/apps/texelterm/parser/sparse/persistence.go
@@ -27,9 +27,9 @@ func NewPersistence(ps *parser.PageStore) *Persistence {
 }
 
 // FlushLines forwards each listed globalIdx's current content in the Store
-// to the PageStore. Missing lines (gaps) are skipped. Lines that already
-// exist in PageStore are updated via UpdateLine; new lines are appended via
-// AppendLineWithGlobalIdx.
+// to the PageStore. Missing lines (gaps in the Store) are skipped.
+// AppendLineWithGlobalIdx handles all three cases internally: update-in-place
+// for existing entries, contiguous append, and out-of-order insert.
 func (p *Persistence) FlushLines(store *Store, globalIdxs []int64) error {
 	now := time.Now()
 	for _, gi := range globalIdxs {
@@ -38,14 +38,8 @@ func (p *Persistence) FlushLines(store *Store, globalIdxs []int64) error {
 			continue
 		}
 		line := &parser.LogicalLine{Cells: cells}
-		if p.page.HasLine(gi) {
-			if err := p.page.UpdateLine(gi, line, now); err != nil {
-				return err
-			}
-		} else {
-			if err := p.page.AppendLineWithGlobalIdx(gi, line, now); err != nil {
-				return err
-			}
+		if err := p.page.AppendLineWithGlobalIdx(gi, line, now); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -76,10 +70,15 @@ func RestoreState(tm *Terminal, state parser.MainScreenState) {
 // given sparse.Store. Used on startup to rebuild the in-memory state from
 // disk. Existing entries in the Store are overwritten when their globalIdx
 // matches; unrelated entries are untouched.
+//
+// Iterates stored positions directly via StoredLineCount +
+// GlobalIdxAtStoredPosition to avoid a linear O(nextGlobalIdx) scan over
+// potentially large gaps.
 func LoadStore(store *Store, ps *parser.PageStore) error {
-	count := ps.LineCount()
-	for gi := int64(0); gi < count; gi++ {
-		if !ps.HasLine(gi) {
+	n := ps.StoredLineCount()
+	for i := int64(0); i < n; i++ {
+		gi := ps.GlobalIdxAtStoredPosition(i)
+		if gi < 0 {
 			continue
 		}
 		line, err := ps.ReadLine(gi)

--- a/apps/texelterm/parser/sparse/persistence.go
+++ b/apps/texelterm/parser/sparse/persistence.go
@@ -1,0 +1,95 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"time"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// Persistence adapts a sparse.Store / sparse.Terminal to the existing
+// PageStore on-disk layer. The same globalIdx is used on both sides, so a
+// line in sparse.Store at globalIdx 42 is persisted at PageStore globalIdx 42.
+//
+// This is a thin forward-only adapter: it does not own lifecycle, it does not
+// manage flush scheduling. Those concerns stay in AdaptivePersistence. The
+// adapter only knows how to take a list of "dirty" globalIdxs and push them
+// to PageStore, and how to save/load MainScreenState.
+type Persistence struct {
+	page *parser.PageStore
+}
+
+// NewPersistence creates a new adapter writing to the given PageStore.
+func NewPersistence(ps *parser.PageStore) *Persistence {
+	return &Persistence{page: ps}
+}
+
+// FlushLines forwards each listed globalIdx's current content in the Store
+// to the PageStore. Missing lines (gaps) are skipped. Lines that already
+// exist in PageStore are updated via UpdateLine; new lines are appended via
+// AppendLineWithGlobalIdx.
+func (p *Persistence) FlushLines(store *Store, globalIdxs []int64) error {
+	now := time.Now()
+	for _, gi := range globalIdxs {
+		cells := store.GetLine(gi)
+		if cells == nil {
+			continue
+		}
+		line := &parser.LogicalLine{Cells: cells}
+		if p.page.HasLine(gi) {
+			if err := p.page.UpdateLine(gi, line, now); err != nil {
+				return err
+			}
+		} else {
+			if err := p.page.AppendLineWithGlobalIdx(gi, line, now); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// SnapshotState captures the current Terminal state into a MainScreenState
+// suitable for WAL persistence.
+func SnapshotState(tm *Terminal) parser.MainScreenState {
+	gi, col := tm.Cursor()
+	return parser.MainScreenState{
+		WriteTop:        tm.WriteTop(),
+		ContentEnd:      tm.ContentEnd(),
+		CursorGlobalIdx: gi,
+		CursorCol:       col,
+		PromptStartLine: -1,
+		SavedAt:         time.Now(),
+	}
+}
+
+// RestoreState applies a MainScreenState to an existing Terminal, overwriting
+// cursor and writeTop. The ViewWindow is put into autoFollow mode snapped to
+// the new writeBottom.
+func RestoreState(tm *Terminal, state parser.MainScreenState) {
+	tm.RestoreWriteState(state.WriteTop, state.CursorGlobalIdx, state.CursorCol)
+}
+
+// LoadStore reads every line currently present in the PageStore into the
+// given sparse.Store. Used on startup to rebuild the in-memory state from
+// disk. Existing entries in the Store are overwritten when their globalIdx
+// matches; unrelated entries are untouched.
+func LoadStore(store *Store, ps *parser.PageStore) error {
+	count := ps.LineCount()
+	for gi := int64(0); gi < count; gi++ {
+		if !ps.HasLine(gi) {
+			continue
+		}
+		line, err := ps.ReadLine(gi)
+		if err != nil {
+			return err
+		}
+		if line == nil {
+			continue
+		}
+		store.SetLine(gi, line.Cells)
+	}
+	return nil
+}

--- a/apps/texelterm/parser/sparse/persistence_test.go
+++ b/apps/texelterm/parser/sparse/persistence_test.go
@@ -111,7 +111,9 @@ func TestPersistence_RoundTripViaPageStore(t *testing.T) {
 	if err := ps1.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	ps1.Close()
+	if err := ps1.Close(); err != nil {
+		t.Fatalf("ps1.Close: %v", err)
+	}
 
 	// Reload into a fresh Terminal.
 	ps2, err := parser.OpenPageStore(cfg)

--- a/apps/texelterm/parser/sparse/persistence_test.go
+++ b/apps/texelterm/parser/sparse/persistence_test.go
@@ -87,3 +87,48 @@ func TestPersistence_RestoreTerminal(t *testing.T) {
 		t.Error("restored Terminal should be in autoFollow mode by default")
 	}
 }
+
+func TestPersistence_RoundTripViaPageStore(t *testing.T) {
+	dir := t.TempDir()
+	cfg := parser.DefaultPageStoreConfig(dir, "unit-test")
+	ps1, err := parser.CreatePageStore(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter1 := NewPersistence(ps1)
+
+	// Build a terminal, write some content, flush all lines.
+	tm := NewTerminal(10, 5)
+	tm.WriteCell(parser.Cell{Rune: 'x'})
+	tm.Newline()
+	tm.WriteCell(parser.Cell{Rune: 'y'})
+	tm.Newline()
+
+	idxs := []int64{0, 1}
+	if err := adapter1.FlushLines(getStore(tm), idxs); err != nil {
+		t.Fatalf("FlushLines: %v", err)
+	}
+	if err := ps1.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	ps1.Close()
+
+	// Reload into a fresh Terminal.
+	ps2, err := parser.OpenPageStore(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ps2.Close()
+
+	tm2 := NewTerminal(10, 5)
+	if err := LoadStore(getStore(tm2), ps2); err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	if got := getStore(tm2).Get(0, 0).Rune; got != 'x' {
+		t.Errorf("reloaded store[0][0] = %q, want x", got)
+	}
+	if got := getStore(tm2).Get(1, 0).Rune; got != 'y' {
+		t.Errorf("reloaded store[1][0] = %q, want y", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence_test.go
+++ b/apps/texelterm/parser/sparse/persistence_test.go
@@ -1,0 +1,48 @@
+package sparse
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestPersistence_FlushLinesToPageStore(t *testing.T) {
+	dir := t.TempDir()
+	cfg := parser.DefaultPageStoreConfig(dir, "unit-test")
+	ps, err := parser.CreatePageStore(cfg)
+	if err != nil {
+		t.Fatalf("CreatePageStore: %v", err)
+	}
+	defer ps.Close()
+
+	adapter := NewPersistence(ps)
+
+	// Write three lines to the sparse side.
+	store := NewStore(10)
+	store.SetLine(0, []parser.Cell{{Rune: 'a'}})
+	store.SetLine(1, []parser.Cell{{Rune: 'b'}})
+	store.SetLine(2, []parser.Cell{{Rune: 'c'}})
+
+	if err := adapter.FlushLines(store, []int64{0, 1, 2}); err != nil {
+		t.Fatalf("FlushLines: %v", err)
+	}
+	if err := ps.Flush(); err != nil {
+		t.Fatalf("ps.Flush: %v", err)
+	}
+
+	// Read back through PageStore.
+	line, err := ps.ReadLine(1)
+	if err != nil {
+		t.Fatalf("ReadLine(1): %v", err)
+	}
+	if len(line.Cells) == 0 || line.Cells[0].Rune != 'b' {
+		t.Errorf("ReadLine(1) first rune = %q, want b", line.Cells[0].Rune)
+	}
+
+	// Ensure the temp dir was actually written to.
+	if _, err := os.Stat(filepath.Join(dir, "terminals")); err != nil {
+		t.Errorf("expected terminal dir under %s: %v", dir, err)
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence_test.go
+++ b/apps/texelterm/parser/sparse/persistence_test.go
@@ -46,3 +46,44 @@ func TestPersistence_FlushLinesToPageStore(t *testing.T) {
 		t.Errorf("expected terminal dir under %s: %v", dir, err)
 	}
 }
+
+func TestPersistence_SnapshotTerminal(t *testing.T) {
+	tm := NewTerminal(80, 24)
+	tm.WriteCell(parser.Cell{Rune: 'a'})
+	tm.Newline()
+	tm.WriteCell(parser.Cell{Rune: 'b'})
+
+	state := SnapshotState(tm)
+	if state.WriteTop != 0 {
+		t.Errorf("WriteTop = %d, want 0", state.WriteTop)
+	}
+	if state.ContentEnd != 1 {
+		t.Errorf("ContentEnd = %d, want 1 (two rows written)", state.ContentEnd)
+	}
+	if state.CursorGlobalIdx != 1 || state.CursorCol != 1 {
+		t.Errorf("Cursor = (%d,%d), want (1,1)",
+			state.CursorGlobalIdx, state.CursorCol)
+	}
+}
+
+func TestPersistence_RestoreTerminal(t *testing.T) {
+	state := parser.MainScreenState{
+		WriteTop:        50,
+		ContentEnd:      70,
+		CursorGlobalIdx: 65,
+		CursorCol:       3,
+	}
+	tm := NewTerminal(80, 24)
+	RestoreState(tm, state)
+
+	if got := tm.WriteTop(); got != 50 {
+		t.Errorf("restored WriteTop = %d, want 50", got)
+	}
+	gi, col := tm.Cursor()
+	if gi != 65 || col != 3 {
+		t.Errorf("restored Cursor = (%d,%d), want (65,3)", gi, col)
+	}
+	if !tm.IsFollowing() {
+		t.Error("restored Terminal should be in autoFollow mode by default")
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -110,6 +110,14 @@ func (t *Terminal) ReadLine(globalIdx int64) []parser.Cell {
 	return t.store.GetLine(globalIdx)
 }
 
+// RestoreWriteState forcibly sets the write window's cursor and anchor,
+// used during session restore. The ViewWindow is re-snapped to the new
+// writeBottom in follow mode.
+func (t *Terminal) RestoreWriteState(writeTop, cursorGlobalIdx int64, cursorCol int) {
+	t.write.RestoreState(writeTop, cursorGlobalIdx, cursorCol)
+	t.view.ScrollToBottom(t.write.WriteBottom())
+}
+
 // Grid builds a dense height x width grid from the current view range by
 // reading the Store. Unwritten cells and short lines are blank-padded.
 //

--- a/apps/texelterm/parser/sparse/terminal_test.go
+++ b/apps/texelterm/parser/sparse/terminal_test.go
@@ -193,6 +193,9 @@ func TestTerminal_ShrinkDragDoesNotDuplicateTextContent(t *testing.T) {
 	}
 }
 
+// getStore is a test-only accessor for the internal Store.
+func getStore(t *Terminal) *Store { return t.store }
+
 // containsRunes reports whether row contains the full sequence needle as a
 // contiguous run of Rune fields.
 func containsRunes(row []parser.Cell, needle []rune) bool {

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -240,3 +240,13 @@ func (w *WriteWindow) EraseLine() {
 	w.mu.Unlock()
 	w.store.ClearRange(gi, gi)
 }
+
+// RestoreState forcibly sets writeTop and cursor, used during session
+// restore. Do not call during normal operation.
+func (w *WriteWindow) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writeTop = writeTop
+	w.cursorGlobalIdx = cursorGlobalIdx
+	w.cursorCol = cursorCol
+}


### PR DESCRIPTION
## Summary

- Adds `MainScreenState` struct to `parser/page_store.go` alongside the existing `ViewportState` — the new struct stores `(writeTop, contentEnd, cursorGlobalIdx, cursorCol, promptStartLine, workingDir, savedAt)` for the sparse model. `ViewportState` is untouched; both coexist until the integration PR removes the old one.
- Adds `sparse.Persistence` adapter in `parser/sparse/persistence.go`:
  - `FlushLines(store, globalIdxs)` — forwards dirty sparse lines to `PageStore.AppendLineWithGlobalIdx` (handles update-in-place, contiguous append, and out-of-order insert internally)
  - `LoadStore(store, ps)` — repopulates a `sparse.Store` from disk via `StoredLineCount` + `GlobalIdxAtStoredPosition` (O(stored lines), not O(nextGlobalIdx))
  - `SnapshotState(tm)` / `RestoreState(tm, state)` — capture and apply `MainScreenState` to a `Terminal`
- Adds `WriteWindow.RestoreState` and `Terminal.RestoreWriteState` for session-restore use

**Design spec:** `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`

## Test plan

- [x] `go test -race ./apps/texelterm/parser/...` — PASS (both packages)
- [x] `gofmt -d` — no diff
- [x] Spec compliance review — APPROVED
- [x] Code quality review — APPROVED (FlushLines simplified to single-path, LoadStore uses stored-position iterator)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)