### PR TITLE
Persist OSC 133 anchors across server restart

### DIFF
--- a/apps/texelterm/parser/osc133_anchor_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_persistence_test.go
@@ -158,6 +158,60 @@ func TestEnableMemoryBuffer_RestoresOSC133Anchors(t *testing.T) {
 	}
 }
 
+// TestED2_RewindAfterRestart_UsesRestoredCommandStart is the full
+// regression for issue #186: it drives OSC 133 anchors in session 1,
+// closes the VTerm (simulating a server shutdown), reopens from disk,
+// overflows the viewport on the reloaded instance, then issues ESC[2J
+// and verifies that writeTop rewinds to the *restored* CommandStart
+// anchor. Without #186 the anchor would have decoded as 0 and the
+// rewind would have landed at globalIdx 0 instead.
+func TestED2_RewindAfterRestart_UsesRestoredCommandStart(t *testing.T) {
+	dir := t.TempDir()
+	id := "anchor-ed2-restart"
+	const cols, rows = 40, 10
+
+	// --- Session 1: set up anchors, then close. ---
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	parseString(p1, "shell banner\r\n")
+	v1.MarkPromptStart()
+	parseString(p1, "prompt> ")
+	v1.MarkInputStart()
+	parseString(p1, "claude\r\n")
+	v1.MarkCommandStart()
+	originalCmd := v1.CommandStartGlobalLine
+	if originalCmd < 0 {
+		t.Fatalf("setup: MarkCommandStart did not set CommandStartGlobalLine")
+	}
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// --- Session 2: reload, overflow the viewport, issue ED 2. ---
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.CommandStartGlobalLine != originalCmd {
+		t.Fatalf("CommandStartGlobalLine not restored: got %d, want %d",
+			v2.CommandStartGlobalLine, originalCmd)
+	}
+
+	p2 := NewParser(v2)
+	writeFullFrameOverflow(p2, 30)
+	if got := v2.mainScreen.WriteTop(); got <= originalCmd {
+		t.Fatalf("setup: writeTop=%d did not advance past restored CommandStart=%d",
+			got, originalCmd)
+	}
+
+	parseString(p2, "\x1b[2J")
+
+	if got := v2.mainScreen.WriteTop(); got != originalCmd {
+		t.Errorf("writeTop after ED 2: got %d, want %d (restored CommandStart anchor)",
+			got, originalCmd)
+	}
+}
+
 // TestEnableMemoryBuffer_DiscardsStaleAnchors verifies that the restore path
 // discards InputStart / CommandStart anchors pointing past the last
 // persisted line, matching the existing PromptStartLine behavior. This

