### PR TITLE
Post-sparse cleanup: dead code, helpers, test gaps, HWM persistence

### DIFF
--- a/apps/texelterm/parser/adaptive_persistence.go
+++ b/apps/texelterm/parser/adaptive_persistence.go
@@ -109,7 +109,7 @@ type pendingLineInfo struct {
 type AdaptivePersistence struct {
 	config  AdaptivePersistenceConfig
 	memBuf  LineStore
-	disk    *PageStore       // Direct PageStore (legacy mode)
+	disk    *PageStore       // Direct PageStore fallback (when no WAL is supplied)
 	wal     *WriteAheadLog   // WAL-based persistence (preferred)
 	nowFunc func() time.Time // For testing; defaults to time.Now
 

--- a/apps/texelterm/parser/alt_screen_test.go
+++ b/apps/texelterm/parser/alt_screen_test.go
@@ -336,7 +336,7 @@ func TestScrollRegionDetailedState(t *testing.T) {
 // correctly updates the normal screen memory buffer so that exiting alt screen produces
 // a grid with the correct dimensions and cursor position.
 func TestAltScreenResizeThenExit(t *testing.T) {
-	v := NewVTerm(80, 24, WithMemoryBuffer())
+	v := NewVTerm(80, 24)
 	p := NewParser(v)
 
 	// Write some content on normal screen
@@ -398,7 +398,7 @@ func TestAltScreenResizeThenExit(t *testing.T) {
 
 // TestAltScreenResizeShrinkThenExit verifies shrinking during alt screen also works.
 func TestAltScreenResizeShrinkThenExit(t *testing.T) {
-	v := NewVTerm(80, 30, WithMemoryBuffer())
+	v := NewVTerm(80, 30)
 	p := NewParser(v)
 
 	// Write enough content to fill the screen

--- a/apps/texelterm/parser/burst_recovery_test.go
+++ b/apps/texelterm/parser/burst_recovery_test.go
@@ -14,8 +14,8 @@
 //   - ContentEnd (highest globalIdx ever written; exclusive "end" is +1)
 //   - MainScreenState (persistent metadata, replaces ViewportState)
 //
-// Helpers `logicalLineToString`, `trimLogicalLine`, and `sparseCellsToString`
-// live in test_helpers_test.go.
+// Helpers `logicalLineToString`, `trimLogicalLine`, and `cellsToString`
+// live in shared_helpers_test.go.
 
 package parser
 
@@ -111,11 +111,11 @@ func captureState(v *VTerm) snapshotState {
 	}
 	if v.mainScreen != nil {
 		if cells := v.mainScreen.ReadLine(writeTop); cells != nil {
-			s.viewportTopLine = trimLogicalLine(sparseCellsToString(cells))
+			s.viewportTopLine = trimLogicalLine(cellsToString(cells))
 		}
 		cursorGlobal := writeTop + int64(v.cursorY)
 		if cells := v.mainScreen.ReadLine(cursorGlobal); cells != nil {
-			s.cursorLine = trimLogicalLine(sparseCellsToString(cells))
+			s.cursorLine = trimLogicalLine(cellsToString(cells))
 		}
 	}
 	return s
@@ -131,7 +131,7 @@ func readSparseLine(v *VTerm, globalIdx int64) string {
 	if cells == nil {
 		return ""
 	}
-	return trimLogicalLine(sparseCellsToString(cells))
+	return trimLogicalLine(cellsToString(cells))
 }
 
 // captureViewport reads all viewport lines from the sparse terminal. The
@@ -371,7 +371,7 @@ func TestBurstWriteRecovery_ContentIntegrity(t *testing.T) {
 			continue
 		}
 		if cells := v1.mainScreen.ReadLine(idx); cells != nil {
-			samples = append(samples, sample{idx, trimLogicalLine(sparseCellsToString(cells))})
+			samples = append(samples, sample{idx, trimLogicalLine(cellsToString(cells))})
 		}
 	}
 
@@ -398,7 +398,7 @@ func TestBurstWriteRecovery_ContentIntegrity(t *testing.T) {
 			t.Errorf("Line %d not found after recovery", s.idx)
 			continue
 		}
-		got := trimLogicalLine(sparseCellsToString(cells))
+		got := trimLogicalLine(cellsToString(cells))
 		if got != s.text {
 			t.Errorf("Line %d: got %q, want %q", s.idx, got, s.text)
 		}

--- a/apps/texelterm/parser/fixed_width_detector.go
+++ b/apps/texelterm/parser/fixed_width_detector.go
@@ -8,22 +8,24 @@
 //
 //	TUI applications like vim, htop, codex use escape sequences that indicate
 //	fixed-width content: scroll regions, cursor jumps, and cursor hiding.
-//	This detector watches for these patterns and flags affected lines in
-//	MemoryBuffer so they won't reflow on terminal resize.
+//	This detector watches for these patterns and flags affected lines in the
+//	backing line store so they won't reflow on terminal resize.
 //
 //	Detection signals:
 //	  - Non-full-screen scroll region (DECSTBM)
 //	  - Large cursor jumps (CUP moving more than 1 row)
 //	  - Cursor visibility changes (DECTCEM)
 //
-//	Lines are flagged immediately via MemoryBuffer.SetLineFixed(lineIdx, width).
+//	Lines are flagged immediately via fixedWidthBuffer.SetLineFixed(lineIdx, width).
 
 package parser
 
 import "strconv"
 
-// fixedWidthBuffer is the subset of MemoryBuffer used by FixedWidthDetector.
-// Passing nil is safe — all methods guard with a nil check.
+// fixedWidthBuffer is the subset of the line-store API used by
+// FixedWidthDetector. Implemented by sparseLineStoreAdapter in production
+// and by MemoryBuffer in tests. Passing nil is safe — all methods guard
+// with a nil check.
 type fixedWidthBuffer interface {
 	GetLine(lineIdx int64) *LogicalLine
 	SetLineFixed(lineIdx int64, width int)
@@ -65,7 +67,7 @@ func DefaultFixedWidthDetectorConfig() FixedWidthDetectorConfig {
 
 // FixedWidthDetector tracks TUI patterns and flags lines as fixed-width.
 // It monitors cursor movements and scroll regions to detect TUI behavior,
-// then marks affected lines in MemoryBuffer as non-reflowable.
+// then marks affected lines in the backing line store as non-reflowable.
 type FixedWidthDetector struct {
 	memBuf fixedWidthBuffer
 	config FixedWidthDetectorConfig

--- a/apps/texelterm/parser/legacy_stubs.go
+++ b/apps/texelterm/parser/legacy_stubs.go
@@ -2,20 +2,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // File: apps/texelterm/parser/legacy_stubs.go
-// Summary: Minimal stub types retained for API compatibility and legacy tests.
+// Summary: Minimal storage types retained for AdaptivePersistence tests.
 //
-// These types were previously defined in memory_buffer.go (deleted during the
-// sparse-viewport cutover). They are kept here so that:
-//   - legacy test files (viewport_window_test, adaptive_persistence_test, …)
-//     continue to compile and exercise low-level storage behaviour;
-//   - the AdaptivePersistence LineStore interface still carries EvictedLine;
-//   - vterm.go can expose MemoryBuffer() and WithMemoryBufferOptions() for
-//     backwards-compatible API callers that inspect the returned nil value.
+// These types were previously defined in memory_buffer.go (deleted during
+// the sparse-viewport cutover). They are kept here so that:
+//   - AdaptivePersistence tests (adaptive_persistence_test,
+//     adaptive_persistence_recovery_test, fixed_width_detector_test) can
+//     supply a MemoryBuffer as the LineStore argument and exercise
+//     eviction semantics that sparse does not model;
+//   - the LineStore interface still carries EvictedLine.
 //
-// MemoryBuffer is a simple in-memory ring-buffer for logical lines.  It does
-// NOT back VTerm's main screen (that is sparse.Terminal).  It is used only by
-// legacy unit tests and by AdaptivePersistence tests that supply it as the
-// LineStore argument.
+// MemoryBuffer is a simple in-memory ring-buffer for logical lines. It
+// does NOT back VTerm's main screen (that is sparse.Terminal in
+// production). It exists purely as a test fixture.
 
 package parser
 

--- a/apps/texelterm/parser/logical_line.go
+++ b/apps/texelterm/parser/logical_line.go
@@ -206,31 +206,6 @@ func (l *LogicalLine) WrapToWidth(width int) []PhysicalLine {
 	return result
 }
 
-// ActiveWrapToWidth returns physical lines for the active content layer.
-// When showOverlay is true and Overlay is set, renders overlay as fixed-width.
-// When showOverlay is false, renders Cells normally (Synthetic lines return nil).
-func (l *LogicalLine) ActiveWrapToWidth(width int, showOverlay bool) []PhysicalLine {
-	if !showOverlay {
-		if l.Synthetic {
-			return nil
-		}
-		return l.WrapToWidth(width)
-	}
-
-	if l.Overlay != nil {
-		overlay := &LogicalLine{
-			Cells:      l.Overlay,
-			FixedWidth: l.OverlayWidth,
-		}
-		if overlay.FixedWidth == 0 {
-			overlay.FixedWidth = len(l.Overlay)
-		}
-		return overlay.WrapToWidth(width)
-	}
-
-	return l.WrapToWidth(width)
-}
-
 // TrimTrailingSpaces removes trailing space cells from the line.
 // Useful for storage efficiency - trailing spaces don't need to be persisted.
 func (l *LogicalLine) TrimTrailingSpaces() {

--- a/apps/texelterm/parser/logical_line_persistence.go
+++ b/apps/texelterm/parser/logical_line_persistence.go
@@ -298,9 +298,6 @@ func decodeColorFromValue(mode ColorMode, value uint32) Color {
 	}
 }
 
-// Note: SaveScrollbackHistory and LoadScrollbackHistory were removed
-// as part of the DisplayBuffer cleanup. MemoryBuffer uses its own persistence.
-
 // ConvertPhysicalToLogical converts physical lines (with Wrapped flag) to logical lines.
 // This is used to migrate from the old storage format.
 // Lines where Wrapped=true are joined with the following line.

--- a/apps/texelterm/parser/logical_line_test.go
+++ b/apps/texelterm/parser/logical_line_test.go
@@ -547,11 +547,3 @@ func makeCells(s string) []Cell {
 	return cells
 }
 
-// Helper to convert cells back to string
-func cellsToString(cells []Cell) string {
-	runes := make([]rune, len(cells))
-	for i, c := range cells {
-		runes[i] = c.Rune
-	}
-	return string(runes)
-}

--- a/apps/texelterm/parser/logical_line_test.go
+++ b/apps/texelterm/parser/logical_line_test.go
@@ -486,58 +486,6 @@ func TestLogicalLine_CloneNilOverlay(t *testing.T) {
 	}
 }
 
-// --- ActiveWrapToWidth Tests ---
-
-func TestLogicalLine_ActiveWrapToWidth_NoOverlay(t *testing.T) {
-	line := NewLogicalLineFromCells(makeCells("Hello World"))
-	// showOverlay=true but no overlay → falls back to Cells
-	physical := line.ActiveWrapToWidth(10, true)
-	if len(physical) != 2 {
-		t.Fatalf("expected 2 physical lines (wrap at 10), got %d", len(physical))
-	}
-}
-
-func TestLogicalLine_ActiveWrapToWidth_WithOverlay(t *testing.T) {
-	line := NewLogicalLineFromCells(makeCells("Hello World"))
-	line.Overlay = makeCells("| Hello | World |")
-	line.OverlayWidth = 80
-
-	// showOverlay=true, has overlay → use overlay as fixed-width
-	physical := line.ActiveWrapToWidth(40, true)
-	if len(physical) != 1 {
-		t.Fatalf("overlay should produce 1 physical line (fixed-width), got %d", len(physical))
-	}
-	if len(physical[0].Cells) != 40 {
-		t.Errorf("expected 40 cells (clipped/padded to viewport width), got %d", len(physical[0].Cells))
-	}
-
-	// showOverlay=false → use original Cells (wraps normally)
-	physical = line.ActiveWrapToWidth(6, false)
-	if len(physical) != 2 {
-		t.Fatalf("original should wrap to 2 lines at width 6, got %d", len(physical))
-	}
-}
-
-func TestLogicalLine_ActiveWrapToWidth_Synthetic(t *testing.T) {
-	line := &LogicalLine{
-		Synthetic:    true,
-		Overlay:      makeCells("+---------+"),
-		OverlayWidth: 80,
-	}
-
-	// showOverlay=true → show overlay
-	physical := line.ActiveWrapToWidth(80, true)
-	if len(physical) != 1 {
-		t.Fatalf("expected 1 physical line, got %d", len(physical))
-	}
-
-	// showOverlay=false → synthetic lines return nil
-	physical = line.ActiveWrapToWidth(80, false)
-	if physical != nil {
-		t.Errorf("synthetic lines should return nil when showOverlay=false, got %d lines", len(physical))
-	}
-}
-
 // Helper to create cells from a string
 func makeCells(s string) []Cell {
 	cells := make([]Cell, len(s))

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -5,9 +5,8 @@ package parser
 
 // MainScreen is the interface that sparse.Terminal satisfies. Defined in
 // the parser package to avoid an import cycle (parser -> sparse -> parser).
-// VTerm holds a MainScreen and dual-writes to it during the transition;
-// after integration the legacy memBufState path is deleted and MainScreen
-// becomes the sole main-screen implementation.
+// sparse.Terminal is the sole production implementation; VTerm drives the
+// main-screen state exclusively through this interface.
 type MainScreen interface {
 	WriteCell(cell Cell)
 	Newline()
@@ -59,7 +58,9 @@ type MainScreen interface {
 	VisibleRange() (top, bottom int64)
 }
 
-// MainScreenFactory creates a MainScreen for the given dimensions.
-// Set by the sparse package's init or by the application layer.
-// If nil, no MainScreen is created and the legacy path is used alone.
+// MainScreenFactory creates a MainScreen for the given dimensions. Set by
+// the sparse package's init (via `import _ ".../parser/sparse"`). When nil
+// — e.g., in parser-only unit tests that don't import sparse — no
+// MainScreen is created and v.mainScreen stays nil; the MainScreen-gated
+// methods on VTerm short-circuit in that case.
 var MainScreenFactory func(width, height int) MainScreen

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -22,6 +22,12 @@ type MainScreen interface {
 	EraseLine()
 	EraseToEndOfLine(col int)
 	EraseFromStartOfLine(col int)
+
+	// SetLine and ClearRange are low-level store-manipulation primitives
+	// that bypass the cursor / writeTop / HWM invariants. They exist for
+	// operations outside the cursor-write model (erase, ICH/DCH, overlay
+	// insert, scroll-region rejoin). Callers are responsible for keeping
+	// the write window consistent with whatever they mutate.
 	SetLine(globalIdx int64, cells []Cell)
 	ClearRange(lo, hi int64)
 

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -43,11 +43,6 @@ type MainScreen interface {
 	OnInput()
 	IsFollowing() bool
 
-	// SyncWriteState updates the write window (writeTop + cursor) to match the
-	// given MemoryBuffer-side state after a resize. Unlike RestoreState, it does
-	// NOT snap the view window to the bottom — user's scroll position is preserved.
-	SyncWriteState(writeTop, cursorGlobalIdx int64, cursorCol int)
-
 	// LoadFromPageStore populates the main screen with all lines currently
 	// stored in the given PageStore. Used on session restore to replay
 	// persistent scrollback into the sparse store.

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -48,8 +48,17 @@ type MainScreen interface {
 	LoadFromPageStore(ps *PageStore) error
 
 	// RestoreState forcibly sets the write window's cursor and anchor,
-	// used during session restore to match the saved WAL metadata.
-	RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int)
+	// used during session restore to match the saved WAL metadata. hwm
+	// seeds the writeBottom high-water mark; passing 0 or a value less
+	// than writeTop+height-1 is equivalent to "unknown" and the
+	// implementation falls back to deriving HWM from writeTop+height-1.
+	RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int, hwm int64)
+
+	// WriteBottomHWM returns the high-water mark of writeBottom across
+	// the session. Persisted into MainScreenState so that a grown
+	// viewport on reload anchors against the true HWM rather than a
+	// diminished value.
+	WriteBottomHWM() int64
 
 	// ReadLine returns a copy of the cells at globalIdx. Returns nil for gaps.
 	ReadLine(globalIdx int64) []Cell

--- a/apps/texelterm/parser/osc7_test.go
+++ b/apps/texelterm/parser/osc7_test.go
@@ -14,7 +14,7 @@ import "testing"
 // CurrentWorkingDir, and that malformed sequences without the file:// prefix
 // are ignored.
 func TestOSC7_WorkingDirectory(t *testing.T) {
-	v := NewVTerm(80, 24, WithMemoryBuffer())
+	v := NewVTerm(80, 24)
 	p := NewParser(v)
 
 	// OSC 7 with hostname: ESC ] 7 ; <uri> BEL

--- a/apps/texelterm/parser/overlay_insert_test.go
+++ b/apps/texelterm/parser/overlay_insert_test.go
@@ -146,6 +146,128 @@ func TestRequestLineInsert_CursorPositionNotFullViewport(t *testing.T) {
 	}
 }
 
+// TestRequestLineInsert_CursorAtBottomRow pins down the semantic of
+// RequestLineInsert when the cursor is on the very last row of the viewport.
+// That is the common case for an interactive shell (cursor sits at the
+// prompt, viewport is full).
+//
+// Current behavior — which this test captures so any change becomes visible:
+//
+//   - InsertLines with cursorRow == marginBottom does not shift any rows
+//     (the shift loop is empty) and simply clears the cursor's row.
+//   - The cursor-follow guard `v.cursorY < v.height-1` is false, so the VTerm
+//     cursor does NOT advance, and cursorGlobalIdx stays where it was.
+//   - SetLine then writes the caller's cells at beforeIdx (i.e. the cursor's
+//     row). The cursor's pre-insert content is lost.
+//
+// Consequence: the next keystroke writes on top of the inserted cells. This
+// is a known limitation; we document it here rather than let it drift. If
+// the semantic changes (e.g. by newline-scrolling the write window first),
+// this test will fail and needs to be rewritten around the new contract.
+func TestRequestLineInsert_CursorAtBottomRow(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	width, height := 40, 24
+
+	v := NewVTerm(width, height)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Fill the viewport so the cursor sits on the bottom row when the
+	// prompt is rendered: height-1 full lines + one unterminated prompt.
+	for i := 0; i < height-1; i++ {
+		parseString(p, fmt.Sprintf("line %d\r\n", i))
+	}
+	parseString(p, "prompt$ ")
+
+	if v.cursorY != height-1 {
+		t.Fatalf("setup: expected cursorY == %d (bottom row), got %d", height-1, v.cursorY)
+	}
+
+	cursorGlobalBefore := v.cursorGlobalIdx()
+	gridBefore := v.Grid()
+	if !strings.Contains(cellsToString(gridBefore[height-1]), "prompt$") {
+		t.Fatalf("setup: bottom row should contain prompt, got %q",
+			cellsToString(gridBefore[height-1]))
+	}
+
+	// Insert at the cursor row itself. This is the code path where both the
+	// content and the cursor-follow guard matter.
+	insertedText := "--- inserted ---"
+	v.RequestLineInsert(cursorGlobalBefore, makeCells(insertedText))
+
+	// Cursor did not advance: guard blocked the follow.
+	if got := v.cursorY; got != height-1 {
+		t.Errorf("cursorY: got %d, want unchanged %d (guard should block follow at bottom row)",
+			got, height-1)
+	}
+	if got := v.cursorGlobalIdx(); got != cursorGlobalBefore {
+		t.Errorf("cursorGlobalIdx: got %d, want unchanged %d", got, cursorGlobalBefore)
+	}
+
+	// Bottom row now shows the inserted cells; the original prompt content
+	// was clobbered by the insert.
+	gridAfter := v.Grid()
+	rowAtBottom := cellsToString(gridAfter[height-1])
+	if !strings.Contains(rowAtBottom, insertedText) {
+		t.Errorf("after insert: bottom row should contain %q, got %q",
+			insertedText, rowAtBottom)
+	}
+	if strings.Contains(rowAtBottom, "prompt$") {
+		t.Errorf("after insert: bottom row still contains prompt %q — expected it to be clobbered",
+			rowAtBottom)
+	}
+}
+
+// TestRequestLineInsert_BothBranchesFire covers a single RequestLineInsert
+// call where the insert point is at or before BOTH the cursor's globalIdx
+// and PromptStartGlobalLine. Both adjustments must fire on that one call:
+// cursorY advances (so subsequent writes land at the right row) and
+// PromptStartGlobalLine shifts (so prompt-aware ops stay pointed at the
+// real prompt line).
+//
+// Rationale: individual branches are exercised by
+// TestRequestLineInsert_CursorPositionNotFullViewport (cursor follow) and
+// TestRequestLineInsert_PromptStartShiftsWithInsertsBeforeIt (prompt shift),
+// but nothing pins down that both fire together on the same call.
+func TestRequestLineInsert_BothBranchesFire(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	v := NewVTerm(40, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Write some output, then mark the prompt start at the current cursor.
+	for i := 0; i < 3; i++ {
+		parseString(p, fmt.Sprintf("output %d\r\n", i))
+	}
+	v.MarkPromptStart()
+
+	cursorGlobalBefore := v.cursorGlobalIdx()
+	promptBefore := v.PromptStartGlobalLine
+	cursorYBefore := v.cursorY
+
+	if promptBefore < 0 {
+		t.Fatalf("MarkPromptStart did not set PromptStartGlobalLine")
+	}
+	if promptBefore != cursorGlobalBefore {
+		t.Fatalf("setup: expected prompt at cursorGlobalIdx %d, got %d",
+			cursorGlobalBefore, promptBefore)
+	}
+
+	// Insert one line at the prompt position. beforeIdx == promptStart ==
+	// cursorGlobal, so both `beforeIdx <= cursorGlobal` and
+	// `beforeIdx <= PromptStartGlobalLine` are true on this single call.
+	v.RequestLineInsert(promptBefore, makeCells("S"))
+
+	if got := v.cursorY; got != cursorYBefore+1 {
+		t.Errorf("cursorY: got %d, want %d (cursor-follow branch should fire)",
+			got, cursorYBefore+1)
+	}
+	if got := v.PromptStartGlobalLine; got != promptBefore+1 {
+		t.Errorf("PromptStartGlobalLine: got %d, want %d (prompt-shift branch should fire)",
+			got, promptBefore+1)
+	}
+}
+
 // TestRequestLineInsert_PromptStartShiftsWithInsertsBeforeIt verifies the
 // minimal invariant covered by TestPromptPositionAfterTransformerInsert but
 // without the reload round-trip: each RequestLineInsert at or before

--- a/apps/texelterm/parser/overlay_insert_test.go
+++ b/apps/texelterm/parser/overlay_insert_test.go
@@ -40,7 +40,7 @@ func TestGetContentText_OverlayWrittenViaSetOverlay(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	width, height := 40, 10
 
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -86,7 +86,7 @@ func TestRequestLineInsert_CursorPositionNotFullViewport(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	width, height := 40, 24
 
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -152,7 +152,7 @@ func TestRequestLineInsert_CursorPositionNotFullViewport(t *testing.T) {
 // PromptStartGlobalLine must increment PromptStartGlobalLine by 1.
 func TestRequestLineInsert_PromptStartShiftsWithInsertsBeforeIt(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	v := NewVTerm(40, 24, WithMemoryBuffer())
+	v := NewVTerm(40, 24)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -87,6 +87,43 @@ type MainScreenState struct {
 	SavedAt time.Time `json:"saved_at"`
 }
 
+// Validate reports whether the state satisfies MainScreenState's intrinsic
+// invariants (those that do not depend on external data like the WAL's line
+// count). It is safe to call on any decoded value and is intended for use at
+// serialization boundaries to reject corrupt data before it is trusted as
+// recovery metadata.
+//
+// The checks are:
+//   - WriteTop must be non-negative (globalIdx is a 0-based index).
+//   - ContentEnd must be >= -1 (-1 is the "empty" sentinel).
+//   - CursorCol must be non-negative.
+//   - PromptStartLine must be >= -1 (-1 is the "unknown" sentinel).
+//   - CursorGlobalIdx must be >= WriteTop (the cursor lives inside the write
+//     window, which starts at WriteTop).
+//
+// Contextual checks (e.g. CursorGlobalIdx not exceeding the WAL's line count)
+// live with their caller; this method only enforces what the struct can know
+// about itself.
+func (s MainScreenState) Validate() error {
+	if s.WriteTop < 0 {
+		return fmt.Errorf("MainScreenState: WriteTop %d must be non-negative", s.WriteTop)
+	}
+	if s.ContentEnd < -1 {
+		return fmt.Errorf("MainScreenState: ContentEnd %d must be >= -1", s.ContentEnd)
+	}
+	if s.CursorCol < 0 {
+		return fmt.Errorf("MainScreenState: CursorCol %d must be non-negative", s.CursorCol)
+	}
+	if s.PromptStartLine < -1 {
+		return fmt.Errorf("MainScreenState: PromptStartLine %d must be >= -1", s.PromptStartLine)
+	}
+	if s.CursorGlobalIdx < s.WriteTop {
+		return fmt.Errorf("MainScreenState: CursorGlobalIdx %d must be >= WriteTop %d",
+			s.CursorGlobalIdx, s.WriteTop)
+	}
+	return nil
+}
+
 // PageStoreConfig holds configuration for the page store.
 type PageStoreConfig struct {
 	// BaseDir is the base directory for all history storage.

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -83,6 +83,14 @@ type MainScreenState struct {
 	// WorkingDir is the last known working directory from OSC 7.
 	WorkingDir string `json:"working_dir"`
 
+	// WriteBottomHWM is the high-water mark of writeBottom (writeTop +
+	// height - 1) across the session. Restored on reload so that a grown
+	// viewport anchors against the true HWM rather than the diminished
+	// value implied by a shrunken writeBottom. A zero value is treated as
+	// "unknown" on restore (older WAL entries without this field decode
+	// to zero); the restore path falls back to writeTop + height - 1.
+	WriteBottomHWM int64 `json:"write_bottom_hwm,omitempty"`
+
 	// SavedAt is when the state was saved.
 	SavedAt time.Time `json:"saved_at"`
 }
@@ -100,6 +108,9 @@ type MainScreenState struct {
 //   - PromptStartLine must be >= -1 (-1 is the "unknown" sentinel).
 //   - CursorGlobalIdx must be >= WriteTop (the cursor lives inside the write
 //     window, which starts at WriteTop).
+//   - WriteBottomHWM must be non-negative (it is a globalIdx). Zero is
+//     accepted as the "unknown/unset" value for backwards compatibility
+//     with older WAL entries that predate this field.
 //
 // Contextual checks (e.g. CursorGlobalIdx not exceeding the WAL's line count)
 // live with their caller; this method only enforces what the struct can know
@@ -120,6 +131,9 @@ func (s MainScreenState) Validate() error {
 	if s.CursorGlobalIdx < s.WriteTop {
 		return fmt.Errorf("MainScreenState: CursorGlobalIdx %d must be >= WriteTop %d",
 			s.CursorGlobalIdx, s.WriteTop)
+	}
+	if s.WriteBottomHWM < 0 {
+		return fmt.Errorf("MainScreenState: WriteBottomHWM %d must be non-negative", s.WriteBottomHWM)
 	}
 	return nil
 }

--- a/apps/texelterm/parser/page_store_main_screen_state_test.go
+++ b/apps/texelterm/parser/page_store_main_screen_state_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -26,5 +27,83 @@ func TestMainScreenState_JSONRoundtrip(t *testing.T) {
 	}
 	if got != s {
 		t.Errorf("roundtrip mismatch:\n got %+v\nwant %+v", got, s)
+	}
+}
+
+func TestMainScreenState_Validate(t *testing.T) {
+	// Baseline valid state used as a starting point for each case.
+	base := MainScreenState{
+		WriteTop:        100,
+		ContentEnd:      150,
+		CursorGlobalIdx: 112,
+		CursorCol:       5,
+		PromptStartLine: 108,
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(s *MainScreenState)
+		wantErr string // substring match; empty means expect nil
+	}{
+		{
+			name:   "valid baseline",
+			mutate: func(*MainScreenState) {},
+		},
+		{
+			name:   "empty store sentinel",
+			mutate: func(s *MainScreenState) { s.ContentEnd = -1 },
+		},
+		{
+			name:   "unknown prompt sentinel",
+			mutate: func(s *MainScreenState) { s.PromptStartLine = -1 },
+		},
+		{
+			name:   "cursor exactly at WriteTop",
+			mutate: func(s *MainScreenState) { s.CursorGlobalIdx = s.WriteTop },
+		},
+		{
+			name:    "negative WriteTop",
+			mutate:  func(s *MainScreenState) { s.WriteTop = -1 },
+			wantErr: "WriteTop -1",
+		},
+		{
+			name:    "ContentEnd below -1 sentinel",
+			mutate:  func(s *MainScreenState) { s.ContentEnd = -2 },
+			wantErr: "ContentEnd -2",
+		},
+		{
+			name:    "negative CursorCol",
+			mutate:  func(s *MainScreenState) { s.CursorCol = -1 },
+			wantErr: "CursorCol -1",
+		},
+		{
+			name:    "PromptStartLine below -1 sentinel",
+			mutate:  func(s *MainScreenState) { s.PromptStartLine = -2 },
+			wantErr: "PromptStartLine -2",
+		},
+		{
+			name:    "cursor above WriteTop",
+			mutate:  func(s *MainScreenState) { s.CursorGlobalIdx = s.WriteTop - 1 },
+			wantErr: "CursorGlobalIdx 99 must be >= WriteTop 100",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := base
+			tc.mutate(&s)
+			err := s.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate: unexpected error %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate: expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate: error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+		})
 	}
 }

--- a/apps/texelterm/parser/phantom_gaps_test.go
+++ b/apps/texelterm/parser/phantom_gaps_test.go
@@ -102,7 +102,7 @@ func TestPhantomGaps_DenseLines(t *testing.T) {
 
 // TestPhantomGaps_DenseLargeLines like above but enough to trigger eviction.
 // Uses 10k lines instead of 60k — sufficient to trigger page eviction while
-// keeping runtime reasonable under -race with dual-write overhead.
+// keeping runtime reasonable under -race.
 func TestPhantomGaps_DenseLargeLines(t *testing.T) {
 	var b strings.Builder
 	for i := 0; i < 10000; i++ {

--- a/apps/texelterm/parser/phantom_gaps_test.go
+++ b/apps/texelterm/parser/phantom_gaps_test.go
@@ -21,7 +21,7 @@ func feedAndCount(t *testing.T, name string, height int, payload string) {
 	dir := t.TempDir()
 	terminalID := "phantom-" + name
 
-	v := NewVTerm(80, height, WithMemoryBuffer())
+	v := NewVTerm(80, height)
 	if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
 		MaxLines:   50000,
 		TerminalID: terminalID,
@@ -140,7 +140,7 @@ func TestPhantomGaps_MultiSession_Reload(t *testing.T) {
 	terminalID := "phantom-multisession"
 
 	feed := func(payload string) {
-		v := NewVTerm(80, 24, WithMemoryBuffer())
+		v := NewVTerm(80, 24)
 		if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,

--- a/apps/texelterm/parser/recovery_metadata_test.go
+++ b/apps/texelterm/parser/recovery_metadata_test.go
@@ -1,0 +1,142 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Coverage for recovery of MainScreenState at session reload. These tests
+// target two specific failure modes:
+//
+//  1. `CursorGlobalIdx < WriteTop` in saved metadata — physically impossible
+//     (the cursor lives inside the write window which starts at WriteTop),
+//     but prior to decoder-side Validate() this was accepted and the load
+//     guard silently fell through with cursorY = 0.
+//
+//  2. `PromptStartLine > pageStoreLineCount` in saved metadata — pointer
+//     into empty scrollback. Restoring verbatim leaves prompt-aware ops
+//     (scroll-to-prompt, erase-to-prompt) pointing at non-existent rows.
+//
+// Both cases are exercised by writing deliberately bogus MainScreenState
+// straight to the WAL (bypassing the AdaptivePersistence flush-time clamp)
+// and then reopening the session.
+
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRecovery_RejectsCursorBelowWriteTop verifies that a MainScreenState
+// whose CursorGlobalIdx is strictly less than WriteTop is rejected at the
+// WAL decode boundary (via MainScreenState.Validate()). Recovery must fall
+// back to a fresh cursor rather than restoring a cursor that lives in
+// scrollback (outside the write window).
+func TestRecovery_RejectsCursorBelowWriteTop(t *testing.T) {
+	dir := t.TempDir()
+	id := "vt-recovery-cursor-below-writetop"
+	const cols, rows = 80, 24
+
+	t.Setenv("HOME", t.TempDir())
+
+	// Session 1: write some lines, then inject bad metadata directly into
+	// the WAL so Validate() on reload is what catches it (not the
+	// AdaptivePersistence clamp on flush).
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	writeNumberedLines(v1, 0, 50)
+
+	badMeta := &MainScreenState{
+		WriteTop:        30,
+		ContentEnd:      50,
+		CursorGlobalIdx: 10, // 10 < WriteTop (30) — invalid
+		CursorCol:       0,
+		PromptStartLine: -1,
+		WorkingDir:      "",
+		SavedAt:         time.Now(),
+	}
+	ap := v1.mainScreenPersistence
+	if ap == nil || ap.wal == nil {
+		t.Fatalf("AdaptivePersistence/WAL not initialized")
+	}
+	if err := ap.wal.WriteMainScreenState(badMeta); err != nil {
+		t.Fatalf("WriteMainScreenState: %v", err)
+	}
+	if err := ap.wal.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	dirtyClose(v1)
+
+	// Session 2: reopen. The bad entry should fail Validate() during WAL
+	// replay, leaving recoveredMainScreenState as nil (no prior valid state)
+	// or at the last checkpoint. Either way, the cursor must not land below
+	// a stale WriteTop.
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	cursorGI, _ := v2.mainScreen.Cursor()
+	writeTop := v2.mainScreen.WriteTop()
+
+	if cursorGI < writeTop {
+		t.Errorf("recovered cursor below writeTop: cursorGI=%d writeTop=%d", cursorGI, writeTop)
+	}
+	// The bad entry in particular should not have been restored verbatim.
+	if cursorGI == 10 && writeTop == 30 {
+		t.Errorf("corrupt metadata was restored verbatim: cursorGI=10 writeTop=30")
+	}
+}
+
+// TestRecovery_DiscardsStalePromptStartLine verifies that a PromptStartLine
+// pointing past the last persisted line is discarded on reload (reset to
+// -1, "unknown"). This covers the case where metadata advanced but the
+// referenced prompt line never made it to PageStore — downstream
+// prompt-aware operations must not dereference that index.
+func TestRecovery_DiscardsStalePromptStartLine(t *testing.T) {
+	dir := t.TempDir()
+	id := "vt-recovery-stale-prompt"
+	const cols, rows = 80, 24
+
+	t.Setenv("HOME", t.TempDir())
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	writeNumberedLines(v1, 0, 50)
+
+	realContentEnd := v1.ContentEnd()
+	realWriteTop := v1.mainScreen.WriteTop()
+	realCursorGI, realCursorCol := v1.mainScreen.Cursor()
+
+	// Preserve the other fields so only PromptStartLine is stale. Point the
+	// prompt far past any line that could ever reach PageStore.
+	staleMeta := &MainScreenState{
+		WriteTop:        realWriteTop,
+		ContentEnd:      realContentEnd,
+		CursorGlobalIdx: realCursorGI,
+		CursorCol:       realCursorCol,
+		PromptStartLine: realContentEnd + 500, // way past the end
+		WorkingDir:      "/tmp",
+		SavedAt:         time.Now(),
+	}
+	ap := v1.mainScreenPersistence
+	if ap == nil || ap.wal == nil {
+		t.Fatalf("AdaptivePersistence/WAL not initialized")
+	}
+	if err := ap.wal.WriteMainScreenState(staleMeta); err != nil {
+		t.Fatalf("WriteMainScreenState: %v", err)
+	}
+	if err := ap.wal.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	dirtyClose(v1)
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	// The stale prompt position must have been discarded (reset to -1).
+	if v2.PromptStartGlobalLine == staleMeta.PromptStartLine {
+		t.Errorf("stale PromptStartLine %d was restored verbatim", v2.PromptStartGlobalLine)
+	}
+	if v2.PromptStartGlobalLine != -1 {
+		// Tolerate an alternative clamp (e.g. to pageStoreLineCount-1) but
+		// fail loudly if it's still pointing into phantom territory.
+		if pageStoreLineCount := v2.mainScreenPageStore.LineCount(); v2.PromptStartGlobalLine >= pageStoreLineCount {
+			t.Errorf("PromptStartGlobalLine %d still past PageStore end %d",
+				v2.PromptStartGlobalLine, pageStoreLineCount)
+		}
+	}
+}

--- a/apps/texelterm/parser/recovery_metadata_test.go
+++ b/apps/texelterm/parser/recovery_metadata_test.go
@@ -2,20 +2,26 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // Coverage for recovery of MainScreenState at session reload. These tests
-// target two specific failure modes:
+// target three specific failure modes:
 //
 //  1. `CursorGlobalIdx < WriteTop` in saved metadata — physically impossible
 //     (the cursor lives inside the write window which starts at WriteTop),
 //     but prior to decoder-side Validate() this was accepted and the load
 //     guard silently fell through with cursorY = 0.
 //
-//  2. `PromptStartLine > pageStoreLineCount` in saved metadata — pointer
+//  2. `WriteBottomHWM` silently re-derived on reload — if the saved HWM
+//     isn't persisted, a grown viewport anchors against writeTop+height-1
+//     and writeTop retreats into scrollback (the pre-sparse liveEdgeBase
+//     bug).
+//
+//  3. `PromptStartLine > pageStoreLineCount` in saved metadata — pointer
 //     into empty scrollback. Restoring verbatim leaves prompt-aware ops
 //     (scroll-to-prompt, erase-to-prompt) pointing at non-existent rows.
 //
-// Both cases are exercised by writing deliberately bogus MainScreenState
-// straight to the WAL (bypassing the AdaptivePersistence flush-time clamp)
-// and then reopening the session.
+// Each case is exercised by flushing real content to the PageStore, then
+// writing deliberately bogus (or specifically-constructed) MainScreenState
+// straight to the WAL (bypassing the AdaptivePersistence snapshot path) and
+// reopening the session.
 
 package parser
 
@@ -42,6 +48,21 @@ func TestRecovery_RejectsCursorBelowWriteTop(t *testing.T) {
 	v1 := newTestVTerm(t, cols, rows, dir, id)
 	writeNumberedLines(v1, 0, 50)
 
+	ap := v1.mainScreenPersistence
+	if ap == nil || ap.wal == nil {
+		t.Fatalf("AdaptivePersistence/WAL not initialized")
+	}
+	// Flush pending content so PageStore holds ≥ 50 lines. Without this, the
+	// outer load-time guard (`WriteTop <= pageStoreLineCount`) would reject
+	// the bad metadata regardless of whether Validate() is working, masking
+	// a regression in Validate().
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := ap.wal.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
 	badMeta := &MainScreenState{
 		WriteTop:        30,
 		ContentEnd:      50,
@@ -50,10 +71,6 @@ func TestRecovery_RejectsCursorBelowWriteTop(t *testing.T) {
 		PromptStartLine: -1,
 		WorkingDir:      "",
 		SavedAt:         time.Now(),
-	}
-	ap := v1.mainScreenPersistence
-	if ap == nil || ap.wal == nil {
-		t.Fatalf("AdaptivePersistence/WAL not initialized")
 	}
 	if err := ap.wal.WriteMainScreenState(badMeta); err != nil {
 		t.Fatalf("WriteMainScreenState: %v", err)
@@ -82,6 +99,77 @@ func TestRecovery_RejectsCursorBelowWriteTop(t *testing.T) {
 	}
 }
 
+// TestRecovery_RestoresWriteBottomHWM verifies that writeBottomHWM survives
+// a session round-trip. Without persistence the new session reinitialized
+// HWM to writeTop+height-1, so a subsequent grow-on-resize would anchor
+// against that diminished value and writeTop would retreat into scrollback
+// — the same failure mode as the pre-sparse liveEdgeBase bug.
+//
+// Scenario: session 1 writes enough lines to move HWM well past the initial
+// height-1, then we manually persist metadata carrying an HWM slightly
+// beyond what derive-from-writeTop would produce. Session 2 must load the
+// saved HWM; the test catches the "silently re-derived" failure mode.
+func TestRecovery_RestoresWriteBottomHWM(t *testing.T) {
+	dir := t.TempDir()
+	id := "vt-recovery-hwm"
+	const cols, rows = 80, 24
+
+	t.Setenv("HOME", t.TempDir())
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	writeNumberedLines(v1, 0, 200)
+
+	realHWM := v1.mainScreen.WriteBottomHWM()
+	realWriteTop := v1.mainScreen.WriteTop()
+	realCursorGI, realCursorCol := v1.mainScreen.Cursor()
+	realContentEnd := v1.ContentEnd()
+
+	ap := v1.mainScreenPersistence
+	if ap == nil || ap.wal == nil {
+		t.Fatalf("AdaptivePersistence/WAL not initialized")
+	}
+	// Force content out of the pending queue and into the PageStore so the
+	// reload guard (`WriteTop <= pageStoreLineCount`) accepts the metadata
+	// we are about to inject. Without this, BestEffort batching can leave
+	// PageStore with only a handful of lines at dirtyClose time.
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := ap.wal.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
+	// Push HWM beyond the value derive-from-writeTop would produce so we can
+	// tell them apart after reload. Both values are persisted, the restore
+	// path must honor the larger.
+	savedHWM := realHWM + 100
+	meta := &MainScreenState{
+		WriteTop:        realWriteTop,
+		ContentEnd:      realContentEnd,
+		CursorGlobalIdx: realCursorGI,
+		CursorCol:       realCursorCol,
+		PromptStartLine: -1,
+		WorkingDir:      "",
+		WriteBottomHWM:  savedHWM,
+		SavedAt:         time.Now(),
+	}
+	if err := ap.wal.WriteMainScreenState(meta); err != nil {
+		t.Fatalf("WriteMainScreenState: %v", err)
+	}
+	if err := ap.wal.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	dirtyClose(v1)
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if got := v2.mainScreen.WriteBottomHWM(); got != savedHWM {
+		t.Errorf("WriteBottomHWM: got %d, want %d (persistence silently dropped HWM?)",
+			got, savedHWM)
+	}
+}
+
 // TestRecovery_DiscardsStalePromptStartLine verifies that a PromptStartLine
 // pointing past the last persisted line is discarded on reload (reset to
 // -1, "unknown"). This covers the case where metadata advanced but the
@@ -101,6 +189,21 @@ func TestRecovery_DiscardsStalePromptStartLine(t *testing.T) {
 	realWriteTop := v1.mainScreen.WriteTop()
 	realCursorGI, realCursorCol := v1.mainScreen.Cursor()
 
+	ap := v1.mainScreenPersistence
+	if ap == nil || ap.wal == nil {
+		t.Fatalf("AdaptivePersistence/WAL not initialized")
+	}
+	// Flush pending content to PageStore so the reload guard accepts the
+	// metadata. Otherwise the whole entry is rejected and the clamp path
+	// we're trying to exercise is never hit (the default PromptStartLine
+	// of -1 would make the test pass by coincidence).
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := ap.wal.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+
 	// Preserve the other fields so only PromptStartLine is stale. Point the
 	// prompt far past any line that could ever reach PageStore.
 	staleMeta := &MainScreenState{
@@ -111,10 +214,6 @@ func TestRecovery_DiscardsStalePromptStartLine(t *testing.T) {
 		PromptStartLine: realContentEnd + 500, // way past the end
 		WorkingDir:      "/tmp",
 		SavedAt:         time.Now(),
-	}
-	ap := v1.mainScreenPersistence
-	if ap == nil || ap.wal == nil {
-		t.Fatalf("AdaptivePersistence/WAL not initialized")
 	}
 	if err := ap.wal.WriteMainScreenState(staleMeta); err != nil {
 		t.Fatalf("WriteMainScreenState: %v", err)

--- a/apps/texelterm/parser/resize_cursor_sync_test.go
+++ b/apps/texelterm/parser/resize_cursor_sync_test.go
@@ -33,7 +33,7 @@ import (
 // short content preserves it in the grid at the new dimensions.
 func TestVTerm_MemoryBufferResize_ShortContent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	v := NewVTerm(80, 24, WithMemoryBuffer())
+	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -60,7 +60,7 @@ func TestVTerm_MemoryBufferResize_ShortContent(t *testing.T) {
 // same grid row as the prompt.
 func TestVTerm_ResizeBeforeContentCursorSync_Grow(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	v := NewVTerm(80, 24, WithMemoryBuffer())
+	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -105,7 +105,7 @@ func TestVTerm_ResizeBeforeContentCursorSync_Grow(t *testing.T) {
 // when shrinking instead of growing.
 func TestVTerm_ResizeBeforeContentCursorSync_Shrink(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	v := NewVTerm(120, 30, WithMemoryBuffer())
+	v := NewVTerm(120, 30)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -138,7 +138,7 @@ func TestVTerm_ResizeBeforeContentCursorSync_Shrink(t *testing.T) {
 func TestResize_HeightChangeCursorDesync(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	width, height := 40, 24
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -170,7 +170,7 @@ func TestResize_HeightChangeCursorDesync(t *testing.T) {
 func TestResize_HeightChangeCursorDesync_FullViewport(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	width, height := 40, 24
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 

--- a/apps/texelterm/parser/resize_cursor_sync_test.go
+++ b/apps/texelterm/parser/resize_cursor_sync_test.go
@@ -49,7 +49,7 @@ func TestVTerm_MemoryBufferResize_ShortContent(t *testing.T) {
 		t.Errorf("cols: got %d, want 40", len(grid[0]))
 	}
 
-	row0 := strings.TrimRight(gridRowToString(grid[0]), " ")
+	row0 := strings.TrimRight(cellsToString(grid[0]), " ")
 	if row0 != "Hello, World!" {
 		t.Errorf("content lost after resize: row 0 = %q, want 'Hello, World!'", row0)
 	}

--- a/apps/texelterm/parser/reverse_search_test.go
+++ b/apps/texelterm/parser/reverse_search_test.go
@@ -82,8 +82,8 @@ func TestReverseSearch_RealReadlineSequences(t *testing.T) {
 
 	// renderBuf and Grid must agree on the cursor's row.
 	grid := v.Grid()
-	gridRow := strings.TrimRight(gridRowToString(grid[v.cursorY]), " ")
-	renderRow := strings.TrimRight(gridRowToString(renderBuf[v.cursorY]), " ")
+	gridRow := strings.TrimRight(cellsToString(grid[v.cursorY]), " ")
+	renderRow := strings.TrimRight(cellsToString(renderBuf[v.cursorY]), " ")
 	if gridRow != renderRow {
 		t.Errorf("render/grid mismatch at row %d: render=%q grid=%q", v.cursorY, renderRow, gridRow)
 	}

--- a/apps/texelterm/parser/reverse_search_test.go
+++ b/apps/texelterm/parser/reverse_search_test.go
@@ -24,7 +24,7 @@ import (
 func TestReverseSearch_RealReadlineSequences(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	width, height := 80, 24
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 

--- a/apps/texelterm/parser/scroll_region_test.go
+++ b/apps/texelterm/parser/scroll_region_test.go
@@ -43,7 +43,7 @@ func captureGridStrings(v *VTerm) []string {
 // line is overwritten by the rotation, not pushed into scrollback.
 func TestVTerm_ScrollRegion_NoHeader(t *testing.T) {
 	width, height := 40, 6
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -93,7 +93,7 @@ func TestVTerm_ScrollRegion_NoHeader(t *testing.T) {
 // header on row 0.
 func TestVTerm_ScrollRegion_NoFooter(t *testing.T) {
 	width, height := 40, 6
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -138,7 +138,7 @@ func TestVTerm_ScrollRegion_NoFooter(t *testing.T) {
 // a scroll region and verifies the rotation amount without touching writeTop.
 func TestVTerm_ScrollRegion_MultipleScrollN(t *testing.T) {
 	width, height := 40, 8
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -193,7 +193,7 @@ func TestVTerm_ScrollRegion_MultipleScrollN(t *testing.T) {
 // (no DECSTBM margins) advance writeTop, the sole path that pushes lines into
 // scrollback in the sparse model.
 func TestVTerm_ScrollRegion_FullScreenUnchanged(t *testing.T) {
-	v := NewVTerm(40, 5, WithMemoryBuffer())
+	v := NewVTerm(40, 5)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -219,7 +219,7 @@ func TestVTerm_ScrollRegion_FullScreenUnchanged(t *testing.T) {
 // down within region) shifts content down without advancing writeTop.
 func TestVTerm_ScrollRegion_ScrollDownUnchanged(t *testing.T) {
 	width, height := 40, 10
-	v := NewVTerm(width, height, WithMemoryBuffer())
+	v := NewVTerm(width, height)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 

--- a/apps/texelterm/parser/scroll_region_test.go
+++ b/apps/texelterm/parser/scroll_region_test.go
@@ -32,7 +32,7 @@ func captureGridStrings(v *VTerm) []string {
 	grid := v.Grid()
 	out := make([]string, len(grid))
 	for y := range grid {
-		out[y] = trimRight(gridRowToString(grid[y]))
+		out[y] = trimRight(cellsToString(grid[y]))
 	}
 	return out
 }
@@ -73,14 +73,14 @@ func TestVTerm_ScrollRegion_NoHeader(t *testing.T) {
 	}
 
 	// Footer preserved at the last row.
-	if got, want := gridRowToString(grid[height-1][:6]), "FOOTER"; got != want {
+	if got, want := cellsToString(grid[height-1][:6]), "FOOTER"; got != want {
 		t.Errorf("Footer corrupted: got %q, want %q", got, want)
 	}
 
 	// Region rotated: after 7 writes in a 5-line region, rows 0..4 should hold
 	// Line-C, Line-D, Line-E, Line-F, Line-G (the first two dropped off the top).
 	for y := 0; y < 5; y++ {
-		got := gridRowToString(grid[y][:6])
+		got := cellsToString(grid[y][:6])
 		want := fmt.Sprintf("Line-%c", 'C'+rune(y))
 		if got != want {
 			t.Errorf("row %d: got %q, want %q", y, got, want)
@@ -120,13 +120,13 @@ func TestVTerm_ScrollRegion_NoFooter(t *testing.T) {
 	}
 
 	// Header preserved.
-	if got, want := gridRowToString(grid[0][:6]), "HEADER"; got != want {
+	if got, want := cellsToString(grid[0][:6]), "HEADER"; got != want {
 		t.Errorf("Header corrupted: got %q, want %q", got, want)
 	}
 
 	// Rows 1..5 hold Line-C..Line-G.
 	for y := 1; y <= 5; y++ {
-		got := gridRowToString(grid[y][:6])
+		got := cellsToString(grid[y][:6])
 		want := fmt.Sprintf("Line-%c", 'C'+rune(y-1))
 		if got != want {
 			t.Errorf("row %d: got %q, want %q", y, got, want)
@@ -165,24 +165,24 @@ func TestVTerm_ScrollRegion_MultipleScrollN(t *testing.T) {
 
 	grid := v.Grid()
 
-	if got, want := gridRowToString(grid[0][:6]), "HEADER"; got != want {
+	if got, want := cellsToString(grid[0][:6]), "HEADER"; got != want {
 		t.Errorf("header corrupted after CSI 3S: got %q, want %q", got, want)
 	}
-	if got, want := gridRowToString(grid[height-1][:6]), "FOOTER"; got != want {
+	if got, want := cellsToString(grid[height-1][:6]), "FOOTER"; got != want {
 		t.Errorf("footer corrupted after CSI 3S: got %q, want %q", got, want)
 	}
 
 	// After rotating up by 3 in a region of 6 rows, rows 1..3 hold
 	// Line-D..Line-F and rows 4..6 are blank.
 	for y := 1; y <= 3; y++ {
-		got := gridRowToString(grid[y][:6])
+		got := cellsToString(grid[y][:6])
 		want := fmt.Sprintf("Line-%c", 'D'+rune(y-1))
 		if got != want {
 			t.Errorf("row %d after CSI 3S: got %q, want %q", y, got, want)
 		}
 	}
 	for y := 4; y <= 6; y++ {
-		got := trimRight(gridRowToString(grid[y]))
+		got := trimRight(cellsToString(grid[y]))
 		if got != "" {
 			t.Errorf("row %d after CSI 3S: expected blank, got %q", y, got)
 		}

--- a/apps/texelterm/parser/scrollback_history_test.go
+++ b/apps/texelterm/parser/scrollback_history_test.go
@@ -27,7 +27,7 @@ import (
 // auto-follow mode and ScrollToBottom returns to it, exercising the
 // ViewWindow autoFollow flag.
 func TestVTerm_UserScroll(t *testing.T) {
-	v := NewVTerm(80, 10, WithMemoryBuffer())
+	v := NewVTerm(80, 10)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -56,7 +56,7 @@ func TestVTerm_UserScroll(t *testing.T) {
 // TestVTerm_TotalLines verifies that ContentEnd advances as lines are
 // appended, matching the pre-sparse memoryBufferTotalLines semantics.
 func TestVTerm_TotalLines(t *testing.T) {
-	v := NewVTerm(80, 24, WithMemoryBuffer())
+	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()
 	p := NewParser(v)
 
@@ -95,7 +95,7 @@ func TestLoadHistory_ResetsTerminalColors(t *testing.T) {
 	terminalID := "test-color-reset"
 
 	{
-		v := NewVTerm(80, 24, WithMemoryBuffer())
+		v := NewVTerm(80, 24)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,
@@ -109,7 +109,7 @@ func TestLoadHistory_ResetsTerminalColors(t *testing.T) {
 	}
 
 	{
-		v := NewVTerm(80, 24, WithMemoryBuffer())
+		v := NewVTerm(80, 24)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,
@@ -153,7 +153,7 @@ func TestPromptPositionOnReload(t *testing.T) {
 	var savedPromptLine int64
 
 	{
-		v := NewVTerm(width, height, WithMemoryBuffer())
+		v := NewVTerm(width, height)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,
@@ -184,7 +184,7 @@ func TestPromptPositionOnReload(t *testing.T) {
 	}
 
 	{
-		v := NewVTerm(width, height, WithMemoryBuffer())
+		v := NewVTerm(width, height)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,
@@ -222,7 +222,7 @@ func TestPromptPositionAfterTransformerInsert(t *testing.T) {
 	width, height := 80, 24
 
 	{
-		v := NewVTerm(width, height, WithMemoryBuffer())
+		v := NewVTerm(width, height)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,
@@ -269,7 +269,7 @@ func TestPromptPositionAfterTransformerInsert(t *testing.T) {
 	}
 
 	{
-		v := NewVTerm(width, height, WithMemoryBuffer())
+		v := NewVTerm(width, height)
 		err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 			MaxLines:   50000,
 			TerminalID: terminalID,

--- a/apps/texelterm/parser/shared_helpers_test.go
+++ b/apps/texelterm/parser/shared_helpers_test.go
@@ -1,27 +1,18 @@
 // Copyright 2025 Texelation contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// File: apps/texelterm/parser/test_helpers_test.go
+// File: apps/texelterm/parser/shared_helpers_test.go
 // Summary: Shared test helper functions used across multiple test files.
 
 package parser
 
-import "strings"
-
-// logicalLineToString converts a LogicalLine to a string.
+// logicalLineToString converts a LogicalLine to a string, mapping null runes
+// to spaces. Returns "" for a nil line.
 func logicalLineToString(line *LogicalLine) string {
 	if line == nil {
 		return ""
 	}
-	runes := make([]rune, len(line.Cells))
-	for i, c := range line.Cells {
-		if c.Rune == 0 {
-			runes[i] = ' '
-		} else {
-			runes[i] = c.Rune
-		}
-	}
-	return string(runes)
+	return cellsToString(line.Cells)
 }
 
 // trimLogicalLine trims trailing spaces and null characters from a line.
@@ -33,33 +24,10 @@ func trimLogicalLine(s string) string {
 	return s[:end]
 }
 
-// sparseCellsToString converts a sparse-terminal []Cell slice to plain text.
-// Note: cellsToString (same signature) is also defined in logical_line_test.go.
-// This alias avoids duplicate declarations while providing the same functionality.
-func sparseCellsToString(cells []Cell) string {
-	var sb strings.Builder
-	for _, c := range cells {
-		if c.Rune == 0 {
-			sb.WriteRune(' ')
-		} else {
-			sb.WriteRune(c.Rune)
-		}
-	}
-	return sb.String()
-}
-
-// parseString feeds every rune of s through p, shorthand for the common
-// `for _, ch := range s { p.Parse(ch) }` test pattern.
-func parseString(p *Parser, s string) {
-	for _, r := range s {
-		p.Parse(r)
-	}
-}
-
-// gridRowToString converts one row of a VTerm grid back to a rune string,
-// replacing the null-rune sentinel with a space so trailing padding prints
-// as blanks rather than NULs.
-func gridRowToString(cells []Cell) string {
+// cellsToString converts a []Cell slice to a rune string, mapping the
+// null-rune sentinel (Rune == 0) to a space so sparse-grid padding prints as
+// blanks rather than NULs.
+func cellsToString(cells []Cell) string {
 	runes := make([]rune, len(cells))
 	for i, c := range cells {
 		if c.Rune == 0 {
@@ -69,6 +37,14 @@ func gridRowToString(cells []Cell) string {
 		}
 	}
 	return string(runes)
+}
+
+// parseString feeds every rune of s through p, shorthand for the common
+// `for _, ch := range s { p.Parse(ch) }` test pattern.
+func parseString(p *Parser, s string) {
+	for _, r := range s {
+		p.Parse(r)
+	}
 }
 
 // trimRight removes trailing whitespace (space, tab, null) from a string.
@@ -99,7 +75,7 @@ func readAllSparseLines(v *VTerm) []string {
 			lines = append(lines, "")
 			continue
 		}
-		lines = append(lines, trimLogicalLine(sparseCellsToString(cells)))
+		lines = append(lines, trimLogicalLine(cellsToString(cells)))
 	}
 	return lines
 }

--- a/apps/texelterm/parser/sparse/persistence.go
+++ b/apps/texelterm/parser/sparse/persistence.go
@@ -55,15 +55,18 @@ func SnapshotState(tm *Terminal) parser.MainScreenState {
 		CursorGlobalIdx: gi,
 		CursorCol:       col,
 		PromptStartLine: -1,
+		WriteBottomHWM:  tm.WriteBottomHWM(),
 		SavedAt:         time.Now(),
 	}
 }
 
 // RestoreState applies a MainScreenState to an existing Terminal, overwriting
 // cursor and writeTop. The ViewWindow is put into autoFollow mode snapped to
-// the new writeBottom.
+// the new writeBottom. WriteBottomHWM is used only when it exceeds the
+// natural floor writeTop+height-1; smaller values (including zero, as
+// written by older WAL entries) fall back to that floor.
 func RestoreState(tm *Terminal, state parser.MainScreenState) {
-	tm.RestoreWriteState(state.WriteTop, state.CursorGlobalIdx, state.CursorCol)
+	tm.RestoreWriteState(state.WriteTop, state.CursorGlobalIdx, state.CursorCol, state.WriteBottomHWM)
 }
 
 // LoadStore reads every line currently present in the PageStore into the

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -164,16 +164,6 @@ func (t *Terminal) RestoreWriteState(writeTop, cursorGlobalIdx int64, cursorCol 
 	t.view.ScrollToBottom(t.write.WriteBottom())
 }
 
-// SyncWriteState updates the write window (writeTop + cursor) to match an
-// externally-computed anchor. Unlike RestoreWriteState, it preserves the
-// ViewWindow's current scroll position: if the user is scrolled back,
-// viewBottom does not change; if autoFollow is active, viewBottom snaps to
-// the new writeBottom.
-func (t *Terminal) SyncWriteState(writeTop, cursorGlobalIdx int64, cursorCol int) {
-	t.write.RestoreState(writeTop, cursorGlobalIdx, cursorCol)
-	t.view.OnWriteBottomChanged(t.write.WriteBottom())
-}
-
 // RestoreState implements MainScreen.RestoreState by delegating to
 // RestoreWriteState.
 func (t *Terminal) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int) {

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -138,15 +138,24 @@ func (t *Terminal) NewlineInRegion(marginTop, marginBottom int) {
 	// ViewWindow notification is needed.
 }
 
-// SetLine overwrites the cells at the given globalIdx in the store.
-// Used to sync from MemoryBuffer after complex operations (scroll regions).
+// SetLine overwrites the cells at globalIdx directly in the store,
+// bypassing the WriteWindow's cursor / writeTop invariants. Intended for
+// callers that need to mutate specific lines outside the cursor model:
+// ED / EL erase operations (fill a range with the current FG/BG), ICH /
+// DCH character edits (rewrite a single row in place), and overlay-insert
+// paths that sync cells into a globalIdx chosen by the parser. It does
+// NOT advance writeTop, touch the cursor, or update HWM; callers are
+// responsible for keeping write-window state consistent with whatever
+// they write here.
 func (t *Terminal) SetLine(globalIdx int64, cells []parser.Cell) {
 	t.store.SetLine(globalIdx, cells)
 }
 
-// ClearRange removes all lines in [lo, hi] from the store.
-// Used to sync from MemoryBuffer after resize-split rejoin and similar
-// operations that collapse multiple logical lines back into one.
+// ClearRange removes all lines in [lo, hi] from the store, bypassing the
+// WriteWindow. Same contract as SetLine: callers take on responsibility
+// for keeping writeTop / cursor / HWM consistent. Typical uses are ED J 3
+// (clear scrollback above writeTop), ED-below-cursor (clear tail of the
+// write window), and scroll-region rejoin that collapses logical lines.
 func (t *Terminal) ClearRange(lo, hi int64) {
 	t.store.ClearRange(lo, hi)
 }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -158,16 +158,23 @@ func (t *Terminal) ReadLine(globalIdx int64) []parser.Cell {
 
 // RestoreWriteState forcibly sets the write window's cursor and anchor,
 // used during session restore. The ViewWindow is re-snapped to the new
-// writeBottom in follow mode.
-func (t *Terminal) RestoreWriteState(writeTop, cursorGlobalIdx int64, cursorCol int) {
-	t.write.RestoreState(writeTop, cursorGlobalIdx, cursorCol)
+// writeBottom in follow mode. hwm seeds writeBottomHWM only when it
+// exceeds writeTop+height-1; smaller values (including zero, as written
+// by older WAL entries that predate this field) fall back to that floor.
+func (t *Terminal) RestoreWriteState(writeTop, cursorGlobalIdx int64, cursorCol int, hwm int64) {
+	t.write.RestoreState(writeTop, cursorGlobalIdx, cursorCol, hwm)
 	t.view.ScrollToBottom(t.write.WriteBottom())
 }
 
 // RestoreState implements MainScreen.RestoreState by delegating to
 // RestoreWriteState.
-func (t *Terminal) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int) {
-	t.RestoreWriteState(writeTop, cursorGlobalIdx, cursorCol)
+func (t *Terminal) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int, hwm int64) {
+	t.RestoreWriteState(writeTop, cursorGlobalIdx, cursorCol, hwm)
+}
+
+// WriteBottomHWM returns the write window's high-water mark for persistence.
+func (t *Terminal) WriteBottomHWM() int64 {
+	return t.write.WriteBottomHWM()
 }
 
 // LoadFromPageStore loads all lines from the PageStore into the sparse

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -73,19 +73,6 @@ func (v *ViewWindow) OnWriteBottomChanged(newWriteBottom int64) {
 	}
 }
 
-// OnWriteTopChanged is called when the WriteWindow retreats its top on grow
-// (i.e. the write window expands upward). Despite the name referring to the
-// top, callers must pass newWriteBottom — the new WriteWindow.WriteBottom()
-// value — because that is what viewBottom tracks. Only advances viewBottom
-// forward, never retreats it.
-func (v *ViewWindow) OnWriteTopChanged(newWriteBottom int64) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if v.autoFollow && newWriteBottom > v.viewBottom {
-		v.viewBottom = newWriteBottom
-	}
-}
-
 // ScrollUp detaches from the live edge and moves viewBottom up by n lines.
 // viewBottom is clamped to at least height-1 (can't show negative globalIdxs
 // as the view bottom).

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -108,8 +108,14 @@ func TestViewWindow_ResizeWhileFollowing(t *testing.T) {
 func TestViewWindow_ResizeWhileScrolledBack(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(30)        // viewBottom = 70, autoFollow off
-	vw.Resize(80, 30, 100) // grow height; writeBottom unchanged
+	vw.ScrollUp(30) // viewBottom = 70, autoFollow off
+
+	// Pass a writeBottom that retreats below the current frozen viewBottom.
+	// The view must stay anchored at 70 — dropping the `if v.autoFollow`
+	// guard from Resize would corrupt the anchor on a smaller writeBottom,
+	// so this test falsifies that regression (the prior test's value of
+	// 100 matched viewBottom's effective floor and wouldn't have caught it).
+	vw.Resize(80, 30, 50)
 	_, bottom := vw.VisibleRange()
 	if bottom != 70 {
 		t.Errorf("frozen view: viewBottom = %d, want 70 (anchored)", bottom)
@@ -119,18 +125,3 @@ func TestViewWindow_ResizeWhileScrolledBack(t *testing.T) {
 	}
 }
 
-func TestViewWindow_OnWriteTopChangedFollows(t *testing.T) {
-	vw := NewViewWindow(80, 24)
-	vw.OnWriteTopChanged(50) // called when grow retreats writeTop
-	_, bottom := vw.VisibleRange()
-	if bottom != 50 {
-		t.Errorf("OnWriteTopChanged while following: viewBottom = %d, want 50", bottom)
-	}
-	// Detach and verify it does not follow.
-	vw.ScrollUp(5)
-	vw.OnWriteTopChanged(100)
-	_, bottom = vw.VisibleRange()
-	if bottom != 45 {
-		t.Errorf("OnWriteTopChanged while frozen: viewBottom = %d, want 45", bottom)
-	}
-}

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -331,15 +331,33 @@ func (w *WriteWindow) NewlineInRegion(marginTop, marginBottom int) {
 	w.store.ClearRange(base+int64(marginBottom), base+int64(marginBottom))
 }
 
+// WriteBottomHWM returns the high-water mark of writeBottom. Exposed so
+// that callers (session save) can persist HWM across reload and prevent
+// a grown viewport from retreating into scrollback. See Resize() for why
+// HWM is load-bearing on expand.
+func (w *WriteWindow) WriteBottomHWM() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writeBottomHWM
+}
+
 // RestoreState forcibly sets writeTop and cursor, used during session
-// restore. Do not call during normal operation.
-func (w *WriteWindow) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int) {
+// restore. Do not call during normal operation. If hwm >= 0 the supplied
+// value seeds writeBottomHWM (the high-water mark cannot move backwards,
+// so a persisted HWM from a prior session must be honored); otherwise
+// HWM is derived from writeTop+height-1 as in fresh construction.
+func (w *WriteWindow) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int, hwm int64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.writeTop = writeTop
 	w.cursorGlobalIdx = cursorGlobalIdx
 	w.cursorCol = cursorCol
-	if wb := w.writeTop + int64(w.height) - 1; wb > w.writeBottomHWM {
-		w.writeBottomHWM = wb
+	// Seed HWM: take the max of the restored value and the current
+	// writeBottom so the invariant HWM >= writeBottom always holds.
+	minHWM := w.writeTop + int64(w.height) - 1
+	if hwm > minHWM {
+		w.writeBottomHWM = hwm
+	} else {
+		w.writeBottomHWM = minHWM
 	}
 }

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -266,6 +266,62 @@ func TestWriteWindow_ResizeShrinkCursorClamped(t *testing.T) {
 	}
 }
 
+// TestWriteWindow_ResizeShrinkThenExpandAnchorsOnHWM pins down the reason
+// writeBottomHWM exists in the first place: on expand we re-anchor against
+// the historical maximum writeBottom, not the current one. Without the
+// HWM, a "shrink while cursor is near the top → expand back" round-trip
+// would let writeTop retreat into scrollback, destroying history that a
+// TUI's ESC[2J would blank on its SIGWINCH redraw.
+//
+// Replacing `writeBottomHWM` with `writeBottom` in the expand formula
+// passes every other existing test (they all measure HWM on the same
+// row as writeBottom at shrink time); this test is the one that flips.
+func TestWriteWindow_ResizeShrinkThenExpandAnchorsOnHWM(t *testing.T) {
+	store := NewStore(80)
+	ww := NewWriteWindow(store, 80, 40)
+
+	// Scroll the window so HWM climbs beyond the initial height.
+	for i := 0; i < 100; i++ {
+		ww.Newline()
+	}
+	// State: writeTop=61, cursor=100, writeBottom=100, HWM=100.
+	if got := ww.WriteTop(); got != 61 {
+		t.Fatalf("pre-shrink WriteTop = %d, want 61", got)
+	}
+	if got := ww.WriteBottomHWM(); got != 100 {
+		t.Fatalf("pre-shrink HWM = %d, want 100", got)
+	}
+
+	// Move cursor near the top of the window so a shrink fits it without
+	// advancing writeTop. This is what causes writeBottom to drop below
+	// HWM on the shrink.
+	ww.SetCursor(2, 0)
+
+	ww.Resize(80, 20)
+	// State: writeTop still 61 (cursor fit), writeBottom=80, HWM still 100.
+	if got := ww.WriteTop(); got != 61 {
+		t.Fatalf("shrink kept-cursor: WriteTop = %d, want 61 (stayed)", got)
+	}
+	if got := ww.WriteBottom(); got != 80 {
+		t.Fatalf("shrink kept-cursor: WriteBottom = %d, want 80", got)
+	}
+	if got := ww.WriteBottomHWM(); got != 100 {
+		t.Fatalf("HWM drifted during shrink: %d, want 100 (monotonic)", got)
+	}
+
+	// Expand back. Must re-anchor on HWM (100), not on the current
+	// writeBottom (80). writeTop = 100 - 40 + 1 = 61.
+	ww.Resize(80, 40)
+	if got := ww.WriteTop(); got != 61 {
+		t.Errorf("expand: WriteTop = %d, want 61 (anchored on HWM=100). "+
+			"If this is 41 the expand formula used writeBottom instead of HWM "+
+			"and history between 41..60 would be destroyed by a TUI redraw.", got)
+	}
+	if got := ww.WriteBottom(); got != 100 {
+		t.Errorf("expand: WriteBottom = %d, want 100", got)
+	}
+}
+
 func TestWriteWindow_EraseDisplayClearsWindow(t *testing.T) {
 	store := NewStore(10)
 	ww := NewWriteWindow(store, 10, 5)

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -213,12 +213,6 @@ func (v *VTerm) MainScreenGrid() [][]Cell {
 	return v.mainScreen.Grid()
 }
 
-// LegacyGrid returns nil — the legacy MemoryBuffer path has been removed.
-// Kept for API compatibility; callers should use Grid() or MainScreenGrid().
-func (v *VTerm) LegacyGrid() [][]Cell {
-	return nil
-}
-
 // ContentEnd returns the highest globalIdx ever written via the sparse
 // MainScreen, or -1 if empty or no MainScreen is configured.
 func (v *VTerm) ContentEnd() int64 {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -488,7 +488,7 @@ func (v *VTerm) MarkPromptStart() {
 // Called when OSC 133;B is received (input start / prompt end marker).
 // This is a stub for future shell integration features.
 func (v *VTerm) MarkInputStart() {
-	// TODO: Record input start position in MemoryBuffer for shell integration
+	// TODO: Record input-start globalIdx on the sparse store for shell integration.
 	// This would enable features like:
 	// - Highlighting user input differently
 	// - Command extraction for history

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -1318,35 +1318,6 @@ func (v *VTerm) NotifyLinePersist(lineIdx int64) {
 	}
 }
 
-// WithMemoryBuffer is a no-op kept for backward compatibility.
-// NewVTerm always initializes the main screen unconditionally.
-func WithMemoryBuffer() Option {
-	return func(v *VTerm) {}
-}
-
-// WithMemoryBufferDisk enables the main screen with disk persistence.
-// The diskPath specifies where to store the history file.
-// TerminalID is required for cross-session history continuity.
-func WithMemoryBufferDisk(diskPath string, maxLines int) Option {
-	return func(v *VTerm) {
-		opts := MemoryBufferOptions{
-			MaxLines: maxLines,
-			DiskPath: diskPath,
-		}
-		// Eagerly enable disk persistence. Error is logged inside.
-		v.EnableMemoryBufferWithDisk(diskPath, opts)
-	}
-}
-
-// WithMemoryBufferOptions enables the main screen with custom options.
-func WithMemoryBufferOptions(opts MemoryBufferOptions) Option {
-	return func(v *VTerm) {
-		if opts.DiskPath != "" {
-			v.EnableMemoryBufferWithDisk(opts.DiskPath, opts)
-		}
-		// Non-disk options are handled by EnableMemoryBuffer (called later in NewVTerm).
-	}
-}
 
 // Resize handles changes to the terminal's dimensions.
 func (v *VTerm) Resize(width, height int) {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -1484,25 +1484,11 @@ func (v *VTerm) IsInTUIMode() bool {
 	return fwd != nil && fwd.IsInTUIMode()
 }
 
-// LiveEdgeBase returns the globalIdx at the top of the sparse write window.
-func (v *VTerm) LiveEdgeBase() int64 {
-	if v.mainScreen == nil {
-		return 0
-	}
-	return v.mainScreen.WriteTop()
-}
-
 // MarginTop returns the current top scroll margin.
 func (v *VTerm) MarginTop() int { return v.marginTop }
 
 // MarginBottom returns the current bottom scroll margin.
 func (v *VTerm) MarginBottom() int { return v.marginBottom }
-
-// MemoryBuffer returns nil — the MemoryBuffer path has been removed.
-// Kept for API compatibility. Callers should use MainScreen() instead.
-func (v *VTerm) MemoryBuffer() *MemoryBuffer {
-	return nil
-}
 
 // GetAltBufferLine returns a copy of the specified line from the alternate screen buffer.
 // Returns nil if index is out of bounds or not in alt screen mode.

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -96,9 +96,6 @@ type VTerm struct {
 	commitInsertOffset int64
 	// fixedWidthDetector tracks TUI patterns for scroll region empty line suppression.
 	fwDetector *FixedWidthDetector
-	// showOverlay controls whether overlay lines (set via SetOverlay) are displayed.
-	// In the sparse model this is always true — overlay writes replace lines directly.
-	showOverlay bool
 }
 
 // NewVTerm creates and initializes a new virtual terminal.
@@ -130,9 +127,8 @@ func NewVTerm(width, height int, opts ...Option) *VTerm {
 
 	v.EnableMemoryBuffer()
 
-	// Initialize TUI detector (nil MemoryBuffer — just tracks signals).
+	// Initialize TUI detector (nil storage — just tracks signals).
 	v.fwDetector = NewFixedWidthDetectorWithConfig(nil, DefaultFixedWidthDetectorConfig())
-	v.showOverlay = true
 
 	// Set up tab stops
 	for i := 0; i < width; i++ {

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -62,7 +62,17 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	pageStoreLineCount := pageStore.LineCount()
 	if recoveredMeta != nil && recoveredMeta.WriteTop <= pageStoreLineCount && recoveredMeta.CursorGlobalIdx <= pageStoreLineCount+int64(v.height) {
 		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol)
-		v.PromptStartGlobalLine = recoveredMeta.PromptStartLine
+		// Discard a stale PromptStartLine that points past the last persisted
+		// line. The prompt position is only meaningful if the referenced line
+		// exists; otherwise prompt-aware operations (scroll-to-prompt,
+		// erase-to-prompt) would target non-existent rows. -1 means "unknown".
+		if recoveredMeta.PromptStartLine >= 0 && recoveredMeta.PromptStartLine >= pageStoreLineCount {
+			log.Printf("[MAIN_SCREEN] Discarded stale PromptStartLine %d (PageStore end=%d)",
+				recoveredMeta.PromptStartLine, pageStoreLineCount)
+			v.PromptStartGlobalLine = -1
+		} else {
+			v.PromptStartGlobalLine = recoveredMeta.PromptStartLine
+		}
 		v.CurrentWorkingDir = recoveredMeta.WorkingDir
 		// Sync VTerm's cursor to the restored state so the next write
 		// lands at the correct row in the viewport. Without this, VTerm's

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -61,7 +61,7 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	recoveredMeta := wal.RecoveredMainScreenState()
 	pageStoreLineCount := pageStore.LineCount()
 	if recoveredMeta != nil && recoveredMeta.WriteTop <= pageStoreLineCount && recoveredMeta.CursorGlobalIdx <= pageStoreLineCount+int64(v.height) {
-		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol)
+		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol, recoveredMeta.WriteBottomHWM)
 		// Discard a stale PromptStartLine that points past the last persisted
 		// line. The prompt position is only meaningful if the referenced line
 		// exists; otherwise prompt-aware operations (scroll-to-prompt,
@@ -144,6 +144,7 @@ func (v *VTerm) snapshotMainScreenState() MainScreenState {
 		CursorCol:       col,
 		PromptStartLine: v.PromptStartGlobalLine,
 		WorkingDir:      v.CurrentWorkingDir,
+		WriteBottomHWM:  v.mainScreen.WriteBottomHWM(),
 		SavedAt:         time.Now(),
 	}
 }

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -460,19 +460,6 @@ func lineHasSparseContent(cells []Cell) bool {
 	return false
 }
 
-// SetShowOverlay controls whether overlay content is visible.
-// In the sparse model, overlay lines are written directly to the store via SetOverlay;
-// this flag is preserved for API compatibility but has no separate rendering effect.
-func (v *VTerm) SetShowOverlay(show bool) {
-	v.showOverlay = show
-	v.MarkAllDirty()
-}
-
-// ShowOverlay returns whether overlay content is being displayed.
-func (v *VTerm) ShowOverlay() bool {
-	return v.showOverlay
-}
-
 // ScrollToLiveEdge scrolls the viewport to show the most recent content.
 func (v *VTerm) ScrollToLiveEdge() {
 	v.mainScreenScrollToBottom()

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -138,6 +138,14 @@ func (v *VTerm) snapshotMainScreenState() MainScreenState {
 	}
 }
 
+// cursorGlobalIdx returns the absolute globalIdx of the cursor's current row,
+// computed as WriteTop + cursorY. Callers MUST ensure v.mainScreen != nil
+// before calling; the helper does not defensive-check so that misuse surfaces
+// as a nil-deref rather than a silent 0.
+func (v *VTerm) cursorGlobalIdx() int64 {
+	return v.mainScreen.WriteTop() + int64(v.cursorY)
+}
+
 // mainScreenPlaceChar writes a rune to the sparse terminal at the current cursor.
 func (v *VTerm) mainScreenPlaceChar(r rune, isWide bool) {
 	if v.mainScreen == nil {
@@ -415,10 +423,9 @@ func (v *VTerm) RequestLineInsert(beforeIdx int64, cells []Cell) {
 	// The insert shifted the cursor's content down. Follow it by advancing
 	// cursorY so subsequent writes land at the new logical row. Without
 	// this, a multi-line prompt written after transformer inserts would
-	// overwrite the inserted lines. The cursor is at globalIdx
-	// `writeTop + cursorY`; if the insert happened at or before that, the
-	// row moved down.
-	cursorGlobal := writeTop + int64(v.cursorY)
+	// overwrite the inserted lines. The cursor is at cursorGlobalIdx();
+	// if the insert happened at or before that, the row moved down.
+	cursorGlobal := v.cursorGlobalIdx()
 	if beforeIdx <= cursorGlobal && v.cursorY < v.height-1 {
 		v.cursorY++
 	}
@@ -565,8 +572,7 @@ func (v *VTerm) mainScreenEraseCharacters(n int) {
 	if v.mainScreen == nil {
 		return
 	}
-	writeTop := v.mainScreen.WriteTop()
-	globalLine := writeTop + int64(v.cursorY)
+	globalLine := v.cursorGlobalIdx()
 	endCol := v.cursorX + n
 	if endCol > v.width {
 		endCol = v.width
@@ -863,8 +869,7 @@ func (v *VTerm) CurrentLineCells() []Cell {
 	if v.mainScreen == nil {
 		return nil
 	}
-	writeTop := v.mainScreen.WriteTop()
-	return v.mainScreen.ReadLine(writeTop + int64(v.cursorY))
+	return v.mainScreen.ReadLine(v.cursorGlobalIdx())
 }
 
 // markLineWrapped sets the Wrapped flag on the last cell of the current cursor
@@ -874,8 +879,7 @@ func (v *VTerm) markLineWrapped() {
 	if v.mainScreen == nil {
 		return
 	}
-	writeTop := v.mainScreen.WriteTop()
-	globalIdx := writeTop + int64(v.cursorY)
+	globalIdx := v.cursorGlobalIdx()
 	cells := v.mainScreen.ReadLine(globalIdx)
 	if len(cells) == 0 {
 		return

--- a/apps/texelterm/parser/vterm_sparse_parity_test.go
+++ b/apps/texelterm/parser/vterm_sparse_parity_test.go
@@ -118,7 +118,7 @@ func TestVTerm_SparseParityOnBasicWrites(t *testing.T) {
 // 1. Write shell output (ls -l) that creates scrollback
 // 2. An app sets up a scroll region and writes content (simulating Claude)
 // 3. Resize the terminal (shrink then grow)
-// 4. Verify: parity between legacy and sparse grids at each step
+// 4. Verify: sparse grid remains non-nil and well-formed at each step
 // 5. Verify: scrollback is preserved (can scroll up to see ls -l output)
 func TestVTerm_SparseScrollRegionThenResize(t *testing.T) {
 	width, height := 40, 10

--- a/apps/texelterm/parser/vterm_sparse_parity_test.go
+++ b/apps/texelterm/parser/vterm_sparse_parity_test.go
@@ -11,31 +11,14 @@ import (
 	_ "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
 )
 
-// normalizeRune treats zero rune the same as space for comparison purposes.
-// The legacy grid fills unwritten cells with ' ' while the sparse grid
-// leaves them as '\x00'.
-func normalizeRune(r rune) rune {
-	if r == 0 {
-		return ' '
-	}
-	return r
-}
-
-// assertGridParity verifies the sparse MainScreen grid is non-nil and
-// internally consistent. LegacyGrid() is always nil now (legacy path removed),
-// so parity comparison is skipped; only the sparse grid is validated.
-func assertGridParity(t *testing.T, v *parser.VTerm, label string) {
+// assertSparseGrid verifies the sparse MainScreen grid is non-nil after the
+// most recent operation.
+func assertSparseGrid(t *testing.T, v *parser.VTerm, label string) {
 	t.Helper()
 	sparseGrid := v.MainScreenGrid()
 	if sparseGrid == nil {
 		t.Fatalf("%s: sparse grid is nil", label)
 	}
-	// Legacy path has been removed; skip parity comparison.
-	legacyGrid := v.LegacyGrid()
-	if legacyGrid != nil {
-		t.Logf("%s: legacy grid unexpectedly non-nil (legacy path thought removed)", label)
-	}
-	// Legacy path removed; verify sparse grid is non-empty and has expected dimensions.
 	t.Logf("%s: sparse grid has %d rows", label, len(sparseGrid))
 	if len(sparseGrid) > 0 {
 		t.Logf("%s: sparse row 0: %q", label, gridRowText(sparseGrid[0]))
@@ -72,7 +55,7 @@ func TestVTerm_SparseParityInsertLines(t *testing.T) {
 	for _, r := range "\x1b[2;1H\x1b[L" {
 		p.Parse(r)
 	}
-	assertGridParity(t, v, "after IL")
+	assertSparseGrid(t, v, "after IL")
 }
 
 // TestVTerm_SparseParityDeleteLines verifies DL (Delete Line) is synced to sparse.
@@ -88,7 +71,7 @@ func TestVTerm_SparseParityDeleteLines(t *testing.T) {
 	for _, r := range "\x1b[2;1H\x1b[M" {
 		p.Parse(r)
 	}
-	assertGridParity(t, v, "after DL")
+	assertSparseGrid(t, v, "after DL")
 }
 
 // TestVTerm_SparseParityScroll verifies scroll events are forwarded to sparse.
@@ -102,24 +85,24 @@ func TestVTerm_SparseParityScroll(t *testing.T) {
 			p.Parse(r)
 		}
 	}
-	assertGridParity(t, v, "before scroll")
+	assertSparseGrid(t, v, "before scroll")
 
 	// Scroll up 3 lines.
 	v.Scroll(-3)
-	assertGridParity(t, v, "after scroll up")
+	assertSparseGrid(t, v, "after scroll up")
 
 	// Scroll down 1 line.
 	v.Scroll(1)
-	assertGridParity(t, v, "after scroll down")
+	assertSparseGrid(t, v, "after scroll down")
 
 	// Scroll to bottom.
 	v.Scroll(100)
-	assertGridParity(t, v, "after scroll to bottom")
+	assertSparseGrid(t, v, "after scroll to bottom")
 }
 
-// TestVTerm_SparseParityOnBasicWrites verifies that during the integration
-// window the legacy memoryBufferGrid() and the new sparse.Terminal.Grid()
-// produce the same output for simple writes.
+// TestVTerm_SparseParityOnBasicWrites verifies that sparse.Terminal.Grid()
+// produces the expected output for simple writes (smoke test retained from
+// the transitional parity suite).
 func TestVTerm_SparseParityOnBasicWrites(t *testing.T) {
 	v := parser.NewVTerm(20, 5)
 
@@ -128,7 +111,7 @@ func TestVTerm_SparseParityOnBasicWrites(t *testing.T) {
 		p.Parse(r)
 	}
 
-	assertGridParity(t, v, "basic writes")
+	assertSparseGrid(t, v, "basic writes")
 }
 
 // TestVTerm_SparseScrollRegionThenResize models the user scenario:
@@ -151,7 +134,7 @@ func TestVTerm_SparseScrollRegionThenResize(t *testing.T) {
 		p.Parse('\r')
 		p.Parse('\n')
 	}
-	assertGridParity(t, v, "after ls output")
+	assertSparseGrid(t, v, "after ls output")
 
 	// Phase 2: Simulate a scroll-region TUI app (like Claude).
 	// Set scroll region to rows 3-9 (1-indexed).
@@ -169,7 +152,7 @@ func TestVTerm_SparseScrollRegionThenResize(t *testing.T) {
 		p.Parse('\r')
 		p.Parse('\n')
 	}
-	assertGridParity(t, v, "after scroll region writes")
+	assertSparseGrid(t, v, "after scroll region writes")
 
 	t.Logf("before shrink: WriteTop=%d ContentEnd=%d", v.WriteTop(), v.ContentEnd())
 
@@ -177,16 +160,9 @@ func TestVTerm_SparseScrollRegionThenResize(t *testing.T) {
 	newHeight := 6
 	v.Resize(width, newHeight)
 	t.Logf("after shrink: WriteTop=%d ContentEnd=%d", v.WriteTop(), v.ContentEnd())
-	// NOTE: The legacy and sparse grids may differ by 1 row after a scroll-region
-	// resize because MemoryBuffer's scroll-region liveEdgeBase advancement and
-	// sparse.WriteWindow.Newline() track scrolling differently. This is a known
-	// dual-write limitation resolved only when MemoryBuffer is removed entirely.
-	// For now, just log any mismatch rather than failing the test.
-	legacyAfterShrink := v.LegacyGrid()
 	sparseAfterShrink := v.MainScreenGrid()
-	if len(legacyAfterShrink) > 0 && len(sparseAfterShrink) > 0 {
-		t.Logf("after shrink: legacy row 0=%q sparse row 0=%q",
-			gridRowText(legacyAfterShrink[0]), gridRowText(sparseAfterShrink[0]))
+	if len(sparseAfterShrink) > 0 {
+		t.Logf("after shrink: sparse row 0=%q", gridRowText(sparseAfterShrink[0]))
 	}
 
 	// Phase 4: Grow back.

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -528,10 +528,14 @@ func (w *WriteAheadLog) RecoveredMainScreenState() *MainScreenState {
 // encodeMainScreenState serializes MainScreenState to bytes.
 // Layout: WriteTop(8) ContentEnd(8) CursorGlobalIdx(8) CursorCol(4)
 //
-//	PromptStartLine(8) SavedAt(8) CWDLen(2) CWD(variable)
+//	PromptStartLine(8) SavedAt(8) CWDLen(2) CWD(variable) WriteBottomHWM(8)
+//
+// WriteBottomHWM is appended as a trailing field so older entries (which
+// end after CWD) decode to WriteBottomHWM=0 and the restore path falls
+// back to derive-from-writeTop behavior.
 func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 	cwdBytes := []byte(state.WorkingDir)
-	totalSize := 8 + 8 + 8 + 4 + 8 + 8 + 2 + len(cwdBytes)
+	totalSize := 8 + 8 + 8 + 4 + 8 + 8 + 2 + len(cwdBytes) + 8
 	buf := make([]byte, totalSize)
 	binary.LittleEndian.PutUint64(buf[0:8], uint64(state.WriteTop))
 	binary.LittleEndian.PutUint64(buf[8:16], uint64(state.ContentEnd))
@@ -540,13 +544,17 @@ func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 	binary.LittleEndian.PutUint64(buf[28:36], uint64(state.PromptStartLine))
 	binary.LittleEndian.PutUint64(buf[36:44], uint64(state.SavedAt.UnixNano()))
 	binary.LittleEndian.PutUint16(buf[44:46], uint16(len(cwdBytes)))
-	copy(buf[46:], cwdBytes)
+	copy(buf[46:46+len(cwdBytes)], cwdBytes)
+	binary.LittleEndian.PutUint64(buf[46+len(cwdBytes):46+len(cwdBytes)+8], uint64(state.WriteBottomHWM))
 	return buf, nil
 }
 
 // decodeMainScreenState deserializes MainScreenState from bytes. The decoded
 // state is validated before returning so malformed WAL data is rejected at the
 // replay boundary rather than propagated into recovery metadata.
+//
+// WriteBottomHWM is read from the trailing 8 bytes if present; older
+// entries without those bytes decode to WriteBottomHWM=0.
 func decodeMainScreenState(data []byte) (*MainScreenState, error) {
 	if len(data) < 46 {
 		return nil, fmt.Errorf("MainScreenState data too short: %d bytes", len(data))
@@ -562,6 +570,10 @@ func decodeMainScreenState(data []byte) (*MainScreenState, error) {
 	cwdLen := int(binary.LittleEndian.Uint16(data[44:46]))
 	if len(data) >= 46+cwdLen {
 		state.WorkingDir = string(data[46 : 46+cwdLen])
+	}
+	// Optional trailing WriteBottomHWM (8 bytes). Missing for older entries.
+	if len(data) >= 46+cwdLen+8 {
+		state.WriteBottomHWM = int64(binary.LittleEndian.Uint64(data[46+cwdLen : 46+cwdLen+8]))
 	}
 	if err := state.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid MainScreenState: %w", err)

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -544,7 +544,9 @@ func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 	return buf, nil
 }
 
-// decodeMainScreenState deserializes MainScreenState from bytes.
+// decodeMainScreenState deserializes MainScreenState from bytes. The decoded
+// state is validated before returning so malformed WAL data is rejected at the
+// replay boundary rather than propagated into recovery metadata.
 func decodeMainScreenState(data []byte) (*MainScreenState, error) {
 	if len(data) < 46 {
 		return nil, fmt.Errorf("MainScreenState data too short: %d bytes", len(data))
@@ -560,6 +562,9 @@ func decodeMainScreenState(data []byte) (*MainScreenState, error) {
 	cwdLen := int(binary.LittleEndian.Uint16(data[44:46]))
 	if len(data) >= 46+cwdLen {
 		state.WorkingDir = string(data[46 : 46+cwdLen])
+	}
+	if err := state.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid MainScreenState: %w", err)
 	}
 	return state, nil
 }

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -1208,7 +1208,6 @@ func (a *TexelTerm) ReloadConfig() {
 		if a.pipeline != nil {
 			a.pipeline.SetEnabled(newTfm)
 			if a.vterm != nil {
-				a.vterm.SetShowOverlay(newTfm)
 				a.vterm.MarkAllDirty()
 			}
 		}
@@ -1271,8 +1270,6 @@ func (a *TexelTerm) toggleTransformers() {
 		// Persist to pane config
 		a.persistConfigKeyLocked("transformers", "enabled", newState)
 	} else {
-		current := a.vterm.ShowOverlay()
-		a.vterm.SetShowOverlay(!current)
 		a.vterm.MarkAllDirty()
 	}
 }
@@ -1299,7 +1296,6 @@ func (a *TexelTerm) persistConfigKeyLocked(section, key string, value interface{
 // setTransformerState sets the pipeline to the given state. Caller must hold a.mu.
 func (a *TexelTerm) setTransformerState(enabled bool) {
 	a.pipeline.SetEnabled(enabled)
-	a.vterm.SetShowOverlay(enabled)
 	a.vterm.MarkAllDirty()
 	a.tfmToggle.Active = enabled
 	if a.statusBar != nil {
@@ -1324,11 +1320,9 @@ func (a *TexelTerm) updateDecoratorState() {
 	tfmActive := a.tfmUserPref && !tfmOverride
 	if tfmOverride && a.pipeline != nil && a.pipeline.Enabled() {
 		a.pipeline.SetEnabled(false)
-		a.vterm.SetShowOverlay(false)
 		a.vterm.MarkAllDirty()
 	} else if !tfmOverride && a.pipeline != nil && a.pipeline.Enabled() != a.tfmUserPref {
 		a.pipeline.SetEnabled(a.tfmUserPref)
-		a.vterm.SetShowOverlay(a.tfmUserPref)
 		a.vterm.MarkAllDirty()
 	}
 

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -646,11 +646,12 @@ func (a *TexelTerm) Render() [][]texelcore.Cell {
 		}
 	}
 
-	// In memory buffer mode, dirty line indices are logical (cursorY offsets
-	// from liveEdgeBase) but the grid uses physical rows where wrapped lines
-	// shift content down. Always repaint all rows to avoid stale content when
-	// lines above the cursor wrap (e.g., wide multi-line prompts).
-	// On alt screen, logical == physical so dirty tracking is safe.
+	// Always repaint all rows when the sparse main screen is active.
+	// Conservative carryover from the pre-sparse era (dirty row indices
+	// were logical offsets from liveEdgeBase, but the grid had physical
+	// rows that shifted under wrap-induced reflow). The sparse store no
+	// longer reflows on resize, so per-row dirty tracking is likely safe
+	// to re-enable here — kept conservative until re-validated.
 	if allDirty || a.vterm.IsMemoryBufferEnabled() {
 		for y := 0; y < termRows; y++ {
 			renderLine(y)
@@ -2101,9 +2102,6 @@ func (a *TexelTerm) initializeVTermFirstRun(cols, rows int, paneID string) {
 	a.populateFromHistoryLocked(savedState)
 	a.applyRestoredStateLocked(savedState)
 }
-
-// Note: initializeDisplayBufferLocked was removed as part of DisplayBuffer cleanup.
-// MemoryBuffer is now the only scrollback system.
 
 // readWALWorkingDir pre-reads the last known CWD from the WAL before the full VTerm is initialized.
 // This allows the shell to start in the correct directory on reload.


### PR DESCRIPTION
## Summary

Three logical groups of post-sparse-cutover work, bundled as one PR:

**1. Dead code sweep** (8 commits)
- Drop `MainScreen.SyncWriteState` + VTerm back-compat shims (superseded by `RestoreState`).
- Drop `WithMemoryBuffer*` options (no-ops post-cutover).
- Merge the three near-identical test helpers (`sparseCellsToString` / `gridRowToString` / `cellsToString`).
- Remove `LegacyGrid` stub + scrub dual-write references from parity tests.
- Drop the `showOverlay` flag and its call sites.
- Three passes of stale comment/doc updates referencing pre-sparse internals.

**2. Helpers + stronger invariants** (2 commits)
- Extract `v.cursorGlobalIdx()` — pulls the `writeTop + cursorRow` recipe out of a dozen call sites.
- Add `MainScreenState.Validate()` and enforce it at the WAL decode boundary, so torn metadata never reaches the recovery path.

**3. HWM persistence + test gaps + back-door scoping** (4 commits)
- Persist `WriteBottomHWM` across reloads; seed it via `RestoreState` instead of rederiving from `writeTop+height-1`. Without this, a resize-shrink-then-expand across sessions could silently destroy scrollback the user had already seen.
- Plug three test gaps found by the 5-agent sparse review — two recovery tests that were passing coincidentally via the outer guard (now properly exercise `Validate` and the stale-prompt clamp path), plus a missing shrink-then-expand regression test that pins down HWM's reason for existing.
- Tighten the `Terminal.SetLine` / `ClearRange` docstrings + `MainScreen` interface contract so the store-manipulation back doors are clearly scoped to the four operations that need them (ED/EL, ICH/DCH, overlay insert, scroll-region rejoin). No behavior change.
- Delete `LogicalLine.ActiveWrapToWidth` — its production callers and the `showOverlay` flag were already removed in the dead-code sweep above; only its own tests remained. The `Overlay`/`OverlayWidth`/`Synthetic` fields stay (still used by `apps/texelterm/txfmt`).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -count=1 ./apps/texelterm/...` — all packages green (parser suite ~68s)
- [ ] Smoke: run a live `texelation` session with scroll-and-resize to confirm HWM persistence round-trip in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)