### PR TITLE
Sparse: view-side reflow on resize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,7 +507,7 @@ err := v.EnableMemoryBufferWithDisk(diskPath, MemoryBufferOptions{
 })
 ```
 
-**Notes**: No reflow on resize — the store is width-set-at-construction and TUIs that rewrite on resize (most of them) emit new content at new globalIdxs. Resize changes what the write/view windows project, not what the store holds.
+**Notes**: Reflow on resize is view-side. The store stays width-independent in structure (cells at `(globalIdx, col)`, `Wrapped` flag on wrap boundaries). `ViewWindow` walks `Wrapped` chains at render time and reflows at current viewport width; widening rejoins, narrowing splits. Per-row `NoWrap` flag (set when DECSTBM has non-default margins at write time) opts structured content out of reflow — that content clips/pads 1:1 instead. A global `globalReflowOff` toggle forces all reflowable rows to 1:1 without affecting NoWrap rows. See `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`.
 
 ## Related Projects
 

--- a/apps/texelterm/parser/live_follow_vterm_test.go
+++ b/apps/texelterm/parser/live_follow_vterm_test.go
@@ -1,0 +1,293 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	_ "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+)
+
+// feed pushes every rune of s through the parser.
+func feed(p *parser.Parser, s string) {
+	for _, r := range s {
+		p.Parse(r)
+	}
+}
+
+// gridTagAtRow returns the leading non-blank text in grid[row].
+func gridTagAtRow(grid [][]parser.Cell, row int) string {
+	if row < 0 || row >= len(grid) {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range grid[row] {
+		if c.Rune == 0 || c.Rune == ' ' {
+			if b.Len() == 0 {
+				continue
+			}
+			break
+		}
+		b.WriteRune(c.Rune)
+	}
+	return b.String()
+}
+
+// TestVTerm_LiveFollowLongOutput simulates an `ls -lR`-style flood: many
+// short lines written consecutively. After the flood, the grid should show
+// the most recent lines and PhysicalCursor should agree — i.e. the cursor's
+// y position should land on a row that is actually in the rendered grid at
+// the cursor's writeTop-relative offset.
+func TestVTerm_LiveFollowLongOutput(t *testing.T) {
+	const w, h = 80, 24
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	// Shell prompt.
+	feed(p, "$ ls -lR\r\n")
+
+	// Flood output — 200 identifiable lines, each one short enough not to wrap.
+	for i := range 200 {
+		feed(p, fmt.Sprintf("L%03d: /path/to/file_%03d.txt\r\n", i, i))
+	}
+
+	grid := v.Grid()
+	if len(grid) != h {
+		t.Fatalf("grid rows = %d, want %d", len(grid), h)
+	}
+
+	// The parser emits CR+LF as "CR then LF". After the final CRLF, the
+	// cursor is on a fresh blank row. The last non-blank row should contain
+	// L199.
+	lastNonBlank := ""
+	for y := h - 1; y >= 0; y-- {
+		if tag := gridTagAtRow(grid, y); tag != "" {
+			lastNonBlank = tag
+			break
+		}
+	}
+	if !strings.HasPrefix(lastNonBlank, "L199") {
+		t.Errorf("live-follow regression: last visible tag = %q, want L199*", lastNonBlank)
+		for y, row := range grid {
+			if tag := gridTagAtRow(grid, y); tag != "" {
+				t.Logf("  grid[%02d]: %s", y, strings.TrimRight(cellsToStringTest(row), " \x00"))
+			}
+		}
+	}
+
+	// PhysicalCursor should also be at the bottom (cursor just newlined).
+	px, py := v.PhysicalCursor()
+	if py < h-2 || py > h-1 {
+		t.Errorf("PhysicalCursor y = %d, want ~%d (last row)", py, h-1)
+	}
+	if px != 0 {
+		t.Errorf("PhysicalCursor x = %d, want 0 (fresh row after CRLF)", px)
+	}
+}
+
+// TestVTerm_LiveFollowWithResize reproduces the exact sequence the user hit:
+// shell prompt, then bulk output on a terminal that just got resized. The
+// real texelterm issues a Resize during pane init, then the shell floods
+// output. If resize leaves viewAnchor in a bad state, the viewport will be
+// stuck on history.
+func TestVTerm_LiveFollowWithResize(t *testing.T) {
+	const w, h = 80, 24
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	feed(p, "$ ")
+	// Resize (real texelterm triggers this during pane init).
+	v.Resize(w, h)
+
+	feed(p, "ls -lR\r\n")
+	for i := range 100 {
+		feed(p, fmt.Sprintf("L%03d: hello\r\n", i))
+	}
+
+	grid := v.Grid()
+	lastNonBlank := ""
+	for y := h - 1; y >= 0; y-- {
+		if tag := gridTagAtRow(grid, y); tag != "" {
+			lastNonBlank = tag
+			break
+		}
+	}
+	if !strings.HasPrefix(lastNonBlank, "L099") {
+		t.Errorf("live-follow after resize: last tag = %q, want L099*", lastNonBlank)
+	}
+}
+
+// TestVTerm_LiveFollowWithColors feeds colored output (CSI SGR) to check that
+// SGR does not break the live-anchor path.
+func TestVTerm_LiveFollowWithColors(t *testing.T) {
+	const w, h = 80, 24
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	for i := range 100 {
+		// Simulate `ls --color=auto` output: bold blue, reset.
+		feed(p, fmt.Sprintf("\x1b[01;34mL%03d\x1b[0m: file\r\n", i))
+	}
+
+	grid := v.Grid()
+	lastNonBlank := ""
+	for y := h - 1; y >= 0; y-- {
+		if tag := gridTagAtRow(grid, y); tag != "" {
+			lastNonBlank = tag
+			break
+		}
+	}
+	if !strings.HasPrefix(lastNonBlank, "L099") {
+		t.Errorf("live-follow with SGR: last tag = %q, want L099*", lastNonBlank)
+	}
+}
+
+// TestVTerm_PhysicalCursorMatchesGrid verifies the cursor's reported physical
+// position is a row that actually exists in Grid() — specifically, that the
+// PhysicalCursor fallback doesn't lie when CursorToView fails. The user's
+// "cursor visible at the bottom of the panel, but can't see output" symptom
+// is exactly this class of bug: cursor and grid disagree about where the
+// live edge is.
+func TestVTerm_PhysicalCursorMatchesGrid(t *testing.T) {
+	const w, h = 80, 10
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	// Write 30 lines so scrolling happens.
+	for i := range 30 {
+		feed(p, fmt.Sprintf("row%02d\r\n", i))
+	}
+	// Write a final marker with no trailing newline.
+	feed(p, "MARK")
+
+	grid := v.Grid()
+	px, py := v.PhysicalCursor()
+
+	if py < 0 || py >= h {
+		t.Fatalf("PhysicalCursor y=%d out of range [0,%d)", py, h)
+	}
+	cellAtCursor := ""
+	if len(grid[py]) > 0 {
+		cellAtCursor = gridTagAtRow(grid, py)
+	}
+	if !strings.HasPrefix(cellAtCursor, "MARK") {
+		t.Errorf("cursor/grid disagree: PhysicalCursor=(%d,%d) points to row %q, expected MARK*",
+			px, py, cellAtCursor)
+		for y, row := range grid {
+			if tag := gridTagAtRow(grid, y); tag != "" {
+				t.Logf("  grid[%02d]: %s", y, strings.TrimRight(cellsToStringTest(row), " \x00"))
+			}
+		}
+	}
+}
+
+// TestVTerm_RestoreScrollOffsetThenNewOutput reproduces Regression A.
+// Scenario: user closes texelterm while scrolled back; saved state carries
+// ScrollOffset=N>0. On restart, applyRestoredStateLocked calls SetScrollOffset(N)
+// BEFORE any render pass. ScrollUp(N) runs while viewAnchor is still 0,
+// decrementing it clamps back to 0, and autoFollow is now false. Subsequent
+// shell output can't pull the viewport back — the view is pinned to oldest
+// history while the cursor is clamped to the bottom row.
+func TestVTerm_RestoreScrollOffsetThenNewOutput(t *testing.T) {
+	const w, h = 80, 10
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	// Populate some history (~30 lines on a 10-row terminal, so plenty of
+	// scrollback).
+	for i := range 30 {
+		feed(p, fmt.Sprintf("H%03d\r\n", i))
+	}
+
+	// Simulate applyRestoredStateLocked with a saved ScrollOffset of 5.
+	// This is the exact call site in term.go:522.
+	v.SetScrollOffset(5)
+
+	// Shell resumes output.
+	for i := range 20 {
+		feed(p, fmt.Sprintf("N%03d\r\n", i))
+	}
+
+	// User hits End / scrolls back to live edge.
+	v.ScrollToLiveEdge()
+
+	grid := v.Grid()
+	lastNonBlank := ""
+	for y := h - 1; y >= 0; y-- {
+		if tag := gridTagAtRow(grid, y); tag != "" {
+			lastNonBlank = tag
+			break
+		}
+	}
+	if !strings.HasPrefix(lastNonBlank, "N019") {
+		t.Errorf("after restore scroll-offset + new output + ScrollToLiveEdge: last tag = %q, want N019*", lastNonBlank)
+		for y, row := range grid {
+			if tag := gridTagAtRow(grid, y); tag != "" {
+				t.Logf("  grid[%02d]: %s", y, strings.TrimRight(cellsToStringTest(row), " \x00"))
+			}
+		}
+	}
+}
+
+// TestVTerm_SetScrollOffsetFromLiveEdge reproduces the "fresh restart with
+// prior scroll offset" scenario more tightly. User never rendered since
+// startup; ScrollUp should still land on a sensible anchor rather than
+// collapsing viewAnchor to 0.
+func TestVTerm_SetScrollOffsetFromLiveEdge(t *testing.T) {
+	const w, h = 80, 10
+	v := parser.NewVTerm(w, h)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	for i := range 30 {
+		feed(p, fmt.Sprintf("H%03d\r\n", i))
+	}
+
+	// SetScrollOffset(3) without any intervening render — simulates the exact
+	// path at startup where applyRestoredStateLocked runs before the first
+	// Render pass.
+	v.SetScrollOffset(3)
+
+	grid := v.Grid()
+	// Expect the view to be scrolled back 3 rows from the live edge. Last
+	// written line before the trailing CRLF was "H029". Live edge had H25..H29
+	// + blank cursor row on 10-row terminal. 3 rows back means the bottom
+	// should now show H26 or thereabouts, NOT H00.
+	lastNonBlank := ""
+	for y := h - 1; y >= 0; y-- {
+		if tag := gridTagAtRow(grid, y); tag != "" {
+			lastNonBlank = tag
+			break
+		}
+	}
+	if strings.HasPrefix(lastNonBlank, "H00") {
+		t.Errorf("SetScrollOffset(3) collapsed viewAnchor to 0: last tag = %q, want H2x", lastNonBlank)
+		for y, row := range grid {
+			if tag := gridTagAtRow(grid, y); tag != "" {
+				t.Logf("  grid[%02d]: %s", y, strings.TrimRight(cellsToStringTest(row), " \x00"))
+			}
+		}
+	}
+}
+
+// cellsToStringTest is a local helper to avoid depending on unexported helpers.
+func cellsToStringTest(row []parser.Cell) string {
+	var b strings.Builder
+	for _, c := range row {
+		if c.Rune == 0 {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(c.Rune)
+		}
+	}
+	return b.String()
+}

--- a/apps/texelterm/parser/logical_line.go
+++ b/apps/texelterm/parser/logical_line.go
@@ -32,6 +32,10 @@ type LogicalLine struct {
 	// Synthetic indicates a transformer-inserted line that is hidden
 	// in the original (non-overlay) view.
 	Synthetic bool
+
+	// NoWrap: line should render 1:1 (clip/pad, not reflow). Set for rows
+	// written during DECSTBM or other structured content.
+	NoWrap bool
 }
 
 // NewLogicalLine creates a new empty logical line.
@@ -108,6 +112,7 @@ func (l *LogicalLine) Clone() *LogicalLine {
 	clone := NewLogicalLineFromCells(l.Cells)
 	clone.FixedWidth = l.FixedWidth
 	clone.Synthetic = l.Synthetic
+	clone.NoWrap = l.NoWrap
 	clone.OverlayWidth = l.OverlayWidth
 	if l.Overlay != nil {
 		clone.Overlay = make([]Cell, len(l.Overlay))

--- a/apps/texelterm/parser/logical_line_nowrap_test.go
+++ b/apps/texelterm/parser/logical_line_nowrap_test.go
@@ -1,0 +1,65 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLogicalLine_NoWrap_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lhist")
+
+	in := []*LogicalLine{
+		{Cells: []Cell{{Rune: 'a'}}, NoWrap: true},
+		{Cells: []Cell{{Rune: 'b'}}, NoWrap: false},
+	}
+	if err := WriteLogicalLines(path, in); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := LoadLogicalLines(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(out))
+	}
+	if !out[0].NoWrap {
+		t.Errorf("line 0: NoWrap flag did not round-trip")
+	}
+	if out[1].NoWrap {
+		t.Errorf("line 1: NoWrap should be false, got true")
+	}
+}
+
+func TestLogicalLine_NoWrap_BackwardCompatibility(t *testing.T) {
+	// Old files (without NoWrap flag set) should load with NoWrap=false.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "old.lhist")
+
+	// Write an LL without NoWrap (flag byte won't have 0x08 set).
+	in := []*LogicalLine{{Cells: []Cell{{Rune: 'x'}}}}
+	if err := WriteLogicalLines(path, in); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate reading — flag 0x08 is absent.
+	out, err := LoadLogicalLines(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0].NoWrap {
+		t.Errorf("default NoWrap should be false")
+	}
+
+	_ = os.Remove(path)
+}
+
+func TestLogicalLine_Clone_PreservesNoWrap(t *testing.T) {
+	ll := &LogicalLine{Cells: []Cell{{Rune: 'a'}}, NoWrap: true}
+	clone := ll.Clone()
+	if !clone.NoWrap {
+		t.Errorf("Clone should preserve NoWrap")
+	}
+}

--- a/apps/texelterm/parser/logical_line_persistence.go
+++ b/apps/texelterm/parser/logical_line_persistence.go
@@ -64,7 +64,7 @@ func WriteLogicalLines(path string, lines []*LogicalLine) error {
 // writeLogicalLine writes a single logical line in v2 format.
 // Format: [flags:1][cell_count:4][cells...][overlay_width:4][overlay_count:4][overlay_cells...]
 func writeLogicalLine(w io.Writer, line *LogicalLine, cellBuf []byte) error {
-	// Flags byte: bit 0 = has overlay, bit 1 = synthetic.
+	// Flags byte: bit 0 = has overlay, bit 1 = synthetic, bit 3 = NoWrap.
 	// Bit 2 is reserved (previously "resize-split", removed post-sparse); old
 	// files may have it set and we silently ignore it on decode.
 	var flags byte
@@ -73,6 +73,9 @@ func writeLogicalLine(w io.Writer, line *LogicalLine, cellBuf []byte) error {
 	}
 	if line.Synthetic {
 		flags |= 0x02
+	}
+	if line.NoWrap {
+		flags |= 0x08
 	}
 	if _, err := w.Write([]byte{flags}); err != nil {
 		return err
@@ -231,6 +234,7 @@ func readLogicalLine(r io.Reader, cellBuf []byte, version int) (*LogicalLine, er
 	line := &LogicalLine{
 		Cells:     cells,
 		Synthetic: flags&0x02 != 0,
+		NoWrap:    flags&0x08 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -40,6 +40,16 @@ type MainScreen interface {
 	NewlineInRegion(marginTop, marginBottom int)
 	Grid() [][]Cell
 
+	// RenderReflow returns the current view reflowed to the viewport width.
+	// Uses chain-walking + NoWrap flags to preserve structured content.
+	RenderReflow() [][]Cell
+
+	// CursorToView maps the current cursor to its viewport-relative (row, col)
+	// in the reflowed view. Returns ok=false if the cursor's globalIdx is not
+	// inside the currently-rendered chain walk, in which case callers should
+	// fall back to writeTop-relative projection.
+	CursorToView() (viewRow, viewCol int, ok bool)
+
 	// Scroll methods keep the sparse ViewWindow in sync with user
 	// navigation. Without these, Grid() would always show the live edge.
 	ScrollUp(n int)

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -69,6 +69,14 @@ type MainScreen interface {
 	// ReadLine returns a copy of the cells at globalIdx. Returns nil for gaps.
 	ReadLine(globalIdx int64) []Cell
 
+	// RowNoWrap reports whether the row at globalIdx is marked NoWrap.
+	// Missing rows return false.
+	RowNoWrap(globalIdx int64) bool
+
+	// SetRowNoWrap marks the row at globalIdx as NoWrap. The flag is sticky
+	// (passing false is a no-op). Called when DECSTBM is active.
+	SetRowNoWrap(globalIdx int64, nowrap bool)
+
 	// VisibleRange returns the (top, bottom) globalIdx pair of the current view.
 	VisibleRange() (top, bottom int64)
 }

--- a/apps/texelterm/parser/page.go
+++ b/apps/texelterm/parser/page.go
@@ -574,9 +574,9 @@ func (p *Page) rebuildLineDataCache() {
 // encodeLineData serializes a LogicalLine to bytes (v2 format).
 // Format: Flags(1) + CellCount(4) + FixedWidth(4) + Cells(N*16) + [OverlayWidth(4) + OverlayCellCount(4) + OverlayCells(M*16)]
 //
-// Flags byte: bit 0 = has overlay, bit 1 = synthetic. Bit 2 is reserved
-// (previously "resize-split", removed post-sparse); old pages may have it
-// set and we silently ignore it on decode.
+// Flags byte: bit 0 = has overlay, bit 1 = synthetic, bit 3 = no-wrap. Bit 2
+// is reserved (previously "resize-split", removed post-sparse); old pages may
+// have it set and we silently ignore it on decode.
 func encodeLineData(line *LogicalLine) []byte {
 	var flags byte
 	if line.Overlay != nil {
@@ -584,6 +584,9 @@ func encodeLineData(line *LogicalLine) []byte {
 	}
 	if line.Synthetic {
 		flags |= 0x02
+	}
+	if line.NoWrap {
+		flags |= 0x08
 	}
 
 	cellCount := uint32(len(line.Cells))
@@ -677,7 +680,7 @@ func decodeLineDataV2(data []byte) (*LogicalLine, error) {
 	}
 
 	flags := data[0]
-	if flags & ^byte(0x07) != 0 {
+	if flags & ^byte(0x0F) != 0 {
 		return nil, fmt.Errorf("invalid v2 flags: 0x%02x", flags)
 	}
 
@@ -703,6 +706,7 @@ func decodeLineDataV2(data []byte) (*LogicalLine, error) {
 		Cells:      cells,
 		FixedWidth: int(fixedWidth),
 		Synthetic:  flags&0x02 != 0,
+		NoWrap:     flags&0x08 != 0,
 	}
 
 	if flags&0x01 != 0 {

--- a/apps/texelterm/parser/page_nowrap_test.go
+++ b/apps/texelterm/parser/page_nowrap_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser
+
+import "testing"
+
+func TestPage_LineData_NoWrapRoundTrip(t *testing.T) {
+	orig := &LogicalLine{Cells: []Cell{{Rune: 'x'}}, NoWrap: true}
+	data := encodeLineData(orig)
+	got, err := decodeLineData(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.NoWrap {
+		t.Errorf("NoWrap did not round-trip")
+	}
+}
+
+func TestPage_LineData_BackwardCompat_NoWrapAbsent(t *testing.T) {
+	// Old records have bit 0x08 clear; decode should yield NoWrap=false.
+	orig := &LogicalLine{Cells: []Cell{{Rune: 'y'}}}
+	data := encodeLineData(orig)
+	got, err := decodeLineData(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.NoWrap {
+		t.Errorf("default NoWrap should be false")
+	}
+}

--- a/apps/texelterm/parser/scrollback_history_test.go
+++ b/apps/texelterm/parser/scrollback_history_test.go
@@ -53,6 +53,42 @@ func TestVTerm_UserScroll(t *testing.T) {
 	}
 }
 
+// TestVTerm_ScrollSignConvention locks in the VTerm.Scroll sign convention that
+// keybinds and mouse wheel rely on: delta < 0 scrolls back (toward older
+// content); delta > 0 scrolls forward (toward live edge). A prior regression
+// swapped these and alt+up/down moved the view the wrong way.
+func TestVTerm_ScrollSignConvention(t *testing.T) {
+	v := NewVTerm(80, 5)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Fill enough history to scroll through.
+	for i := 0; i < 40; i++ {
+		p.Parse('A' + rune(i%26))
+		p.Parse('\n')
+		p.Parse('\r')
+	}
+
+	_, liveBottom := v.mainScreen.VisibleRange()
+
+	// delta < 0 = scroll back: bottom should decrease.
+	v.Scroll(-3)
+	_, afterBack := v.mainScreen.VisibleRange()
+	if afterBack >= liveBottom {
+		t.Fatalf("Scroll(-3) did not move view back: bottom %d -> %d", liveBottom, afterBack)
+	}
+	if v.mainScreen.IsFollowing() {
+		t.Errorf("Scroll(-3) should disengage autoFollow")
+	}
+
+	// delta > 0 = scroll forward: bottom should increase back toward live.
+	v.Scroll(1)
+	_, afterForward := v.mainScreen.VisibleRange()
+	if afterForward <= afterBack {
+		t.Fatalf("Scroll(+1) did not move view forward: bottom %d -> %d", afterBack, afterForward)
+	}
+}
+
 // TestVTerm_TotalLines verifies that ContentEnd advances as lines are
 // appended, matching the pre-sparse memoryBufferTotalLines semantics.
 func TestVTerm_TotalLines(t *testing.T) {

--- a/apps/texelterm/parser/sparse/blank_line_anchor_test.go
+++ b/apps/texelterm/parser/sparse/blank_line_anchor_test.go
@@ -1,0 +1,136 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"fmt"
+	"testing"
+)
+
+// writeEmptyLine writes a bare Newline (no cells) — used to simulate a blank
+// line in output like `ls -lR` section separators.
+func writeEmptyLine(tm *Terminal) {
+	tm.Newline()
+}
+
+// TestTerminal_LiveFollowThroughBlankLines reproduces the user's
+// "ls -lR viewport stuck on top" symptom. `ls -lR` emits blank lines
+// between directory sections, which land as empty rows in the sparse store.
+// If RecomputeLiveAnchor's backward walk trips on the first empty row above
+// the cursor, it falls through to "ran out of content" and snaps viewAnchor
+// to 0 — pinning the viewport to the top of history even though autoFollow
+// is still on.
+func TestTerminal_LiveFollowThroughBlankLines(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+
+	for i := range 10 {
+		writeTagged(tm, fmt.Sprintf("A%02d", i))
+	}
+	writeEmptyLine(tm)
+	for i := range 10 {
+		writeTagged(tm, fmt.Sprintf("B%02d", i))
+	}
+
+	grid := tm.RenderReflow()
+	tags := gridTags(grid)
+
+	// Last non-blank row should reference B09 (last written content).
+	lastNonBlank := ""
+	for i := len(tags) - 1; i >= 0; i-- {
+		if tags[i] != "" {
+			lastNonBlank = tags[i]
+			break
+		}
+	}
+	if lastNonBlank != "B09" {
+		t.Errorf("blank-line trap: last visible tag = %q, want B09 (tags=%v)", lastNonBlank, tags)
+	}
+}
+
+// TestTerminal_FastScrollDownNeverLandsAtTop reproduces the user's "fast
+// scrollwheel down sometimes jumps back to the top of history" symptom. After
+// scrolling deep into history, rapid ScrollDown calls with render-simulated
+// RecomputeLiveAnchor checkpoints must never leave the viewport anchored at
+// globalIdx 0 unless we genuinely arrived there — we're moving toward the
+// live edge, not away from it.
+func TestTerminal_FastScrollDownNeverLandsAtTop(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+
+	// 100 lines of output with a blank-line section break every 10 lines.
+	for i := range 100 {
+		writeTagged(tm, fmt.Sprintf("L%03d", i))
+		if i%10 == 9 {
+			writeEmptyLine(tm)
+		}
+	}
+
+	// Scroll to top of history.
+	tm.ScrollUp(200)
+	if tags := gridTags(tm.RenderReflow()); tags[0] != "L000" {
+		t.Fatalf("after ScrollUp(200), expected to be at top. tags=%v", tags)
+	}
+
+	// Rapid scroll-down: 20 ticks of 3 rows each. Render between each to let
+	// RecomputeLiveAnchor run.
+	for range 20 {
+		tm.ScrollDown(3)
+		tags := gridTags(tm.RenderReflow())
+		// At no point should the viewport regress to "L000" once we've started
+		// scrolling down — the test's whole premise is forward motion.
+		if tags[0] == "L000" {
+			t.Errorf("scroll-down regressed to top of history: tags=%v", tags)
+			break
+		}
+	}
+
+	// Final: large ScrollDown should leave us at the live edge.
+	tm.ScrollDown(500)
+	tags := gridTags(tm.RenderReflow())
+	lastNonBlank := ""
+	for i := len(tags) - 1; i >= 0; i-- {
+		if tags[i] != "" {
+			lastNonBlank = tags[i]
+			break
+		}
+	}
+	if lastNonBlank != "L099" {
+		t.Errorf("after full scroll-down, last visible = %q, want L099 (tags=%v)", lastNonBlank, tags)
+	}
+	if !tm.IsFollowing() {
+		t.Error("after full scroll-down, IsFollowing should be true")
+	}
+}
+
+// TestTerminal_LiveFollowManyBlankLines exercises multiple blank-line
+// separators scattered through the output, matching real `ls -lR`
+// behavior across many subdirectories.
+func TestTerminal_LiveFollowManyBlankLines(t *testing.T) {
+	const height = 10
+	tm := NewTerminal(40, height)
+
+	for section := range 5 {
+		writeTagged(tm, fmt.Sprintf("./dir%d:", section))
+		for i := range 5 {
+			writeTagged(tm, fmt.Sprintf("S%dF%02d entry", section, i))
+		}
+		writeEmptyLine(tm)
+	}
+
+	grid := tm.RenderReflow()
+	tags := gridTags(grid)
+
+	// Expect some S4-prefixed (last section) entries visible.
+	sawLast := false
+	for _, tag := range tags {
+		if len(tag) >= 3 && tag[:2] == "S4" {
+			sawLast = true
+			break
+		}
+	}
+	if !sawLast {
+		t.Errorf("blank-line trap: no S4* entries visible. tags=%v", tags)
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence.go
+++ b/apps/texelterm/parser/sparse/persistence.go
@@ -37,7 +37,7 @@ func (p *Persistence) FlushLines(store *Store, globalIdxs []int64) error {
 		if cells == nil {
 			continue
 		}
-		line := &parser.LogicalLine{Cells: cells}
+		line := &parser.LogicalLine{Cells: cells, NoWrap: store.RowNoWrap(gi)}
 		if err := p.page.AppendLineWithGlobalIdx(gi, line, now); err != nil {
 			return err
 		}
@@ -91,7 +91,11 @@ func LoadStore(store *Store, ps *parser.PageStore) error {
 		if line == nil {
 			continue
 		}
-		store.SetLine(gi, line.Cells)
+		if line.NoWrap {
+			store.SetLineWithNoWrap(gi, line.Cells, true)
+		} else {
+			store.SetLine(gi, line.Cells)
+		}
 	}
 	return nil
 }

--- a/apps/texelterm/parser/sparse/reflow_tail_test.go
+++ b/apps/texelterm/parser/sparse/reflow_tail_test.go
@@ -185,3 +185,43 @@ func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
 		t.Errorf("ScrollUp(1) top row = %q; want 40 d's (last reflowed row)", row0)
 	}
 }
+
+// TestScrollUp_MultiRowChainResizeSubRowGranularity is the regression guard for
+// multi-row-chain scroll after a narrowing resize. Chain [0..1] stores 160
+// cells total: 2 reflowed rows at width 80, 4 at width 40. After Resize to the
+// narrower width, each ScrollUp(1) must step exactly one sub-row — not one
+// stored row, not the whole chain. Failure modes this guards: (a) scroll units
+// in globalIdx instead of reflowed rows; (b) anchor offset reset to 0 on any
+// chain-boundary walk.
+func TestScrollUp_MultiRowChainResizeSubRowGranularity(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 0, strings.Repeat("a", 80), true)
+	fillRow(s, 1, strings.Repeat("b", 80), false)
+	fillRow(s, 2, "tail", false)
+
+	// Start wide (width 80): chain reflows to 2 rows. Anchor at tail.
+	vw := NewViewWindow(80, 3)
+	vw.SetViewAnchor(2, 0)
+
+	// Resize narrower — chain is now 4 reflowed rows.
+	vw.Resize(40, 3, 2)
+
+	// Pre-conditions: sanity check reflow row counts.
+	if got := chainReflowedRowCount(s, 0, 1, 40, false); got != 4 {
+		t.Fatalf("chain @w40 = %d rows, want 4", got)
+	}
+
+	// Walk back through the chain one sub-row at a time. After each step the
+	// anchor must advance by exactly one reflowed row.
+	wantOffsets := []int{3, 2, 1, 0} // last-sub-row ... first-sub-row
+	for i, wantOff := range wantOffsets {
+		vw.ScrollUpRows(s, 1)
+		gi, off := vw.Anchor()
+		if gi != 0 {
+			t.Fatalf("step %d: anchor gi=%d; want 0 (chain start)", i, gi)
+		}
+		if off != wantOff {
+			t.Fatalf("step %d: anchor offset=%d; want %d", i, off, wantOff)
+		}
+	}
+}

--- a/apps/texelterm/parser/sparse/reflow_tail_test.go
+++ b/apps/texelterm/parser/sparse/reflow_tail_test.go
@@ -1,0 +1,187 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCursor_EmptyContinuationAfterWrappedFullRow reproduces the "cursor
+// jumps below the prompt on clear lines after resize" bug. When a chain has
+// a Wrapped full row followed by an empty continuation row (cursor just
+// newlined past a wrap, hasn't written yet), the reflow concatenation drops
+// the empty row's implicit physical slot — so the cursor's computed row
+// overshoots by one. reflowChain must emit a blank row for the trailing
+// empty continuation, and the row-count helper must count it.
+func TestCursor_EmptyContinuationAfterWrappedFullRow(t *testing.T) {
+	s := NewStore(80)
+	// Line 0: 80 cells, Wrapped (fills the row; cursor would newline past).
+	text80 := strings.Repeat("x", 80)
+	fillRow(s, 0, text80, true)
+	// Line 1: empty — cursor sits at (1, 0) awaiting input.
+	s.SetLine(1, nil)
+
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(0, 0)
+
+	// Cursor at (1, 0): visually one row below line 0.
+	vr, vc, ok := vw.CursorToView(s, 1, 0)
+	if !ok {
+		t.Fatalf("CursorToView(1,0)=ok=false, want ok=true")
+	}
+	if vr != 1 || vc != 0 {
+		t.Errorf("CursorToView(1,0)=(%d,%d); want (1,0)", vr, vc)
+	}
+}
+
+// TestCursor_EmptyContinuationNarrower simulates a resize that forces the
+// prompt row to wrap, putting the cursor on an empty continuation row.
+func TestCursor_EmptyContinuationNarrower(t *testing.T) {
+	s := NewStore(80)
+	// Line 0: 80 cells Wrapped; line 1 empty — cursor at (1, 0).
+	text80 := strings.Repeat("x", 80)
+	fillRow(s, 0, text80, true)
+	s.SetLine(1, nil)
+
+	// Reflow at width 40: line 0 → 2 reflowed rows; cursor's continuation
+	// should be row 2 (the third row), col 0.
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 1, 0)
+	if !ok {
+		t.Fatalf("CursorToView(1,0)=ok=false, want ok=true")
+	}
+	if vr != 2 || vc != 0 {
+		t.Errorf("CursorToView(1,0)@w40=(%d,%d); want (2,0)", vr, vc)
+	}
+}
+
+// TestCursor_EmptyContinuationWider exercises the width-dependent cursor-flip:
+// when the view is wider than the stored line, the Wrapped flag on line 0
+// still conceptually means "followed by a continuation row" but the physical
+// cells now fit in 1 row — so the cursor on gi=1 (empty) must land on row 1,
+// not row 0. Previously logicalCol=80/width was < 1, putting the cursor back
+// on row 0 (visually above the actual cursor position).
+func TestCursor_EmptyContinuationWider(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("x", 80)
+	fillRow(s, 0, text80, true)
+	s.SetLine(1, nil)
+
+	// Width 81: content fits row 0 (80 cells), trailing empty row is row 1.
+	vw := NewViewWindow(81, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 1, 0)
+	if !ok {
+		t.Fatalf("CursorToView(1,0)=ok=false, want ok=true")
+	}
+	if vr != 1 || vc != 0 {
+		t.Errorf("CursorToView(1,0)@w81=(%d,%d); want (1,0)", vr, vc)
+	}
+}
+
+// TestCursor_EmptyContinuationPartialLine tests a partial-length Wrapped line
+// followed by empty continuation. Stored content: 50 cells Wrapped, then empty.
+// At width 80: content=1 row, trailing=1 row. Cursor at (gi=1,col=0) must land
+// on row 1 (the trailing empty).
+func TestCursor_EmptyContinuationPartialLine(t *testing.T) {
+	s := NewStore(80)
+	text50 := strings.Repeat("x", 50)
+	fillRow(s, 0, text50, true)
+	s.SetLine(1, nil)
+
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 1, 0)
+	if !ok {
+		t.Fatalf("CursorToView(1,0)=ok=false, want ok=true")
+	}
+	if vr != 1 || vc != 0 {
+		t.Errorf("CursorToView(1,0) partial @w80=(%d,%d); want (1,0)", vr, vc)
+	}
+}
+
+// TestRender_EmptyContinuationEmitsRow ensures Render produces an actual
+// physical row for the empty continuation — otherwise the cursor position
+// above would match what's painted, but the row below line 0 would be the
+// NEXT chain's content (visually wrong).
+func TestRender_EmptyContinuationEmitsRow(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("x", 80)
+	fillRow(s, 0, text80, true)
+	s.SetLine(1, nil)
+	fillRow(s, 2, "next", false)
+
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+
+	if len(out) < 3 {
+		t.Fatalf("Render too short: %d rows", len(out))
+	}
+	// Row 0: the wrapped "x...x" content.
+	if !strings.HasPrefix(cellsToStringSparse(out[0]), "xxxx") {
+		t.Errorf("row 0 = %q; want xxxx...", cellsToStringSparse(out[0]))
+	}
+	// Row 1: empty continuation (where cursor would sit).
+	if s := strings.TrimSpace(cellsToStringSparse(out[1])); s != "" {
+		t.Errorf("row 1 should be blank continuation, got %q", s)
+	}
+	// Row 2: "next" from the following chain.
+	if !strings.HasPrefix(cellsToStringSparse(out[2]), "next") {
+		t.Errorf("row 2 = %q; want next", cellsToStringSparse(out[2]))
+	}
+}
+
+// TestScrollUp_ReflowedChainNoFragment reproduces the "line-joining visible
+// at the top of the viewport" bug. A wrapped chain reflows to multiple rows
+// at a narrower view width; scrolling up one reflowed row at a time should
+// reveal the next earlier reflowed row, NOT refragment the chain. viewAnchor
+// must land at the chain start with an offset, not in the middle of the
+// chain.
+func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
+	s := NewStore(80)
+	// Chain: line 0 wraps to 1, wraps to 2, ends at 3 (non-wrapped).
+	// Each line 80 cells. 80*4 = 320 cells total.
+	fillRow(s, 0, strings.Repeat("a", 80), true)
+	fillRow(s, 1, strings.Repeat("b", 80), true)
+	fillRow(s, 2, strings.Repeat("c", 80), true)
+	fillRow(s, 3, strings.Repeat("d", 40), false)
+	// Post-chain content so we can distinguish "chain start" from "start
+	// of store". Line 4 is a separate chain.
+	fillRow(s, 4, "tail", false)
+
+	// Reflow at width 40. Chain [0..3] = 240 cells + 40 cells = 280 cells
+	// → 7 reflowed rows.
+	vw := NewViewWindow(40, 3)
+	// Start by anchoring at the tail (line 4) so we're "past" the chain.
+	vw.SetViewAnchor(4, 0)
+	baseline := cellsToStringSparse(vw.Render(s)[0])
+	if !strings.HasPrefix(baseline, "tail") {
+		t.Fatalf("baseline row 0 = %q; expected tail", baseline)
+	}
+
+	// ScrollUp by 1 reflowed row. Anchor should land at chain start (0)
+	// with offset = rows - 1 = 6 (the chain's last reflowed row).
+	vw.ScrollUpRows(s, 1)
+	gi, off := vw.Anchor()
+	if gi != 0 {
+		t.Errorf("ScrollUp(1) anchor gi=%d; want 0 (chain start)", gi)
+	}
+	if off != 6 {
+		t.Errorf("ScrollUp(1) anchor offset=%d; want 6 (last reflowed row of chain)", off)
+	}
+
+	// Top of viewport should show a non-fragmented reflowed row from the
+	// chain. Row 6 of the reflow = cells [240..280] = all 'd' (40 cells).
+	out := vw.Render(s)
+	row0 := cellsToStringSparse(out[0])
+	if !strings.HasPrefix(row0, strings.Repeat("d", 40)) {
+		t.Errorf("ScrollUp(1) top row = %q; want 40 d's (last reflowed row)", row0)
+	}
+}

--- a/apps/texelterm/parser/sparse/scroll_regression_test.go
+++ b/apps/texelterm/parser/sparse/scroll_regression_test.go
@@ -1,0 +1,374 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// writeTagged writes "<tag>\n" via WriteCell/Newline. Each line is a tag that
+// uniquely identifies a source globalIdx so tests can assert which logical
+// rows landed in the viewport.
+func writeTagged(tm *Terminal, tag string) {
+	for _, r := range tag {
+		tm.WriteCell(parser.Cell{Rune: r})
+	}
+	tm.Newline()
+}
+
+// gridRowToTag extracts the leading non-blank rune sequence of a grid row.
+func gridRowToTag(row []parser.Cell) string {
+	var b strings.Builder
+	for _, c := range row {
+		if c.Rune == 0 || c.Rune == ' ' {
+			if b.Len() == 0 {
+				continue
+			}
+			break
+		}
+		b.WriteRune(c.Rune)
+	}
+	return b.String()
+}
+
+// gridTags returns every row's leading tag, in order.
+func gridTags(grid [][]parser.Cell) []string {
+	out := make([]string, len(grid))
+	for i, row := range grid {
+		out[i] = gridRowToTag(row)
+	}
+	return out
+}
+
+// TestTerminal_RenderReflowLiveFollow verifies that RenderReflow on a freshly
+// filled terminal shows the most-recent N lines (the live edge), not stale
+// history anchored at globalIdx 0. This is Regression A from manual testing:
+// the viewport stopped following output.
+func TestTerminal_RenderReflowLiveFollow(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+
+	// Write 20 tagged lines. Each newline advances the cursor; once the cursor
+	// exceeds the viewport, writeTop scrolls.
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+
+	grid := tm.RenderReflow()
+	if len(grid) != height {
+		t.Fatalf("RenderReflow rows = %d, want %d", len(grid), height)
+	}
+
+	tags := gridTags(grid)
+	// Cursor just newlined to row 20 (blank). Expected viewport rows 16..20.
+	want := []string{"L16", "L17", "L18", "L19", ""}
+	for i, w := range want {
+		if tags[i] != w {
+			t.Errorf("row %d: got %q, want %q (full tags=%v)", i, tags[i], w, tags)
+		}
+	}
+}
+
+// TestTerminal_ScrollUpChangesRenderedView is the core Regression B test: a
+// user-initiated ScrollUp must make older content visible via RenderReflow.
+// Before the fix, ScrollUp only mutates the legacy viewBottom field while
+// RenderReflow reads from viewAnchor — so the rendered grid was unchanged.
+func TestTerminal_ScrollUpChangesRenderedView(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+
+	before := gridTags(tm.RenderReflow())
+
+	tm.ScrollUp(3)
+
+	after := gridTags(tm.RenderReflow())
+
+	if equalSlices(before, after) {
+		t.Fatalf("ScrollUp(3) did not change RenderReflow output: %v", before)
+	}
+	if tm.IsFollowing() {
+		t.Error("after ScrollUp, IsFollowing should be false")
+	}
+
+	// Explicit shape: scrolled 3 rows back from the live edge, so the
+	// viewport should now end 3 rows earlier. before ended at blank-cursor-row
+	// (L16..L19,""); after should end at L16 (or thereabouts).
+	lastNonBlank := ""
+	for i := len(after) - 1; i >= 0; i-- {
+		if after[i] != "" {
+			lastNonBlank = after[i]
+			break
+		}
+	}
+	if lastNonBlank == "" {
+		t.Fatalf("after ScrollUp, all rows blank: %v", after)
+	}
+	if lastNonBlank == "L19" {
+		t.Errorf("after ScrollUp(3), last visible tag is still %q — view did not move", lastNonBlank)
+	}
+}
+
+// TestTerminal_ScrollDownDoesNotSnapPrematurely exercises the symmetry bug
+// between ScrollUpRows and ScrollDownRows. After scrolling up by several
+// reflowed rows, a single ScrollDown should advance by one reflowed row —
+// NOT snap to the live edge. The previous failure was that viewBottom
+// diverged from the actual scrolled amount (reflow walked farther than
+// viewBottom was decremented), so ScrollDown hit writeBottom after one click.
+func TestTerminal_ScrollDownDoesNotSnapPrematurely(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+
+	tm.ScrollUp(5)
+	if tm.IsFollowing() {
+		t.Fatalf("after ScrollUp(5), IsFollowing should be false")
+	}
+	afterUp := gridTags(tm.RenderReflow())
+
+	tm.ScrollDown(1)
+	afterDown1 := gridTags(tm.RenderReflow())
+
+	if tm.IsFollowing() {
+		t.Errorf("after ScrollDown(1) from 5-back, IsFollowing should still be false; view=%v", afterDown1)
+	}
+	if equalSlices(afterUp, afterDown1) {
+		t.Errorf("ScrollDown(1) from 5-rows-back did not move view\nafterUp=  %v\nafterDown=%v", afterUp, afterDown1)
+	}
+}
+
+// TestTerminal_ScrollUpDownRoundTrip verifies that scrolling up N reflowed
+// rows then down N rows returns to the live view.
+func TestTerminal_ScrollUpDownRoundTrip(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	live := gridTags(tm.RenderReflow())
+
+	for range 4 {
+		tm.ScrollUp(1)
+	}
+	for range 4 {
+		tm.ScrollDown(1)
+	}
+	after := gridTags(tm.RenderReflow())
+
+	if !equalSlices(live, after) {
+		t.Errorf("ScrollUp(1)x4 then ScrollDown(1)x4 did not round-trip\nlive:  %v\nafter: %v", live, after)
+	}
+}
+
+// TestTerminal_ScrollWithWrappedChainRoundTrip verifies that when the live
+// edge sits on a wrapped chain (cursor position advances the view past
+// multiple reflowed rows per globalIdx), ScrollUp(1) followed by ScrollDown(1)
+// returns to the same view — testing the viewBottom / viewAnchor divergence.
+func TestTerminal_ScrollWithWrappedChainRoundTrip(t *testing.T) {
+	const width, height = 20, 5
+	tm := NewTerminal(width, height)
+	// 5 plain lines, then a 60-char line that'll wrap 3 rows at width 20.
+	for i := range 5 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	long := strings.Repeat("x", 60)
+	for _, r := range long {
+		tm.WriteCell(parser.Cell{Rune: r})
+	}
+	tm.Newline()
+	writeTagged(tm, "END")
+
+	live := gridTags(tm.RenderReflow())
+	tm.ScrollUp(1)
+	tm.ScrollDown(1)
+	after := gridTags(tm.RenderReflow())
+	if !equalSlices(live, after) {
+		t.Errorf("ScrollUp(1)+ScrollDown(1) near wrapped chain did not round-trip\nlive:  %v\nafter: %v", live, after)
+	}
+}
+
+// TestTerminal_ScrollUpClampedThenScrollDown reproduces the velocity-overshoot
+// regression: ScrollUp with a large n hits the top (viewAnchor=0) with n
+// unsatisfied. Previously viewBottom was decremented by the full n, so a
+// subsequent ScrollDown(1) saw viewBottom way below writeBottom and took
+// many clicks to reach the live edge. The fix: only decrement viewBottom by
+// rows actually walked.
+func TestTerminal_ScrollUpClampedThenScrollDown(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 10 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	// 10 lines written, height 5, so only ~5 rows of scrollback above the
+	// live view. Scroll up by a large amount; the clamp should kick in.
+	tm.ScrollUp(50)
+
+	// Now ScrollDown(1) should move the view down by 1 — not snap to live
+	// edge from the phantom "scrolled 50 back" state.
+	tm.ScrollDown(1)
+	if tm.IsFollowing() {
+		t.Errorf("ScrollDown(1) after clamped ScrollUp(50) snapped to live edge prematurely")
+	}
+}
+
+// TestTerminal_VelocityScrollDownDoesNotOvershoot simulates the scenario where
+// a user scrolls up by small amounts, then scrolls down with a velocity-
+// multiplied click. The velocity n can exceed the distance to the live edge;
+// the scroll down should snap to live — but only because we're at live, not
+// because viewBottom was in a stale state.
+func TestTerminal_VelocityScrollDownDoesNotOvershoot(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	// Scroll up 2 rows.
+	tm.ScrollUp(2)
+	if tm.IsFollowing() {
+		t.Fatalf("after ScrollUp(2), IsFollowing should be false")
+	}
+
+	// Scroll down with velocity-multiplied n (10). Should snap to live edge.
+	tm.ScrollDown(10)
+	if !tm.IsFollowing() {
+		t.Errorf("ScrollDown(10) past live edge should snap + re-engage autoFollow")
+	}
+}
+
+// TestTerminal_ScrollToBottomReturnsToLiveEdge verifies that after scrolling
+// back and re-engaging auto-follow, RenderReflow shows the latest content.
+func TestTerminal_ScrollToBottomReturnsToLiveEdge(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	live := gridTags(tm.RenderReflow())
+
+	tm.ScrollUp(5)
+	scrolled := gridTags(tm.RenderReflow())
+	if equalSlices(live, scrolled) {
+		t.Fatal("ScrollUp had no effect on RenderReflow")
+	}
+
+	tm.ScrollToBottom()
+	restored := gridTags(tm.RenderReflow())
+
+	if !equalSlices(live, restored) {
+		t.Errorf("ScrollToBottom did not restore live view\nlive:     %v\nrestored: %v", live, restored)
+	}
+	if !tm.IsFollowing() {
+		t.Error("after ScrollToBottom, IsFollowing should be true")
+	}
+}
+
+// TestTerminal_NewContentAdvancesLiveView verifies that while auto-following,
+// writing new content advances the rendered viewport.
+func TestTerminal_NewContentAdvancesLiveView(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 10 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	before := gridTags(tm.RenderReflow())
+
+	for i := 10; i < 20; i++ {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	after := gridTags(tm.RenderReflow())
+
+	if equalSlices(before, after) {
+		t.Fatalf("live-follow: viewport did not advance after 10 new lines: %v", before)
+	}
+	// Expect the last non-blank row to now reference L19.
+	lastNonBlank := ""
+	for i := len(after) - 1; i >= 0; i-- {
+		if after[i] != "" {
+			lastNonBlank = after[i]
+			break
+		}
+	}
+	if lastNonBlank != "L19" {
+		t.Errorf("live-follow: last visible tag = %q, want L19 (full tags=%v)", lastNonBlank, after)
+	}
+}
+
+// TestTerminal_ScrollUpSingleRowDoesNotJumpToTop is the core "binary jump"
+// regression. Previously, ScrollUpRows' post-loop cleanup unconditionally
+// reset viewAnchor = 0 after the walk loop terminated, even when the loop
+// exited normally because `remaining` had been fully consumed. Consequence:
+// a single ScrollUp(1) through a chain that consumed exactly one reflowed
+// row in one iteration landed viewAnchor at the chain start (correct), then
+// the cleanup overwrote it to 0 (top of history). Reflowed rows should move
+// incrementally — not teleport to the top on any non-partial-chain walk.
+func TestTerminal_ScrollUpSingleRowDoesNotJumpToTop(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	// 20 single-row chains. At live edge, viewAnchor is L15, offset=0 for
+	// a height-5 viewport showing L15..L19. ScrollUp(1) should walk back to
+	// L14, NOT to L00.
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	_ = tm.RenderReflow() // Triggers RecomputeLiveAnchor.
+
+	tm.ScrollUp(1)
+	after := gridTags(tm.RenderReflow())
+	// Live view was L16..L19, "" (blank cursor row). ScrollUp(1) shifts the
+	// viewport back by exactly one reflowed row → L15..L19. The binary-jump
+	// bug previously teleported viewAnchor to 0 here (L00..L04).
+	want := []string{"L15", "L16", "L17", "L18", "L19"}
+	for i, w := range want {
+		if after[i] != w {
+			t.Errorf("row %d: got %q, want %q (full=%v)", i, after[i], w, after)
+		}
+	}
+}
+
+// TestTerminal_ScrollDownSingleRowDoesNotJumpToLive verifies the same
+// per-row granularity holds for the symmetric direction after several
+// ScrollUp clicks: ScrollDown(1) should advance by exactly one reflowed
+// row, not snap to the live edge on the first click.
+func TestTerminal_ScrollDownSingleRowDoesNotJumpToLive(t *testing.T) {
+	const height = 5
+	tm := NewTerminal(20, height)
+	for i := range 20 {
+		writeTagged(tm, fmt.Sprintf("L%02d", i))
+	}
+	// Scroll up 5 rows from live edge so we have room to scroll down by 1.
+	for range 5 {
+		tm.ScrollUp(1)
+	}
+	before := gridTags(tm.RenderReflow())
+
+	tm.ScrollDown(1)
+	after := gridTags(tm.RenderReflow())
+
+	if equalSlices(before, after) {
+		t.Fatalf("ScrollDown(1) did not move view\nbefore=%v\nafter=%v", before, after)
+	}
+	if tm.IsFollowing() {
+		t.Errorf("ScrollDown(1) 5-back snapped to live edge prematurely")
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -13,7 +13,8 @@ import (
 // A missing map entry represents "no content at this globalIdx" — reads of
 // missing globalIdxs return blank cells.
 type storeLine struct {
-	cells []parser.Cell
+	cells  []parser.Cell
+	nowrap bool
 }
 
 // Store is a sparse, globalIdx-keyed cell storage.
@@ -106,8 +107,9 @@ func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
 }
 
 // GetLine returns a copy of the cells at globalIdx. Returns nil if the
-// globalIdx has never been written to. The returned slice is safe to mutate
-// — it does not alias Store internal state.
+// globalIdx has never been written to. Returns a non-nil (possibly zero-length)
+// slice for a row that exists but has no cells (e.g. created by SetRowNoWrap).
+// The returned slice is safe to mutate — it does not alias Store internal state.
 func (s *Store) GetLine(globalIdx int64) []parser.Cell {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -121,8 +123,10 @@ func (s *Store) GetLine(globalIdx int64) []parser.Cell {
 }
 
 // SetLine replaces the cells at globalIdx with a copy of cells. Any existing
-// content at that globalIdx is overwritten in full. To preserve alignment
-// with column 0, callers must pass cells starting at column 0.
+// content at that globalIdx is overwritten in full. The NoWrap flag is
+// preserved — use SetLineWithNoWrap to set an explicit flag value.
+// To preserve alignment with column 0, callers must pass cells starting at
+// column 0.
 func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -133,6 +137,59 @@ func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
 	}
 	line.cells = make([]parser.Cell, len(cells))
 	copy(line.cells, cells)
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}
+
+// RowNoWrap reports whether the row at globalIdx is marked NoWrap.
+// Missing rows return false.
+func (s *Store) RowNoWrap(globalIdx int64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return false
+	}
+	return line.nowrap
+}
+
+// SetRowNoWrap sets the NoWrap flag on the row at globalIdx. The flag is
+// sticky: passing false does NOT clear it. Callers that need to clear must
+// replace the row via SetLineWithNoWrap.
+//
+// If the row does not yet exist, it is created empty so the flag sticks.
+func (s *Store) SetRowNoWrap(globalIdx int64, nowrap bool) {
+	if !nowrap {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.nowrap = true
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}
+
+// SetLineWithNoWrap replaces both cells and the NoWrap flag at globalIdx.
+// Used by IL/DL/scroll shifts that move a row (and its NoWrap semantics)
+// from one globalIdx to another.
+func (s *Store) SetLineWithNoWrap(globalIdx int64, cells []parser.Cell, nowrap bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.cells = make([]parser.Cell, len(cells))
+	copy(line.cells, cells)
+	line.nowrap = nowrap
 	if globalIdx > s.contentEnd {
 		s.contentEnd = globalIdx
 	}

--- a/apps/texelterm/parser/sparse/store_nowrap_shift_test.go
+++ b/apps/texelterm/parser/sparse/store_nowrap_shift_test.go
@@ -1,0 +1,120 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// When a row is shifted within a scroll region (via IL/DL/NewlineInRegion),
+// its NoWrap flag must travel with its cells, not stay on the old globalIdx.
+func TestStore_RowShift_NoWrapFollows(t *testing.T) {
+	s := NewStore(80)
+	s.Set(10, 0, parser.Cell{Rune: 'A'})
+	s.SetRowNoWrap(10, true)
+
+	// Simulate "move row at 10 to 11" via explicit shift helpers.
+	cells := s.GetLine(10)
+	nw := s.RowNoWrap(10)
+	s.SetLineWithNoWrap(11, cells, nw)
+	s.ClearRange(10, 10)
+
+	if !s.RowNoWrap(11) {
+		t.Errorf("NoWrap must follow cells to new row")
+	}
+	if s.RowNoWrap(10) {
+		t.Errorf("old row should be cleared (NoWrap=false)")
+	}
+}
+
+// TestWriteWindow_InsertLines_NoWrapFollows verifies that when InsertLines
+// shifts rows down, the NoWrap flag travels with the cells.
+func TestWriteWindow_InsertLines_NoWrapFollows(t *testing.T) {
+	s := NewStore(80)
+	ww := NewWriteWindow(s, 80, 10)
+
+	// Write content on rows 2 and 3 (both relative to writeTop=0).
+	s.Set(2, 0, parser.Cell{Rune: 'A'})
+	s.SetRowNoWrap(2, true)
+	s.Set(3, 0, parser.Cell{Rune: 'B'})
+	// Row 3 does NOT have NoWrap.
+
+	// Insert 1 blank line at cursorRow=2, within scroll region [0, 9].
+	// This should shift row 2 -> 3, row 3 -> 4. Row 2 is cleared (blank inserted).
+	ww.InsertLines(1, 2, 0, 9)
+
+	// Row 3 (was row 2) must carry NoWrap.
+	if !s.RowNoWrap(3) {
+		t.Errorf("after InsertLines: row 3 (was row 2) should have NoWrap=true")
+	}
+	// Row 2 is the newly-inserted blank — NoWrap must be false.
+	if s.RowNoWrap(2) {
+		t.Errorf("after InsertLines: newly-inserted row 2 should have NoWrap=false")
+	}
+	// Row 4 (was row 3) must NOT have NoWrap.
+	if s.RowNoWrap(4) {
+		t.Errorf("after InsertLines: row 4 (was row 3) should have NoWrap=false")
+	}
+	// Content must have moved with NoWrap.
+	if got := s.Get(3, 0).Rune; got != 'A' {
+		t.Errorf("cell at row 3, col 0 = %q, want 'A'", got)
+	}
+}
+
+// TestWriteWindow_DeleteLines_NoWrapFollows verifies that when DeleteLines
+// shifts rows up, the NoWrap flag travels with the cells.
+func TestWriteWindow_DeleteLines_NoWrapFollows(t *testing.T) {
+	s := NewStore(80)
+	ww := NewWriteWindow(s, 80, 10)
+
+	// Write content on row 3 with NoWrap, and row 2 without.
+	s.Set(2, 0, parser.Cell{Rune: 'X'})
+	// Row 2 does NOT have NoWrap.
+	s.Set(3, 0, parser.Cell{Rune: 'Y'})
+	s.SetRowNoWrap(3, true)
+
+	// Delete 1 line at cursorRow=2, within scroll region [0, 9].
+	// This shifts row 3 -> 2, row 4 -> 3, etc. Bottom row (9) is cleared.
+	ww.DeleteLines(1, 2, 0, 9)
+
+	// Row 2 (was row 3) must carry NoWrap.
+	if !s.RowNoWrap(2) {
+		t.Errorf("after DeleteLines: row 2 (was row 3) should have NoWrap=true")
+	}
+	// Content must have moved.
+	if got := s.Get(2, 0).Rune; got != 'Y' {
+		t.Errorf("cell at row 2, col 0 = %q, want 'Y'", got)
+	}
+}
+
+// TestWriteWindow_NewlineInRegion_NoWrapFollows verifies that when
+// NewlineInRegion scrolls a region, the NoWrap flag travels with cells.
+func TestWriteWindow_NewlineInRegion_NoWrapFollows(t *testing.T) {
+	s := NewStore(80)
+	ww := NewWriteWindow(s, 80, 10)
+
+	// Row 5 has content and NoWrap; row 4 does not.
+	s.Set(4, 0, parser.Cell{Rune: 'P'})
+	s.Set(5, 0, parser.Cell{Rune: 'Q'})
+	s.SetRowNoWrap(5, true)
+
+	// Newline in region [3, 6]: rows shift up by 1, bottom (6) is cleared.
+	// Row 5 -> 4, row 6 -> 5, row 6 cleared.
+	ww.NewlineInRegion(3, 6)
+
+	// Row 4 (was row 5) must carry NoWrap.
+	if !s.RowNoWrap(4) {
+		t.Errorf("after NewlineInRegion: row 4 (was row 5) should have NoWrap=true")
+	}
+	// Row 6 is the newly-cleared bottom — must not have NoWrap.
+	if s.RowNoWrap(6) {
+		t.Errorf("after NewlineInRegion: cleared row 6 should have NoWrap=false")
+	}
+	// Content must have moved.
+	if got := s.Get(4, 0).Rune; got != 'Q' {
+		t.Errorf("cell at row 4, col 0 = %q, want 'Q'", got)
+	}
+}

--- a/apps/texelterm/parser/sparse/store_nowrap_test.go
+++ b/apps/texelterm/parser/sparse/store_nowrap_test.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestStore_RowNoWrap_DefaultFalse(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'x'})
+	if s.RowNoWrap(5) {
+		t.Errorf("new row should default NoWrap=false")
+	}
+	if s.RowNoWrap(99) {
+		t.Errorf("missing row should report NoWrap=false")
+	}
+}
+
+func TestStore_SetRowNoWrap_StickyOR(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'x'})
+	s.SetRowNoWrap(5, true)
+	if !s.RowNoWrap(5) {
+		t.Errorf("after SetRowNoWrap(true), expected true")
+	}
+	// Sticky: setting false does not clear
+	s.SetRowNoWrap(5, false)
+	if !s.RowNoWrap(5) {
+		t.Errorf("SetRowNoWrap(false) must not clear sticky flag")
+	}
+}
+
+func TestStore_SetRowNoWrap_AutoCreateRow(t *testing.T) {
+	s := NewStore(80)
+	s.SetRowNoWrap(7, true)
+	if !s.RowNoWrap(7) {
+		t.Errorf("SetRowNoWrap on missing row should create row + set flag")
+	}
+	got := s.GetLine(7)
+	if got == nil {
+		t.Errorf("row should be created by SetRowNoWrap")
+	}
+}
+
+func TestStore_SetLine_CarriesNoWrap(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'a'})
+	s.SetRowNoWrap(5, true)
+	s.SetLine(5, []parser.Cell{{Rune: 'b'}})
+	if !s.RowNoWrap(5) {
+		t.Errorf("SetLine must preserve NoWrap flag")
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -203,6 +203,16 @@ func (t *Terminal) LoadFromPageStore(ps *parser.PageStore) error {
 	return LoadStore(t.store, ps)
 }
 
+// RenderReflow produces the viewport via the reflow-aware ViewWindow.Render
+// path. Recomputes the live anchor from the cursor's chain first so that
+// autoFollow keeps the cursor on the bottom row of the viewport. This is the
+// bridge method; callers switch over from Grid() in a later step.
+func (t *Terminal) RenderReflow() [][]parser.Cell {
+	cursorGI, cursorCol := t.write.Cursor()
+	t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol)
+	return t.view.Render(t.store)
+}
+
 // Grid builds a dense height x width grid from the current view range by
 // reading the Store. Unwritten cells and short lines are blank-padded.
 //

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -203,6 +203,16 @@ func (t *Terminal) LoadFromPageStore(ps *parser.PageStore) error {
 	return LoadStore(t.store, ps)
 }
 
+// CursorToView maps the current cursor to its viewport-relative (row, col).
+// Returns ok=false if the cursor's globalIdx is outside the currently-rendered
+// chain walk (e.g. scrolled far back). Callers may fall back to writeTop-
+// relative projection in that case.
+func (t *Terminal) CursorToView() (viewRow, viewCol int, ok bool) {
+	gi, col := t.write.Cursor()
+	t.view.RecomputeLiveAnchor(t.store, gi, col)
+	return t.view.CursorToView(t.store, gi, col)
+}
+
 // RenderReflow produces the viewport via the reflow-aware ViewWindow.Render
 // path. Recomputes the live anchor from the cursor's chain first so that
 // autoFollow keeps the cursor on the bottom row of the viewport. This is the

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -83,11 +83,30 @@ func (t *Terminal) Resize(newWidth, newHeight int) {
 	t.view.Resize(newWidth, newHeight, t.write.WriteBottom())
 }
 
-// ScrollUp scrolls the view back by n lines and disengages autoFollow.
-func (t *Terminal) ScrollUp(n int) { t.view.ScrollUp(n) }
+// ScrollUp scrolls the view back by n reflowed rows and disengages autoFollow.
+// If the view was auto-following, the live-edge anchor is first computed from
+// the cursor's chain so the scroll is relative to what the user was looking
+// at — not the stale viewAnchor (which may still be 0 if RenderReflow hasn't
+// run yet, e.g. on session restore via SetScrollOffset). Units are reflowed
+// rows so scrolling through a wrapped chain advances one sub-row at a time.
+func (t *Terminal) ScrollUp(n int) {
+	if t.view.IsFollowing() {
+		gi, col := t.write.Cursor()
+		t.view.RecomputeLiveAnchor(t.store, gi, col)
+	}
+	t.view.ScrollUpRows(t.store, n)
+}
 
-// ScrollDown scrolls the view forward by n lines toward the live edge.
-func (t *Terminal) ScrollDown(n int) { t.view.ScrollDown(n, t.write.WriteBottom()) }
+// ScrollDown scrolls the view forward by n reflowed rows toward the live
+// edge. Same RecomputeLiveAnchor pre-step as ScrollUp for identical reasons:
+// the "from" anchor must be the live-edge anchor when auto-following.
+func (t *Terminal) ScrollDown(n int) {
+	if t.view.IsFollowing() {
+		gi, col := t.write.Cursor()
+		t.view.RecomputeLiveAnchor(t.store, gi, col)
+	}
+	t.view.ScrollDownRows(t.store, n, t.write.WriteBottom())
+}
 
 // ScrollToBottom snaps the view to the live edge and re-engages autoFollow.
 func (t *Terminal) ScrollToBottom() { t.view.ScrollToBottom(t.write.WriteBottom()) }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -165,6 +165,17 @@ func (t *Terminal) ReadLine(globalIdx int64) []parser.Cell {
 	return t.store.GetLine(globalIdx)
 }
 
+// RowNoWrap reports whether the row at globalIdx is marked NoWrap.
+func (t *Terminal) RowNoWrap(globalIdx int64) bool {
+	return t.store.RowNoWrap(globalIdx)
+}
+
+// SetRowNoWrap marks the row at globalIdx as NoWrap. The flag is sticky
+// (passing false is a no-op).
+func (t *Terminal) SetRowNoWrap(globalIdx int64, nowrap bool) {
+	t.store.SetRowNoWrap(globalIdx, nowrap)
+}
+
 // RestoreWriteState forcibly sets the write window's cursor and anchor,
 // used during session restore. The ViewWindow is re-snapped to the new
 // writeBottom in follow mode. hwm seeds writeBottomHWM only when it

--- a/apps/texelterm/parser/sparse/view_reflow.go
+++ b/apps/texelterm/parser/sparse/view_reflow.go
@@ -36,7 +36,10 @@ func walkChain(s *Store, startGI int64, maxSteps int) (end int64, nowrap bool) {
 // at viewWidth. Each returned slice has length ≤ viewWidth (the caller pads
 // to viewWidth via clipRow as needed).
 //
-// Concatenates all cells in the chain, then slices at viewWidth.
+// Concatenates all cells in the chain, then slices at viewWidth. Trailing
+// empty rows within the chain (wrap continuations the cursor sits on before
+// any content has been written) are emitted as explicit blank rows so the
+// chain's reflowed row count matches its physical-row footprint.
 func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell {
 	if viewWidth <= 0 {
 		return nil
@@ -45,7 +48,8 @@ func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell 
 	for gi := startGI; gi <= endGI; gi++ {
 		logical = append(logical, s.GetLine(gi)...)
 	}
-	if len(logical) == 0 {
+	trailing := trailingEmptyRows(s, startGI, endGI)
+	if len(logical) == 0 && trailing == 0 {
 		return [][]parser.Cell{nil}
 	}
 	var rows [][]parser.Cell
@@ -58,7 +62,69 @@ func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell 
 		copy(row, logical[off:end])
 		rows = append(rows, row)
 	}
+	for i := 0; i < trailing; i++ {
+		rows = append(rows, nil)
+	}
 	return rows
+}
+
+// trailingEmptyRows counts empty rows at the tail of the chain [start..end].
+// Only counts rows strictly after start (start itself is the chain head and
+// may legitimately be empty). These represent wrap continuations where the
+// cursor has newlined past a Wrapped full row but hasn't written any cell.
+func trailingEmptyRows(s *Store, start, end int64) int {
+	n := 0
+	for r := end; r > start; r-- {
+		if len(s.GetLine(r)) > 0 {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+// chainReflowedRowCount returns the number of physical rows the chain
+// [start..end] occupies when reflowed at width. Matches reflowChain's output
+// row count, including trailing empty continuation rows.
+func chainReflowedRowCount(s *Store, start, end int64, width int, nowrap bool) int {
+	if nowrap {
+		return int(end - start + 1)
+	}
+	total := 0
+	for r := start; r <= end; r++ {
+		total += len(s.GetLine(r))
+	}
+	var rows int
+	if total == 0 {
+		rows = 1
+	} else {
+		rows = (total + width - 1) / width
+	}
+	return rows + trailingEmptyRows(s, start, end)
+}
+
+// findChainStart walks backward from gi to the head of its wrap chain. A
+// chain head is a globalIdx whose predecessor is either absent, empty, or
+// does not have Wrapped=true on its last cell. Empty rows are themselves
+// chain starts.
+func findChainStart(s *Store, gi int64, maxSteps int) int64 {
+	cells := s.GetLine(gi)
+	if len(cells) == 0 {
+		return gi
+	}
+	start := gi
+	for steps := 0; steps < maxSteps && start > 0; steps++ {
+		prev := start - 1
+		prevCells := s.GetLine(prev)
+		if len(prevCells) == 0 {
+			break
+		}
+		if !prevCells[len(prevCells)-1].Wrapped {
+			break
+		}
+		start = prev
+	}
+	return start
 }
 
 // clipRow returns cells truncated or padded to viewWidth. Used for NoWrap

--- a/apps/texelterm/parser/sparse/view_reflow.go
+++ b/apps/texelterm/parser/sparse/view_reflow.go
@@ -1,0 +1,74 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import "github.com/framegrace/texelation/apps/texelterm/parser"
+
+// walkChain returns the end globalIdx of the Wrapped chain starting at
+// startGI, plus whether any row in the chain is marked NoWrap (chain
+// propagation). Walks at most maxSteps rows to bound pathological inputs.
+//
+// A chain is defined as a sequence of globalIdxs where every row except
+// the last has its final cell Wrapped=true and the next row exists in
+// the store. A missing row terminates the chain at the current idx.
+func walkChain(s *Store, startGI int64, maxSteps int) (end int64, nowrap bool) {
+	end = startGI
+	nowrap = s.RowNoWrap(startGI)
+	for steps := 1; steps < maxSteps; steps++ {
+		cells := s.GetLine(end)
+		if len(cells) == 0 || !cells[len(cells)-1].Wrapped {
+			return end, nowrap
+		}
+		next := end + 1
+		if s.GetLine(next) == nil {
+			return end, nowrap
+		}
+		end = next
+		if s.RowNoWrap(end) {
+			nowrap = true
+		}
+	}
+	return end, nowrap
+}
+
+// reflowChain returns the reflowed physical rows of the chain [startGI, endGI]
+// at viewWidth. Each returned slice has length ≤ viewWidth (the caller pads
+// to viewWidth via clipRow as needed).
+//
+// Concatenates all cells in the chain, then slices at viewWidth.
+func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell {
+	if viewWidth <= 0 {
+		return nil
+	}
+	var logical []parser.Cell
+	for gi := startGI; gi <= endGI; gi++ {
+		logical = append(logical, s.GetLine(gi)...)
+	}
+	if len(logical) == 0 {
+		return [][]parser.Cell{nil}
+	}
+	var rows [][]parser.Cell
+	for off := 0; off < len(logical); off += viewWidth {
+		end := off + viewWidth
+		if end > len(logical) {
+			end = len(logical)
+		}
+		row := make([]parser.Cell, end-off)
+		copy(row, logical[off:end])
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// clipRow returns cells truncated or padded to viewWidth. Used for NoWrap
+// rows that render 1:1 inside the viewport.
+func clipRow(cells []parser.Cell, viewWidth int) []parser.Cell {
+	out := make([]parser.Cell, viewWidth)
+	for i := 0; i < viewWidth; i++ {
+		if i < len(cells) {
+			out[i] = cells[i]
+		}
+	}
+	return out
+}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -104,6 +104,39 @@ func TestClipRow_TruncatesAndPads(t *testing.T) {
 	}
 }
 
+// Locks in that a NoWrap chain reports one physical row per stored row
+// regardless of width — matches Render's nowrap branch (clipRow per row).
+// Regression guard: if the short-circuit is replaced by width-based math the
+// count would diverge from Render's output and cause cursor/anchor drift.
+func TestChainReflowedRowCount_NoWrap(t *testing.T) {
+	s := NewStore(200)
+	fillRow(s, 10, "0123456789012345", false) // 16 chars
+	fillRow(s, 11, "abcdefghij", false)       // 10 chars
+	s.SetRowNoWrap(10, true)
+	s.SetRowNoWrap(11, true)
+
+	for _, width := range []int{1, 5, 8, 16, 80} {
+		got := chainReflowedRowCount(s, 10, 11, width, true)
+		if got != 2 {
+			t.Errorf("width=%d: got %d rows, want 2 (one per stored row)", width, got)
+		}
+	}
+}
+
+// Wrapping branch must still grow with narrower widths.
+func TestChainReflowedRowCount_WrapGrowsWithWidth(t *testing.T) {
+	s := NewStore(200)
+	fillRow(s, 0, "0123456789", true)
+	fillRow(s, 1, "abcde", false)
+	// 15 total cells; widths sampled against ceil(15/width).
+	for width, want := range map[int]int{5: 3, 8: 2, 15: 1, 20: 1} {
+		got := chainReflowedRowCount(s, 0, 1, width, false)
+		if got != want {
+			t.Errorf("width=%d: got %d rows, want %d", width, got, want)
+		}
+	}
+}
+
 // Test helper
 func cellsToStringSparse(cells []parser.Cell) string {
 	b := strings.Builder{}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -1,0 +1,118 @@
+package sparse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func fillRow(s *Store, gi int64, text string, wrapped bool) {
+	cells := make([]parser.Cell, len(text))
+	for i, r := range text {
+		cells[i] = parser.Cell{Rune: r}
+	}
+	if wrapped && len(cells) > 0 {
+		cells[len(cells)-1].Wrapped = true
+	}
+	s.SetLine(gi, cells)
+}
+
+func TestChainWalk_SingleRowNoWrap(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 0, "hello", false)
+	end, nowrap := walkChain(s, 0, 4*24)
+	if end != 0 {
+		t.Errorf("single non-wrapped row: end=%d want 0", end)
+	}
+	if nowrap {
+		t.Errorf("row without NoWrap flag: expected nowrap=false")
+	}
+}
+
+func TestChainWalk_TwoRowChain(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true)
+	fillRow(s, 6, "abc", false)
+	end, _ := walkChain(s, 5, 4*24)
+	if end != 6 {
+		t.Errorf("chain end=%d want 6", end)
+	}
+}
+
+func TestChainWalk_NoWrapPropagation(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true)
+	fillRow(s, 6, "abc", false)
+	s.SetRowNoWrap(6, true) // any NoWrap in chain → whole chain NoWrap
+	_, nowrap := walkChain(s, 5, 4*24)
+	if !nowrap {
+		t.Errorf("any NoWrap in chain should propagate")
+	}
+}
+
+func TestChainWalk_MalformedChainStopsAtGap(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true) // claims wrapped but row 6 missing
+	end, _ := walkChain(s, 5, 4*24)
+	if end != 5 {
+		t.Errorf("malformed chain should stop at gap; end=%d want 5", end)
+	}
+}
+
+func TestChainWalk_CapOnUnboundedChain(t *testing.T) {
+	s := NewStore(10)
+	for gi := int64(0); gi < 100; gi++ {
+		fillRow(s, gi, "0123456789", true)
+	}
+	end, _ := walkChain(s, 0, 20)
+	if end > 19 {
+		t.Errorf("chain walk exceeded cap: end=%d (cap=20)", end)
+	}
+}
+
+func TestReflowChain_SingleLogical(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 0, "0123456789", true)
+	fillRow(s, 1, "abcde", false)
+	// chain at width 5 → 3 rows: "01234", "56789", "abcde"
+	rows := reflowChain(s, 0, 1, 5)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	if cellsToStringSparse(rows[0]) != "01234" {
+		t.Errorf("row 0 = %q want %q", cellsToStringSparse(rows[0]), "01234")
+	}
+	if cellsToStringSparse(rows[2]) != "abcde" {
+		t.Errorf("row 2 = %q want %q", cellsToStringSparse(rows[2]), "abcde")
+	}
+}
+
+func TestClipRow_TruncatesAndPads(t *testing.T) {
+	cells := []parser.Cell{{Rune: 'a'}, {Rune: 'b'}, {Rune: 'c'}}
+	got := clipRow(cells, 5)
+	if len(got) != 5 {
+		t.Fatalf("clipRow should return length=width")
+	}
+	if got[0].Rune != 'a' || got[2].Rune != 'c' {
+		t.Errorf("clipRow dropped content")
+	}
+	// Truncate:
+	got2 := clipRow(cells, 2)
+	if len(got2) != 2 || got2[1].Rune != 'b' {
+		t.Errorf("clipRow should truncate")
+	}
+}
+
+// Test helper
+func cellsToStringSparse(cells []parser.Cell) string {
+	b := strings.Builder{}
+	for _, c := range cells {
+		if c.Rune == 0 {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(c.Rune)
+		}
+	}
+	return b.String()
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -3,7 +3,11 @@
 
 package sparse
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
 
 // ViewWindow is the user-facing portion of a sparse terminal. It owns the
 // viewBottom anchor and the autoFollow flag, and it responds to write-window
@@ -18,17 +22,105 @@ type ViewWindow struct {
 	height     int
 	viewBottom int64
 	autoFollow bool
+
+	// Reflow state (2026-04-16 resize-reflow)
+	viewAnchor       int64
+	viewAnchorOffset int
+	globalReflowOff  bool
+	autoJumpOnInput  bool
 }
 
 // NewViewWindow creates a ViewWindow in autoFollow mode. viewBottom starts
 // at height-1 so a fresh terminal projects rows [0, height-1].
 func NewViewWindow(width, height int) *ViewWindow {
 	return &ViewWindow{
-		width:      width,
-		height:     height,
-		viewBottom: int64(height - 1),
-		autoFollow: true,
+		width:           width,
+		height:          height,
+		viewBottom:      int64(height - 1),
+		autoFollow:      true,
+		autoJumpOnInput: true,
 	}
+}
+
+// SetViewAnchor sets the chain globalIdx and sub-row offset that the view
+// begins at. offset skips reflowed sub-rows within the first chain.
+func (v *ViewWindow) SetViewAnchor(globalIdx int64, offset int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.viewAnchor = globalIdx
+	v.viewAnchorOffset = offset
+}
+
+// SetGlobalReflowOff toggles reflow off globally. When true, all chains
+// render 1:1 (clipped), ignoring the Wrapped flag.
+func (v *ViewWindow) SetGlobalReflowOff(off bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.globalReflowOff = off
+}
+
+// Render projects the viewport by walking chains from viewAnchor. Each
+// chain is reflowed to viewWidth (unless NoWrap or globalReflowOff is set,
+// in which case rows render 1:1 via clipRow). Returns exactly viewHeight
+// rows, padded with empty cells if content is exhausted.
+func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
+	v.mu.Lock()
+	width := v.width
+	height := v.height
+	anchor := v.viewAnchor
+	skip := v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	out := make([][]parser.Cell, 0, height)
+	maxSteps := 4 * height
+	if maxSteps < 4 {
+		maxSteps = 4
+	}
+
+	gi := anchor
+	first := true
+	for len(out) < height {
+		// Past content: stop.
+		if s.GetLine(gi) == nil && !s.RowNoWrap(gi) {
+			break
+		}
+		end, nowrap := walkChain(s, gi, maxSteps)
+
+		var rows [][]parser.Cell
+		if reflowOff || nowrap {
+			for r := gi; r <= end; r++ {
+				rows = append(rows, clipRow(s.GetLine(r), width))
+			}
+		} else {
+			reflowed := reflowChain(s, gi, end, width)
+			for _, row := range reflowed {
+				rows = append(rows, clipRow(row, width))
+			}
+		}
+
+		if first {
+			first = false
+			if skip < len(rows) {
+				rows = rows[skip:]
+			} else {
+				rows = nil
+			}
+		}
+
+		for _, row := range rows {
+			if len(out) >= height {
+				break
+			}
+			out = append(out, row)
+		}
+		gi = end + 1
+	}
+
+	for len(out) < height {
+		out = append(out, make([]parser.Cell, width))
+	}
+	return out
 }
 
 // Width returns the current column width.

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -117,7 +117,7 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 		// writeTop..writeTop+h-1 window), and the old Grid() path surfaced
 		// them as blank rows. We preserve that behavior and rely on the
 		// caller's viewport bounds (via anchor+height) to stop the walk.
-		if s.GetLine(gi) == nil && !s.RowNoWrap(gi) {
+		if len(s.GetLine(gi)) == 0 && !s.RowNoWrap(gi) {
 			if first {
 				first = false
 				// A skip on an empty first chain is a no-op.
@@ -652,13 +652,11 @@ func (v *ViewWindow) ScrollDownRows(s *Store, n int, writeBottom int64) {
 	}
 }
 
-// ScrollUp detaches from the live edge and moves the view back by n rows.
-// Both anchors are moved: viewBottom (legacy, still used by Grid() and
-// VisibleRange()) and viewAnchor (used by Render() / RenderReflow()). When
-// autoFollow was on, viewAnchor was recomputed on the last RenderReflow so it
-// reflects the current live anchor; decrementing from there moves the view
-// back relative to where the user was actually looking.
-func (v *ViewWindow) ScrollUp(n int) {
+// scrollUp is the legacy (globalIdx-unit) scroll-back used by tests only.
+// Production scrolls go through Terminal.ScrollUp -> ScrollUpRows, which works
+// in reflowed-row units and walks wrap chains. Kept private so test helpers
+// can continue to exercise the anchor-decrement path.
+func (v *ViewWindow) scrollUp(n int) {
 	if n <= 0 {
 		return
 	}
@@ -677,12 +675,9 @@ func (v *ViewWindow) ScrollUp(n int) {
 	v.viewAnchorOffset = 0
 }
 
-// ScrollDown moves the view forward by n rows toward the live edge.
-// writeBottom is the current WriteWindow bottom; ScrollDown will not move
-// viewBottom past it. If viewBottom reaches writeBottom, autoFollow is
-// re-engaged — the next RenderReflow pass will recompute viewAnchor via
-// RecomputeLiveAnchor.
-func (v *ViewWindow) ScrollDown(n int, writeBottom int64) {
+// scrollDown is the legacy (globalIdx-unit) scroll-forward used by tests only.
+// Production scrolls go through Terminal.ScrollDown -> ScrollDownRows.
+func (v *ViewWindow) scrollDown(n int, writeBottom int64) {
 	if n <= 0 {
 		return
 	}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -81,9 +81,19 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 	gi := anchor
 	first := true
 	for len(out) < height {
-		// Past content: stop.
+		// Gap / past content: emit a blank row for this gi and continue.
+		// Live mode may have interior gaps (EL/ED erasing lines inside the
+		// writeTop..writeTop+h-1 window), and the old Grid() path surfaced
+		// them as blank rows. We preserve that behavior and rely on the
+		// caller's viewport bounds (via anchor+height) to stop the walk.
 		if s.GetLine(gi) == nil && !s.RowNoWrap(gi) {
-			break
+			if first {
+				first = false
+				// A skip on an empty first chain is a no-op.
+			}
+			out = append(out, make([]parser.Cell, width))
+			gi++
+			continue
 		}
 		end, nowrap := walkChain(s, gi, maxSteps)
 

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -208,28 +208,37 @@ func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int
 		chainStart = prev
 	}
 
-	// Walk chains backward, accumulating reflowed row counts.
+	// Walk chains backward, accumulating reflowed row counts. Empty rows
+	// (blank-line separators in plain output like `ls -lR`, or erased lines)
+	// are not chain starts, but they still occupy one physical row. Treat them
+	// as 1-row "chains" and continue walking rather than bailing — bailing on
+	// the first blank above the cursor would pin the viewport to the top of
+	// history on perfectly ordinary output.
 	accumulated := 0
 	gi := chainStart
 	for {
+		cells := s.GetLine(gi)
+		if len(cells) == 0 && !s.RowNoWrap(gi) {
+			accumulated++
+			if accumulated >= height {
+				offset := accumulated - height
+				v.mu.Lock()
+				v.viewAnchor = gi
+				v.viewAnchorOffset = offset
+				v.mu.Unlock()
+				return
+			}
+			if gi == 0 {
+				break
+			}
+			gi--
+			continue
+		}
 		end, nowrap := walkChain(s, gi, maxSteps)
 		if reflowOff {
 			nowrap = true
 		}
-		var chainRows int
-		if nowrap {
-			chainRows = int(end - gi + 1)
-		} else {
-			total := 0
-			for r := gi; r <= end; r++ {
-				total += len(s.GetLine(r))
-			}
-			if total == 0 {
-				chainRows = 1
-			} else {
-				chainRows = (total + width - 1) / width
-			}
-		}
+		chainRows := chainReflowedRowCount(s, gi, end, width, nowrap)
 		accumulated += chainRows
 		if accumulated >= height {
 			offset := accumulated - height
@@ -242,11 +251,14 @@ func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int
 		if gi == 0 {
 			break
 		}
-		// Walk to start of previous chain.
+		// Walk to the start of the previous chain. An empty prev row is
+		// itself the "previous chain" — fall through to the top of the loop
+		// to count it as 1 row.
 		prevGI := gi - 1
 		prevCells := s.GetLine(prevGI)
 		if len(prevCells) == 0 {
-			break
+			gi = prevGI
+			continue
 		}
 		prevChainStart := prevGI
 		for steps := 0; steps < maxSteps && prevChainStart > 0; steps++ {
@@ -309,6 +321,47 @@ func (v *ViewWindow) CursorToView(s *Store, cursorGI int64, cursorCol int) (view
 				}
 				return vr, vc, true
 			}
+			// Reflowed path. If the cursor sits on an empty trailing row
+			// (cursorGI > chain head and cursorGI's line is empty), the
+			// logical-column calculation can't express its position — at
+			// widths where the preceding content fits without wrapping, every
+			// post-content row would collapse to logicalCol/width = 0. Compute
+			// the row as contentRows + (count of empty rows before cursorGI).
+			if cursorGI > gi && len(s.GetLine(cursorGI)) == 0 {
+				total := 0
+				for r := gi; r < cursorGI; r++ {
+					total += len(s.GetLine(r))
+				}
+				contentRows := 0
+				if total == 0 {
+					contentRows = 1
+				} else {
+					contentRows = (total + width - 1) / width
+				}
+				emptiesBefore := 0
+				for r := gi + 1; r < cursorGI; r++ {
+					if len(s.GetLine(r)) == 0 {
+						emptiesBefore++
+					}
+				}
+				rowInChain := contentRows + emptiesBefore
+				startAt := 0
+				if gi == anchor {
+					startAt = offset
+				}
+				if rowInChain < startAt {
+					return 0, 0, false
+				}
+				vr := emitted + (rowInChain - startAt)
+				if vr >= height {
+					return 0, 0, false
+				}
+				vc := cursorCol
+				if vc >= width {
+					vc = width - 1
+				}
+				return vr, vc, true
+			}
 			// Reflowed: compute logical column.
 			logicalCol := 0
 			for r := gi; r < cursorGI; r++ {
@@ -331,18 +384,7 @@ func (v *ViewWindow) CursorToView(s *Store, cursorGI int64, cursorCol int) (view
 			return vr, colInRow, true
 		}
 		// Advance past chain.
-		chainRows := int(end - gi + 1)
-		if !nowrap {
-			total := 0
-			for r := gi; r <= end; r++ {
-				total += len(s.GetLine(r))
-			}
-			if total == 0 {
-				chainRows = 1
-			} else {
-				chainRows = (total + width - 1) / width
-			}
-		}
+		chainRows := chainReflowedRowCount(s, gi, end, width, nowrap)
 		startAt := 0
 		if gi == anchor {
 			startAt = offset
@@ -381,20 +423,7 @@ func (v *ViewWindow) ViewToCursor(s *Store, viewRow, viewCol int) (globalIdx int
 		if reflowOff {
 			nowrap = true
 		}
-		var chainRows int
-		if nowrap {
-			chainRows = int(end - gi + 1)
-		} else {
-			total := 0
-			for r := gi; r <= end; r++ {
-				total += len(s.GetLine(r))
-			}
-			if total == 0 {
-				chainRows = 1
-			} else {
-				chainRows = (total + width - 1) / width
-			}
-		}
+		chainRows := chainReflowedRowCount(s, gi, end, width, nowrap)
 		startAt := 0
 		if gi == anchor {
 			startAt = offset
@@ -466,9 +495,169 @@ func (v *ViewWindow) OnWriteBottomChanged(newWriteBottom int64) {
 	}
 }
 
-// ScrollUp detaches from the live edge and moves viewBottom up by n lines.
-// viewBottom is clamped to at least height-1 (can't show negative globalIdxs
-// as the view bottom).
+// ScrollUpRows detaches from the live edge and moves the view back by n
+// reflowed rows. Unlike ScrollUp (which decrements viewAnchor by n globalIdx
+// units and so can land mid-chain, producing a partial-chain fragment at the
+// top of the viewport), ScrollUpRows walks chains in reflowed-row units so
+// viewAnchor always lands at a chain start with viewAnchorOffset tracking the
+// sub-row position. viewBottom is decremented by the number of rows actually
+// walked — NOT by n — so a clamped scroll (viewAnchor hit 0 with remaining > 0)
+// doesn't push viewBottom into a stale state that lets a subsequent
+// ScrollDownRows with velocity snap prematurely to the live edge.
+func (v *ViewWindow) ScrollUpRows(s *Store, n int) {
+	if n <= 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoFollow = false
+
+	remaining := n
+	walked := 0
+	if v.viewAnchorOffset >= remaining {
+		v.viewAnchorOffset -= remaining
+		walked = remaining
+		v.viewBottom -= int64(walked)
+		v.clampViewBottom()
+		return
+	}
+	walked += v.viewAnchorOffset
+	remaining -= v.viewAnchorOffset
+	v.viewAnchorOffset = 0
+
+	width := v.width
+	reflowOff := v.globalReflowOff
+	maxSteps := 4 * v.height
+	if maxSteps < 4 {
+		maxSteps = 4
+	}
+	for remaining > 0 && v.viewAnchor > 0 {
+		prevGI := v.viewAnchor - 1
+		prevStart := findChainStart(s, prevGI, maxSteps)
+		end, nowrap := walkChain(s, prevStart, maxSteps)
+		if reflowOff {
+			nowrap = true
+		}
+		rows := chainReflowedRowCount(s, prevStart, end, width, nowrap)
+		if rows > remaining {
+			v.viewAnchor = prevStart
+			v.viewAnchorOffset = rows - remaining
+			walked += remaining
+			v.viewBottom -= int64(walked)
+			v.clampViewBottom()
+			return
+		}
+		remaining -= rows
+		walked += rows
+		v.viewAnchor = prevStart
+	}
+	// Loop exits either because remaining == 0 (scrolled the full requested
+	// amount and viewAnchor is now at a correct chain start) or because we
+	// ran off the top of history. Only in the latter case do we pin to 0;
+	// otherwise preserve the viewAnchor the loop computed.
+	if remaining > 0 {
+		v.viewAnchor = 0
+		v.viewAnchorOffset = 0
+	}
+	v.viewBottom -= int64(walked)
+	v.clampViewBottom()
+}
+
+// clampViewBottom enforces viewBottom >= height-1. Must be called with mu held.
+func (v *ViewWindow) clampViewBottom() {
+	minBottom := int64(v.height - 1)
+	if v.viewBottom < minBottom {
+		v.viewBottom = minBottom
+	}
+}
+
+// ScrollDownRows moves the view forward by n reflowed rows toward the live
+// edge. Walks chains the same way ScrollUpRows does but in the forward
+// direction. Live-edge detection is based on how far we're currently scrolled
+// back (writeBottom - viewBottom), not on incrementing viewBottom by n
+// up-front — a velocity-multiplied n would otherwise overshoot and snap to the
+// live edge after a single click. Only when the viewAnchor walk reaches a
+// position that covers writeBottom do we re-engage autoFollow.
+func (v *ViewWindow) ScrollDownRows(s *Store, n int, writeBottom int64) {
+	if n <= 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	// Cap n to however many rows we're currently scrolled back. Anything
+	// beyond that is a snap to live edge.
+	scrolledBack := writeBottom - v.viewBottom
+	if scrolledBack < 0 {
+		scrolledBack = 0
+	}
+	capped := int64(n)
+	snapToLive := false
+	if capped >= scrolledBack {
+		capped = scrolledBack
+		snapToLive = true
+	}
+
+	width := v.width
+	reflowOff := v.globalReflowOff
+	maxSteps := 4 * v.height
+	if maxSteps < 4 {
+		maxSteps = 4
+	}
+	remaining := int(capped)
+	walked := 0
+	for remaining > 0 {
+		cells := s.GetLine(v.viewAnchor)
+		if len(cells) == 0 && !s.RowNoWrap(v.viewAnchor) {
+			// 1-row empty chain.
+			avail := 1 - v.viewAnchorOffset
+			if avail <= 0 {
+				v.viewAnchor++
+				v.viewAnchorOffset = 0
+				continue
+			}
+			if remaining < avail {
+				v.viewAnchorOffset += remaining
+				walked += remaining
+				remaining = 0
+				break
+			}
+			remaining -= avail
+			walked += avail
+			v.viewAnchor++
+			v.viewAnchorOffset = 0
+			continue
+		}
+		end, nowrap := walkChain(s, v.viewAnchor, maxSteps)
+		if reflowOff {
+			nowrap = true
+		}
+		rows := chainReflowedRowCount(s, v.viewAnchor, end, width, nowrap)
+		avail := rows - v.viewAnchorOffset
+		if remaining < avail {
+			v.viewAnchorOffset += remaining
+			walked += remaining
+			remaining = 0
+			break
+		}
+		remaining -= avail
+		walked += avail
+		v.viewAnchor = end + 1
+		v.viewAnchorOffset = 0
+	}
+	v.viewBottom += int64(walked)
+	if snapToLive {
+		v.viewBottom = writeBottom
+		v.autoFollow = true
+	}
+}
+
+// ScrollUp detaches from the live edge and moves the view back by n rows.
+// Both anchors are moved: viewBottom (legacy, still used by Grid() and
+// VisibleRange()) and viewAnchor (used by Render() / RenderReflow()). When
+// autoFollow was on, viewAnchor was recomputed on the last RenderReflow so it
+// reflects the current live anchor; decrementing from there moves the view
+// back relative to where the user was actually looking.
 func (v *ViewWindow) ScrollUp(n int) {
 	if n <= 0 {
 		return
@@ -481,11 +670,18 @@ func (v *ViewWindow) ScrollUp(n int) {
 	if v.viewBottom < minBottom {
 		v.viewBottom = minBottom
 	}
+	v.viewAnchor -= int64(n)
+	if v.viewAnchor < 0 {
+		v.viewAnchor = 0
+	}
+	v.viewAnchorOffset = 0
 }
 
-// ScrollDown moves viewBottom down by n lines toward the live edge. writeBottom
-// is the current WriteWindow bottom; ScrollDown will not move past it. If
-// viewBottom reaches writeBottom, autoFollow is automatically re-engaged.
+// ScrollDown moves the view forward by n rows toward the live edge.
+// writeBottom is the current WriteWindow bottom; ScrollDown will not move
+// viewBottom past it. If viewBottom reaches writeBottom, autoFollow is
+// re-engaged — the next RenderReflow pass will recompute viewAnchor via
+// RecomputeLiveAnchor.
 func (v *ViewWindow) ScrollDown(n int, writeBottom int64) {
 	if n <= 0 {
 		return
@@ -493,6 +689,8 @@ func (v *ViewWindow) ScrollDown(n int, writeBottom int64) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	v.viewBottom += int64(n)
+	v.viewAnchor += int64(n)
+	v.viewAnchorOffset = 0
 	if v.viewBottom >= writeBottom {
 		v.viewBottom = writeBottom
 		v.autoFollow = true
@@ -500,6 +698,9 @@ func (v *ViewWindow) ScrollDown(n int, writeBottom int64) {
 }
 
 // ScrollToBottom snaps viewBottom to writeBottom and re-engages autoFollow.
+// viewAnchor is left alone here — the next RenderReflow will call
+// RecomputeLiveAnchor (which now runs because autoFollow is true) and
+// reposition the anchor to the cursor's chain.
 func (v *ViewWindow) ScrollToBottom(writeBottom int64) {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -123,6 +123,160 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 	return out
 }
 
+// CursorToView maps a store (globalIdx, col) to (viewRow, viewCol) within
+// the current view. Returns ok=false if the cursor is not inside the visible
+// chain walk.
+func (v *ViewWindow) CursorToView(s *Store, cursorGI int64, cursorCol int) (viewRow, viewCol int, ok bool) {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	anchor, offset := v.viewAnchor, v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	emitted := 0
+	gi := anchor
+	maxSteps := 4 * height
+	for emitted < height {
+		end, nowrap := walkChain(s, gi, maxSteps)
+		if reflowOff {
+			nowrap = true
+		}
+		if cursorGI >= gi && cursorGI <= end {
+			// In this chain.
+			if nowrap {
+				rowInChain := int(cursorGI - gi)
+				startAt := 0
+				if gi == anchor {
+					startAt = offset
+				}
+				if rowInChain < startAt {
+					return 0, 0, false
+				}
+				vr := emitted + (rowInChain - startAt)
+				if vr >= height {
+					return 0, 0, false
+				}
+				vc := cursorCol
+				if vc >= width {
+					vc = width - 1
+				}
+				return vr, vc, true
+			}
+			// Reflowed: compute logical column.
+			logicalCol := 0
+			for r := gi; r < cursorGI; r++ {
+				logicalCol += len(s.GetLine(r))
+			}
+			logicalCol += cursorCol
+			rowInChain := logicalCol / width
+			colInRow := logicalCol % width
+			startAt := 0
+			if gi == anchor {
+				startAt = offset
+			}
+			if rowInChain < startAt {
+				return 0, 0, false
+			}
+			vr := emitted + (rowInChain - startAt)
+			if vr >= height {
+				return 0, 0, false
+			}
+			return vr, colInRow, true
+		}
+		// Advance past chain.
+		chainRows := int(end - gi + 1)
+		if !nowrap {
+			total := 0
+			for r := gi; r <= end; r++ {
+				total += len(s.GetLine(r))
+			}
+			if total == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (total + width - 1) / width
+			}
+		}
+		startAt := 0
+		if gi == anchor {
+			startAt = offset
+		}
+		emitted += chainRows - startAt
+		gi = end + 1
+		if s.GetLine(gi) == nil {
+			break
+		}
+	}
+	return 0, 0, false
+}
+
+// ViewToCursor maps (viewRow, viewCol) to (globalIdx, col) in the store.
+// If viewRow is past content end, returns a fabricated "blank area" result
+// (globalIdx beyond writeTop, col=viewCol).
+func (v *ViewWindow) ViewToCursor(s *Store, viewRow, viewCol int) (globalIdx int64, col int, ok bool) {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	anchor, offset := v.viewAnchor, v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	if viewRow < 0 || viewRow >= height {
+		return 0, 0, false
+	}
+
+	emitted := 0
+	gi := anchor
+	maxSteps := 4 * height
+	for emitted < height {
+		if s.GetLine(gi) == nil {
+			break
+		}
+		end, nowrap := walkChain(s, gi, maxSteps)
+		if reflowOff {
+			nowrap = true
+		}
+		var chainRows int
+		if nowrap {
+			chainRows = int(end - gi + 1)
+		} else {
+			total := 0
+			for r := gi; r <= end; r++ {
+				total += len(s.GetLine(r))
+			}
+			if total == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (total + width - 1) / width
+			}
+		}
+		startAt := 0
+		if gi == anchor {
+			startAt = offset
+		}
+		rowsFromThisChain := chainRows - startAt
+		if viewRow < emitted+rowsFromThisChain {
+			rowInChain := (viewRow - emitted) + startAt
+			if nowrap {
+				return gi + int64(rowInChain), viewCol, true
+			}
+			// Walk cells to find (gi, col)
+			logicalCol := rowInChain*width + viewCol
+			for r := gi; r <= end; r++ {
+				rowLen := len(s.GetLine(r))
+				if logicalCol < rowLen {
+					return r, logicalCol, true
+				}
+				logicalCol -= rowLen
+			}
+			// viewCol past end of logical — return at end of chain
+			return end, len(s.GetLine(end)), true
+		}
+		emitted += rowsFromThisChain
+		gi = end + 1
+	}
+	// Past content.
+	return gi + int64(viewRow-emitted), viewCol, true
+}
+
 // Width returns the current column width.
 func (v *ViewWindow) Width() int {
 	v.mu.Lock()

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -123,6 +123,112 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 	return out
 }
 
+// RecomputeLiveAnchor repositions viewAnchor/viewAnchorOffset so that the
+// cursor's chain sits on the bottom of the viewport. Called once per render
+// pass when autoFollow is active: the view is a trailing window over the
+// write activity, and the cursor's chain is what the user needs to see.
+//
+// Algorithm: find the chain containing cursorGI (walk back while the previous
+// row's last cell has Wrapped=true), then walk backward one chain at a time
+// accumulating reflowed rows per chain. Stop when the accumulated total
+// covers the viewport; anchor at that chain with an offset to trim the top.
+func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int) {
+	v.mu.Lock()
+	height := v.height
+	width := v.width
+	reflowOff := v.globalReflowOff
+	autoFollow := v.autoFollow
+	v.mu.Unlock()
+
+	if !autoFollow {
+		return
+	}
+	if height <= 0 || width <= 0 {
+		return
+	}
+
+	maxSteps := 4 * height
+	if maxSteps < 4 {
+		maxSteps = 4
+	}
+
+	// Find the start of the chain containing cursorGI: walk backward while
+	// the prior row's last cell has Wrapped=true and exists.
+	chainStart := cursorGI
+	for steps := 0; steps < maxSteps && chainStart > 0; steps++ {
+		prev := chainStart - 1
+		prevCells := s.GetLine(prev)
+		if len(prevCells) == 0 {
+			break
+		}
+		if !prevCells[len(prevCells)-1].Wrapped {
+			break
+		}
+		chainStart = prev
+	}
+
+	// Walk chains backward, accumulating reflowed row counts.
+	accumulated := 0
+	gi := chainStart
+	for {
+		end, nowrap := walkChain(s, gi, maxSteps)
+		if reflowOff {
+			nowrap = true
+		}
+		var chainRows int
+		if nowrap {
+			chainRows = int(end - gi + 1)
+		} else {
+			total := 0
+			for r := gi; r <= end; r++ {
+				total += len(s.GetLine(r))
+			}
+			if total == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (total + width - 1) / width
+			}
+		}
+		accumulated += chainRows
+		if accumulated >= height {
+			offset := accumulated - height
+			v.mu.Lock()
+			v.viewAnchor = gi
+			v.viewAnchorOffset = offset
+			v.mu.Unlock()
+			return
+		}
+		if gi == 0 {
+			break
+		}
+		// Walk to start of previous chain.
+		prevGI := gi - 1
+		prevCells := s.GetLine(prevGI)
+		if len(prevCells) == 0 {
+			break
+		}
+		prevChainStart := prevGI
+		for steps := 0; steps < maxSteps && prevChainStart > 0; steps++ {
+			pp := prevChainStart - 1
+			ppCells := s.GetLine(pp)
+			if len(ppCells) == 0 {
+				break
+			}
+			if !ppCells[len(ppCells)-1].Wrapped {
+				break
+			}
+			prevChainStart = pp
+		}
+		gi = prevChainStart
+	}
+
+	// Ran out of content: anchor at the top.
+	v.mu.Lock()
+	v.viewAnchor = 0
+	v.viewAnchorOffset = 0
+	v.mu.Unlock()
+}
+
 // CursorToView maps a store (globalIdx, col) to (viewRow, viewCol) within
 // the current view. Returns ok=false if the cursor is not inside the visible
 // chain walk.

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -81,6 +81,15 @@ func (v *ViewWindow) SetGlobalReflowOff(off bool) {
 	v.globalReflowOff = off
 }
 
+// SetAutoJumpOnInput controls whether OnInput snaps the view back to the
+// live edge. When false, the user's scroll position is preserved when they
+// type; when true (default), any input re-engages autoFollow at writeBottom.
+func (v *ViewWindow) SetAutoJumpOnInput(enabled bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoJumpOnInput = enabled
+}
+
 // Render projects the viewport by walking chains from viewAnchor. Each
 // chain is reflowed to viewWidth (unless NoWrap or globalReflowOff is set,
 // in which case rows render 1:1 via clipRow). Returns exactly viewHeight
@@ -499,8 +508,15 @@ func (v *ViewWindow) ScrollToBottom(writeBottom int64) {
 }
 
 // OnInput is called when the user types or clicks in the pane. Re-engages
-// autoFollow at the current writeBottom.
+// autoFollow at the current writeBottom unless autoJumpOnInput has been
+// disabled, in which case the current scroll position is preserved.
 func (v *ViewWindow) OnInput(writeBottom int64) {
+	v.mu.Lock()
+	jump := v.autoJumpOnInput
+	v.mu.Unlock()
+	if !jump {
+		return
+	}
 	v.ScrollToBottom(writeBottom)
 }
 

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -51,6 +51,28 @@ func (v *ViewWindow) SetViewAnchor(globalIdx int64, offset int) {
 	v.viewAnchorOffset = offset
 }
 
+// Anchor returns the current (viewAnchor, viewAnchorOffset) pair.
+func (v *ViewWindow) Anchor() (int64, int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.viewAnchor, v.viewAnchorOffset
+}
+
+// ScrollBy moves the viewAnchor by dRows (negative scrolls up into history,
+// positive scrolls down toward the live edge). Disables autoFollow so the
+// view stays put instead of snapping back. viewAnchor is clamped to >= 0 and
+// viewAnchorOffset is reset to 0.
+func (v *ViewWindow) ScrollBy(s *Store, dRows int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoFollow = false
+	v.viewAnchor += int64(dRows)
+	if v.viewAnchor < 0 {
+		v.viewAnchor = 0
+	}
+	v.viewAnchorOffset = 0
+}
+
 // SetGlobalReflowOff toggles reflow off globally. When true, all chains
 // render 1:1 (clipped), ignoring the Wrapped flag.
 func (v *ViewWindow) SetGlobalReflowOff(off bool) {

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -130,3 +130,36 @@ func TestViewWindow_ScrollBy_DetachesAutoFollow(t *testing.T) {
 		t.Errorf("after ScrollBy, autoFollow off; RecomputeLiveAnchor should not move anchor. gi=%d", gi)
 	}
 }
+
+func TestViewWindow_AutoJumpOnInput_ConfigurableOff(t *testing.T) {
+	vw := NewViewWindow(80, 5)
+	vw.SetAutoJumpOnInput(false)
+	vw.SetViewAnchor(3, 0)
+	vw.ScrollBy(nil, -1) // also forces autoFollow=false for deterministic state
+	vw.SetViewAnchor(3, 0)
+	vw.OnInput(99)
+	gi, _ := vw.Anchor()
+	if gi != 3 {
+		t.Errorf("autoJumpOnInput=false: anchor should stay at 3, got %d", gi)
+	}
+	if vw.IsFollowing() {
+		t.Errorf("autoJumpOnInput=false: autoFollow should remain false after OnInput")
+	}
+}
+
+func TestViewWindow_AutoJumpOnInput_DefaultOnSnapsToBottom(t *testing.T) {
+	vw := NewViewWindow(80, 5)
+	// default autoJumpOnInput = true
+	vw.SetViewAnchor(3, 0)
+	vw.ScrollBy(nil, -1)
+	vw.SetViewAnchor(3, 0)
+	if vw.IsFollowing() {
+		t.Fatalf("precondition: autoFollow should be false after ScrollBy")
+	}
+	vw.OnInput(99)
+	// ScrollToBottom re-engages autoFollow and sets viewBottom. The cleanest
+	// observable side effect is IsFollowing() flipping back to true.
+	if !vw.IsFollowing() {
+		t.Errorf("autoJumpOnInput=true: OnInput should re-engage autoFollow")
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -91,3 +91,42 @@ func TestViewWindow_LiveMode_AnchorTracksCursor(t *testing.T) {
 		t.Errorf("live anchor: cursor should be on bottom row; got (%d,%d,%v)", vr, vc, ok)
 	}
 }
+
+func TestViewWindow_ScrollBy_MovesAnchor(t *testing.T) {
+	s := NewStore(80)
+	for gi := int64(0); gi < 20; gi++ {
+		fillRow(s, gi, "x", false)
+	}
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(15, 0)
+	vw.ScrollBy(s, -3)
+	gi, off := vw.Anchor()
+	if gi != 12 || off != 0 {
+		t.Errorf("ScrollBy(-3) anchor=(%d,%d) want (12,0)", gi, off)
+	}
+}
+
+func TestViewWindow_ScrollBy_ClampsToZero(t *testing.T) {
+	s := NewStore(80)
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(2, 0)
+	vw.ScrollBy(s, -100)
+	gi, off := vw.Anchor()
+	if gi != 0 || off != 0 {
+		t.Errorf("ScrollBy should clamp to 0; got (%d,%d)", gi, off)
+	}
+}
+
+func TestViewWindow_ScrollBy_DetachesAutoFollow(t *testing.T) {
+	s := NewStore(80)
+	vw := NewViewWindow(80, 5)
+	// Initial autoFollow = true by construction
+	vw.ScrollBy(s, -1)
+	// Verify autoFollow disabled — RecomputeLiveAnchor should be no-op now.
+	vw.SetViewAnchor(0, 0)
+	vw.RecomputeLiveAnchor(s, 10, 0)
+	gi, _ := vw.Anchor()
+	if gi != 0 {
+		t.Errorf("after ScrollBy, autoFollow off; RecomputeLiveAnchor should not move anchor. gi=%d", gi)
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -1,0 +1,46 @@
+package sparse
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestViewWindow_Render_ReflowsOnNarrow(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+
+	if len(out) != 5 {
+		t.Fatalf("Render should return viewHeight=5 rows, got %d", len(out))
+	}
+	if !strings.HasPrefix(cellsToStringSparse(out[0]), "01234") {
+		t.Errorf("row 0 unexpected: %q", cellsToStringSparse(out[0]))
+	}
+	if !strings.HasPrefix(cellsToStringSparse(out[2]), "abcde") {
+		t.Errorf("row 2 unexpected: %q", cellsToStringSparse(out[2]))
+	}
+}
+
+func TestViewWindow_Render_NoWrapChainStays1to1(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+	s.SetRowNoWrap(0, true)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+
+	if !strings.HasPrefix(cellsToStringSparse(out[0]), "01234567890123456789") {
+		t.Errorf("NoWrap row 0 should be clipped 1:1, got %q", cellsToStringSparse(out[0]))
+	}
+	if !strings.HasPrefix(cellsToStringSparse(out[1]), "abcde") {
+		t.Errorf("NoWrap row 1 = %q", cellsToStringSparse(out[1]))
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -44,3 +44,36 @@ func TestViewWindow_Render_NoWrapChainStays1to1(t *testing.T) {
 		t.Errorf("NoWrap row 1 = %q", cellsToStringSparse(out[1]))
 	}
 }
+
+func TestCursor_RoundTrip_ReflowedChain(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 0, 45)
+	if !ok || vr != 1 || vc != 5 {
+		t.Errorf("CursorToView(0,45)=(%d,%d,%v) want (1,5,true)", vr, vc, ok)
+	}
+	gi, col, ok := vw.ViewToCursor(s, 1, 5)
+	if !ok || gi != 0 || col != 45 {
+		t.Errorf("ViewToCursor(1,5)=(%d,%d,%v) want (0,45,true)", gi, col, ok)
+	}
+}
+
+func TestCursor_RoundTrip_NoWrapChain(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 0, "hello", false)
+	s.SetRowNoWrap(0, true)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 0, 3)
+	if !ok || vr != 0 || vc != 3 {
+		t.Errorf("NoWrap CursorToView(0,3)=(%d,%d,%v) want (0,3,true)", vr, vc, ok)
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -77,3 +77,17 @@ func TestCursor_RoundTrip_NoWrapChain(t *testing.T) {
 		t.Errorf("NoWrap CursorToView(0,3)=(%d,%d,%v) want (0,3,true)", vr, vc, ok)
 	}
 }
+
+func TestViewWindow_LiveMode_AnchorTracksCursor(t *testing.T) {
+	s := NewStore(80)
+	for gi := int64(0); gi < 10; gi++ {
+		fillRow(s, gi, "x", false)
+	}
+
+	vw := NewViewWindow(80, 3)
+	vw.RecomputeLiveAnchor(s, 9, 0)
+	vr, vc, ok := vw.CursorToView(s, 9, 0)
+	if !ok || vr != 2 {
+		t.Errorf("live anchor: cursor should be on bottom row; got (%d,%d,%v)", vr, vc, ok)
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_test.go
+++ b/apps/texelterm/parser/sparse/view_window_test.go
@@ -39,7 +39,7 @@ func TestViewWindow_FollowsWriteBottom(t *testing.T) {
 func TestViewWindow_DoesNotFollowWhenScrolledBack(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(10) // detaches from live edge
+	vw.scrollUp(10) // detaches from live edge
 	if vw.IsFollowing() {
 		t.Error("after ScrollUp, should not be following")
 	}
@@ -53,8 +53,8 @@ func TestViewWindow_DoesNotFollowWhenScrolledBack(t *testing.T) {
 func TestViewWindow_ScrollDownClampedToWriteBottom(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(30)
-	vw.ScrollDown(100, 100) // n, writeBottom
+	vw.scrollUp(30)
+	vw.scrollDown(100, 100) // n, writeBottom
 	_, bottom := vw.VisibleRange()
 	if bottom != 100 {
 		t.Errorf("ScrollDown clamped at writeBottom: viewBottom = %d, want 100", bottom)
@@ -64,7 +64,7 @@ func TestViewWindow_ScrollDownClampedToWriteBottom(t *testing.T) {
 func TestViewWindow_ScrollToBottomReattaches(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(50)
+	vw.scrollUp(50)
 	vw.ScrollToBottom(100)
 
 	if !vw.IsFollowing() {
@@ -79,7 +79,7 @@ func TestViewWindow_ScrollToBottomReattaches(t *testing.T) {
 func TestViewWindow_OnInputReattaches(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(50)
+	vw.scrollUp(50)
 	vw.OnInput(100)
 	if !vw.IsFollowing() {
 		t.Error("OnInput should re-engage autoFollow")
@@ -108,7 +108,7 @@ func TestViewWindow_ResizeWhileFollowing(t *testing.T) {
 func TestViewWindow_ResizeWhileScrolledBack(t *testing.T) {
 	vw := NewViewWindow(80, 24)
 	vw.OnWriteBottomChanged(100)
-	vw.ScrollUp(30) // viewBottom = 70, autoFollow off
+	vw.scrollUp(30) // viewBottom = 70, autoFollow off
 
 	// Pass a writeBottom that retreats below the current frozen viewBottom.
 	// The view must stay anchored at 70 — dropping the `if v.autoFollow`

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -295,7 +295,8 @@ func (w *WriteWindow) InsertLines(n, cursorRow, marginTop, marginBottom int) {
 
 	// Shift lines down within [cursorRow, marginBottom].
 	for y := marginBottom; y >= cursorRow+n; y-- {
-		w.store.SetLine(base+int64(y), w.store.GetLine(base+int64(y-n)))
+		src := base + int64(y-n)
+		w.store.SetLineWithNoWrap(base+int64(y), w.store.GetLine(src), w.store.RowNoWrap(src))
 	}
 	// Clear the inserted rows.
 	for y := cursorRow; y < cursorRow+n && y <= marginBottom; y++ {
@@ -320,7 +321,8 @@ func (w *WriteWindow) DeleteLines(n, cursorRow, marginTop, marginBottom int) {
 
 	// Shift lines up within [cursorRow, marginBottom].
 	for y := cursorRow; y <= marginBottom-n; y++ {
-		w.store.SetLine(base+int64(y), w.store.GetLine(base+int64(y+n)))
+		src := base + int64(y+n)
+		w.store.SetLineWithNoWrap(base+int64(y), w.store.GetLine(src), w.store.RowNoWrap(src))
 	}
 	// Clear the vacated bottom rows.
 	clearStart := marginBottom - n + 1
@@ -349,7 +351,8 @@ func (w *WriteWindow) NewlineInRegion(marginTop, marginBottom int) {
 
 	// Shift lines up within the region.
 	for y := marginTop; y < marginBottom; y++ {
-		w.store.SetLine(base+int64(y), w.store.GetLine(base+int64(y+1)))
+		src := base + int64(y+1)
+		w.store.SetLineWithNoWrap(base+int64(y), w.store.GetLine(src), w.store.RowNoWrap(src))
 	}
 	// Clear the bottom line of the region.
 	w.store.ClearRange(base+int64(marginBottom), base+int64(marginBottom))

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -96,6 +96,10 @@ type VTerm struct {
 	commitInsertOffset int64
 	// fixedWidthDetector tracks TUI patterns for scroll region empty line suppression.
 	fwDetector *FixedWidthDetector
+	// decstbmActive reports whether DECSTBM has set non-default margins.
+	// When true, writes mark the target row as NoWrap in the sparse store,
+	// protecting structured TUI content from reflow on resize.
+	decstbmActive bool
 }
 
 // NewVTerm creates and initializes a new virtual terminal.
@@ -1079,6 +1083,7 @@ func (v *VTerm) SetMargins(top, bottom int) {
 		// Invalid region, reset to full screen
 		v.marginTop = 0
 		v.marginBottom = v.height - 1
+		v.decstbmActive = false
 		v.notifyDetectorScrollRegionClear()
 		return
 	}
@@ -1086,8 +1091,12 @@ func (v *VTerm) SetMargins(top, bottom int) {
 	v.marginBottom = bottom - 1
 	v.logDebug("[SCROLL] SetMargins: top=%d, bottom=%d (0-indexed: %d-%d), height=%d", top, bottom, v.marginTop, v.marginBottom, v.height)
 
-	// Notify FixedWidthDetector for TUI detection
+	// Track whether a non-default scroll region is active. When true, writes
+	// mark rows as NoWrap so resize-reflow skips structured TUI content.
 	isFullScreen := (top == 1 && bottom == v.height)
+	v.decstbmActive = !isFullScreen
+
+	// Notify FixedWidthDetector for TUI detection
 	if !isFullScreen {
 		v.notifyDetectorScrollRegion(v.marginTop, v.marginBottom, v.height)
 	} else {
@@ -1374,10 +1383,11 @@ func (v *VTerm) Resize(width, height int) {
 	}
 
 	v.MarkAllDirty()
-	// Reset margins on resize (without moving cursor)
-	// Note: We can't use SetMargins() because it moves cursor to home per VT spec
+	// Reset margins on resize (without moving cursor).
+	// Note: We can't use SetMargins() because it moves cursor to home per VT spec.
 	v.marginTop = 0
 	v.marginBottom = v.height - 1
+	v.decstbmActive = false
 }
 
 // --- Simple Getters ---

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -1412,10 +1412,24 @@ func (v *VTerm) PhysicalCursor() (physX, physY int) {
 		return physX, physY
 	}
 
-	// Sparse main screen: the cursor's globalIdx must be mapped to the
-	// view's coordinate system, since the view may be offset from the
-	// write window after a resize (viewTop ≠ writeTop).
+	// Sparse main screen: prefer the reflow-aware CursorToView mapping so
+	// wrapped lines above the cursor shift its physical row correctly. If the
+	// cursor isn't inside the currently-rendered chain walk (e.g. scrolled
+	// back beyond the anchor), fall back to writeTop-relative projection.
 	if v.mainScreen != nil {
+		if vr, vc, ok := v.mainScreen.CursorToView(); ok {
+			physY = vr
+			physX = vc
+			if physY < 0 {
+				physY = 0
+			} else if physY >= v.height {
+				physY = v.height - 1
+			}
+			if physX >= v.width {
+				physX = v.width - 1
+			}
+			return physX, physY
+		}
 		gi, _ := v.mainScreen.Cursor()
 		viewTop, _ := v.mainScreen.VisibleRange()
 		physY = int(gi - viewTop)

--- a/apps/texelterm/parser/vterm_decstbm_nowrap_test.go
+++ b/apps/texelterm/parser/vterm_decstbm_nowrap_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	_ "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+)
+
+// feedBytes feeds raw bytes through the parser, one rune at a time.
+func feedBytes(p *parser.Parser, data []byte) {
+	for _, b := range string(data) {
+		p.Parse(b)
+	}
+}
+
+// TestVTerm_DECSTBM_MarksRowNoWrap verifies that cells written while DECSTBM
+// has non-default margins are marked NoWrap in the sparse store, and that cells
+// written with default margins are not.
+func TestVTerm_DECSTBM_MarksRowNoWrap(t *testing.T) {
+	v := parser.NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	// Write with default (full-screen) margins — should NOT be NoWrap.
+	feedBytes(p, []byte("hello"))
+	cursorGI, _ := v.CursorGlobalIdx()
+	if v.MainScreenRowNoWrap(cursorGI) {
+		t.Fatalf("with default margins, row should not be NoWrap")
+	}
+
+	// Set non-default scroll region: rows 2–5 (1-indexed), then write a cell.
+	feedBytes(p, []byte("\x1b[2;5r")) // non-default scroll region
+	feedBytes(p, []byte("\x1b[HX"))   // home within region, write X
+
+	cursorGI, _ = v.CursorGlobalIdx()
+	if !v.MainScreenRowNoWrap(cursorGI) {
+		t.Errorf("after DECSTBM [2;5r, written row should be NoWrap")
+	}
+}
+
+// TestVTerm_DECSTBM_Reset_ClearsActive verifies that resetting DECSTBM to
+// full-screen margins causes subsequent writes to NOT be marked NoWrap.
+func TestVTerm_DECSTBM_Reset_ClearsActive(t *testing.T) {
+	v := parser.NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	feedBytes(p, []byte("\x1b[2;5r")) // activate non-default region
+	feedBytes(p, []byte("\x1b[r"))    // reset to full-screen region
+	feedBytes(p, []byte("\x1b[HY"))   // home, write Y
+	cursorGI, _ := v.CursorGlobalIdx()
+	if v.MainScreenRowNoWrap(cursorGI) {
+		t.Errorf("after DECSTBM reset, subsequent writes should not be NoWrap")
+	}
+}
+
+// TestVTerm_DECSTBM_Resize_ClearsActive verifies that Resize resets
+// decstbmActive so writes after resize are not spuriously marked NoWrap.
+func TestVTerm_DECSTBM_Resize_ClearsActive(t *testing.T) {
+	v := parser.NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := parser.NewParser(v)
+
+	feedBytes(p, []byte("\x1b[2;5r")) // activate non-default region
+
+	// Resize clears margins per VT spec.
+	v.Resize(80, 25)
+
+	feedBytes(p, []byte("\x1b[HZ")) // home, write Z
+	cursorGI, _ := v.CursorGlobalIdx()
+	if v.MainScreenRowNoWrap(cursorGI) {
+		t.Errorf("after Resize, decstbmActive should be cleared; writes should not be NoWrap")
+	}
+}

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -157,12 +157,31 @@ func (v *VTerm) cursorGlobalIdx() int64 {
 	return v.mainScreen.WriteTop() + int64(v.cursorY)
 }
 
+// CursorGlobalIdx returns the cursor's (globalIdx, col) for tests and external
+// callers. Returns (0, 0) if no main screen is active.
+func (v *VTerm) CursorGlobalIdx() (int64, int) {
+	if v.mainScreen == nil {
+		return 0, 0
+	}
+	return v.mainScreen.Cursor()
+}
+
+// MainScreenRowNoWrap reports whether the sparse store row at globalIdx is
+// marked NoWrap. Returns false if no main screen is active.
+func (v *VTerm) MainScreenRowNoWrap(globalIdx int64) bool {
+	if v.mainScreen == nil {
+		return false
+	}
+	return v.mainScreen.RowNoWrap(globalIdx)
+}
+
 // mainScreenPlaceChar writes a rune to the sparse terminal at the current cursor.
 func (v *VTerm) mainScreenPlaceChar(r rune, isWide bool) {
 	if v.mainScreen == nil {
 		return
 	}
 	v.mainScreen.SetCursor(v.cursorY, v.cursorX)
+	gi, _ := v.mainScreen.Cursor()
 	v.mainScreen.WriteCell(Cell{
 		Rune: r,
 		FG:   v.currentFG,
@@ -170,8 +189,10 @@ func (v *VTerm) mainScreenPlaceChar(r rune, isWide bool) {
 		Attr: v.currentAttr,
 		Wide: isWide,
 	})
+	if v.decstbmActive {
+		v.mainScreen.SetRowNoWrap(gi, true)
+	}
 	if v.mainScreenPersistence != nil {
-		gi, _ := v.mainScreen.Cursor()
 		v.mainScreenPersistence.NotifyWrite(gi)
 	}
 }

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -223,6 +223,7 @@ func (v *VTerm) mainScreenLineFeed() {
 			} else {
 				ll = &LogicalLine{}
 			}
+			ll.NoWrap = v.mainScreen.RowNoWrap(committedGlobal)
 			if v.OnLineCommit(committedGlobal, ll, v.CommandActive) {
 				// Transformer is buffering this line; skip persistence for now.
 				return
@@ -286,6 +287,7 @@ func (v *VTerm) mainScreenLineFeedInternal() {
 		if line != nil {
 			ll.Cells = line
 		}
+		ll.NoWrap = v.mainScreen.RowNoWrap(committedGlobal)
 		if v.OnLineCommit(committedGlobal, ll, v.CommandActive) {
 			return
 		}
@@ -993,7 +995,7 @@ func (a *sparseLineStoreAdapter) GetLine(globalIdx int64) *LogicalLine {
 	if cells == nil {
 		return nil
 	}
-	return &LogicalLine{Cells: cells}
+	return &LogicalLine{Cells: cells, NoWrap: a.tm.RowNoWrap(globalIdx)}
 }
 
 func (a *sparseLineStoreAdapter) ClearDirty(globalIdx int64) {

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -358,7 +358,7 @@ func (v *VTerm) mainScreenGrid() [][]Cell {
 	if v.mainScreen == nil {
 		return nil
 	}
-	grid := v.mainScreen.Grid()
+	grid := v.mainScreen.RenderReflow()
 	// Sparse Grid() returns Cell{} (Rune=0) for unwritten/erased cells.
 	// Convert to space so callers see consistent blank cells.
 	for _, row := range grid {

--- a/apps/texelterm/parser/vterm_reflow_test.go
+++ b/apps/texelterm/parser/vterm_reflow_test.go
@@ -1,0 +1,71 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	_ "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+)
+
+func feedBytesReflow(p *parser.Parser, data []byte) {
+	for _, b := range string(data) {
+		p.Parse(b)
+	}
+}
+
+// Fill a line longer than 80, resize narrower, verify it reflows.
+func TestVTerm_Reflow_WidenAndNarrow(t *testing.T) {
+	v := parser.NewVTerm(80, 24)
+	p := parser.NewParser(v)
+	long := strings.Repeat("abcdefghij", 12) // 120 chars
+	feedBytesReflow(p, []byte(long))
+
+	grid := v.Grid()
+	row0 := cellsToStringParserReflow(grid[0])
+	if !strings.HasPrefix(row0, "abcdefghij") {
+		t.Fatalf("row 0 at width 80: %q", row0)
+	}
+
+	v.Resize(40, 24)
+	grid = v.Grid()
+	joined := cellsToStringParserReflow(grid[0]) + cellsToStringParserReflow(grid[1]) + cellsToStringParserReflow(grid[2])
+	if !strings.Contains(joined, long) {
+		t.Errorf("after narrow resize, content did not reflow; joined=%q", joined)
+	}
+
+	v.Resize(120, 24)
+	grid = v.Grid()
+	row0 = cellsToStringParserReflow(grid[0])
+	if !strings.HasPrefix(row0, long) {
+		t.Errorf("after widen, single row should hold full line; got %q", row0)
+	}
+}
+
+func TestVTerm_Reflow_NoWrapRowsSurviveResize(t *testing.T) {
+	v := parser.NewVTerm(80, 24)
+	p := parser.NewParser(v)
+	feedBytesReflow(p, []byte("\x1b[2;5r"))
+	feedBytesReflow(p, []byte("\x1b[HABCDE"))
+	feedBytesReflow(p, []byte("\x1b[r"))
+	v.Resize(3, 24)
+	grid := v.Grid()
+	if !strings.HasPrefix(cellsToStringParserReflow(grid[0]), "ABC") {
+		t.Errorf("NoWrap row should clip at width 3, got %q", cellsToStringParserReflow(grid[0]))
+	}
+}
+
+func cellsToStringParserReflow(cells []parser.Cell) string {
+	b := strings.Builder{}
+	for _, c := range cells {
+		if c.Rune == 0 {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(c.Rune)
+		}
+	}
+	return b.String()
+}

--- a/apps/texelterm/parser/write_ahead_log_nowrap_test.go
+++ b/apps/texelterm/parser/write_ahead_log_nowrap_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestWAL_LineWrite_NoWrap_Roundtrip ensures the NoWrap flag on LogicalLine
+// survives a WAL Append -> Close -> reopen -> recover -> PageStore.ReadLine
+// round-trip. It exercises the shared encodeLineData/decodeLineDataV2 path
+// (flag bit 0x08) from the WAL side.
+func TestWAL_LineWrite_NoWrap_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultWALConfig(filepath.Join(dir, "hist"), "wal-nowrap-test")
+	cfg.CheckpointInterval = 0
+	cfg.CheckpointMaxSize = 1 << 30
+
+	wal1, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog #1: %v", err)
+	}
+
+	ll := &LogicalLine{Cells: []Cell{{Rune: 'A'}}, NoWrap: true}
+	if err := wal1.Append(42, ll, time.Now()); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Close without checkpoint so the entry must be recovered from the WAL
+	// on next open (replay writes it to PageStore).
+	if err := wal1.Close(); err != nil {
+		t.Fatalf("wal1.Close: %v", err)
+	}
+
+	wal2, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog #2: %v", err)
+	}
+	defer wal2.Close()
+
+	got, err := wal2.ReadLine(42)
+	if err != nil {
+		t.Fatalf("ReadLine: %v", err)
+	}
+	if got == nil {
+		t.Fatal("line 42 nil after WAL recovery")
+	}
+	if !got.NoWrap {
+		t.Errorf("NoWrap lost through WAL round-trip")
+	}
+}
+
+// TestWAL_LineWrite_NoWrap_DefaultFalse confirms that omitting NoWrap
+// preserves the zero-value on the other side.
+func TestWAL_LineWrite_NoWrap_DefaultFalse(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultWALConfig(filepath.Join(dir, "hist"), "wal-nowrap-default-test")
+	cfg.CheckpointInterval = 0
+	cfg.CheckpointMaxSize = 1 << 30
+
+	wal1, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog #1: %v", err)
+	}
+
+	ll := &LogicalLine{Cells: []Cell{{Rune: 'B'}}}
+	if err := wal1.Append(7, ll, time.Now()); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := wal1.Close(); err != nil {
+		t.Fatalf("wal1.Close: %v", err)
+	}
+
+	wal2, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog #2: %v", err)
+	}
+	defer wal2.Close()
+
+	got, err := wal2.ReadLine(7)
+	if err != nil {
+		t.Fatalf("ReadLine: %v", err)
+	}
+	if got == nil {
+		t.Fatal("line 7 nil after WAL recovery")
+	}
+	if got.NoWrap {
+		t.Errorf("default NoWrap should be false")
+	}
+}

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -887,8 +887,9 @@ func (a *TexelTerm) handleConfirmationKey(ev *tcell.EventKey) bool {
 }
 
 // handleScrollAction scrolls the terminal by the given number of lines and
-// requests a refresh. Positive values scroll up (back in history); negative
-// values scroll down (toward live edge).
+// requests a refresh. Negative values scroll up (back in history); positive
+// values scroll down (toward live edge). Matches VTerm.Scroll's convention
+// and mouse-wheel delta sign (wheel up is -1).
 func (a *TexelTerm) handleScrollAction(lines int) {
 	a.mu.Lock()
 	if a.vterm != nil {
@@ -1058,16 +1059,16 @@ func (a *TexelTerm) HandleKey(ev *tcell.EventKey) {
 			a.takeScreenshot()
 			return
 		case keybind.TermScrollUp:
-			a.handleScrollAction(1)
-			return
-		case keybind.TermScrollDown:
 			a.handleScrollAction(-1)
 			return
+		case keybind.TermScrollDown:
+			a.handleScrollAction(1)
+			return
 		case keybind.TermScrollPgUp:
-			a.handleScrollAction(a.termHeight())
+			a.handleScrollAction(-a.termHeight())
 			return
 		case keybind.TermScrollPgDn:
-			a.handleScrollAction(-a.termHeight())
+			a.handleScrollAction(a.termHeight())
 			return
 		}
 	}

--- a/docs/superpowers/plans/2026-04-16-sparse-resize-reflow.md
+++ b/docs/superpowers/plans/2026-04-16-sparse-resize-reflow.md
@@ -1646,6 +1646,10 @@ git commit -m "sparse: make autoJumpOnInput configurable"
 
 - [ ] **Edge cases:** resize to width 1 briefly — should be slow but correct, not crash. `yes | head -c 1000000` then resize — the `4 × height` cap should keep the UI responsive.
 
+- [ ] **TUI app (Claude) alt-screen + resize.** Launch `claude` inside a texelterm pane, interact, then resize the outer terminal. Entering and exiting the alt screen must preserve main-screen scrollback intact. Resize during alt-screen must not corrupt the main-screen view on exit. Scroll regions set by the TUI should be NoWrap-marked and clip 1:1 on resize. Note: TUI-side duplicated lines on resize are acceptable (ghostty has the same behavior) and not a blocker.
+
+- [ ] **Keyboard and mouse scroll.** In a long history, `<alt-up>`/`<alt-down>` and mouse-wheel should scroll incrementally (single row per tick), not jump to top/bottom. Page-up/page-down should move by viewport height.
+
 If all pass, commit any test/debug hooks removal:
 
 ```bash

