### PR TITLE
Sparse small wins: drop ResizeSplit, add HWM round-trip smoke test

### DIFF
--- a/apps/texelterm/parser/logical_line.go
+++ b/apps/texelterm/parser/logical_line.go
@@ -32,12 +32,6 @@ type LogicalLine struct {
 	// Synthetic indicates a transformer-inserted line that is hidden
 	// in the original (non-overlay) view.
 	Synthetic bool
-
-	// ResizeSplit indicates this line was created by memoryBufferResize
-	// splitting a long logical line into width-sized chunks. Used by
-	// rejoinResizeSplitChain to identify resize-created chains without
-	// confusing them with natural auto-wrap chains.
-	ResizeSplit bool
 }
 
 // NewLogicalLine creates a new empty logical line.
@@ -114,7 +108,6 @@ func (l *LogicalLine) Clone() *LogicalLine {
 	clone := NewLogicalLineFromCells(l.Cells)
 	clone.FixedWidth = l.FixedWidth
 	clone.Synthetic = l.Synthetic
-	clone.ResizeSplit = l.ResizeSplit
 	clone.OverlayWidth = l.OverlayWidth
 	if l.Overlay != nil {
 		clone.Overlay = make([]Cell, len(l.Overlay))

--- a/apps/texelterm/parser/logical_line_persistence.go
+++ b/apps/texelterm/parser/logical_line_persistence.go
@@ -64,16 +64,15 @@ func WriteLogicalLines(path string, lines []*LogicalLine) error {
 // writeLogicalLine writes a single logical line in v2 format.
 // Format: [flags:1][cell_count:4][cells...][overlay_width:4][overlay_count:4][overlay_cells...]
 func writeLogicalLine(w io.Writer, line *LogicalLine, cellBuf []byte) error {
-	// Flags byte: bit 0 = has overlay, bit 1 = synthetic, bit 2 = resize-split
+	// Flags byte: bit 0 = has overlay, bit 1 = synthetic.
+	// Bit 2 is reserved (previously "resize-split", removed post-sparse); old
+	// files may have it set and we silently ignore it on decode.
 	var flags byte
 	if line.Overlay != nil {
 		flags |= 0x01
 	}
 	if line.Synthetic {
 		flags |= 0x02
-	}
-	if line.ResizeSplit {
-		flags |= 0x04
 	}
 	if _, err := w.Write([]byte{flags}); err != nil {
 		return err
@@ -230,9 +229,8 @@ func readLogicalLine(r io.Reader, cellBuf []byte, version int) (*LogicalLine, er
 	}
 
 	line := &LogicalLine{
-		Cells:       cells,
-		Synthetic:   flags&0x02 != 0,
-		ResizeSplit: flags&0x04 != 0,
+		Cells:     cells,
+		Synthetic: flags&0x02 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/logical_line_persistence_test.go
+++ b/apps/texelterm/parser/logical_line_persistence_test.go
@@ -400,40 +400,5 @@ func TestLogicalLinePersistence_OverlayRoundTrip(t *testing.T) {
 	}
 }
 
-func TestLogicalLinePersistence_ResizeSplitRoundTrip(t *testing.T) {
-	tmpDir := t.TempDir()
-	histFile := filepath.Join(tmpDir, "test.lhist")
-
-	lines := []*LogicalLine{
-		{Cells: makeCells("normal line"), ResizeSplit: false},
-		{Cells: makeCells("split chunk"), ResizeSplit: true},
-		{Cells: makeCells("synth+split"), Synthetic: true, ResizeSplit: true},
-	}
-
-	if err := WriteLogicalLines(histFile, lines); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
-
-	loaded, err := LoadLogicalLines(histFile)
-	if err != nil {
-		t.Fatalf("load failed: %v", err)
-	}
-
-	if len(loaded) != 3 {
-		t.Fatalf("expected 3 lines, got %d", len(loaded))
-	}
-
-	if loaded[0].ResizeSplit {
-		t.Error("line 0 should not be ResizeSplit")
-	}
-	if !loaded[1].ResizeSplit {
-		t.Error("line 1 should be ResizeSplit")
-	}
-	if !loaded[2].ResizeSplit || !loaded[2].Synthetic {
-		t.Errorf("line 2: ResizeSplit=%v (want true), Synthetic=%v (want true)",
-			loaded[2].ResizeSplit, loaded[2].Synthetic)
-	}
-}
-
 // Note: TestScrollbackHistory_SaveAndLoad was removed as part of DisplayBuffer cleanup.
 // The ScrollbackHistory type has been replaced by MemoryBuffer.

--- a/apps/texelterm/parser/page.go
+++ b/apps/texelterm/parser/page.go
@@ -573,6 +573,10 @@ func (p *Page) rebuildLineDataCache() {
 
 // encodeLineData serializes a LogicalLine to bytes (v2 format).
 // Format: Flags(1) + CellCount(4) + FixedWidth(4) + Cells(N*16) + [OverlayWidth(4) + OverlayCellCount(4) + OverlayCells(M*16)]
+//
+// Flags byte: bit 0 = has overlay, bit 1 = synthetic. Bit 2 is reserved
+// (previously "resize-split", removed post-sparse); old pages may have it
+// set and we silently ignore it on decode.
 func encodeLineData(line *LogicalLine) []byte {
 	var flags byte
 	if line.Overlay != nil {
@@ -580,9 +584,6 @@ func encodeLineData(line *LogicalLine) []byte {
 	}
 	if line.Synthetic {
 		flags |= 0x02
-	}
-	if line.ResizeSplit {
-		flags |= 0x04
 	}
 
 	cellCount := uint32(len(line.Cells))
@@ -699,10 +700,9 @@ func decodeLineDataV2(data []byte) (*LogicalLine, error) {
 	}
 
 	line := &LogicalLine{
-		Cells:       cells,
-		FixedWidth:  int(fixedWidth),
-		Synthetic:   flags&0x02 != 0,
-		ResizeSplit: flags&0x04 != 0,
+		Cells:      cells,
+		FixedWidth: int(fixedWidth),
+		Synthetic:  flags&0x02 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/page_store_test.go
+++ b/apps/texelterm/parser/page_store_test.go
@@ -1055,73 +1055,27 @@ func TestCellEncoding_BackwardCompat(t *testing.T) {
 	}
 }
 
-// --- ResizeSplit Line Encoding Round-Trip Tests ---
+// --- Reserved Flag Bit Forward-Compat Test ---
 
-func TestLineEncoding_ResizeSplitRoundTrip(t *testing.T) {
-	line := &LogicalLine{
-		Cells:       []Cell{{Rune: 'A'}, {Rune: 'B'}},
-		ResizeSplit: true,
-	}
-	data := encodeLineData(line)
-	got, err := decodeLineData(data)
-	if err != nil {
-		t.Fatalf("decodeLineData: %v", err)
-	}
-	if !got.ResizeSplit {
-		t.Error("ResizeSplit should be true after round-trip")
-	}
-	if got.Synthetic {
-		t.Error("Synthetic should be false")
-	}
-}
-
-func TestLineEncoding_ResizeSplitBackwardCompat(t *testing.T) {
-	// Line without ResizeSplit → bit 2 is 0
+// Bit 2 of the flags byte was "resize-split" and has been removed; decoder
+// must silently ignore it so old on-disk pages still load without corrupting
+// other fields.
+func TestLineEncoding_IgnoresReservedFlagBit(t *testing.T) {
 	line := &LogicalLine{
 		Cells:     []Cell{{Rune: 'X'}},
 		Synthetic: true,
 	}
 	data := encodeLineData(line)
+	// Flip bit 2 on the first byte (flags) as if an older writer set it.
+	data[0] |= 0x04
 	got, err := decodeLineData(data)
 	if err != nil {
-		t.Fatalf("decodeLineData: %v", err)
-	}
-	if got.ResizeSplit {
-		t.Error("ResizeSplit should be false when not set")
+		t.Fatalf("decodeLineData on line with reserved bit 2 set: %v", err)
 	}
 	if !got.Synthetic {
-		t.Error("Synthetic should be true")
+		t.Error("Synthetic should survive even with reserved bit 2 set")
 	}
-}
-
-func TestPage_ResizeSplitRoundTrip(t *testing.T) {
-	page := NewPage(1, 0)
-	now := time.Now()
-
-	line := &LogicalLine{
-		Cells:       []Cell{{Rune: 'H'}, {Rune: 'i', Wrapped: true}},
-		ResizeSplit: true,
-	}
-	page.AddLine(line, now, 0)
-
-	var buf bytes.Buffer
-	if _, err := page.WriteTo(&buf); err != nil {
-		t.Fatalf("WriteTo: %v", err)
-	}
-
-	page2 := &Page{}
-	if _, err := page2.ReadFrom(&buf); err != nil {
-		t.Fatalf("ReadFrom: %v", err)
-	}
-
-	if len(page2.Lines) != 1 {
-		t.Fatalf("expected 1 line, got %d", len(page2.Lines))
-	}
-	got := page2.Lines[0]
-	if !got.ResizeSplit {
-		t.Error("ResizeSplit should survive page round-trip")
-	}
-	if !got.Cells[1].Wrapped {
-		t.Error("Wrapped should survive page round-trip")
+	if len(got.Cells) != 1 || got.Cells[0].Rune != 'X' {
+		t.Errorf("cell payload corrupted by reserved bit: %+v", got.Cells)
 	}
 }

--- a/apps/texelterm/parser/recovery_metadata_test.go
+++ b/apps/texelterm/parser/recovery_metadata_test.go
@@ -239,3 +239,96 @@ func TestRecovery_DiscardsStalePromptStartLine(t *testing.T) {
 		}
 	}
 }
+
+// TestRecovery_HWMSurvivesShrinkCloseExpand is the end-to-end smoke test for
+// HWM persistence: no hand-rolled WAL injection, just the real close / reopen
+// path.
+//
+// Scenario: fill the viewport past the initial height, place the cursor near
+// the top of the window, shrink so the cursor still fits (writeTop stays,
+// writeBottom drops, HWM stays unchanged), clean-close, reopen at the
+// smaller size, then expand back. The HWM-anchored expand must land at the
+// pre-shrink writeTop. Without HWM persistence the new session re-derives
+// HWM from writeTop+height-1 at the smaller height; on expand that smaller
+// derived HWM pulls writeTop back into scrollback and clobbers history.
+func TestRecovery_HWMSurvivesShrinkCloseExpand(t *testing.T) {
+	dir := t.TempDir()
+	id := "vt-recovery-hwm-e2e"
+	const cols = 80
+	const bigRows, smallRows = 40, 20
+	const numLines = 100
+
+	t.Setenv("HOME", t.TempDir())
+
+	// Session 1: fill past the viewport so writeTop and HWM climb, then move
+	// the cursor to a row that will still fit after shrink.
+	v1 := newTestVTerm(t, cols, bigRows, dir, id)
+	writeNumberedLines(v1, 0, numLines)
+
+	// Cursor near top — row 2 fits inside smallRows=20, so the shrink below
+	// exercises the "cursor fits, writeTop stays" branch.
+	v1.SetCursorPos(2, 0)
+	v1.mainScreen.SetCursor(2, 0)
+
+	wantWriteTop := v1.mainScreen.WriteTop()
+	wantHWM := v1.mainScreen.WriteBottomHWM()
+	if wantHWM <= int64(smallRows) {
+		t.Fatalf("precondition: HWM=%d must exceed smallRows=%d for the test to be meaningful",
+			wantHWM, smallRows)
+	}
+
+	// Capture a content sample we can re-verify after reopen+expand. Line at
+	// writeTop has a known number embedded by writeNumberedLines.
+	topLineBefore := trimLogicalLine(cellsToString(v1.mainScreen.ReadLine(wantWriteTop)))
+
+	// Shrink: cursor at row 2 fits in the smaller window, so writeTop must
+	// not move and HWM must not change.
+	v1.Resize(cols, smallRows)
+	if got := v1.mainScreen.WriteTop(); got != wantWriteTop {
+		t.Fatalf("shrink moved writeTop unexpectedly: want %d, got %d (cursor should have fit)",
+			wantWriteTop, got)
+	}
+	if got := v1.mainScreen.WriteBottomHWM(); got != wantHWM {
+		t.Fatalf("shrink changed HWM: want %d, got %d", wantHWM, got)
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// Session 2: reopen at the smaller size. Without HWM persistence the
+	// reopened WriteWindow would rebuild HWM = writeTop+smallRows-1, losing
+	// the memory of the earlier taller window.
+	v2 := newTestVTerm(t, cols, smallRows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if got := v2.mainScreen.WriteBottomHWM(); got != wantHWM {
+		t.Errorf("HWM not restored across close/reopen: want %d, got %d", wantHWM, got)
+	}
+	if got := v2.mainScreen.WriteTop(); got != wantWriteTop {
+		t.Errorf("writeTop not restored across close/reopen: want %d, got %d",
+			wantWriteTop, got)
+	}
+
+	// Expand back to the original height. With HWM honored, writeTop slides
+	// back to HWM-bigRows+1 (== original wantWriteTop). Without HWM, it would
+	// anchor against the diminished derived value and retreat further.
+	v2.Resize(cols, bigRows)
+	expectedExpandWriteTop := wantHWM - int64(bigRows) + 1
+	if expectedExpandWriteTop < 0 {
+		expectedExpandWriteTop = 0
+	}
+	if got := v2.mainScreen.WriteTop(); got != expectedExpandWriteTop {
+		t.Errorf("expand did not honor HWM: want writeTop=%d, got %d (HWM=%d bigRows=%d)",
+			expectedExpandWriteTop, got, wantHWM, bigRows)
+	}
+
+	// Content check: the line at the restored writeTop must still carry its
+	// original payload. If HWM were re-derived and writeTop retreated, this
+	// line would be different (or a blank line below the old viewport).
+	topLineAfter := trimLogicalLine(cellsToString(v2.mainScreen.ReadLine(expectedExpandWriteTop)))
+	if topLineAfter != topLineBefore {
+		t.Errorf("content at expanded writeTop drifted after HWM round-trip:\n  before: %q\n  after:  %q",
+			topLineBefore, topLineAfter)
+	}
+}


### PR DESCRIPTION
## Summary
Follow-ups to #181, bundled together:

- **Drop dead `LogicalLine.ResizeSplit` field.** No production code reads or writes it post-sparse cutover; only the disk-format tests did, and those are now replaced with a single forward-compat test that flips the reserved bit 2 and verifies decode still works. Disk format is backwards compatible — decoders silently ignore bit 2 on old files.
- **Add end-to-end HWM round-trip smoke test.** Covers the last unchecked box from #181's test plan: a full `write → shrink (cursor fits) → CloseMemoryBuffer → reopen → expand` cycle with no hand-rolled WAL injection. Catches regressions where HWM silently drops across close/reopen and a later expand pulls writeTop back into scrollback.
- **Drop the dead `suppressNextScrollbackPush` stash.** `stash@{0}` predated the sparse redesign and is fully superseded; removed locally.

## Test plan
- [x] `go build ./...`
- [x] `go test ./apps/texelterm/parser/ -run TestRecovery_HWMSurvivesShrinkCloseExpand -v`
- [x] `go test ./apps/texelterm/parser/ -run 'TestRecovery_|TestBurst' -count=1` (full suite, 38.7s)
- [x] `go test ./apps/texelterm/parser/ -run TestLineEncoding_IgnoresReservedFlagBit -v` (forward-compat on old pages with bit 2 set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)