### PR TITLE
Blank live viewport on restore when a command was running

### DIFF
--- a/apps/texelterm/parser/osc133_anchor_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_persistence_test.go
@@ -212,6 +212,154 @@ func TestED2_RewindAfterRestart_UsesRestoredCommandStart(t *testing.T) {
 	}
 }
 
+// TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand guards
+// the "stale frame bleed-through" bug: when a TUI like Claude is running
+// at server shutdown (OSC 133;C fired, no 133;D yet), the sparse store
+// holds the last-drawn frame cells at the restored live range
+// [writeTop, max(writeTop+height-1, HWM)]. On reload, the respawned
+// shell only writes the cells it actually draws (prompt, a new command
+// line), so every untouched cell — blank rows, trailing columns past
+// the command — would show the old TUI frame. The restore path must
+// blank this range so the new session starts on a clean canvas.
+// Scrollback above writeTop must NOT be cleared.
+func TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand(t *testing.T) {
+	dir := t.TempDir()
+	id := "restore-blank-viewport-midcmd"
+	const cols, rows = 40, 10
+
+	// --- Session 1: shell session with a running TUI command. ---
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	// Scrollback we want preserved.
+	parseString(p1, "scrollback line A\r\n")
+	parseString(p1, "scrollback line B\r\n")
+	scrollbackEnd := v1.mainScreen.WriteTop() + int64(v1.cursorY) - 1
+
+	// Bash prompt + input + command-start (simulates `claude` launching).
+	v1.MarkPromptStart()
+	parseString(p1, "prompt> ")
+	v1.MarkInputStart()
+	parseString(p1, "claude\r\n")
+	v1.MarkCommandStart()
+	if v1.CommandStartGlobalLine < 0 {
+		t.Fatalf("setup: MarkCommandStart did not set CommandStartGlobalLine")
+	}
+
+	// Fill the remaining viewport rows with "TUI" content that must NOT
+	// survive restore — these are cells Claude drew in its last frame.
+	for i := 0; i < rows; i++ {
+		parseString(p1, fmt.Sprintf("tui-frame-row-%02d padded %s\r\n", i, "zzzzzzz"))
+	}
+	writeTopBefore := v1.mainScreen.WriteTop()
+	hwmBefore := v1.mainScreen.WriteBottomHWM()
+	if hwmBefore < writeTopBefore+int64(rows)-1 {
+		t.Fatalf("setup: HWM %d did not reach end of viewport (writeTop=%d, rows=%d)",
+			hwmBefore, writeTopBefore, rows)
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// --- Session 2: reload. ---
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	writeTopAfter := v2.mainScreen.WriteTop()
+	if writeTopAfter != writeTopBefore {
+		t.Fatalf("writeTop not restored: got %d, want %d", writeTopAfter, writeTopBefore)
+	}
+
+	// Live range [writeTop, HWM] must be fully blank so the new session
+	// doesn't see stale TUI content bleeding through.
+	for gi := writeTopAfter; gi <= hwmBefore; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells != nil && lineHasSparseContent(cells) {
+			t.Errorf("live-range line %d still has content after restore: %q",
+				gi, cellsPreview(cells))
+		}
+	}
+
+	// Scrollback above writeTop must be preserved.
+	for gi := int64(0); gi <= scrollbackEnd; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells == nil || !lineHasSparseContent(cells) {
+			t.Errorf("scrollback line %d was wrongly cleared", gi)
+		}
+	}
+}
+
+// TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell is the
+// counterpart: when no command is running at shutdown (CommandStart
+// < 0), the viewport holds legitimate plain-text output the user wants
+// to see on reload. The restore path must NOT blank it.
+func TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell(t *testing.T) {
+	dir := t.TempDir()
+	id := "restore-preserve-viewport-idle"
+	const cols, rows = 40, 10
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	// Plain output — no OSC 133;C. Think `ls` output followed by a
+	// returned shell prompt.
+	const contentLines = 8
+	for i := 0; i < contentLines; i++ {
+		parseString(p1, fmt.Sprintf("output-line-%02d\r\n", i))
+	}
+
+	// Snapshot the populated lines as session 1 saw them so session 2
+	// can be compared cell-for-cell.
+	writeTopBefore := v1.mainScreen.WriteTop()
+	before := make([][]Cell, contentLines)
+	for i := 0; i < contentLines; i++ {
+		before[i] = v1.mainScreen.ReadLine(writeTopBefore + int64(i))
+		if before[i] == nil || !lineHasSparseContent(before[i]) {
+			t.Fatalf("setup: line %d has no content in session 1", i)
+		}
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.CommandStartGlobalLine >= 0 {
+		t.Fatalf("setup invariant: CommandStartGlobalLine should be -1, got %d",
+			v2.CommandStartGlobalLine)
+	}
+
+	for i := 0; i < contentLines; i++ {
+		got := v2.mainScreen.ReadLine(writeTopBefore + int64(i))
+		if got == nil || !lineHasSparseContent(got) {
+			t.Errorf("idle-shell line %d (globalIdx %d) was wrongly cleared on restore",
+				i, writeTopBefore+int64(i))
+		}
+	}
+}
+
+// cellsPreview turns a cell slice into a short printable string for
+// failure messages. Intentionally tiny — we just need to see which TUI
+// content bled through when a test fails.
+func cellsPreview(cells []Cell) string {
+	const max = 20
+	out := make([]rune, 0, max)
+	for i, c := range cells {
+		if i >= max {
+			break
+		}
+		if c.Rune == 0 {
+			out = append(out, ' ')
+		} else {
+			out = append(out, c.Rune)
+		}
+	}
+	return string(out)
+}
+
 // TestEnableMemoryBuffer_DiscardsStaleAnchors verifies that the restore path
 // discards InputStart / CommandStart anchors pointing past the last
 // persisted line, matching the existing PromptStartLine behavior. This

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -60,7 +60,9 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// than propagating it into a new session.
 	recoveredMeta := wal.RecoveredMainScreenState()
 	pageStoreLineCount := pageStore.LineCount()
+	restored := false
 	if recoveredMeta != nil && recoveredMeta.WriteTop <= pageStoreLineCount && recoveredMeta.CursorGlobalIdx <= pageStoreLineCount+int64(v.height) {
+		restored = true
 		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol, recoveredMeta.WriteBottomHWM)
 		// Discard a stale PromptStartLine that points past the last persisted
 		// line. The prompt position is only meaningful if the referenced line
@@ -112,6 +114,27 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// Load historical lines from PageStore into sparse store.
 	if err := v.mainScreen.LoadFromPageStore(pageStore); err != nil {
 		log.Printf("[MAIN_SCREEN] LoadFromPageStore failed: %v", err)
+	}
+
+	// If a foreground command was running at shutdown (OSC 133;C fired,
+	// no 133;D yet), the live range [writeTop, max(writeTop+height-1,
+	// HWM)] holds that command's in-flight frame. After a server restart
+	// the command (Claude, htop, vim, ...) is gone; the respawned shell
+	// only writes cells for its new prompt, so everything the shell
+	// doesn't overwrite would show the stale frame bleeding through.
+	// Blank the live range so the new session starts on a clean canvas.
+	// Scrollback above writeTop is preserved.
+	//
+	// Idle / between-commands sessions (CommandStart < 0) keep viewport
+	// content intact — that path is a plain-text scrollback of the prior
+	// session's output that users legitimately want to see on reload.
+	if restored && v.CommandStartGlobalLine >= 0 {
+		writeTop := v.mainScreen.WriteTop()
+		hi := writeTop + int64(v.height) - 1
+		if hwm := v.mainScreen.WriteBottomHWM(); hwm > hi {
+			hi = hwm
+		}
+		v.mainScreen.ClearRange(writeTop, hi)
 	}
 
 	// Create persistence adapter.


### PR DESCRIPTION
## Summary

Follow-up to #189. After anchors are correctly restored, a mid-TUI server restart still showed the prior session's Claude/htop/vim frame bleeding through every cell the respawned shell didn't overwrite (blank rows, trailing columns past the new command line). The sparse store holds those cells at \`[writeTop, HWM]\` and the new shell only writes a tiny fraction of that range.

Fix: on reload, if \`CommandStartGlobalLine >= 0\` (OSC 133;C fired, no 133;D — a command was in flight at shutdown), blank \`[writeTop, max(writeTop+height-1, HWM)]\` so the new session starts on a clean canvas. Scrollback above \`writeTop\` is untouched.

The gate matters: idle-shell reloads (plain \`ls\`-style scrollback, no 133;C) must still preserve viewport content — the existing \`TestVTermCoherence_*\` / \`TestBurstWriteRecovery_*\` tests cover that contract and stay green.

## Test plan

- [x] \`go test ./apps/texelterm/... -count=1\` all green
- [x] New tests:
  - \`TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand\` — session 1 runs a fake TUI after 133;C; session 2 asserts \`[writeTop, HWM]\` is fully blank and scrollback above is intact
  - \`TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell\` — no 133;C; asserts all populated lines survive verbatim (guards against regressing the idle-shell contract)
- [ ] Manual: restart \`texelation\` mid-Claude-session, confirm no stale frame bleed-through on the newly spawned prompt