### PR TITLE
Sparse WriteWindow: HWM/Resize/RestoreState hardening

### DIFF
--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -370,12 +370,46 @@ func (w *WriteWindow) WriteBottomHWM() int64 {
 // value seeds writeBottomHWM (the high-water mark cannot move backwards,
 // so a persisted HWM from a prior session must be honored); otherwise
 // HWM is derived from writeTop+height-1 as in fresh construction.
+//
+// Basic invariants (writeTop >= 0, cursorGlobalIdx >= writeTop) are
+// checked at the WAL decode boundary via MainScreenState.Validate, but
+// width/height-dependent invariants (cursor inside the write window,
+// cursorCol inside [0, width)) live here because Validate has no window
+// dimensions to check against. Out-of-range values are clamped and
+// logged rather than propagated — a corrupt entry that survived decode
+// should leave a trail and then deposit the cursor somewhere safe.
 func (w *WriteWindow) RestoreState(writeTop, cursorGlobalIdx int64, cursorCol int, hwm int64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+
+	if writeTop < 0 {
+		log.Printf("[sparse] WriteWindow.RestoreState: writeTop=%d clamped to 0", writeTop)
+		writeTop = 0
+	}
 	w.writeTop = writeTop
+
+	bottom := writeTop + int64(w.height) - 1
+	if cursorGlobalIdx < writeTop {
+		log.Printf("[sparse] WriteWindow.RestoreState: cursorGlobalIdx=%d below writeTop=%d, clamped to writeTop",
+			cursorGlobalIdx, writeTop)
+		cursorGlobalIdx = writeTop
+	} else if cursorGlobalIdx > bottom {
+		log.Printf("[sparse] WriteWindow.RestoreState: cursorGlobalIdx=%d above writeBottom=%d, clamped to writeBottom",
+			cursorGlobalIdx, bottom)
+		cursorGlobalIdx = bottom
+	}
 	w.cursorGlobalIdx = cursorGlobalIdx
+
+	if cursorCol < 0 {
+		log.Printf("[sparse] WriteWindow.RestoreState: cursorCol=%d clamped to 0", cursorCol)
+		cursorCol = 0
+	} else if cursorCol >= w.width {
+		log.Printf("[sparse] WriteWindow.RestoreState: cursorCol=%d >= width=%d, clamped to width-1",
+			cursorCol, w.width)
+		cursorCol = w.width - 1
+	}
 	w.cursorCol = cursorCol
+
 	// Seed HWM: take the max of the restored value and the current
 	// writeBottom so the invariant HWM >= writeBottom always holds.
 	minHWM := w.writeTop + int64(w.height) - 1

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -161,8 +161,16 @@ func (w *WriteWindow) Newline() {
 	}
 	w.cursorCol = 0
 	// Update HWM after potential scroll.
-	if wb := w.writeTop + int64(w.height) - 1; wb > w.writeBottomHWM {
-		w.writeBottomHWM = wb
+	w.extendHWMLocked(w.writeTop + int64(w.height) - 1)
+}
+
+// extendHWMLocked advances writeBottomHWM to newBottom if newBottom is
+// greater. Caller must hold w.mu. HWM never moves backwards — a persisted
+// HWM across reload, a grow-on-resize, or a defensive bump from an op that
+// touched a row past the nominal writeBottom all funnel through here.
+func (w *WriteWindow) extendHWMLocked(newBottom int64) {
+	if newBottom > w.writeBottomHWM {
+		w.writeBottomHWM = newBottom
 	}
 }
 
@@ -208,9 +216,7 @@ func (w *WriteWindow) Resize(newWidth, newHeight int) {
 	}
 
 	// Update HWM if the new writeBottom exceeds it.
-	if wb := w.writeTop + int64(w.height) - 1; wb > w.writeBottomHWM {
-		w.writeBottomHWM = wb
-	}
+	w.extendHWMLocked(w.writeTop + int64(w.height) - 1)
 
 	// Clamp cursor into the new window.
 	if w.cursorGlobalIdx < w.writeTop {
@@ -267,12 +273,17 @@ func (w *WriteWindow) EraseFromStartOfLine(col int) {
 // Lines from cursorRow..marginBottom-n shift down; bottom n lines are cleared.
 // The write window anchor and cursor are not moved — IL does not scroll.
 // cursorRow, marginTop, marginBottom are all relative to writeTop.
+//
+// Invariant: marginBottom < height. HWM is bumped defensively to
+// writeTop+marginBottom in case a caller violates that, so the "furthest
+// row the window has touched" stays monotonic even across misuse.
 func (w *WriteWindow) InsertLines(n, cursorRow, marginTop, marginBottom int) {
 	if n <= 0 {
 		return
 	}
 	w.mu.Lock()
 	base := w.writeTop
+	w.extendHWMLocked(base + int64(marginBottom))
 	w.mu.Unlock()
 
 	// Shift lines down within [cursorRow, marginBottom].
@@ -289,12 +300,15 @@ func (w *WriteWindow) InsertLines(n, cursorRow, marginTop, marginBottom int) {
 // Lines from cursorRow+n..marginBottom shift up; bottom n lines are cleared.
 // The write window anchor and cursor are not moved.
 // cursorRow, marginTop, marginBottom are all relative to writeTop.
+//
+// Invariant: marginBottom < height. Defensive HWM bump as in InsertLines.
 func (w *WriteWindow) DeleteLines(n, cursorRow, marginTop, marginBottom int) {
 	if n <= 0 {
 		return
 	}
 	w.mu.Lock()
 	base := w.writeTop
+	w.extendHWMLocked(base + int64(marginBottom))
 	w.mu.Unlock()
 
 	// Shift lines up within [cursorRow, marginBottom].
@@ -318,9 +332,12 @@ func (w *WriteWindow) DeleteLines(n, cursorRow, marginTop, marginBottom int) {
 // region is affected.
 //
 // Call Newline() instead for full-screen (marginTop==0 AND marginBottom==height-1).
+//
+// Invariant: marginBottom < height. Defensive HWM bump as in InsertLines.
 func (w *WriteWindow) NewlineInRegion(marginTop, marginBottom int) {
 	w.mu.Lock()
 	base := w.writeTop
+	w.extendHWMLocked(base + int64(marginBottom))
 	w.mu.Unlock()
 
 	// Shift lines up within the region.

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -4,6 +4,7 @@
 package sparse
 
 import (
+	"log"
 	"sync"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
@@ -190,6 +191,12 @@ func (w *WriteWindow) extendHWMLocked(newBottom int64) {
 // will reposition it.
 func (w *WriteWindow) Resize(newWidth, newHeight int) {
 	if newWidth <= 0 || newHeight <= 0 {
+		// Silently ignoring zero dimensions used to be a dead end for
+		// diagnosing broken SIGWINCH propagation — the window stayed at
+		// its previous size with no trail. Log so at least the symptom
+		// shows up in the terminal's own log.
+		log.Printf("[sparse] WriteWindow.Resize ignored: newWidth=%d newHeight=%d (both must be > 0)",
+			newWidth, newHeight)
 		return
 	}
 	w.mu.Lock()

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -437,3 +437,118 @@ func TestWriteWindow_ResizeZeroDimensionsLogs(t *testing.T) {
 		t.Errorf("Resize(10,0) produced no diagnostic log; got %q", buf.String())
 	}
 }
+
+// TestWriteWindow_RestoreStateClampsNegativeWriteTop covers the corrupt-WAL
+// path where writeTop slips past the basic MainScreenState.Validate check
+// (or arrives from a caller that bypasses decode). A negative writeTop
+// would push the write window into a phantom region; RestoreState must
+// clamp to 0 and log so the symptom is visible.
+func TestWriteWindow_RestoreStateClampsNegativeWriteTop(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	ww.RestoreState(-7, 0, 0, -1)
+
+	if got := ww.WriteTop(); got != 0 {
+		t.Errorf("writeTop not clamped to 0: got %d", got)
+	}
+	if !strings.Contains(buf.String(), "writeTop=-7 clamped to 0") {
+		t.Errorf("no diagnostic for negative writeTop; log = %q", buf.String())
+	}
+}
+
+// TestWriteWindow_RestoreStateClampsCursorOutsideWindow covers the case
+// where cursorGlobalIdx lands above the window bottom. Validate rejects
+// cursors below writeTop; the above-bottom case is width/height-dependent
+// and only reachable here.
+func TestWriteWindow_RestoreStateClampsCursorOutsideWindow(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	// Window is [100, 104]. Cursor at 999 should clamp to 104.
+	ww.RestoreState(100, 999, 0, -1)
+
+	gi, _ := ww.Cursor()
+	if gi != 104 {
+		t.Errorf("cursorGlobalIdx not clamped to writeBottom: got %d, want 104", gi)
+	}
+	if !strings.Contains(buf.String(), "above writeBottom") {
+		t.Errorf("no diagnostic for cursor above bottom; log = %q", buf.String())
+	}
+}
+
+// TestWriteWindow_RestoreStateClampsCursorCol covers out-of-range
+// cursorCol. The WAL-layer Validate accepts any non-negative CursorCol
+// because it doesn't know the window width, so clamping against width
+// has to happen here.
+func TestWriteWindow_RestoreStateClampsCursorCol(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	// width=10 — cursorCol=50 should clamp to 9.
+	ww.RestoreState(0, 0, 50, -1)
+
+	_, col := ww.Cursor()
+	if col != 9 {
+		t.Errorf("cursorCol not clamped to width-1: got %d, want 9", col)
+	}
+	if !strings.Contains(buf.String(), "cursorCol=50") {
+		t.Errorf("no diagnostic for cursorCol above width; log = %q", buf.String())
+	}
+
+	// Negative cursorCol should also clamp (to 0) and log.
+	buf.Reset()
+	ww.RestoreState(0, 0, -3, -1)
+	_, col = ww.Cursor()
+	if col != 0 {
+		t.Errorf("negative cursorCol not clamped to 0: got %d", col)
+	}
+	if !strings.Contains(buf.String(), "cursorCol=-3") {
+		t.Errorf("no diagnostic for negative cursorCol; log = %q", buf.String())
+	}
+}
+
+// TestWriteWindow_RestoreStateValidInputsNoLog confirms the silent path:
+// well-formed restore inputs must not produce any diagnostic log, so the
+// warnings above actually mean something when they appear.
+func TestWriteWindow_RestoreStateValidInputsNoLog(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	// Cursor at writeTop+2 in a height-5 window, col 3 in width 10.
+	ww.RestoreState(100, 102, 3, 200)
+
+	if buf.Len() != 0 {
+		t.Errorf("valid RestoreState produced diagnostic log: %q", buf.String())
+	}
+	if got := ww.WriteTop(); got != 100 {
+		t.Errorf("WriteTop: got %d, want 100", got)
+	}
+	gi, col := ww.Cursor()
+	if gi != 102 || col != 3 {
+		t.Errorf("Cursor: got (%d,%d), want (102,3)", gi, col)
+	}
+	if got := ww.WriteBottomHWM(); got != 200 {
+		t.Errorf("WriteBottomHWM: got %d, want 200", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -1,6 +1,9 @@
 package sparse
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
@@ -401,5 +404,36 @@ func TestWriteWindow_InsertLinesDoesNotDriftHWMOnValidMargin(t *testing.T) {
 	ww.InsertLines(1, 0, 0, 4)
 	if got := ww.WriteBottomHWM(); got != 4 {
 		t.Errorf("HWM moved on in-window IL: got %d, want 4", got)
+	}
+}
+
+// TestWriteWindow_ResizeZeroDimensionsLogs covers the silent-early-return
+// diagnostic: a broken SIGWINCH that calls Resize with 0 cols or rows must
+// leave a trail in the log so the symptom can be pinned to this site.
+func TestWriteWindow_ResizeZeroDimensionsLogs(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+
+	ww.Resize(0, 5)
+	if !strings.Contains(buf.String(), "Resize ignored") {
+		t.Errorf("Resize(0,5) produced no diagnostic log; got %q", buf.String())
+	}
+	// State unchanged after the ignored call.
+	if got := ww.Width(); got != 10 {
+		t.Errorf("Resize(0,5) mutated width: got %d, want 10", got)
+	}
+	if got := ww.Height(); got != 5 {
+		t.Errorf("Resize(0,5) mutated height: got %d, want 5", got)
+	}
+
+	buf.Reset()
+	ww.Resize(10, 0)
+	if !strings.Contains(buf.String(), "Resize ignored") {
+		t.Errorf("Resize(10,0) produced no diagnostic log; got %q", buf.String())
 	}
 }

--- a/apps/texelterm/parser/sparse/write_window_test.go
+++ b/apps/texelterm/parser/sparse/write_window_test.go
@@ -353,3 +353,53 @@ func TestWriteWindow_EraseLineClearsCurrentRow(t *testing.T) {
 		t.Errorf("row 2 should be cleared, got %v", got)
 	}
 }
+
+// The following three tests pin down the defensive HWM bump in IL/DL/NIR.
+// Normal callers pass marginBottom < height, and HWM never drifts. But if a
+// caller violates that invariant (parser bug, misuse), the operation still
+// touches rows past the nominal writeBottom — and HWM must catch up or a
+// later expand-resize will anchor against a stale value. The bump is cheap
+// enough to run unconditionally, so we do.
+
+func TestWriteWindow_InsertLinesExtendsHWMOnOutOfBoundsMargin(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	if got := ww.WriteBottomHWM(); got != 4 {
+		t.Fatalf("initial HWM = %d, want 4 (height-1)", got)
+	}
+	// Call with marginBottom = 20, well past height-1 = 4.
+	ww.InsertLines(1, 0, 0, 20)
+	if got := ww.WriteBottomHWM(); got != 20 {
+		t.Errorf("HWM after IL(marginBottom=20) = %d, want 20 (defensive bump)", got)
+	}
+}
+
+func TestWriteWindow_DeleteLinesExtendsHWMOnOutOfBoundsMargin(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.DeleteLines(1, 0, 0, 30)
+	if got := ww.WriteBottomHWM(); got != 30 {
+		t.Errorf("HWM after DL(marginBottom=30) = %d, want 30 (defensive bump)", got)
+	}
+}
+
+func TestWriteWindow_NewlineInRegionExtendsHWMOnOutOfBoundsMargin(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.NewlineInRegion(0, 12)
+	if got := ww.WriteBottomHWM(); got != 12 {
+		t.Errorf("HWM after NIR(marginBottom=12) = %d, want 12 (defensive bump)", got)
+	}
+}
+
+// And the happy path: with marginBottom < height, HWM doesn't move — the
+// bump is a no-op because writeTop+marginBottom stays inside [writeTop,
+// writeBottom] which is at or below HWM.
+func TestWriteWindow_InsertLinesDoesNotDriftHWMOnValidMargin(t *testing.T) {
+	store := NewStore(10)
+	ww := NewWriteWindow(store, 10, 5)
+	ww.InsertLines(1, 0, 0, 4)
+	if got := ww.WriteBottomHWM(); got != 4 {
+		t.Errorf("HWM moved on in-window IL: got %d, want 4", got)
+	}
+}


### PR DESCRIPTION
## Summary

Acts on the three small/medium items from the deferred post-sparse review (`project_sparse_review_findings.md`). Each touches `sparse.WriteWindow` defensively — same semantics for well-formed callers, loud (and safe) failure modes for bad inputs.

- **Defensive HWM bump in `InsertLines` / `DeleteLines` / `NewlineInRegion`.** Normal VTerm callers pass `marginBottom < height`, so HWM is untouched; but if a caller ever violated that invariant the "furthest globalIdx ever touched" would have drifted out of sync. Funnels through a new `extendHWMLocked` helper that `Newline` and `Resize` also use.
- **Log `Resize(0, _)` / `Resize(_, 0)`.** Previously a silent early-return — a dead end for diagnosing broken SIGWINCH propagation. Now leaves a trail in the terminal's own log.
- **Validate `RestoreState` inputs.** `MainScreenState.Validate` at the WAL boundary can't check width/height-dependent bounds. `RestoreState` now clamps `writeTop < 0` → 0, clamps the cursor into `[writeTop, writeBottom]`, and clamps `cursorCol` into `[0, width)`. Each clamp logs.

## Test plan

- [x] `go test ./apps/texelterm/parser/sparse/ -count=1` — passes
- [x] `go test ./apps/texelterm/parser/... -count=1` — passes (full parser tree)
- [x] 4 new HWM bump tests (InsertLines/DeleteLines/NewlineInRegion out-of-bounds; plus a no-drift case for valid margins)
- [x] 1 new Resize zero-dimension log-capture test
- [x] 4 new RestoreState clamp tests (negative writeTop; cursor above writeBottom; cursorCol out-of-range both ways; valid-inputs no-log baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)