--- a/apps/texelterm/parser/osc133_anchor_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_persistence_test.go
@@ -1,0 +1,219 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: apps/texelterm/parser/osc133_anchor_persistence_test.go
+// Summary: Regression tests for OSC 133 anchor persistence across server
+// restart (issue #186). Covers the WAL binary encoding (round-trip +
+// backward-compat when older payloads lack the trailing anchor fields),
+// and the end-to-end VTerm save/reload cycle including stale-anchor
+// discard when the reference exceeds the PageStore's line count.
+
+package parser
+
+import (
+	"encoding/binary"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestEncodeDecodeMainScreenState_AnchorsRoundtrip exercises the binary
+// encoding for the two new OSC 133 anchor fields. Each field is a trailing
+// int64 past WriteBottomHWM.
+func TestEncodeDecodeMainScreenState_AnchorsRoundtrip(t *testing.T) {
+	original := &MainScreenState{
+		WriteTop:         100,
+		ContentEnd:       250,
+		CursorGlobalIdx:  240,
+		CursorCol:        12,
+		PromptStartLine:  230,
+		InputStartLine:   235,
+		CommandStartLine: 240,
+		WorkingDir:       "/home/user/work",
+		WriteBottomHWM:   280,
+		SavedAt:          time.Unix(1700000000, 0).UTC(),
+	}
+
+	encoded, err := encodeMainScreenState(original)
+	if err != nil {
+		t.Fatalf("encodeMainScreenState: %v", err)
+	}
+	decoded, err := decodeMainScreenState(encoded)
+	if err != nil {
+		t.Fatalf("decodeMainScreenState: %v", err)
+	}
+
+	if decoded.InputStartLine != original.InputStartLine {
+		t.Errorf("InputStartLine: got %d, want %d", decoded.InputStartLine, original.InputStartLine)
+	}
+	if decoded.CommandStartLine != original.CommandStartLine {
+		t.Errorf("CommandStartLine: got %d, want %d", decoded.CommandStartLine, original.CommandStartLine)
+	}
+	// Sanity-check the previously-added trailing field to make sure appending
+	// more trailing fields didn't shift the HWM offset.
+	if decoded.WriteBottomHWM != original.WriteBottomHWM {
+		t.Errorf("WriteBottomHWM: got %d, want %d (offset regressed?)", decoded.WriteBottomHWM, original.WriteBottomHWM)
+	}
+}
+
+// TestDecodeMainScreenState_BackwardCompat_NoTrailingAnchors synthesizes a
+// pre-issue-#186 binary payload (everything up to and including
+// WriteBottomHWM but no InputStartLine / CommandStartLine trailers) and
+// verifies both fields default to -1 ("unknown"). Without this guarantee,
+// an upgrade would silently load a bogus anchor of 0 and the next ED 2
+// repaint would rewind to globalIdx 0.
+func TestDecodeMainScreenState_BackwardCompat_NoTrailingAnchors(t *testing.T) {
+	const cwd = "/tmp/test"
+	cwdBytes := []byte(cwd)
+	// Layout as it stood before #186: fixed 46 + cwd + 8 bytes HWM.
+	size := 46 + len(cwdBytes) + 8
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint64(buf[0:8], 100)  // WriteTop
+	binary.LittleEndian.PutUint64(buf[8:16], 150) // ContentEnd
+	binary.LittleEndian.PutUint64(buf[16:24], 110) // CursorGlobalIdx
+	binary.LittleEndian.PutUint32(buf[24:28], 3)   // CursorCol
+	binary.LittleEndian.PutUint64(buf[28:36], 108) // PromptStartLine
+	binary.LittleEndian.PutUint64(buf[36:44], uint64(time.Unix(1700000000, 0).UnixNano()))
+	binary.LittleEndian.PutUint16(buf[44:46], uint16(len(cwdBytes)))
+	copy(buf[46:46+len(cwdBytes)], cwdBytes)
+	binary.LittleEndian.PutUint64(buf[46+len(cwdBytes):46+len(cwdBytes)+8], 145) // WriteBottomHWM
+
+	decoded, err := decodeMainScreenState(buf)
+	if err != nil {
+		t.Fatalf("decodeMainScreenState (old format): %v", err)
+	}
+
+	// Old fields must still decode correctly.
+	if decoded.WriteBottomHWM != 145 {
+		t.Errorf("WriteBottomHWM: got %d, want 145", decoded.WriteBottomHWM)
+	}
+	if decoded.PromptStartLine != 108 {
+		t.Errorf("PromptStartLine: got %d, want 108", decoded.PromptStartLine)
+	}
+	// New anchor fields default to -1 for pre-#186 payloads.
+	if decoded.InputStartLine != -1 {
+		t.Errorf("InputStartLine: got %d, want -1 (default for pre-#186 format)", decoded.InputStartLine)
+	}
+	if decoded.CommandStartLine != -1 {
+		t.Errorf("CommandStartLine: got %d, want -1 (default for pre-#186 format)", decoded.CommandStartLine)
+	}
+}
+
+// TestEnableMemoryBuffer_RestoresOSC133Anchors writes content, marks all
+// three OSC 133 anchors, closes the VTerm, reopens from disk, and verifies
+// each anchor came back. This is the acceptance test for issue #186: a
+// mid-Claude-session server restart preserves the exact rewind target.
+func TestEnableMemoryBuffer_RestoresOSC133Anchors(t *testing.T) {
+	dir := t.TempDir()
+	id := "anchor-persist"
+	const cols, rows = 80, 24
+
+	// --- Session 1 ---
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p := NewParser(v1)
+
+	// Write a few lines of output and set each OSC 133 anchor on its own
+	// line so the three fields end up at distinct globalIdx values; the
+	// test can then tell from the reload which restored value came from
+	// which field.
+	for i := 0; i < 3; i++ {
+		parseString(p, fmt.Sprintf("banner line %d\r\n", i))
+	}
+	v1.MarkPromptStart()
+	parseString(p, "fake-prompt-line\r\n")
+	v1.MarkInputStart()
+	parseString(p, "fake-input-line\r\n")
+	v1.MarkCommandStart()
+
+	prompt := v1.PromptStartGlobalLine
+	input := v1.InputStartGlobalLine
+	command := v1.CommandStartGlobalLine
+	if prompt < 0 || input < 0 || command < 0 {
+		t.Fatalf("setup: all three anchors must be set; got prompt=%d input=%d command=%d",
+			prompt, input, command)
+	}
+	// They should be distinct — otherwise the test can't distinguish which
+	// field survived which.
+	if prompt == input || input == command {
+		t.Fatalf("setup: anchors should be distinct; got prompt=%d input=%d command=%d",
+			prompt, input, command)
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// --- Session 2: reload from disk ---
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.PromptStartGlobalLine != prompt {
+		t.Errorf("PromptStartGlobalLine: got %d, want %d (not restored)", v2.PromptStartGlobalLine, prompt)
+	}
+	if v2.InputStartGlobalLine != input {
+		t.Errorf("InputStartGlobalLine: got %d, want %d (not restored)", v2.InputStartGlobalLine, input)
+	}
+	if v2.CommandStartGlobalLine != command {
+		t.Errorf("CommandStartGlobalLine: got %d, want %d (not restored)", v2.CommandStartGlobalLine, command)
+	}
+}
+
+// TestEnableMemoryBuffer_DiscardsStaleAnchors verifies that the restore path
+// discards InputStart / CommandStart anchors pointing past the last
+// persisted line, matching the existing PromptStartLine behavior. This
+// guards against metadata that was written just before a crash without the
+// referenced lines reaching disk.
+func TestEnableMemoryBuffer_DiscardsStaleAnchors(t *testing.T) {
+	dir := t.TempDir()
+	id := "anchor-stale"
+	const cols, rows = 80, 24
+
+	// Session 1: just open + close to produce a valid PageStore and WAL
+	// without writing any lines.
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// Hand-craft a MainScreenState with anchors that point past the empty
+	// PageStore. Write it into the WAL via a second open.
+	cfg := DefaultWALConfig(dir, id)
+	wal, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+	stale := &MainScreenState{
+		WriteTop:         0,
+		ContentEnd:       -1,
+		CursorGlobalIdx:  0,
+		CursorCol:        0,
+		PromptStartLine:  500,
+		InputStartLine:   600,
+		CommandStartLine: 700,
+		SavedAt:          time.Now(),
+	}
+	if err := wal.WriteMainScreenState(stale); err != nil {
+		t.Fatalf("WriteMainScreenState: %v", err)
+	}
+	if err := wal.Close(); err != nil {
+		t.Fatalf("wal.Close: %v", err)
+	}
+
+	// Session 2: reload. All three anchors should be discarded because they
+	// exceed pageStoreLineCount (which is 0 — no lines were written).
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.PromptStartGlobalLine != -1 {
+		t.Errorf("PromptStartGlobalLine: got %d, want -1 (stale should have been discarded)",
+			v2.PromptStartGlobalLine)
+	}
+	if v2.InputStartGlobalLine != -1 {
+		t.Errorf("InputStartGlobalLine: got %d, want -1 (stale should have been discarded)",
+			v2.InputStartGlobalLine)
+	}
+	if v2.CommandStartGlobalLine != -1 {
+		t.Errorf("CommandStartGlobalLine: got %d, want -1 (stale should have been discarded)",
+			v2.CommandStartGlobalLine)
+	}
+}

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -80,6 +80,20 @@ type MainScreenState struct {
 	// -1 means unknown.
 	PromptStartLine int64 `json:"prompt_start_line"`
 
+	// InputStartLine is the global line index of the last OSC 133;B (input
+	// start). -1 means unknown. Persisted so that an ED 2 repaint issued
+	// immediately after server restart still rewinds to a precise anchor,
+	// rather than falling back past it to PromptStart+1. Older WAL entries
+	// without this field decode to -1.
+	InputStartLine int64 `json:"input_start_line,omitempty"`
+
+	// CommandStartLine is the global line index of the currently running
+	// foreground command's frame top (OSC 133;C, cleared on 133;D). -1 means
+	// no command in flight. Persisted so that a restart mid-TUI-session (e.g.
+	// Claude) preserves the correct rewind anchor until the TUI's next
+	// OSC 133;C tick. Older WAL entries without this field decode to -1.
+	CommandStartLine int64 `json:"command_start_line,omitempty"`
+
 	// WorkingDir is the last known working directory from OSC 7.
 	WorkingDir string `json:"working_dir"`
 
@@ -106,6 +120,8 @@ type MainScreenState struct {
 //   - ContentEnd must be >= -1 (-1 is the "empty" sentinel).
 //   - CursorCol must be non-negative.
 //   - PromptStartLine must be >= -1 (-1 is the "unknown" sentinel).
+//   - InputStartLine must be >= -1 (-1 is the "unknown" sentinel).
+//   - CommandStartLine must be >= -1 (-1 is the "no command in flight" sentinel).
 //   - CursorGlobalIdx must be >= WriteTop (the cursor lives inside the write
 //     window, which starts at WriteTop).
 //   - WriteBottomHWM must be non-negative (it is a globalIdx). Zero is
@@ -127,6 +143,12 @@ func (s MainScreenState) Validate() error {
 	}
 	if s.PromptStartLine < -1 {
 		return fmt.Errorf("MainScreenState: PromptStartLine %d must be >= -1", s.PromptStartLine)
+	}
+	if s.InputStartLine < -1 {
+		return fmt.Errorf("MainScreenState: InputStartLine %d must be >= -1", s.InputStartLine)
+	}
+	if s.CommandStartLine < -1 {
+		return fmt.Errorf("MainScreenState: CommandStartLine %d must be >= -1", s.CommandStartLine)
 	}
 	if s.CursorGlobalIdx < s.WriteTop {
 		return fmt.Errorf("MainScreenState: CursorGlobalIdx %d must be >= WriteTop %d",

--- a/apps/texelterm/parser/page_store_main_screen_state_test.go
+++ b/apps/texelterm/parser/page_store_main_screen_state_test.go
@@ -82,6 +82,24 @@ func TestMainScreenState_Validate(t *testing.T) {
 			wantErr: "PromptStartLine -2",
 		},
 		{
+			name:   "unknown input-start sentinel",
+			mutate: func(s *MainScreenState) { s.InputStartLine = -1 },
+		},
+		{
+			name:   "unknown command-start sentinel",
+			mutate: func(s *MainScreenState) { s.CommandStartLine = -1 },
+		},
+		{
+			name:    "InputStartLine below -1 sentinel",
+			mutate:  func(s *MainScreenState) { s.InputStartLine = -2 },
+			wantErr: "InputStartLine -2",
+		},
+		{
+			name:    "CommandStartLine below -1 sentinel",
+			mutate:  func(s *MainScreenState) { s.CommandStartLine = -2 },
+			wantErr: "CommandStartLine -2",
+		},
+		{
 			name:    "cursor above WriteTop",
 			mutate:  func(s *MainScreenState) { s.CursorGlobalIdx = s.WriteTop - 1 },
 			wantErr: "CursorGlobalIdx 99 must be >= WriteTop 100",

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -66,12 +66,34 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 		// line. The prompt position is only meaningful if the referenced line
 		// exists; otherwise prompt-aware operations (scroll-to-prompt,
 		// erase-to-prompt) would target non-existent rows. -1 means "unknown".
-		if recoveredMeta.PromptStartLine >= 0 && recoveredMeta.PromptStartLine >= pageStoreLineCount {
+		// An anchor exactly at pageStoreLineCount is the first unwritten line
+		// — legitimate when the last write ended with \r\n and the anchor is
+		// the starting point for the next input/command. Only anchors strictly
+		// past the stored content are considered dangling.
+		if recoveredMeta.PromptStartLine >= 0 && recoveredMeta.PromptStartLine > pageStoreLineCount {
 			log.Printf("[MAIN_SCREEN] Discarded stale PromptStartLine %d (PageStore end=%d)",
 				recoveredMeta.PromptStartLine, pageStoreLineCount)
 			v.PromptStartGlobalLine = -1
 		} else {
 			v.PromptStartGlobalLine = recoveredMeta.PromptStartLine
+		}
+		// Same stale-discard rule for the OSC 133 input/command anchors: if
+		// they point strictly past the last persisted line the reference is
+		// dangling and any ED-2 rewind driven by them would land on
+		// non-existent rows.
+		if recoveredMeta.InputStartLine >= 0 && recoveredMeta.InputStartLine > pageStoreLineCount {
+			log.Printf("[MAIN_SCREEN] Discarded stale InputStartLine %d (PageStore end=%d)",
+				recoveredMeta.InputStartLine, pageStoreLineCount)
+			v.InputStartGlobalLine = -1
+		} else {
+			v.InputStartGlobalLine = recoveredMeta.InputStartLine
+		}
+		if recoveredMeta.CommandStartLine >= 0 && recoveredMeta.CommandStartLine > pageStoreLineCount {
+			log.Printf("[MAIN_SCREEN] Discarded stale CommandStartLine %d (PageStore end=%d)",
+				recoveredMeta.CommandStartLine, pageStoreLineCount)
+			v.CommandStartGlobalLine = -1
+		} else {
+			v.CommandStartGlobalLine = recoveredMeta.CommandStartLine
 		}
 		v.CurrentWorkingDir = recoveredMeta.WorkingDir
 		// Sync VTerm's cursor to the restored state so the next write
@@ -138,14 +160,16 @@ func (v *VTerm) CloseMemoryBuffer() error {
 func (v *VTerm) snapshotMainScreenState() MainScreenState {
 	gi, col := v.mainScreen.Cursor()
 	return MainScreenState{
-		WriteTop:        v.mainScreen.WriteTop(),
-		ContentEnd:      v.mainScreen.ContentEnd(),
-		CursorGlobalIdx: gi,
-		CursorCol:       col,
-		PromptStartLine: v.PromptStartGlobalLine,
-		WorkingDir:      v.CurrentWorkingDir,
-		WriteBottomHWM:  v.mainScreen.WriteBottomHWM(),
-		SavedAt:         time.Now(),
+		WriteTop:         v.mainScreen.WriteTop(),
+		ContentEnd:       v.mainScreen.ContentEnd(),
+		CursorGlobalIdx:  gi,
+		CursorCol:        col,
+		PromptStartLine:  v.PromptStartGlobalLine,
+		InputStartLine:   v.InputStartGlobalLine,
+		CommandStartLine: v.CommandStartGlobalLine,
+		WorkingDir:       v.CurrentWorkingDir,
+		WriteBottomHWM:   v.mainScreen.WriteBottomHWM(),
+		SavedAt:          time.Now(),
 	}
 }
 

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -529,13 +529,14 @@ func (w *WriteAheadLog) RecoveredMainScreenState() *MainScreenState {
 // Layout: WriteTop(8) ContentEnd(8) CursorGlobalIdx(8) CursorCol(4)
 //
 //	PromptStartLine(8) SavedAt(8) CWDLen(2) CWD(variable) WriteBottomHWM(8)
+//	InputStartLine(8) CommandStartLine(8)
 //
-// WriteBottomHWM is appended as a trailing field so older entries (which
-// end after CWD) decode to WriteBottomHWM=0 and the restore path falls
-// back to derive-from-writeTop behavior.
+// WriteBottomHWM, InputStartLine, and CommandStartLine are appended as
+// trailing fields. Older entries missing any of them decode to the field's
+// "unknown" sentinel (0 for HWM, -1 for the two anchors).
 func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 	cwdBytes := []byte(state.WorkingDir)
-	totalSize := 8 + 8 + 8 + 4 + 8 + 8 + 2 + len(cwdBytes) + 8
+	totalSize := 8 + 8 + 8 + 4 + 8 + 8 + 2 + len(cwdBytes) + 8 + 8 + 8
 	buf := make([]byte, totalSize)
 	binary.LittleEndian.PutUint64(buf[0:8], uint64(state.WriteTop))
 	binary.LittleEndian.PutUint64(buf[8:16], uint64(state.ContentEnd))
@@ -545,7 +546,10 @@ func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 	binary.LittleEndian.PutUint64(buf[36:44], uint64(state.SavedAt.UnixNano()))
 	binary.LittleEndian.PutUint16(buf[44:46], uint16(len(cwdBytes)))
 	copy(buf[46:46+len(cwdBytes)], cwdBytes)
-	binary.LittleEndian.PutUint64(buf[46+len(cwdBytes):46+len(cwdBytes)+8], uint64(state.WriteBottomHWM))
+	off := 46 + len(cwdBytes)
+	binary.LittleEndian.PutUint64(buf[off:off+8], uint64(state.WriteBottomHWM))
+	binary.LittleEndian.PutUint64(buf[off+8:off+16], uint64(state.InputStartLine))
+	binary.LittleEndian.PutUint64(buf[off+16:off+24], uint64(state.CommandStartLine))
 	return buf, nil
 }
 
@@ -553,27 +557,36 @@ func encodeMainScreenState(state *MainScreenState) ([]byte, error) {
 // state is validated before returning so malformed WAL data is rejected at the
 // replay boundary rather than propagated into recovery metadata.
 //
-// WriteBottomHWM is read from the trailing 8 bytes if present; older
-// entries without those bytes decode to WriteBottomHWM=0.
+// Optional trailing fields are read when present; missing fields decode to
+// their "unknown" sentinels: WriteBottomHWM=0, InputStartLine=-1,
+// CommandStartLine=-1.
 func decodeMainScreenState(data []byte) (*MainScreenState, error) {
 	if len(data) < 46 {
 		return nil, fmt.Errorf("MainScreenState data too short: %d bytes", len(data))
 	}
 	state := &MainScreenState{
-		WriteTop:        int64(binary.LittleEndian.Uint64(data[0:8])),
-		ContentEnd:      int64(binary.LittleEndian.Uint64(data[8:16])),
-		CursorGlobalIdx: int64(binary.LittleEndian.Uint64(data[16:24])),
-		CursorCol:       int(binary.LittleEndian.Uint32(data[24:28])),
-		PromptStartLine: int64(binary.LittleEndian.Uint64(data[28:36])),
-		SavedAt:         time.Unix(0, int64(binary.LittleEndian.Uint64(data[36:44]))),
+		WriteTop:         int64(binary.LittleEndian.Uint64(data[0:8])),
+		ContentEnd:       int64(binary.LittleEndian.Uint64(data[8:16])),
+		CursorGlobalIdx:  int64(binary.LittleEndian.Uint64(data[16:24])),
+		CursorCol:        int(binary.LittleEndian.Uint32(data[24:28])),
+		PromptStartLine:  int64(binary.LittleEndian.Uint64(data[28:36])),
+		SavedAt:          time.Unix(0, int64(binary.LittleEndian.Uint64(data[36:44]))),
+		InputStartLine:   -1,
+		CommandStartLine: -1,
 	}
 	cwdLen := int(binary.LittleEndian.Uint16(data[44:46]))
 	if len(data) >= 46+cwdLen {
 		state.WorkingDir = string(data[46 : 46+cwdLen])
 	}
-	// Optional trailing WriteBottomHWM (8 bytes). Missing for older entries.
-	if len(data) >= 46+cwdLen+8 {
-		state.WriteBottomHWM = int64(binary.LittleEndian.Uint64(data[46+cwdLen : 46+cwdLen+8]))
+	off := 46 + cwdLen
+	if len(data) >= off+8 {
+		state.WriteBottomHWM = int64(binary.LittleEndian.Uint64(data[off : off+8]))
+	}
+	if len(data) >= off+16 {
+		state.InputStartLine = int64(binary.LittleEndian.Uint64(data[off+8 : off+16]))
+	}
+	if len(data) >= off+24 {
+		state.CommandStartLine = int64(binary.LittleEndian.Uint64(data[off+16 : off+24]))
 	}
 	if err := state.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid MainScreenState: %w", err)


### PR DESCRIPTION
## Summary

- Persist OSC 133 `InputStartLine` / `CommandStartLine` in `MainScreenState` alongside `PromptStartLine` so a mid-TUI-session server restart preserves the correct ED 2 rewind anchor.
- WAL binary framing gets two trailing `int64` fields after `WriteBottomHWM`; older payloads decode with the new fields defaulting to `-1`.
- Restore applies the anchors with the same stale-discard guard used for `PromptStartLine`. The rule tightens from `>=` to `>` so an anchor exactly at the write edge (common: last write ended with `\r\n`, anchor points at the next-to-be-written line) survives reload instead of being dropped.

Closes #186. Unblocks #188 (history recovery can now collapse to using the restored anchors directly).

## Test plan

- [x] `go test ./apps/texelterm/... -count=1` all green
- [x] New targeted tests:
  - `TestEncodeDecodeMainScreenState_AnchorsRoundtrip` — round-trip of all three anchors
  - `TestDecodeMainScreenState_BackwardCompat_NoTrailingAnchors` — synthetic pre-#186 payload decodes trailers to `-1`
  - `TestEnableMemoryBuffer_RestoresOSC133Anchors` — end-to-end VTerm save/reload restores all three
  - `TestEnableMemoryBuffer_DiscardsStaleAnchors` — anchors past persisted content dropped
  - `TestED2_RewindAfterRestart_UsesRestoredCommandStart` — full chain: save anchors → close → reopen → overflow viewport → ESC[2J → verify `writeTop` rewinds to the *restored* CommandStart (the exact mid-session-restart scenario from #186)
  - 4 new `TestMainScreenState_Validate` cases for the `-1`/`-2` boundaries on the new fields