--- a/docs/superpowers/plans/2026-04-16-sparse-resize-reflow.md
+++ b/docs/superpowers/plans/2026-04-16-sparse-resize-reflow.md
@@ -1,0 +1,1720 @@
+# Sparse Resize-Reflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore reflow-on-resize for the sparse terminal: widening rejoins wrapped lines, shrinking splits them, for both live shell output and scrollback history. DECSTBM/structured content is protected via a per-row NoWrap flag.
+
+**Architecture:** View-side reflow. `sparse.Store` gets a per-row `NoWrap` bit. `VTerm` sets it when DECSTBM is active at write time. `ViewWindow` walks `Wrapped` chains and reflows at current viewWidth (or renders 1:1 for NoWrap chains or when the user toggles reflow off). Cursor position is derived via forward/inverse mappings through the chain. Store layout is unchanged; resize is O(1) in content size.
+
+**Tech Stack:** Go 1.24.3, sparse viewport package (`apps/texelterm/parser/sparse`), VTerm parser, `.lhist` persistence, WAL. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/texelterm/parser/sparse/view_reflow.go` — chain walker + reflow helpers (keeps `view_window.go` focused)
+- `apps/texelterm/parser/sparse/view_reflow_test.go` — unit tests for chain walking / reflow
+- `apps/texelterm/parser/sparse/view_window_reflow_test.go` — Render/CursorToView/ViewToCursor tests
+- `apps/texelterm/parser/sparse/store_nowrap_test.go` — NoWrap storage unit tests
+
+**Modified files:**
+- `apps/texelterm/parser/sparse/store.go` — add `nowrap` bit on `storeLine`, `SetRowNoWrap`, `RowNoWrap`, extend `SetLine`
+- `apps/texelterm/parser/sparse/view_window.go` — add `viewAnchor`, `viewAnchorOffset`, `globalReflowOff`, `autoJumpOnInput`; new `Render`, `CursorToView`, `ViewToCursor`, `ScrollBy`; replace `VisibleRange`-based callers where needed
+- `apps/texelterm/parser/sparse/write_window.go` — carry NoWrap through `SetLine`-equivalent paths for IL/DL/scroll shifts
+- `apps/texelterm/parser/sparse/terminal.go` — wire decstbm propagation hook, expose toggle getters
+- `apps/texelterm/parser/vterm.go` — track `decstbmActive`, call `SetRowNoWrap` on cell writes
+- `apps/texelterm/parser/logical_line.go` — add `NoWrap bool` field
+- `apps/texelterm/parser/logical_line_persistence.go` — serialize NoWrap as optional trailing field (backward compatible)
+- `apps/texelterm/parser/write_ahead_log.go` — extend row-write WAL entry with NoWrap (optional trailing, old entries decode with false)
+- `apps/texelterm/parser/vterm_main_screen.go` — thread NoWrap through `sparseLineStoreAdapter` at load/save
+- `CLAUDE.md` — replace "No reflow on resize" note with view-side-reflow description
+
+---
+
+## Task 1: Store — NoWrap flag storage
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/store.go`
+- Create: `apps/texelterm/parser/sparse/store_nowrap_test.go`
+
+- [ ] **Step 1: Write failing test for default NoWrap = false**
+
+```go
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestStore_RowNoWrap_DefaultFalse(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'x'})
+	if s.RowNoWrap(5) {
+		t.Errorf("new row should default NoWrap=false")
+	}
+	if s.RowNoWrap(99) {
+		t.Errorf("missing row should report NoWrap=false")
+	}
+}
+
+func TestStore_SetRowNoWrap_StickyOR(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'x'})
+	s.SetRowNoWrap(5, true)
+	if !s.RowNoWrap(5) {
+		t.Errorf("after SetRowNoWrap(true), expected true")
+	}
+	// Sticky: setting false does not clear
+	s.SetRowNoWrap(5, false)
+	if !s.RowNoWrap(5) {
+		t.Errorf("SetRowNoWrap(false) must not clear sticky flag")
+	}
+}
+
+func TestStore_SetRowNoWrap_AutoCreateRow(t *testing.T) {
+	s := NewStore(80)
+	s.SetRowNoWrap(7, true)
+	if !s.RowNoWrap(7) {
+		t.Errorf("SetRowNoWrap on missing row should create row + set flag")
+	}
+	// Row should now exist as empty (GetLine returns zero-length slice, not nil)
+	got := s.GetLine(7)
+	if got == nil {
+		t.Errorf("row should be created by SetRowNoWrap")
+	}
+}
+
+func TestStore_SetLine_CarriesNoWrap(t *testing.T) {
+	s := NewStore(80)
+	s.Set(5, 0, parser.Cell{Rune: 'a'})
+	s.SetRowNoWrap(5, true)
+	// Rewriting the row via SetLine (without explicit flag) must preserve NoWrap
+	s.SetLine(5, []parser.Cell{{Rune: 'b'}})
+	if !s.RowNoWrap(5) {
+		t.Errorf("SetLine must preserve NoWrap flag")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestStore_RowNoWrap -v`
+Expected: FAIL with "undefined: RowNoWrap" / "undefined: SetRowNoWrap"
+
+- [ ] **Step 3: Add NoWrap to storeLine + accessors**
+
+In `store.go`, extend `storeLine`:
+
+```go
+type storeLine struct {
+	cells  []parser.Cell
+	nowrap bool
+}
+```
+
+Add methods (place after `SetLine`):
+
+```go
+// RowNoWrap reports whether the row at globalIdx is marked NoWrap.
+// Missing rows return false.
+func (s *Store) RowNoWrap(globalIdx int64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return false
+	}
+	return line.nowrap
+}
+
+// SetRowNoWrap sets the NoWrap flag on the row at globalIdx. The flag is
+// sticky: passing false does NOT clear it. Callers that need to clear must
+// replace the row (e.g., via SetLine after row reuse).
+//
+// If the row does not yet exist, it is created empty so the flag sticks.
+func (s *Store) SetRowNoWrap(globalIdx int64, nowrap bool) {
+	if !nowrap {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.nowrap = true
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}
+```
+
+Modify `SetLine` to preserve nowrap across re-writes — change the body so that when a line already exists, its `nowrap` is retained:
+
+```go
+func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.cells = make([]parser.Cell, len(cells))
+	copy(line.cells, cells)
+	// nowrap is preserved across SetLine (sticky). Callers that shift rows
+	// (IL/DL) must use SetLineWithNoWrap to move the flag explicitly.
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}
+
+// SetLineWithNoWrap replaces both cells and the NoWrap flag at globalIdx.
+// Used by IL/DL/scroll shifts that move a row (and its NoWrap semantics)
+// from one globalIdx to another.
+func (s *Store) SetLineWithNoWrap(globalIdx int64, cells []parser.Cell, nowrap bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		line = &storeLine{}
+		s.lines[globalIdx] = line
+	}
+	line.cells = make([]parser.Cell, len(cells))
+	copy(line.cells, cells)
+	line.nowrap = nowrap
+	if globalIdx > s.contentEnd {
+		s.contentEnd = globalIdx
+	}
+}
+```
+
+Also update `ClearRange` to drop nowrap when the row is deleted — already satisfied (map delete).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestStore_ -v`
+Expected: PASS (all four tests)
+
+- [ ] **Step 5: Verify existing sparse tests still pass**
+
+Run: `go test ./apps/texelterm/parser/sparse -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/store.go apps/texelterm/parser/sparse/store_nowrap_test.go
+git commit -m "sparse: add per-row NoWrap flag on Store"
+```
+
+---
+
+## Task 2: VTerm — DECSTBM tracking and write-time propagation
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Test: `apps/texelterm/parser/vterm_decstbm_nowrap_test.go`
+
+- [ ] **Step 1: Locate existing DECSTBM handler**
+
+Run: `grep -n "scrollTop\|scrollBottom\|DECSTBM\|\\[r" apps/texelterm/parser/vterm.go | head -20`
+
+Read the hits. Identify (a) where scrollTop/scrollBottom are stored, (b) where `CSI r` (DECSTBM) is parsed. Record line numbers here:
+
+- DECSTBM parse site: `vterm.go:<LINE>`
+- scrollTop/scrollBottom fields: `vterm.go:<LINE>`
+
+(Fill in during execution. If scrollTop==0 and scrollBottom==height-1 at all times, that's "default margins" per the spec.)
+
+- [ ] **Step 2: Write failing test for decstbmActive propagation**
+
+Create `apps/texelterm/parser/vterm_decstbm_nowrap_test.go`:
+
+```go
+package parser
+
+import (
+	"testing"
+)
+
+// After DECSTBM [2;5r sets non-default margins, any cell written should
+// propagate NoWrap=true to the store row.
+func TestVTerm_DECSTBM_MarksRowNoWrap(t *testing.T) {
+	v := NewVTerm(80, 24)
+	// Default margins: nothing marked NoWrap
+	v.Write([]byte("hello"))
+	cursorGI, _ := v.CursorGlobalIdx()
+	if v.mainScreen.RowNoWrap(cursorGI) {
+		t.Fatalf("with default margins, row should not be NoWrap")
+	}
+
+	// Set non-default scroll region
+	v.Write([]byte("\x1b[2;5r"))
+	// Cursor home within region, write a char
+	v.Write([]byte("\x1b[HX"))
+
+	cursorGI, _ = v.CursorGlobalIdx()
+	if !v.mainScreen.RowNoWrap(cursorGI) {
+		t.Errorf("after DECSTBM [2;5r, written row should be NoWrap")
+	}
+}
+
+func TestVTerm_DECSTBM_Reset_ClearsActive(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.Write([]byte("\x1b[2;5r"))    // non-default
+	v.Write([]byte("\x1b[r"))        // reset to full
+	v.Write([]byte("\x1b[HY"))       // write at home
+	cursorGI, _ := v.CursorGlobalIdx()
+	if v.mainScreen.RowNoWrap(cursorGI) {
+		t.Errorf("after DECSTBM reset, subsequent writes should not be NoWrap")
+	}
+}
+```
+
+Note: if `v.mainScreen.RowNoWrap` / `v.CursorGlobalIdx` are not the exact exported surface, adjust to the equivalent test accessors. If they don't exist, add thin accessors in `vterm_main_screen.go` first.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser -run TestVTerm_DECSTBM -v`
+Expected: FAIL — the NoWrap propagation is not wired yet.
+
+- [ ] **Step 4: Add decstbmActive and propagation**
+
+In `vterm.go`, add to the VTerm struct (near other scroll-region fields):
+
+```go
+// decstbmActive reports whether DECSTBM has set non-default margins,
+// i.e., anything other than [0, height-1]. When true, new cell writes
+// mark the target row as NoWrap in the sparse store, protecting
+// structured content from reflow on resize.
+decstbmActive bool
+```
+
+In the DECSTBM parse site, after updating scrollTop/scrollBottom:
+
+```go
+v.decstbmActive = !(v.scrollTop == 0 && v.scrollBottom == v.height-1)
+```
+
+In the cell-write path (wherever `store.Set(cursorGlobalIdx, cursorX, cell)` is called — likely in `sparseLineStoreAdapter` or the VTerm cell-emit path):
+
+```go
+store.Set(globalIdx, col, cell)
+if decstbmActive {
+    store.SetRowNoWrap(globalIdx, true)
+}
+```
+
+(If `decstbmActive` lives on VTerm but the adapter writes into the store, thread it through. The simplest path is a bool arg on the adapter's write entrypoint; if that's noisy, stash it on the adapter struct and have VTerm update it whenever `decstbmActive` changes.)
+
+- [ ] **Step 5: Also propagate on height resize**
+
+When height changes, `scrollBottom` may be auto-adjusted to `newHeight-1`. Recompute `decstbmActive` after any height change in `Resize`:
+
+```go
+v.decstbmActive = !(v.scrollTop == 0 && v.scrollBottom == v.height-1)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser -run TestVTerm_DECSTBM -v`
+Expected: PASS
+
+- [ ] **Step 7: Run full parser tests for regressions**
+
+Run: `go test ./apps/texelterm/parser/...`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/vterm_main_screen.go apps/texelterm/parser/vterm_decstbm_nowrap_test.go
+git commit -m "vterm: track DECSTBM active, propagate NoWrap on writes"
+```
+
+---
+
+## Task 3: Store — row-shift helpers for IL/DL
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/write_window.go` (or wherever IL/DL/scroll shifts live)
+- Test: `apps/texelterm/parser/sparse/store_nowrap_shift_test.go`
+
+- [ ] **Step 1: Locate IL/DL/NewlineInRegion implementations**
+
+Run: `grep -rn "RequestLineInsert\|RequestLineDelete\|NewlineInRegion\|InsertLines\|DeleteLines" apps/texelterm/parser/sparse/`
+
+Record the call sites that move cells between globalIdx rows — these are the places that must carry NoWrap with the cells.
+
+- [ ] **Step 2: Write failing test for NoWrap movement under IL**
+
+Create `apps/texelterm/parser/sparse/store_nowrap_shift_test.go`:
+
+```go
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// When a row is shifted within a scroll region (via IL/DL/NewlineInRegion),
+// its NoWrap flag must travel with its cells, not stay on the old globalIdx.
+func TestStore_RowShift_NoWrapFollows(t *testing.T) {
+	s := NewStore(80)
+	s.Set(10, 0, parser.Cell{Rune: 'A'})
+	s.SetRowNoWrap(10, true)
+
+	// Simulate "move row at 10 to 11" via SetLineWithNoWrap + clear
+	cells := s.GetLine(10)
+	nw := s.RowNoWrap(10)
+	s.SetLineWithNoWrap(11, cells, nw)
+	s.ClearRange(10, 10)
+
+	if s.RowNoWrap(11) != true {
+		t.Errorf("NoWrap must follow cells to new row")
+	}
+	if s.RowNoWrap(10) != false {
+		t.Errorf("old row should be cleared (NoWrap=false)")
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+If `SetLineWithNoWrap` was added in Task 1, this test is already satisfied. Run:
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestStore_RowShift -v`
+Expected: PASS (sanity check)
+
+- [ ] **Step 4: Audit IL/DL/scroll-region code to use the shift helper**
+
+Review the sites found in Step 1. For each row-move operation, replace `store.SetLine(dst, cells)` with:
+
+```go
+nw := store.RowNoWrap(src)
+store.SetLineWithNoWrap(dst, cells, nw)
+```
+
+For rows being cleared (blanked by the shift), use `ClearRange(idx, idx)` so NoWrap is dropped.
+
+- [ ] **Step 5: Run all sparse + parser tests**
+
+Run: `go test ./apps/texelterm/parser/... ./apps/texelterm/parser/sparse/...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/
+git commit -m "sparse: preserve NoWrap flag across IL/DL row shifts"
+```
+
+---
+
+## Task 4: ViewWindow — chain walker (reflow primitive)
+
+**Files:**
+- Create: `apps/texelterm/parser/sparse/view_reflow.go`
+- Create: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write failing tests for chain walking**
+
+Create `apps/texelterm/parser/sparse/view_reflow_test.go`:
+
+```go
+package sparse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func fillRow(s *Store, gi int64, text string, wrapped bool) {
+	cells := make([]parser.Cell, len(text))
+	for i, r := range text {
+		cells[i] = parser.Cell{Rune: r}
+	}
+	if wrapped && len(cells) > 0 {
+		cells[len(cells)-1].Wrapped = true
+	}
+	s.SetLine(gi, cells)
+}
+
+func TestChainWalk_SingleRowNoWrap(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 0, "hello", false)
+	end, nowrap := walkChain(s, 0, 4*24)
+	if end != 0 {
+		t.Errorf("single non-wrapped row: end=%d want 0", end)
+	}
+	if nowrap {
+		t.Errorf("row without NoWrap flag: expected nowrap=false")
+	}
+}
+
+func TestChainWalk_TwoRowChain(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true)
+	fillRow(s, 6, "abc", false)
+	end, _ := walkChain(s, 5, 4*24)
+	if end != 6 {
+		t.Errorf("chain end=%d want 6", end)
+	}
+}
+
+func TestChainWalk_NoWrapPropagation(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true)
+	fillRow(s, 6, "abc", false)
+	s.SetRowNoWrap(6, true) // middle/last row NoWrap → whole chain NoWrap
+	_, nowrap := walkChain(s, 5, 4*24)
+	if !nowrap {
+		t.Errorf("any NoWrap in chain should propagate")
+	}
+}
+
+func TestChainWalk_MalformedChainStopsAtGap(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 5, "0123456789", true) // says "wrapped" but row 6 missing
+	end, _ := walkChain(s, 5, 4*24)
+	if end != 5 {
+		t.Errorf("malformed chain should stop at gap; end=%d want 5", end)
+	}
+}
+
+func TestChainWalk_CapOnUnboundedChain(t *testing.T) {
+	s := NewStore(10)
+	// 100 wrapped rows in a row
+	for gi := int64(0); gi < 100; gi++ {
+		fillRow(s, gi, "0123456789", true) // all wrapped
+	}
+	// Cap = 20
+	end, _ := walkChain(s, 0, 20)
+	if end-0+1 > 20 {
+		t.Errorf("chain walk exceeded cap: end=%d", end)
+	}
+}
+
+func TestReflowChain_SingleLogical(t *testing.T) {
+	s := NewStore(10)
+	fillRow(s, 0, "0123456789", true)
+	fillRow(s, 1, "abcde", false)
+	// Chain at width 5 → expect 3 rows: "01234", "56789", "abcde"
+	rows := reflowChain(s, 0, 1, 5)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+	got := strings.TrimRight(cellsToString(rows[0]), " ")
+	if got != "01234" {
+		t.Errorf("row 0 = %q want %q", got, "01234")
+	}
+	got = strings.TrimRight(cellsToString(rows[2]), " ")
+	if got != "abcde" {
+		t.Errorf("row 2 = %q want %q", got, "abcde")
+	}
+}
+
+// Test helper
+func cellsToString(cells []parser.Cell) string {
+	b := strings.Builder{}
+	for _, c := range cells {
+		if c.Rune == 0 {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(c.Rune)
+		}
+	}
+	return b.String()
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestChainWalk -v`
+Expected: FAIL with "undefined: walkChain" / "undefined: reflowChain"
+
+- [ ] **Step 3: Implement chain walker + reflow**
+
+Create `apps/texelterm/parser/sparse/view_reflow.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import "github.com/framegrace/texelation/apps/texelterm/parser"
+
+// walkChain returns the end globalIdx of the Wrapped chain starting at
+// startGI, plus whether any row in the chain is marked NoWrap (chain
+// propagation). Walks at most cap rows to bound pathological inputs.
+//
+// A chain is defined as a sequence of globalIdxs where every row except
+// the last has its final cell Wrapped=true and the next row exists in
+// the store. A missing row terminates the chain at the current idx.
+func walkChain(s *Store, startGI int64, cap int) (end int64, nowrap bool) {
+	end = startGI
+	nowrap = s.RowNoWrap(startGI)
+	for steps := 0; steps < cap; steps++ {
+		cells := s.GetLine(end)
+		if len(cells) == 0 || !cells[len(cells)-1].Wrapped {
+			return end, nowrap
+		}
+		next := end + 1
+		nextCells := s.GetLine(next)
+		if nextCells == nil {
+			return end, nowrap
+		}
+		end = next
+		if s.RowNoWrap(end) {
+			nowrap = true
+		}
+	}
+	return end, nowrap
+}
+
+// reflowChain returns the reflowed physical rows of the chain [startGI, endGI]
+// at viewWidth. Each returned slice has length ≤ viewWidth. Trailing empty
+// rows are NOT padded — the caller pads the viewport as needed.
+//
+// Concatenates all cells in the chain, then slices at viewWidth.
+func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell {
+	if viewWidth <= 0 {
+		return nil
+	}
+	// Concatenate
+	var logical []parser.Cell
+	for gi := startGI; gi <= endGI; gi++ {
+		logical = append(logical, s.GetLine(gi)...)
+	}
+	if len(logical) == 0 {
+		return [][]parser.Cell{nil}
+	}
+	var rows [][]parser.Cell
+	for off := 0; off < len(logical); off += viewWidth {
+		end := off + viewWidth
+		if end > len(logical) {
+			end = len(logical)
+		}
+		row := make([]parser.Cell, end-off)
+		copy(row, logical[off:end])
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// clipRow returns cells truncated or padded to viewWidth. Used for NoWrap
+// rows that render 1:1.
+func clipRow(cells []parser.Cell, viewWidth int) []parser.Cell {
+	out := make([]parser.Cell, viewWidth)
+	for i := 0; i < viewWidth; i++ {
+		if i < len(cells) {
+			out[i] = cells[i]
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/sparse -run "TestChainWalk|TestReflowChain" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow.go apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "sparse: add chain walker and reflow primitives"
+```
+
+---
+
+## Task 5: ViewWindow — view anchor fields and Render()
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Create: `apps/texelterm/parser/sparse/view_window_reflow_test.go`
+
+- [ ] **Step 1: Write failing test for Render at width 40**
+
+Create `apps/texelterm/parser/sparse/view_window_reflow_test.go`:
+
+```go
+package sparse
+
+import (
+	"strings"
+	"testing"
+)
+
+// A chain that wraps at width 80 should reflow down to 2 rows at width 40.
+func TestViewWindow_Render_ReflowsOnNarrow(t *testing.T) {
+	s := NewStore(80)
+	// Logical "0..79 80..89" — single chain of 2 physical rows at width 80
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+
+	// Expect 3 rows: 2 halves of 80-char line + "abcde" (reflowed into width 40).
+	if len(out) != 5 {
+		t.Fatalf("Render should return viewHeight=5 rows, got %d", len(out))
+	}
+	if !strings.HasPrefix(cellsToString(out[0]), "01234") {
+		t.Errorf("row 0 unexpected: %q", cellsToString(out[0]))
+	}
+	if !strings.HasPrefix(cellsToString(out[2]), "abcde") {
+		t.Errorf("row 2 unexpected: %q", cellsToString(out[2]))
+	}
+}
+
+func TestViewWindow_Render_NoWrapChainStays1to1(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+	s.SetRowNoWrap(0, true) // chain becomes NoWrap
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+
+	// NoWrap: row 0 clips to 40, row 1 clips to 40. Only 2 content rows.
+	if !strings.HasPrefix(cellsToString(out[0]), "01234567890123456789") {
+		t.Errorf("NoWrap row 0 should be clipped 1:1, got %q", cellsToString(out[0]))
+	}
+	if !strings.HasPrefix(cellsToString(out[1]), "abcde") {
+		t.Errorf("NoWrap row 1 = %q", cellsToString(out[1]))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_Render -v`
+Expected: FAIL — `SetViewAnchor` / `Render` undefined.
+
+- [ ] **Step 3: Add anchor fields + Render**
+
+In `view_window.go`, extend struct:
+
+```go
+type ViewWindow struct {
+	mu         sync.Mutex
+	width      int
+	height     int
+	viewBottom int64
+	autoFollow bool
+
+	// Reflow state (2026-04-16 resize-reflow)
+	viewAnchor       int64 // globalIdx of first chain at view top
+	viewAnchorOffset int   // view-row offset within that chain (when reflowed)
+	globalReflowOff  bool  // user toggle: force all reflowable rows to 1:1
+	autoJumpOnInput  bool  // default true: user input snaps to live edge
+}
+```
+
+In `NewViewWindow`, initialize:
+
+```go
+return &ViewWindow{
+	width:           width,
+	height:          height,
+	viewBottom:      int64(height - 1),
+	autoFollow:      true,
+	viewAnchor:      0,
+	viewAnchorOffset: 0,
+	autoJumpOnInput: true,
+}
+```
+
+Add methods:
+
+```go
+// SetViewAnchor pins the view to start at (globalIdx, offset-within-chain).
+// Used by tests and by scroll operations.
+func (v *ViewWindow) SetViewAnchor(globalIdx int64, offset int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.viewAnchor = globalIdx
+	v.viewAnchorOffset = offset
+}
+
+// SetGlobalReflowOff flips the user toggle. NoWrap rows are unaffected
+// (NoWrap is always 1:1). When true, reflowable chains are rendered 1:1.
+func (v *ViewWindow) SetGlobalReflowOff(off bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.globalReflowOff = off
+}
+
+// Render produces a []row of exactly v.height rows from the store, starting
+// at viewAnchor/viewAnchorOffset. Empty rows are zero-valued cell slices
+// of length v.width. Callers overlay the cursor separately.
+func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	anchor, offset := v.viewAnchor, v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	out := make([][]parser.Cell, height)
+	emitted := 0
+	gi := anchor
+	cap := 4 * height
+	for emitted < height {
+		if s.GetLine(gi) == nil && !s.RowNoWrap(gi) {
+			// past content — pad with blanks
+			break
+		}
+		end, nowrap := walkChain(s, gi, cap)
+		if reflowOff {
+			nowrap = true
+		}
+		var rows [][]parser.Cell
+		if nowrap {
+			for r := gi; r <= end; r++ {
+				rows = append(rows, clipRow(s.GetLine(r), width))
+			}
+		} else {
+			rows = reflowChain(s, gi, end, width)
+			for i, row := range rows {
+				rows[i] = clipRow(row, width)
+			}
+		}
+		// Skip viewAnchorOffset on the first chain only
+		startAt := 0
+		if gi == anchor {
+			startAt = offset
+			if startAt > len(rows) {
+				startAt = len(rows)
+			}
+		}
+		for i := startAt; i < len(rows) && emitted < height; i++ {
+			out[emitted] = rows[i]
+			emitted++
+		}
+		gi = end + 1
+	}
+	// Pad remaining rows with blanks of width w
+	for emitted < height {
+		out[emitted] = make([]parser.Cell, width)
+		emitted++
+	}
+	return out
+}
+```
+
+Add the `parser` import if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_Render -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go apps/texelterm/parser/sparse/view_window_reflow_test.go
+git commit -m "sparse: add ViewWindow.Render with chain-based reflow"
+```
+
+---
+
+## Task 6: Cursor mapping — CursorToView and ViewToCursor
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Extend: `apps/texelterm/parser/sparse/view_window_reflow_test.go`
+
+- [ ] **Step 1: Write failing test for round-trip cursor mapping**
+
+Append to `view_window_reflow_test.go`:
+
+```go
+func TestCursor_RoundTrip_ReflowedChain(t *testing.T) {
+	s := NewStore(80)
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+
+	// Cursor at (globalIdx=0, col=45) — logically the 45th char of chain.
+	// At width 40 that's view row 1, col 5.
+	vr, vc, ok := vw.CursorToView(s, 0, 45)
+	if !ok || vr != 1 || vc != 5 {
+		t.Errorf("CursorToView(0,45)=(%d,%d,%v) want (1,5,true)", vr, vc, ok)
+	}
+	gi, col, ok := vw.ViewToCursor(s, 1, 5)
+	if !ok || gi != 0 || col != 45 {
+		t.Errorf("ViewToCursor(1,5)=(%d,%d,%v) want (0,45,true)", gi, col, ok)
+	}
+}
+
+func TestCursor_RoundTrip_NoWrapChain(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 0, "hello", false)
+	s.SetRowNoWrap(0, true)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+
+	vr, vc, ok := vw.CursorToView(s, 0, 3)
+	if !ok || vr != 0 || vc != 3 {
+		t.Errorf("NoWrap CursorToView(0,3)=(%d,%d,%v) want (0,3,true)", vr, vc, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestCursor_RoundTrip -v`
+Expected: FAIL (undefined)
+
+- [ ] **Step 3: Implement CursorToView and ViewToCursor**
+
+Add to `view_window.go`:
+
+```go
+// CursorToView maps a store (globalIdx, col) to (viewRow, viewCol) within
+// the current view. Returns ok=false if the cursor is not inside the visible
+// chain walk.
+func (v *ViewWindow) CursorToView(s *Store, cursorGI int64, cursorCol int) (viewRow, viewCol int, ok bool) {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	anchor, offset := v.viewAnchor, v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	emitted := 0
+	gi := anchor
+	cap := 4 * height
+	for emitted < height {
+		end, nowrap := walkChain(s, gi, cap)
+		if reflowOff {
+			nowrap = true
+		}
+		if cursorGI >= gi && cursorGI <= end {
+			// In this chain.
+			if nowrap {
+				rowInChain := int(cursorGI - gi)
+				startAt := 0
+				if gi == anchor {
+					startAt = offset
+				}
+				if rowInChain < startAt {
+					return 0, 0, false
+				}
+				vr := emitted + (rowInChain - startAt)
+				if vr >= height {
+					return 0, 0, false
+				}
+				vc := cursorCol
+				if vc >= width {
+					vc = width - 1
+				}
+				return vr, vc, true
+			}
+			// Reflowed: compute logical column.
+			logicalCol := 0
+			for r := gi; r < cursorGI; r++ {
+				logicalCol += len(s.GetLine(r))
+			}
+			logicalCol += cursorCol
+			rowInChain := logicalCol / width
+			colInRow := logicalCol % width
+			startAt := 0
+			if gi == anchor {
+				startAt = offset
+			}
+			if rowInChain < startAt {
+				return 0, 0, false
+			}
+			vr := emitted + (rowInChain - startAt)
+			if vr >= height {
+				return 0, 0, false
+			}
+			return vr, colInRow, true
+		}
+		// Advance past chain.
+		chainRows := int(end - gi + 1)
+		if !nowrap {
+			// count reflowed rows
+			chainRows = 0
+			for r := gi; r <= end; r++ {
+				chainRows += len(s.GetLine(r))
+			}
+			if chainRows == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (chainRows + width - 1) / width
+			}
+		}
+		startAt := 0
+		if gi == anchor {
+			startAt = offset
+		}
+		emitted += chainRows - startAt
+		gi = end + 1
+		if s.GetLine(gi) == nil {
+			break
+		}
+	}
+	return 0, 0, false
+}
+
+// ViewToCursor maps (viewRow, viewCol) to (globalIdx, col) in the store.
+// If viewRow is past content end, returns a fabricated "blank area" result
+// (globalIdx beyond writeTop, col=viewCol).
+func (v *ViewWindow) ViewToCursor(s *Store, viewRow, viewCol int) (globalIdx int64, col int, ok bool) {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	anchor, offset := v.viewAnchor, v.viewAnchorOffset
+	reflowOff := v.globalReflowOff
+	v.mu.Unlock()
+
+	if viewRow < 0 || viewRow >= height {
+		return 0, 0, false
+	}
+
+	emitted := 0
+	gi := anchor
+	cap := 4 * height
+	for emitted < height {
+		if s.GetLine(gi) == nil {
+			break
+		}
+		end, nowrap := walkChain(s, gi, cap)
+		if reflowOff {
+			nowrap = true
+		}
+		var chainRows int
+		if nowrap {
+			chainRows = int(end - gi + 1)
+		} else {
+			total := 0
+			for r := gi; r <= end; r++ {
+				total += len(s.GetLine(r))
+			}
+			if total == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (total + width - 1) / width
+			}
+		}
+		startAt := 0
+		if gi == anchor {
+			startAt = offset
+		}
+		rowsFromThisChain := chainRows - startAt
+		if viewRow < emitted+rowsFromThisChain {
+			rowInChain := (viewRow - emitted) + startAt
+			if nowrap {
+				return gi + int64(rowInChain), viewCol, true
+			}
+			// Walk cells to find (gi, col)
+			logicalCol := rowInChain*width + viewCol
+			for r := gi; r <= end; r++ {
+				rowLen := len(s.GetLine(r))
+				if logicalCol < rowLen {
+					return r, logicalCol, true
+				}
+				logicalCol -= rowLen
+			}
+			// viewCol past end of logical — return at end of chain
+			return end, len(s.GetLine(end)), true
+		}
+		emitted += rowsFromThisChain
+		gi = end + 1
+	}
+	// Past content.
+	return gi + int64(viewRow-emitted), viewCol, true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestCursor_RoundTrip -v`
+Expected: PASS
+
+- [ ] **Step 5: Run all sparse tests**
+
+Run: `go test ./apps/texelterm/parser/sparse`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go apps/texelterm/parser/sparse/view_window_reflow_test.go
+git commit -m "sparse: add CursorToView / ViewToCursor mapping"
+```
+
+---
+
+## Task 7: Live-mode anchor recompute + integrate into render pipeline
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Modify: `apps/texelterm/parser/sparse/terminal.go`
+
+- [ ] **Step 1: Write failing test for live-mode anchor tracks writeBottom**
+
+Append to `view_window_reflow_test.go`:
+
+```go
+func TestViewWindow_LiveMode_AnchorTracksCursor(t *testing.T) {
+	s := NewStore(80)
+	// Fill 10 short lines
+	for gi := int64(0); gi < 10; gi++ {
+		fillRow(s, gi, "x", false)
+	}
+
+	vw := NewViewWindow(80, 3) // height=3
+	vw.RecomputeLiveAnchor(s, /*cursorGI=*/9, /*cursorCol=*/0)
+	vr, vc, ok := vw.CursorToView(s, 9, 0)
+	if !ok || vr != 2 {
+		t.Errorf("live anchor: cursor should be on bottom row; got (%d,%d,%v)", vr, vc, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_LiveMode -v`
+Expected: FAIL (undefined: RecomputeLiveAnchor)
+
+- [ ] **Step 3: Implement live-mode recompute**
+
+Add to `view_window.go`:
+
+```go
+// RecomputeLiveAnchor sets viewAnchor so that (cursorGI, cursorCol) is
+// visible on the last view row when autoFollow is active. Called from
+// Render-time in live mode; cheap.
+//
+// Algorithm: walk chains backward from the cursor's chain, accumulating
+// view rows, until we've gathered v.height rows or run out of content.
+func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int) {
+	v.mu.Lock()
+	height, width := v.height, v.width
+	reflowOff := v.globalReflowOff
+	if !v.autoFollow {
+		v.mu.Unlock()
+		return
+	}
+	v.mu.Unlock()
+
+	// Find the chain containing the cursor.
+	chainStart := cursorGI
+	for chainStart > 0 {
+		prev := s.GetLine(chainStart - 1)
+		if len(prev) == 0 || !prev[len(prev)-1].Wrapped {
+			break
+		}
+		chainStart--
+	}
+	// Walk backward, counting reflowed rows per chain.
+	target := height
+	gi := chainStart
+	offset := 0
+	for target > 0 && gi >= 0 {
+		end, nowrap := walkChain(s, gi, 4*height)
+		if reflowOff {
+			nowrap = true
+		}
+		var chainRows int
+		if nowrap {
+			chainRows = int(end - gi + 1)
+		} else {
+			total := 0
+			for r := gi; r <= end; r++ {
+				total += len(s.GetLine(r))
+			}
+			if total == 0 {
+				chainRows = 1
+			} else {
+				chainRows = (total + width - 1) / width
+			}
+		}
+		if chainRows >= target {
+			offset = chainRows - target
+			v.mu.Lock()
+			v.viewAnchor = gi
+			v.viewAnchorOffset = offset
+			v.mu.Unlock()
+			return
+		}
+		target -= chainRows
+		if gi == 0 {
+			break
+		}
+		// Walk back to the previous chain's start.
+		gi--
+		for gi > 0 {
+			prev := s.GetLine(gi - 1)
+			if len(prev) == 0 || !prev[len(prev)-1].Wrapped {
+				break
+			}
+			gi--
+		}
+	}
+	// Not enough content; anchor at top.
+	v.mu.Lock()
+	v.viewAnchor = 0
+	v.viewAnchorOffset = 0
+	v.mu.Unlock()
+}
+```
+
+- [ ] **Step 4: Wire into Terminal.Render (or equivalent)**
+
+In `terminal.go`, find the render entrypoint. Before it produces a grid, call `ViewWindow.RecomputeLiveAnchor` using the current cursor globalIdx/col. Produce the grid via `ViewWindow.Render(store)`. If a legacy `VisibleRange`/projection path exists, gate it behind a fallback flag for now.
+
+- [ ] **Step 5: Run all sparse tests**
+
+Run: `go test ./apps/texelterm/parser/sparse`
+Expected: PASS
+
+- [ ] **Step 6: Run full texelterm tests**
+
+Run: `go test ./apps/texelterm/...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go apps/texelterm/parser/sparse/terminal.go apps/texelterm/parser/sparse/view_window_reflow_test.go
+git commit -m "sparse: live-mode anchor recompute on render"
+```
+
+---
+
+## Task 8: VTerm resize uses new Render path + cursor mapping
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go` (Grid, Resize, cursor accessors)
+- Modify: `apps/texelterm/parser/vterm_main_screen.go`
+
+- [ ] **Step 1: Write failing end-to-end reflow test**
+
+Create `apps/texelterm/parser/vterm_reflow_test.go`:
+
+```go
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fill a line longer than 80, resize narrower, verify it reflows.
+func TestVTerm_Reflow_WidenAndNarrow(t *testing.T) {
+	v := NewVTerm(80, 24)
+	long := strings.Repeat("abcdefghij", 12) // 120 chars
+	v.Write([]byte(long))
+
+	// At width 80, line wraps into 2 physical rows.
+	grid := v.Grid()
+	row0 := cellsToStringParser(grid[0])
+	if !strings.HasPrefix(row0, "abcdefghij") {
+		t.Fatalf("row 0 at width 80: %q", row0)
+	}
+
+	// Narrow to 40 — same logical line should span 3 rows.
+	v.Resize(40, 24)
+	grid = v.Grid()
+	// First three rows should contain "abcdef...".
+	joined := cellsToStringParser(grid[0]) + cellsToStringParser(grid[1]) + cellsToStringParser(grid[2])
+	if !strings.Contains(joined, long) {
+		t.Errorf("after narrow resize, content did not reflow; joined=%q", joined)
+	}
+
+	// Widen to 120 — single row holds it all.
+	v.Resize(120, 24)
+	grid = v.Grid()
+	row0 = cellsToStringParser(grid[0])
+	if !strings.HasPrefix(row0, long) {
+		t.Errorf("after widen, single row should hold full line; got %q", row0)
+	}
+}
+
+func TestVTerm_Reflow_NoWrapRowsSurviveResize(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.Write([]byte("\x1b[2;5r"))       // non-default DECSTBM
+	v.Write([]byte("\x1b[HABCDE"))      // write "ABCDE" at home within region
+	v.Write([]byte("\x1b[r"))            // reset margins
+	// Resize narrower; NoWrap row must NOT reflow.
+	v.Resize(3, 24)
+	grid := v.Grid()
+	if !strings.HasPrefix(cellsToStringParser(grid[0]), "ABC") {
+		t.Errorf("NoWrap row should clip at width 3, got %q", cellsToStringParser(grid[0]))
+	}
+}
+
+func cellsToStringParser(cells []Cell) string {
+	b := strings.Builder{}
+	for _, c := range cells {
+		if c.Rune == 0 {
+			b.WriteByte(' ')
+		} else {
+			b.WriteRune(c.Rune)
+		}
+	}
+	return b.String()
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `go test ./apps/texelterm/parser -run TestVTerm_Reflow -v`
+
+Either PASS (if Task 7 already wired through), or FAIL with a specific grid mismatch — in which case, find the Grid accessor and route it through `ViewWindow.Render` instead of the legacy projection.
+
+- [ ] **Step 3: Route Grid() through ViewWindow.Render**
+
+In `vterm.go` / `vterm_main_screen.go`, locate `Grid()` — if it reads from the sparse store via `VisibleRange` + `GetLine`, replace with:
+
+```go
+v.mainScreen.ViewWindow().RecomputeLiveAnchor(v.mainScreen.Store(), cursorGI, cursorCol)
+grid := v.mainScreen.ViewWindow().Render(v.mainScreen.Store())
+```
+
+(Exact wrapper depends on the current MainScreen interface — adjust.)
+
+- [ ] **Step 4: Route cursor position reads through ViewWindow**
+
+In whatever place VTerm reports cursor X/Y to the renderer, replace store-coordinate math with `ViewWindow.CursorToView(store, cursorGI, cursorCol)`.
+
+In the cursor-addressing path (CSI H / CSI f / CSI A etc.), replace "view row → store row" math with `ViewToCursor`. Specifically, the parser should take `(viewRow, viewCol)` and set `cursorGlobalIdx, cursorCol` via `ViewToCursor`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./apps/texelterm/parser -run TestVTerm_Reflow -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full texelterm test suite**
+
+Run: `go test ./apps/texelterm/...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/vterm_main_screen.go apps/texelterm/parser/vterm_reflow_test.go
+git commit -m "vterm: route Grid and cursor mapping through ViewWindow"
+```
+
+---
+
+## Task 9: Persistence — LogicalLine.NoWrap field
+
+**Files:**
+- Modify: `apps/texelterm/parser/logical_line.go`
+- Modify: `apps/texelterm/parser/logical_line_persistence.go`
+- Modify: `apps/texelterm/parser/vterm_main_screen.go` (sparseLineStoreAdapter)
+
+- [ ] **Step 1: Write failing test for .lhist round-trip of NoWrap**
+
+Run: `grep -n "TestLhist\|TestLogicalLine" apps/texelterm/parser/logical_line_persistence*.go` to find existing serialization tests.
+
+Add to the persistence test file (or create `logical_line_nowrap_test.go`):
+
+```go
+func TestLogicalLine_NoWrap_RoundTrip(t *testing.T) {
+	ll := NewLogicalLineFromCells([]Cell{{Rune: 'a'}})
+	ll.NoWrap = true
+	buf := encodeLogicalLine(ll) // adjust to the real encoder name
+	got, err := decodeLogicalLine(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.NoWrap {
+		t.Errorf("NoWrap flag did not survive round-trip")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser -run TestLogicalLine_NoWrap -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add NoWrap to LogicalLine**
+
+In `logical_line.go`, add field:
+
+```go
+type LogicalLine struct {
+	Cells        []Cell
+	FixedWidth   int
+	Overlay      []Cell
+	OverlayWidth int
+	Synthetic    bool
+
+	// NoWrap: line should render 1:1 (clip/pad, not reflow). Derived from
+	// per-row NoWrap in the sparse store via chain propagation at save time.
+	NoWrap bool
+}
+```
+
+Update `Clone()` to carry NoWrap.
+
+- [ ] **Step 4: Extend serialization format with optional trailing field**
+
+In `logical_line_persistence.go`, locate the encode/decode pair. Add NoWrap as an optional trailing byte:
+
+```go
+// Encode: after existing fields, append one more byte: 0 (reflowable) or 1 (NoWrap).
+// Decode: if trailing byte is present, read it; if absent (old file), default false.
+```
+
+Exact serialization layout depends on the current scheme. If it uses length-prefixed fields or a version byte, prefer appending at the end guarded by a remaining-bytes check:
+
+```go
+// after existing Decode steps:
+if buf.Len() > 0 {
+    nw, err := buf.ReadByte()
+    if err == nil && nw != 0 {
+        ll.NoWrap = true
+    }
+}
+```
+
+- [ ] **Step 5: Update save and load bridging (sparseLineStoreAdapter)**
+
+At save time: for each logical line being built from a chain, propagate NoWrap:
+
+```go
+ll.NoWrap = chainIsNoWrap // computed via walkChain in Task 4
+```
+
+At load time: when restoring rows into the store, call `store.SetRowNoWrap(gi, true)` on the first row of the chain (propagation ensures the whole chain looks NoWrap to the renderer).
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./apps/texelterm/parser -run TestLogicalLine -v`
+Expected: PASS
+
+- [ ] **Step 7: Run full parser tests**
+
+Run: `go test ./apps/texelterm/...`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/texelterm/parser/logical_line.go apps/texelterm/parser/logical_line_persistence.go apps/texelterm/parser/vterm_main_screen.go apps/texelterm/parser/logical_line_nowrap_test.go
+git commit -m "parser: persist NoWrap on LogicalLine (backward-compatible)"
+```
+
+---
+
+## Task 10: WAL — row-write entry carries NoWrap
+
+**Files:**
+- Modify: `apps/texelterm/parser/write_ahead_log.go`
+- Test: `apps/texelterm/parser/write_ahead_log_nowrap_test.go`
+
+- [ ] **Step 1: Locate the row-write WAL entry type**
+
+Run: `grep -n "type.*Entry\|row\|Row" apps/texelterm/parser/write_ahead_log.go | head -30`
+
+Identify the struct that records "write row cells at globalIdx". Record the name here: `<EntryStruct>`.
+
+- [ ] **Step 2: Write failing test for WAL NoWrap round-trip**
+
+Create `apps/texelterm/parser/write_ahead_log_nowrap_test.go`:
+
+```go
+func TestWAL_RowWrite_NoWrapRoundTrip(t *testing.T) {
+	// Construct entry with NoWrap=true, encode, decode, assert.
+	// Also: decode an old-format entry (without trailing byte), assert NoWrap=false.
+	// (Fill in with real WAL constructor + encoder names.)
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser -run TestWAL_RowWrite_NoWrap -v`
+Expected: FAIL
+
+- [ ] **Step 4: Extend WAL row-write entry**
+
+Add `NoWrap bool` to the entry struct. In the encoder, append 1 byte after the existing fields. In the decoder, if bytes remain after existing fields, read it; otherwise default to false.
+
+- [ ] **Step 5: Update the write path**
+
+Wherever the WAL records a row write, pass in `store.RowNoWrap(gi)`:
+
+```go
+wal.AppendRowWrite(gi, cells, store.RowNoWrap(gi))
+```
+
+- [ ] **Step 6: Update replay**
+
+When replaying WAL entries on crash recovery, call `store.SetRowNoWrap(gi, entry.NoWrap)` after `store.SetLine`.
+
+- [ ] **Step 7: Run WAL tests**
+
+Run: `go test ./apps/texelterm/parser -run "TestWAL|TestRecovery" -v`
+Expected: PASS
+
+- [ ] **Step 8: Run full texelterm tests**
+
+Run: `go test ./apps/texelterm/...`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/texelterm/parser/write_ahead_log.go apps/texelterm/parser/write_ahead_log_nowrap_test.go
+git commit -m "wal: carry NoWrap through row-write entries (backward-compatible)"
+```
+
+---
+
+## Task 11: Scroll operations use new ViewWindow API
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Modify: callers of `ScrollUp`/`ScrollDown`/`ScrollToBottom` (search the tree)
+
+- [ ] **Step 1: Audit scroll callers**
+
+Run: `grep -rn "ScrollUp\|ScrollDown\|ScrollToBottom\|OnWriteBottomChanged" apps/texelterm/ client/ internal/`
+
+Record the user-facing scroll entrypoints. Usually they translate user keys (PageUp etc.) into `ScrollUp(n)` calls on the ViewWindow.
+
+- [ ] **Step 2: Write failing test for ScrollBy adjusting viewAnchor**
+
+```go
+func TestViewWindow_ScrollBy_MovesAnchor(t *testing.T) {
+	s := NewStore(80)
+	for gi := int64(0); gi < 20; gi++ {
+		fillRow(s, gi, "x", false)
+	}
+	vw := NewViewWindow(80, 5)
+	vw.SetViewAnchor(15, 0)
+	vw.ScrollBy(s, -3) // scroll up 3
+	gi, off := vw.Anchor()
+	if gi != 12 || off != 0 {
+		t.Errorf("ScrollBy(-3) anchor=(%d,%d) want (12,0)", gi, off)
+	}
+}
+```
+
+- [ ] **Step 3: Implement ScrollBy + Anchor accessor**
+
+Add to `view_window.go`:
+
+```go
+// Anchor returns the current (globalIdx, offset-in-chain) anchor.
+func (v *ViewWindow) Anchor() (int64, int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.viewAnchor, v.viewAnchorOffset
+}
+
+// ScrollBy moves the view anchor by dRows (negative = up into history).
+// Detaches from autoFollow. Clamps to [0, writeTop].
+func (v *ViewWindow) ScrollBy(s *Store, dRows int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoFollow = false
+	// Simple implementation: treat dRows as chain-row deltas for now.
+	// (For width-accurate scroll, a future revision can walk reflowed rows.)
+	v.viewAnchor += int64(dRows)
+	if v.viewAnchor < 0 {
+		v.viewAnchor = 0
+	}
+	v.viewAnchorOffset = 0
+}
+```
+
+Keep existing `ScrollUp`/`ScrollDown` as compatibility shims that call `ScrollBy`.
+
+- [ ] **Step 4: Run test**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_ScrollBy -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go
+git commit -m "sparse: add ScrollBy / Anchor for reflow-aware scrolling"
+```
+
+---
+
+## Task 12: User toggles — autoJumpOnInput and globalReflowOff
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Modify: `apps/texelterm/parser/sparse/terminal.go`
+
+- [ ] **Step 1: Write failing test for autoJumpOnInput configurability**
+
+```go
+func TestViewWindow_AutoJumpOnInput_ConfigurableOff(t *testing.T) {
+	vw := NewViewWindow(80, 5)
+	vw.SetAutoJumpOnInput(false)
+	vw.SetViewAnchor(3, 0) // scrolled back
+	vw.OnInput(99)          // simulate user input at writeBottom=99
+	gi, _ := vw.Anchor()
+	if gi != 3 {
+		t.Errorf("autoJumpOnInput=false: anchor should stay at 3, got %d", gi)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_AutoJumpOnInput -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement SetAutoJumpOnInput and gate OnInput**
+
+In `view_window.go`:
+
+```go
+func (v *ViewWindow) SetAutoJumpOnInput(enabled bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.autoJumpOnInput = enabled
+}
+
+// OnInput is called when the user types. If autoJumpOnInput is true,
+// snaps to live edge; otherwise does nothing (user stays scrolled back).
+func (v *ViewWindow) OnInput(writeBottom int64) {
+	v.mu.Lock()
+	if !v.autoJumpOnInput {
+		v.mu.Unlock()
+		return
+	}
+	v.mu.Unlock()
+	v.ScrollToBottom(writeBottom)
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `go test ./apps/texelterm/parser/sparse -run TestViewWindow_AutoJumpOnInput -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go
+git commit -m "sparse: make autoJumpOnInput configurable"
+```
+
+---
+
+## Task 13: Manual verification checklist
+
+**No code changes.** After Tasks 1–12, run the following by hand. If any fail, stop and file a follow-up task before proceeding to Task 14.
+
+- [ ] **Start texelation, run `ls -la` in a wide terminal, resize narrower mid-output.** Wrapped rows should rejoin after widening and split correctly after narrowing. No duplicated or lost characters.
+
+- [ ] **Scroll back through history after reflow.** Historical content should also reflow at current width.
+
+- [ ] **Run a DECSTBM app (`progress` or similar).** Resize the terminal during its run. The structured content should NOT reflow — it should clip/pad at the new width.
+
+- [ ] **Toggle reflow off (add a temporary test hook / debug command if needed).** Reflowable chains should snap to 1:1; NoWrap chains are unaffected.
+
+- [ ] **Start a session, write some content, close texelation, reopen.** Check that `.lhist` is loaded, reflow still works, and NoWrap rows (from DECSTBM apps) still clip on resize.
+
+- [ ] **Kill the server mid-session.** On restart, WAL replay should restore NoWrap flags — DECSTBM-written content should still clip.
+
+- [ ] **Edge cases:** resize to width 1 briefly — should be slow but correct, not crash. `yes | head -c 1000000` then resize — the `4 × height` cap should keep the UI responsive.
+
+If all pass, commit any test/debug hooks removal:
+
+```bash
+git status
+# (should be clean or only debug removals)
+git commit -m "chore: clean up reflow debug hooks" --allow-empty
+```
+
+---
+
+## Task 14: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (root of `texelation-sparse`)
+
+- [ ] **Step 1: Locate the "Scrollback Persistence" section**
+
+Current text (around the bottom): "**Notes**: No reflow on resize — the store is width-set-at-construction..."
+
+- [ ] **Step 2: Replace with updated description**
+
+New text:
+
+```markdown
+**Notes**: Reflow on resize is view-side. The store stays width-independent in structure (cells at `(globalIdx, col)`, `Wrapped` flag on wrap boundaries). `ViewWindow` walks `Wrapped` chains at render time and reflows at current viewport width; widening rejoins, narrowing splits. Per-row `NoWrap` flag (set when DECSTBM has non-default margins at write time) opts structured content out of reflow — that content clips/pads 1:1 instead. A global `globalReflowOff` toggle forces all reflowable rows to 1:1 without affecting NoWrap rows. See `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: CLAUDE.md reflects view-side resize-reflow"
+```
+
+---
+
+## Task 15: Final regression + create PR
+
+- [ ] **Step 1: Run everything**
+
+Run: `cd /home/marc/projects/texel/texelation-sparse && make test`
+Expected: PASS
+
+Run: `go test -tags=integration ./internal/runtime/server/...`
+Expected: PASS
+
+- [ ] **Step 2: Push branch and open PR**
+
+```bash
+git push -u origin <branch>
+gh pr create --title "Sparse: view-side reflow on resize" --body "$(cat <<'EOF'
+## Summary
+- Restore reflow-on-resize for the sparse terminal: widening rejoins wrapped lines, shrinking splits them, for both live shell output and scrollback history.
+- DECSTBM-protected rows carry a NoWrap flag and render 1:1 instead of reflowing.
+- User toggle `globalReflowOff` forces all reflowable rows to 1:1 (NoWrap rows unaffected).
+
+Spec: `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`
+
+## Test plan
+- [x] Unit tests: store NoWrap, chain walker, reflow, cursor mapping round-trip
+- [x] Integration tests: VTerm reflow widen/narrow, NoWrap resize survival
+- [x] Manual: ls resize, DECSTBM resize, scrollback reflow, width=1, yes-stress cap
+- [x] Persistence: `.lhist` NoWrap round-trip, WAL replay carries NoWrap
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Record PR URL**
+
+Return PR URL to the user.

--- a/docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md
+++ b/docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md
@@ -1,0 +1,321 @@
+# Sparse Resize-Reflow via View-Side Projection + NoWrap Rows
+
+**Status**: Design
+**Date**: 2026-04-16
+**Relates to**: `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`
+
+## Background
+
+The sparse cutover (PR #179, 2026-04-14) replaced the pre-sparse `MemoryBuffer` (which stored logical lines natively and reflowed on resize) with a width-indexed `sparse.Store` (cells addressed by `(globalIdx, col)`, with `Wrapped` flags on last cells of wrapped lines). The cutover deliberately dropped reflow-on-resize — it was explicitly a non-goal, because the old reflow path was tangled with `liveEdgeBase` / `ViewportWindow` anchoring bugs that the sparse redesign was built to kill.
+
+With the sparse stack landed and stable, reflow is now wanted back. User-visible behavior goal:
+
+> Same reflow as before: I can resize at any point in history or at the edge. Once resized, I want to see all the content adapt at that — widening rejoins wrapped lines, shrinking splits them. Both live shell output and scrollback history.
+
+The sparse store already retains enough information to reconstruct logical lines: the `Wrapped` chain on last cells of physical rows marks logical-line boundaries. `ConvertPhysicalToLogical` performs this reconstruction today at the persistence boundary. This spec moves reconstruction into the read path so the view can reflow on the fly.
+
+## Goals
+
+- Widening the viewport rejoins wrapped lines; narrowing splits them.
+- Both live shell output and scrollback history reflow.
+- O(1) cost in content size on resize (no walk-and-rewrite of the store).
+- Storage format unchanged in structure: cells at `(globalIdx, col)`, `Wrapped` flag on wraps.
+- Cursor `(globalIdx, col)` store representation unchanged.
+- DECSTBM scroll regions and other structured content keep working (no silent layout corruption under reflow).
+- Provide a clean pivot point for a future user-level "reflow off" toggle.
+
+## Non-goals
+
+- Alt-screen reflow. Alt-screen keeps current dense-grid behavior (TUIs redraw on SIGWINCH). Explicitly out of scope per the sparse design spec's non-goals.
+- Changing the storage format. Cells stay width-indexed.
+- Changing the cursor's store representation. Stays `(cursorGlobalIdx, cursorCol)`.
+- Rewriting pre-existing scrollback to include NoWrap metadata. Old sessions load with NoWrap=false and reflow as best they can.
+- Revisiting pre-sparse `liveEdgeBase` / `ViewportWindow` bugs. The sparse stack already fixed those; this spec builds on top of that foundation.
+
+## The Approach
+
+### Architecture
+
+Three components, minimal structural change:
+
+```
+VTerm (write path, mostly unchanged)
+    • writes cells at current view width
+    • sets Wrapped on last cell when line wraps
+    • NEW: propagates DECSTBM-active state to the row's NoWrap flag
+          │
+          ▼
+sparse.Store (minor extension)
+    • cells at (globalIdx, col) — unchanged
+    • NEW: per-row NoWrap flag + getters/setters
+          │
+          ▼
+ViewWindow (significant new logic)
+    • walks rows top-to-bottom
+    • per row: NoWrap → render 1:1; else → reflow chain at view width
+    • tracks view anchor independent of writeTop
+    • provides forward/inverse cursor mappings
+          │
+          ▼
+     Screen buffer
+```
+
+**Principle:** writes and storage are unchanged in structure. Reflow happens entirely in the view layer. The NoWrap flag is the escape hatch for content that would misbehave under reflow.
+
+### The NoWrap flag
+
+Per physical row in the store. Set at write time based on whether DECSTBM is active. Sticky per-row — once true, stays true (avoids ambiguity if DECSTBM toggles mid-row).
+
+**Detection rule (v1):** `NoWrap = true` when the write happens while DECSTBM has been set to non-default margins (any margins other than `[0, height-1]`).
+
+**Why DECSTBM only:**
+- It's the strongest signal an app is managing its own layout.
+- Direct cursor addressing (`ESC[H`) is used heavily by shells for prompt redraw, which is reflow-friendly.
+- Keeps the rule simple. Add more detectors later if specific apps break.
+
+**Chain propagation rule:** if any row in a `Wrapped` chain is NoWrap, the whole chain is treated as NoWrap for rendering. Avoids half-reflowed logical lines. See memory note `project_sparse_nowrap_chain_propagation.md` — revisit if this produces visually ugly reflow in practice.
+
+### Rendering
+
+Per-frame, the `ViewWindow` walks rows from its view anchor, groups physical rows into `Wrapped` chains, and renders each chain:
+
+```
+for chain in chains_from(viewAnchor):
+    chainNoWrap = any(row.NoWrap for row in chain) OR globalReflowOff
+    if chainNoWrap:
+        emit each row in chain as one view row (1:1, truncate/pad to viewWidth)
+    else:
+        concat all cells in chain → logical line
+        re-wrap logical line at viewWidth → N view rows
+        emit each view row (respecting viewAnchorOffset on the first chain)
+    if emitted >= viewHeight: break
+```
+
+Per-frame cost: bounded by view height × average chain length. Not a hot-path concern for typical terminals.
+
+### Cursor mapping
+
+Cursor is at `(cursorGlobalIdx, cursorCol)` in the store. Visual position is derived via two mappings:
+
+**Forward** `(globalIdx, col)` → `(viewRow, viewCol)`:
+1. Find chain containing `(globalIdx, col)`.
+2. If chain is NoWrap: `viewRow = offset from view-top, viewCol = col` (truncated to viewWidth).
+3. Else: compute logical-col = sum of prior row lengths in chain + col; reflow at viewWidth.
+4. Add view-row contribution of prior chains in view to get absolute viewRow.
+
+**Inverse** `(viewRow, viewCol)` → `(globalIdx, col)`:
+1. Walk chains from view anchor, accumulating view rows each contributes.
+2. Find the chain covering the target viewRow.
+3. Within that chain, map `(viewRow - chainStartViewRow, viewCol)` back to `(globalIdx, col)`.
+4. If target is past content end, fabricate blank-area result (matches current VT "address past end" behavior).
+
+Both walks are bounded by the view height plus the tail of the chain the cursor lands in. Hard cap on chain walk: `4 × viewHeight` — pathologically long logical lines (e.g., `yes` piped with no newlines) get visually truncated rather than freezing the UI.
+
+### View anchoring
+
+`ViewWindow` gains a new anchor independent of `writeTop`:
+
+```go
+type ViewWindow struct {
+    // existing fields...
+    viewAnchor       int64 // globalIdx of first row of logical chain at view top
+    viewAnchorOffset int   // if that chain reflows, which of its view rows is at top
+    globalReflowOff  bool  // user toggle (default false)
+}
+```
+
+**Live mode** (user not scrolled back): `viewAnchor` is recomputed lazily on each `Render()` call so the cursor is visible. The recompute is cheap (once per frame) and batches naturally — a burst of writes between frames costs one recompute.
+
+**Scrolled-back mode**: `viewAnchor` is pinned to the user-selected position. User scroll operations adjust `viewAnchor`/`viewAnchorOffset`.
+
+**Mode transitions:**
+- On user scroll: switch to scrolled-back, pin anchor.
+- On explicit jump-to-end action: switch to live, recompute anchor on next render.
+- Auto-jump-on-input (user types → scroll to bottom): configurable toggle, default ON (standard terminal UX). User can disable to stay scrolled back while typing.
+
+### Writes unchanged
+
+VTerm writes continue at current view width (`WriteWindow.width`, updated on resize as today). Wrap semantics unchanged: `cursorX > rightEdge` → mark wrapped, advance globalIdx, continue at col 0. New writes land at new width; old content sits at whatever widths it was written. Reflow only cares about logical-line identity (via `Wrapped` chains), not per-row widths.
+
+### Resize
+
+`VTerm.Resize(newW, newH)`:
+1. `WriteWindow.Resize(newW, newH)` — unchanged: updates width, height, writeTop, HWM, cursor clamping in store terms.
+2. `ViewWindow.OnResize(newW, newH)` — rebuilds view projection. If live, anchor is recomputed on next render. If scrolled back, `viewAnchor` stays pinned.
+
+Store is never walked or rewritten. Cost is O(1) in content size; O(height) render work happens at next frame anyway.
+
+### Persistence
+
+Two persistence paths, both must carry NoWrap:
+
+- **`.lhist` (long-term scrollback):** `LogicalLine` gains a `NoWrap bool` field in the serialized form. Old files without the field load with `NoWrap=false` (reflowable). New files persist the flag per line. At persistence time the `Wrapped` chain has already been collapsed to a single LogicalLine, so chain-propagation has already applied — a single bit per line suffices.
+
+- **WAL (crash recovery):** the WAL records row-level operations. The record for "write row cells" must carry the NoWrap flag alongside the cells, so replay reconstructs the flag. This is an additive field on the existing row-write entry; old WAL entries decode with NoWrap=false. MainScreenState session metadata is unchanged (NoWrap is per-row, not per-session).
+
+### User toggle
+
+Global `globalReflowOff bool` on ViewWindow. One branch in the render loop: `effectiveNoWrap = row.NoWrap || globalReflowOff`.
+
+Semantics: the toggle only affects reflowable rows. NoWrap rows are **always** 1:1 regardless of toggle state — NoWrap is a hard property. No "force reflow" direction exists; there's no footgun where the user can reflow DECSTBM content and see it shatter.
+
+UX wiring (keybind, per-pane setting, persistence) is out of scope for this design; the architecture provides the pivot point.
+
+## Data flow
+
+### Write flow
+
+```
+VTerm receives cell
+  ├─ check wrapNext: if cursorX > rightEdge:
+  │    markLineWrapped(cursorGlobalIdx)
+  │    lineFeedForWrap() advances globalIdx, cursorX = 0
+  ├─ store.Set(cursorGlobalIdx, cursorX, cell)
+  └─ store.SetRowNoWrap(cursorGlobalIdx, decstbmActive)
+        (sticky OR: row.NoWrap = row.NoWrap || decstbmActive)
+```
+
+### Render flow
+
+```
+ViewWindow.Render():
+  start at (viewAnchor, viewAnchorOffset)
+  while emitted < viewHeight AND content remains:
+    walk chain from current idx (find chain end via Wrapped flags)
+    chainNoWrap = any(row.NoWrap) OR globalReflowOff
+    if chainNoWrap: emit rows 1:1
+    else: concat + re-wrap at viewWidth, emit
+    advance idx past chain
+  pad remainder with blanks
+  overlay cursor at CursorToView(cursorGlobalIdx, cursorCol)
+```
+
+### Cursor addressing flow (TUI `ESC[r;cH`)
+
+```
+VTerm parses CSI H/f → target (viewRow, viewCol)
+ViewToCursor(viewRow, viewCol):
+  walk chains from viewAnchor, accumulating view rows
+  find chain covering viewRow
+  within chain: map (viewRow - chainStart, viewCol) → (globalIdx, col)
+  if past content end: fabricate blank-area result
+WriteWindow.SetCursorAbsolute(globalIdx, col)
+```
+
+### Resize flow
+
+```
+VTerm.Resize(newW, newH):
+  WriteWindow.Resize(newW, newH)        // store-level anchoring unchanged
+  ViewWindow.OnResize(newW, newH)       // next Render() rebuilds projection
+```
+
+### Persistence flow
+
+**Save:** `.lhist` LogicalLine entries carry NoWrap. At persistence time, the Wrapped chain has already been collapsed to a LogicalLine, so "any row's NoWrap → chain NoWrap" has already applied. Single bit per line.
+
+**Load:** old files → `NoWrap=false` default. New files restore per-line. Rows in the store get the flag set during reconstruction.
+
+## Edge cases
+
+### Malformed Wrapped chains
+
+Row has `Wrapped=true` but next globalIdx is empty. Chain walker stops at first missing row; treat terminator as end-of-chain. Debug-level log; no spam.
+
+### Pathologically long logical lines
+
+Chain walk capped at `4 × viewHeight`. Beyond cap: visually truncate (show tail that fits, discard head for reflow). Store data is unaffected. Prevents render-path footgun from unbounded walks.
+
+### Cursor outside any known chain
+
+Post-erase or gap scenarios: `CursorToView` treats the cursor's row as a degenerate single-row chain, renders at its own globalIdx offset. Matches current behavior.
+
+### Resize to very small dimensions
+
+Existing `WriteWindow.Resize` rejects `w ≤ 0 || h ≤ 0`. Small-but-positive sizes (e.g., width=1) go through. Reflow at width 1: each cell becomes one view row. Slow but correct.
+
+### Inverse mapping past content end
+
+`ViewToCursor` walks chains until exhausted, then fabricates `globalIdx = writeTop + (viewRow - contentRows)`, `col = viewCol`. Matches existing VT "address past content extends blank space" behavior.
+
+### Resize mid-wrapped-write
+
+VTerm's `wrapNext` evaluates against the new `rightEdge` at next write. If the new width makes the current cursor position in-bounds, `wrapNext` naturally clears. No new code needed.
+
+### NoWrap flag on a row whose content is shifted by DECSTBM operations
+
+When `NewlineInRegion` / `InsertLines` / `DeleteLines` shift rows, the NoWrap flag must move with the cells. `store.SetLine` extended to copy the flag along with cells. Narrow change.
+
+### Corrupt persisted NoWrap bit
+
+NoWrap is visual-only. Wrong value means a display quirk (row doesn't reflow when it should, or vice versa), not a correctness issue. No validation; recovery is "start a new session."
+
+### Toggle flip while scrolled back
+
+Recompute render at current `viewAnchor`. Flipping the toggle on (reflow off) snaps reflowable chains to 1:1; flipping it back restores reflow. Visible content position shifts at the flip but no data is lost.
+
+## Testing
+
+### Reflow correctness (`view_window_reflow_test.go`)
+
+- Single logical line reflows at various widths (40, 80, 120).
+- Multiple short lines (no wrapping) — reflow is a no-op.
+- Mixed reflowable + NoWrap rows interleave correctly.
+- NoWrap chain renders 1:1 even when contents would wrap.
+- Chain propagation: mixed NoWrap in a chain renders whole chain as 1:1.
+- Long line hits the `4 × height` cap gracefully.
+- Reflow at width 1 (degenerate but valid).
+- Global toggle: reflow-off renders everything 1:1 except NoWrap rows (already 1:1).
+
+### Cursor mapping
+
+- Round-trip: `CursorToView(ViewToCursor(r, c)) == (r, c)` for valid (r, c).
+- Round-trip: `ViewToCursor(CursorToView(g, c)) == (g, c)` for in-view cursor.
+- Cursor past view bottom → returns out-of-bounds.
+- Cursor in NoWrap chain: 1:1 mapping.
+- Cursor in reflowed chain: logical-col math correct.
+- Inverse mapping past content end: extends blank.
+
+### End-to-end resize
+
+- Fill viewport → narrow → verify content reflowed.
+- Fill viewport → widen → verify content rejoined.
+- Shrink then expand → verify round-trip preserves original content.
+- Resize with cursor in various positions (reflowable / NoWrap content).
+- Resize while DECSTBM is active — NoWrap rows preserved 1:1.
+- Session save/restore with NoWrap rows — flags survive round-trip.
+
+### Regression
+
+All existing tests in `sparse/*_test.go`, `parser/*_test.go`, and recovery tests must pass unchanged. Particular watchpoints:
+
+- `TestRecovery_HWMSurvivesShrinkCloseExpand` — HWM persistence unaffected.
+- Sparse cursor tests — `(globalIdx, col)` representation unchanged.
+- DECSTBM tests — IL/DL/NewlineInRegion arithmetic unchanged (NoWrap preserves globalIdx-1:1 semantics for those regions).
+
+### Visual/manual
+
+- `ls -la` in a wide terminal, resize narrower mid-output — reflow looks right.
+- Scroll back through history after reflow — historical content reflows.
+- Main-screen app using DECSTBM (e.g., `progress`) — content stable on resize.
+- Toggle reflow off with a reflowable viewport — snaps to 1:1.
+
+## Rollout plan
+
+1. Extend `sparse.Store` with per-row NoWrap flag + getters/setters. Make `SetLine` carry the flag through.
+2. Add `decstbmActive` tracking to VTerm; propagate to `SetRowNoWrap` on writes.
+3. Implement `ViewWindow.Render()`, `CursorToView`, `ViewToCursor`, `ScrollBy`. Keep old 1:1 path accessible as a fallback in case regressions surface.
+4. Extend `.lhist` and WAL row-write serialization with NoWrap field (optional trailing, backward compatible).
+5. Wire global toggle (default false, no keybind yet).
+6. Test suite expansion per Section 5.
+7. Manual verification + dogfooding.
+8. Update `CLAUDE.md` — the "Scrollback Persistence" section currently states "No reflow on resize — the store is width-set-at-construction". Update to reflect view-side reflow.
+
+Each step lands as its own PR where feasible; the `ViewWindow` change is the largest single chunk.
+
+## Open questions (for implementation plan)
+
+- Exact `.lhist` serialization: new version byte vs. optional trailing field? Preference: optional trailing for backward compat.
+- Pending-scroll-region tracking: should NoWrap also apply during `DECSTBM` stores made outside the non-default range? (Answer leans toward "only non-default ranges count", per Section 3.2.)
+- Visual-truncation behavior for the `4 × height` cap — show ellipsis? Truncate silently? Probably silent truncation + a render-time log.
+- UX for the toggle (keybind, per-pane config) — out of scope for this design, tracked separately.

--- a/internal/effects/fadetint.go
+++ b/internal/effects/fadetint.go
@@ -9,6 +9,7 @@
 package effects
 
 import (
+	"sync"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
@@ -30,6 +31,9 @@ type fadeTintEffect struct {
 	wsDuration  time.Duration
 	// Track panes that have been active at least once.
 	// Panes never seen active (e.g., status bar) are not tinted.
+	// Written from the dispatcher goroutine (HandleTrigger) and read from the
+	// render goroutine (ApplyPane); guarded by seenMu.
+	seenMu     sync.RWMutex
 	seenActive map[[16]byte]bool
 }
 
@@ -89,7 +93,9 @@ func (e *fadeTintEffect) HandleTrigger(trigger EffectTrigger) {
 	switch trigger.Type {
 	case TriggerPaneActive:
 		if trigger.Active {
+			e.seenMu.Lock()
 			e.seenActive[trigger.PaneID] = true
+			e.seenMu.Unlock()
 		}
 		target := float32(0)
 		if !trigger.Active {
@@ -128,7 +134,10 @@ func (e *fadeTintEffect) ApplyPane(pane *client.PaneState, buffer [][]client.Cel
 
 	// Skip panes that have never been active (e.g., status bar).
 	// Only darken panes that participate in the focus system.
-	if !e.seenActive[pane.ID] {
+	e.seenMu.RLock()
+	seen := e.seenActive[pane.ID]
+	e.seenMu.RUnlock()
+	if !seen {
 		return
 	}
 

--- a/internal/effects/fadetint.go
+++ b/internal/effects/fadetint.go
@@ -23,18 +23,18 @@ type fadeTintEffect struct {
 	intensity float32
 	defaultFg tcell.Color
 	defaultBg tcell.Color
-	// Workspace-level state (for workspace.control binding)
+	// wsDuration is set at construction; never mutated.
+	wsDuration time.Duration
+
+	// mu guards all cross-goroutine state below. HandleTrigger runs on the
+	// dispatcher goroutine; Update / ApplyPane / ApplyWorkspace / Active run
+	// on the render goroutine.
+	mu          sync.Mutex
 	wsActive    bool
 	wsIntensity float32 // current animated intensity
 	wsTarget    float32
 	wsStart     time.Time
-	wsDuration  time.Duration
-	// Track panes that have been active at least once.
-	// Panes never seen active (e.g., status bar) are not tinted.
-	// Written from the dispatcher goroutine (HandleTrigger) and read from the
-	// render goroutine (ApplyPane); guarded by seenMu.
-	seenMu     sync.RWMutex
-	seenActive map[[16]byte]bool
+	seenActive  map[[16]byte]bool
 }
 
 func newFadeTintEffect(color tcell.Color, intensity float32, duration time.Duration, defaultFg, defaultBg tcell.Color) Effect {
@@ -60,11 +60,18 @@ func newFadeTintEffect(color tcell.Color, intensity float32, duration time.Durat
 func (e *fadeTintEffect) ID() string { return "fadeTint" }
 
 func (e *fadeTintEffect) Active(now time.Time) bool {
-	return e.PaneEffectBase.Active(now) || e.wsIntensity > 0 || e.wsTarget > 0
+	if e.PaneEffectBase.Active(now) {
+		return true
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.wsIntensity > 0 || e.wsTarget > 0
 }
 
 func (e *fadeTintEffect) Update(now time.Time) {
 	e.PaneEffectBase.Update(now)
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	// Animate workspace intensity toward target
 	if e.wsDuration <= 0 {
 		e.wsIntensity = e.wsTarget
@@ -93,9 +100,9 @@ func (e *fadeTintEffect) HandleTrigger(trigger EffectTrigger) {
 	switch trigger.Type {
 	case TriggerPaneActive:
 		if trigger.Active {
-			e.seenMu.Lock()
+			e.mu.Lock()
 			e.seenActive[trigger.PaneID] = true
-			e.seenMu.Unlock()
+			e.mu.Unlock()
 		}
 		target := float32(0)
 		if !trigger.Active {
@@ -109,15 +116,14 @@ func (e *fadeTintEffect) HandleTrigger(trigger EffectTrigger) {
 		}
 		e.Animate(trigger.PaneID, target, trigger.Timestamp)
 	case TriggerWorkspaceControl:
+		e.mu.Lock()
 		e.wsActive = trigger.Active
 		e.wsTarget = 0
 		if trigger.Active {
 			e.wsTarget = e.intensity
 		}
 		e.wsStart = trigger.Timestamp
-		if e.wsStart.IsZero() {
-			e.wsStart = trigger.Timestamp
-		}
+		e.mu.Unlock()
 	}
 }
 
@@ -134,9 +140,9 @@ func (e *fadeTintEffect) ApplyPane(pane *client.PaneState, buffer [][]client.Cel
 
 	// Skip panes that have never been active (e.g., status bar).
 	// Only darken panes that participate in the focus system.
-	e.seenMu.RLock()
+	e.mu.Lock()
 	seen := e.seenActive[pane.ID]
-	e.seenMu.RUnlock()
+	e.mu.Unlock()
 	if !seen {
 		return
 	}
@@ -160,7 +166,10 @@ func (e *fadeTintEffect) ApplyPane(pane *client.PaneState, buffer [][]client.Cel
 }
 
 func (e *fadeTintEffect) ApplyWorkspace(buffer [][]client.Cell) {
-	if e.wsIntensity <= 0 {
+	e.mu.Lock()
+	intensity := e.wsIntensity
+	e.mu.Unlock()
+	if intensity <= 0 {
 		return
 	}
 	fgFallback := e.defaultFg
@@ -174,7 +183,7 @@ func (e *fadeTintEffect) ApplyWorkspace(buffer [][]client.Cell) {
 	for y := range buffer {
 		for x := range buffer[y] {
 			cell := &buffer[y][x]
-			cell.Style = tintStyle(cell.Style, e.color, e.wsIntensity, false, fgFallback, bgFallback)
+			cell.Style = tintStyle(cell.Style, e.color, intensity, false, fgFallback, bgFallback)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Restore reflow-on-resize for the sparse terminal: widening rejoins wrapped lines, shrinking splits them, for both live shell output and scrollback history.
- DECSTBM-protected rows carry a `NoWrap` flag and render 1:1 instead of reflowing.
- User toggle `globalReflowOff` forces all reflowable rows to 1:1 (NoWrap rows unaffected).
- Fix two scroll regressions uncovered during verification: binary-jump in `ScrollUpRows` (unconditional `viewAnchor = 0` reset), and inverted keyboard scroll sign (`<alt-up>` / `<alt-down>` / page-up / page-down).
- Post-review round: broaden fadeTint mutex to all cross-goroutine state, privatize legacy ViewWindow scroll helpers, standardize the empty-row predicate, add multi-row wrap-chain scroll + VTerm.Scroll sign + chainReflowedRowCount regression tests.

Spec: `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`
Plan: `docs/superpowers/plans/2026-04-16-sparse-resize-reflow.md`

## Test plan
- [x] Unit tests: store `NoWrap`, chain walker, reflow, cursor mapping round-trip, scroll regression suite
- [x] Integration tests: VTerm reflow widen/narrow, NoWrap resize survival
- [x] Race-detector run on `internal/effects/...` and `apps/texelterm/parser/...` green
- [x] Manual: `ls` resize, DECSTBM resize, scrollback reflow, width=1, `yes`-stress cap, keyboard/mouse incremental scroll

## Known issues (follow-ups, not blockers)
- **Claude TUI produces duplicate lines on horizontal resize.** Reflow itself works; the alt-screen path appears to interact differently than before this branch. Tracking as a follow-up — modern alt-screen TUIs don't set DECSTBM, so no `NoWrap` rows are detected.
- **Prompt duplication on history recovery.** A fresh shell prompt draws below the last stored prompt on session restore. `LastPromptLine` / `SetOnLineIndexed` are still stubs in the sparse path. Tracked as a follow-up.
- **`TestClientResumeReceivesSnapshot` integration test hangs** — pre-existing (reproduces on a clean tree), unrelated to this PR.

## Drive-by cleanups to do next (deferred)
- `ViewWindow.ScrollBy(*Store, n)` takes an unused `*Store` — drop the parameter in a follow-up.
- `viewBottom` is described as "legacy" in code comments (view_window.go:655–660 range); retire it entirely once `VisibleRange()`/`Grid()` consumers have migrated to the chain-aware anchor.
- Silent fallbacks: `CursorToView` returns `(0,0,true)` when outside the viewport, `ScrollUpRows` pins to `viewAnchor=0` on exhaustion, and `findChainStart` silently returns when the step budget is hit. None are wrong today, but they hide malformed-chain and viewport-drift bugs; replace with callable predicates + asserts in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)