### PR TITLE
ED-clear tombstones: persist deletes across server restart

### DIFF
--- a/apps/texelterm/parser/adaptive_persistence.go
+++ b/apps/texelterm/parser/adaptive_persistence.go
@@ -557,6 +557,16 @@ func (ap *AdaptivePersistence) NotifyClearRange(lo, hi int64) {
 	}
 }
 
+// PendingOpCount returns the number of queued persistence operations that have
+// not yet been flushed. Test-only introspection helper; not safe to rely on in
+// production code because the count can change immediately after the call
+// returns.
+func (ap *AdaptivePersistence) PendingOpCount() int {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	return len(ap.pendingOps)
+}
+
 // Flush forces immediate flush of all pending writes.
 func (ap *AdaptivePersistence) Flush() error {
 	ap.mu.Lock()

--- a/apps/texelterm/parser/adaptive_persistence.go
+++ b/apps/texelterm/parser/adaptive_persistence.go
@@ -501,6 +501,60 @@ func (ap *AdaptivePersistence) handleWriteLockedWithMeta(lineIdx int64, ts time.
 	}
 }
 
+// NotifyClearRange records a tombstone for the closed range [lo, hi]. Any
+// queued writes for line indices in that range are marked dropped and removed
+// from pendingSet so they are not flushed to disk. An opDelete op is then
+// appended to the FIFO ops queue.
+//
+// Flush semantics match the current mode:
+//   - WriteThrough: flush immediately (same as NotifyWrite in WriteThrough).
+//   - Debounced:    arm the debounce timer; ordering preserved by FIFO queue.
+//   - BestEffort:   queue only; flush on idle or explicit Flush / Close.
+//
+// A lo > hi or negative value is a no-op.
+func (ap *AdaptivePersistence) NotifyClearRange(lo, hi int64) {
+	if lo < 0 || hi < lo {
+		return
+	}
+
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	if ap.stopped {
+		return
+	}
+
+	// Sweep pendingSet: drop any queued write op whose lineIdx falls in [lo, hi].
+	for gi, opIdx := range ap.pendingSet {
+		if gi >= lo && gi <= hi {
+			ap.pendingOps[opIdx].dropped = true
+			delete(ap.pendingSet, gi)
+		}
+	}
+
+	// Append the delete op in FIFO order.
+	ap.pendingOps = append(ap.pendingOps, pendingOp{
+		kind: opDelete,
+		lo:   lo,
+		hi:   hi,
+		ts:   ap.nowFunc(),
+	})
+
+	// Flush or schedule based on current mode.
+	switch ap.currentMode {
+	case PersistWriteThrough:
+		ap.flushPendingLocked()
+
+	case PersistDebounced:
+		// Use minimum delay for a single delete — responsiveness matters more
+		// than batching here since deletes are rare ops.
+		ap.scheduleFlushLocked(ap.config.DebounceMinDelay)
+
+	case PersistBestEffort:
+		// Leave in pending; idle monitor or explicit Flush will drain it.
+	}
+}
+
 // Flush forces immediate flush of all pending writes.
 func (ap *AdaptivePersistence) Flush() error {
 	ap.mu.Lock()
@@ -634,34 +688,45 @@ func (ap *AdaptivePersistence) flushPendingLocked() error {
 
 	// --- Collect phase (locked): clone lines and snapshot state ---
 	// Walk the FIFO ops list in enqueue order, skipping dropped entries.
-	type flushEntry struct {
-		lineIdx int64
+	// Both write and delete ops are collected in order to preserve FIFO
+	// semantics between writes and deletes.
+	type ioOp struct {
+		kind    opKind
+		lineIdx int64 // for writes
 		line    *LogicalLine
 		ts      time.Time
 		isCmd   bool
+		lo, hi  int64 // for deletes
 	}
-	entries := make([]flushEntry, 0, len(ap.pendingOps))
+	ioOps := make([]ioOp, 0, len(ap.pendingOps))
 
 	for _, op := range ap.pendingOps {
 		if op.dropped {
 			continue
 		}
-		if op.kind != opWrite {
-			// opDelete handled by Task 6; skip for now.
-			continue
-		}
-		line := ap.memBuf.GetLine(op.lo)
-		if line == nil {
+		switch op.kind {
+		case opWrite:
+			line := ap.memBuf.GetLine(op.lo)
+			if line == nil {
+				ap.memBuf.ClearDirty(op.lo)
+				continue
+			}
+			ioOps = append(ioOps, ioOp{
+				kind:    opWrite,
+				lineIdx: op.lo,
+				line:    line.Clone(),
+				ts:      op.ts,
+				isCmd:   op.isCmd,
+			})
 			ap.memBuf.ClearDirty(op.lo)
-			continue
+		case opDelete:
+			ioOps = append(ioOps, ioOp{
+				kind: opDelete,
+				lo:   op.lo,
+				hi:   op.hi,
+				ts:   op.ts,
+			})
 		}
-		entries = append(entries, flushEntry{
-			lineIdx: op.lo,
-			line:    line.Clone(),
-			ts:      op.ts,
-			isCmd:   op.isCmd,
-		})
-		ap.memBuf.ClearDirty(op.lo)
 	}
 
 	pendingMeta := ap.pendingMetadata
@@ -681,23 +746,38 @@ func (ap *AdaptivePersistence) flushPendingLocked() error {
 	}()
 
 	var firstErr error
-	for _, e := range entries {
-		var err error
-		if ap.wal != nil {
-			err = ap.wal.Append(e.lineIdx, e.line, ap.nowFunc())
-		} else {
-			err = ap.diskWriteOrUpdate(e.lineIdx, e.line, ap.nowFunc())
-		}
-		if err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("failed to write line %d: %w", e.lineIdx, err)
+	for _, op := range ioOps {
+		switch op.kind {
+		case opWrite:
+			var err error
+			if ap.wal != nil {
+				err = ap.wal.Append(op.lineIdx, op.line, ap.nowFunc())
+			} else {
+				err = ap.diskWriteOrUpdate(op.lineIdx, op.line, ap.nowFunc())
 			}
-			ap.metrics.FailedWrites++
-			continue
-		}
-		ap.metrics.LinesWritten++
-		if ap.OnLineIndexed != nil {
-			ap.OnLineIndexed(e.lineIdx, e.line, e.ts, e.isCmd)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("failed to write line %d: %w", op.lineIdx, err)
+				}
+				ap.metrics.FailedWrites++
+				continue
+			}
+			ap.metrics.LinesWritten++
+			if ap.OnLineIndexed != nil {
+				ap.OnLineIndexed(op.lineIdx, op.line, op.ts, op.isCmd)
+			}
+		case opDelete:
+			if ap.wal != nil {
+				if err := ap.wal.DeleteRange(op.lo, op.hi); err != nil {
+					if firstErr == nil {
+						firstErr = fmt.Errorf("failed to delete range [%d, %d]: %w", op.lo, op.hi, err)
+					}
+				}
+			}
+			// No disk-only path for deletes: the WAL is always required for
+			// range tombstones. If ap.wal == nil (legacy no-WAL mode), the
+			// delete is silently ignored — the no-WAL path does not support
+			// crash-safe tombstones.
 		}
 	}
 

--- a/apps/texelterm/parser/adaptive_persistence.go
+++ b/apps/texelterm/parser/adaptive_persistence.go
@@ -546,8 +546,10 @@ func (ap *AdaptivePersistence) NotifyClearRange(lo, hi int64) {
 		ap.flushPendingLocked()
 
 	case PersistDebounced:
-		// Use minimum delay for a single delete — responsiveness matters more
-		// than batching here since deletes are rare ops.
+		// Deletes are rare, high-priority tombstone ops where responsiveness
+		// matters more than batching. Hardcoding DebounceMinDelay ensures
+		// prompt propagation to disk even during high-write-rate bursts that
+		// would otherwise push the adaptive delay toward DebounceMaxDelay.
 		ap.scheduleFlushLocked(ap.config.DebounceMinDelay)
 
 	case PersistBestEffort:

--- a/apps/texelterm/parser/adaptive_persistence.go
+++ b/apps/texelterm/parser/adaptive_persistence.go
@@ -32,7 +32,6 @@ package parser
 
 import (
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -99,13 +98,27 @@ type LineStore interface {
 	SetPreEvictCallback(func([]EvictedLine))
 }
 
-// AdaptivePersistence manages disk writes with dynamic rate adjustment.
-// pendingLineInfo stores metadata for a line awaiting flush.
-type pendingLineInfo struct {
-	timestamp time.Time
-	isCommand bool
+// opKind identifies the kind of pending persistence operation.
+type opKind uint8
+
+const (
+	opWrite  opKind = 1
+	opDelete opKind = 2
+)
+
+// pendingOp is one entry in the FIFO ops list maintained by AdaptivePersistence.
+// For writes: lo == hi == lineIdx.
+// For deletes (added by Task 6): lo..hi is the deleted range.
+// dropped is set when a later write for the same lineIdx supersedes this op.
+type pendingOp struct {
+	kind    opKind
+	lo, hi  int64
+	ts      time.Time
+	isCmd   bool // writes only
+	dropped bool // superseded by a later write or swallowed by a delete
 }
 
+// AdaptivePersistence manages disk writes with dynamic rate adjustment.
 type AdaptivePersistence struct {
 	config  AdaptivePersistenceConfig
 	memBuf  LineStore
@@ -119,8 +132,9 @@ type AdaptivePersistence struct {
 
 	// State
 	currentMode     PersistMode
-	pendingLines    map[int64]*pendingLineInfo // Lines awaiting flush with metadata
-	pendingMetadata *MainScreenState           // Metadata awaiting flush (written with content)
+	pendingOps      []pendingOp      // FIFO list of pending operations
+	pendingSet      map[int64]int    // lineIdx -> index in pendingOps for most recent write op
+	pendingMetadata *MainScreenState // Metadata awaiting flush (written with content)
 	lastActivity    time.Time
 
 	// Callback for search indexing - called AFTER line is persisted to WAL
@@ -251,18 +265,19 @@ func newAdaptivePersistenceWithNow(
 	rm.CalculateRate(nowFunc())
 
 	ap := &AdaptivePersistence{
-		config:       config,
-		memBuf:       memBuf,
-		disk:         disk,
-		wal:          wal,
-		nowFunc:      nowFunc,
-		rateMonitor:  rm,
-		modeCtrl:     NewModeController(config.WriteThroughMaxRate, config.DebouncedMaxRate),
-		currentMode:  PersistWriteThrough,
-		pendingLines: make(map[int64]*pendingLineInfo),
+		config:      config,
+		memBuf:      memBuf,
+		disk:        disk,
+		wal:         wal,
+		nowFunc:     nowFunc,
+		rateMonitor: rm,
+		modeCtrl:    NewModeController(config.WriteThroughMaxRate, config.DebouncedMaxRate),
+		currentMode: PersistWriteThrough,
+		pendingOps:  nil,
+		pendingSet:  make(map[int64]int),
 		lastActivity: nowFunc(),
-		stopCh:       make(chan struct{}),
-		stopped:      false,
+		stopCh:      make(chan struct{}),
+		stopped:     false,
 		metrics: PersistenceMetrics{
 			CurrentMode: PersistWriteThrough,
 		},
@@ -270,7 +285,7 @@ func newAdaptivePersistenceWithNow(
 
 	// Install pre-evict callback so memBuf flushes dirty lines before
 	// they leave the ring buffer. Without this, dirty lines that piled
-	// up in pendingLines (e.g. during a BestEffort burst) get silently
+	// up in pendingOps (e.g. during a BestEffort burst) get silently
 	// dropped when memBuf evicts to make room — flushPendingLocked
 	// later sees mb.GetLine(idx) == nil and skips them, producing huge
 	// gaps in pageStore.
@@ -289,8 +304,8 @@ func newAdaptivePersistenceWithNow(
 //
 // We must NOT acquire ap.mu here because the persistence flush path
 // may already hold it indirectly via NotifyWrite → memBuf.Write paths.
-// Instead we write directly to the WAL/disk and clear pendingLines
-// entries via a brief lock acquisition at the end.
+// Instead we write directly to the WAL/disk and mark pendingOps entries
+// dropped via a brief lock acquisition at the end.
 func (ap *AdaptivePersistence) flushEvictedLines(lines []EvictedLine) {
 	if len(lines) == 0 {
 		return
@@ -308,12 +323,14 @@ func (ap *AdaptivePersistence) flushEvictedLines(lines []EvictedLine) {
 		}
 		ap.metrics.LinesWritten++
 	}
-	// Clear pendingLines entries for the evicted lines so a later
-	// flush doesn't try to fetch them from memBuf (where they no
-	// longer exist).
+	// Mark any pending write ops for evicted lines as dropped so a later
+	// flush doesn't try to fetch them from memBuf (where they no longer exist).
 	ap.mu.Lock()
 	for _, e := range lines {
-		delete(ap.pendingLines, e.GlobalIdx)
+		if idx, ok := ap.pendingSet[e.GlobalIdx]; ok {
+			ap.pendingOps[idx].dropped = true
+			delete(ap.pendingSet, e.GlobalIdx)
+		}
 	}
 	ap.mu.Unlock()
 }
@@ -346,14 +363,8 @@ func (ap *AdaptivePersistence) NotifyWriteWithMeta(lineIdx int64, timestamp time
 		timestamp = ap.lastActivity
 	}
 
-	// Store metadata for this line
-	info := &pendingLineInfo{
-		timestamp: timestamp,
-		isCommand: isCommand,
-	}
-
 	// Handle based on mode
-	ap.handleWriteLockedWithMeta(lineIdx, info, writeRate)
+	ap.handleWriteLockedWithMeta(lineIdx, timestamp, isCommand, writeRate)
 }
 
 // NotifyWriteBatch records multiple line writes efficiently.
@@ -377,11 +388,7 @@ func (ap *AdaptivePersistence) NotifyWriteBatch(lineIndices []int64) {
 
 	// Handle based on mode - batch lines share timestamp
 	for _, idx := range lineIndices {
-		info := &pendingLineInfo{
-			timestamp: timestamp,
-			isCommand: false,
-		}
-		ap.handleWriteLockedWithMeta(idx, info, writeRate)
+		ap.handleWriteLockedWithMeta(idx, timestamp, false, writeRate)
 	}
 }
 
@@ -434,7 +441,7 @@ func (ap *AdaptivePersistence) updateRateAndModeLocked() float64 {
 		// Log mode transitions, especially to BestEffort (high activity)
 		if newMode == PersistBestEffort {
 			debuglog.Printf("[AdaptivePersistence] Mode transition: %s -> %s (rate=%.1f/s, pending=%d) - high activity detected",
-				oldMode, newMode, writeRate, len(ap.pendingLines))
+				oldMode, newMode, writeRate, len(ap.pendingSet))
 		} else if oldMode == PersistBestEffort {
 			debuglog.Printf("[AdaptivePersistence] Mode transition: %s -> %s (rate=%.1f/s) - activity normalized",
 				oldMode, newMode, writeRate)
@@ -444,24 +451,37 @@ func (ap *AdaptivePersistence) updateRateAndModeLocked() float64 {
 	// Warn if write rate is unusually high
 	if writeRate > highWriteRateThreshold && ap.metrics.TotalWrites%100 == 0 {
 		debuglog.Printf("[AdaptivePersistence] High write rate: %.1f/s (mode=%s, pending=%d)",
-			writeRate, ap.currentMode, len(ap.pendingLines))
+			writeRate, ap.currentMode, len(ap.pendingSet))
 	}
 
 	return writeRate
 }
 
-// handleWriteLocked processes line writes based on current mode.
+// handleWriteLockedWithMeta processes line writes based on current mode.
 // Must be called with ap.mu held.
-func (ap *AdaptivePersistence) handleWriteLockedWithMeta(lineIdx int64, info *pendingLineInfo, writeRate float64) {
+func (ap *AdaptivePersistence) handleWriteLockedWithMeta(lineIdx int64, ts time.Time, isCmd bool, writeRate float64) {
+	// Supersede any earlier pending write for this line: mark it dropped so
+	// the FIFO flush skips it. The new op takes the tail position (call order).
+	if prev, ok := ap.pendingSet[lineIdx]; ok {
+		ap.pendingOps[prev].dropped = true
+	}
+	newIdx := len(ap.pendingOps)
+	ap.pendingOps = append(ap.pendingOps, pendingOp{
+		kind:  opWrite,
+		lo:    lineIdx,
+		hi:    lineIdx,
+		ts:    ts,
+		isCmd: isCmd,
+	})
+	ap.pendingSet[lineIdx] = newIdx
+
 	switch ap.currentMode {
 	case PersistWriteThrough:
-		// Immediate write - store info temporarily for the callback
-		ap.pendingLines[lineIdx] = info
+		// Immediate write: flush the single op we just enqueued.
 		ap.flushLineLocked(lineIdx)
 
 	case PersistDebounced:
-		// Add to pending and schedule debounced flush with adaptive delay
-		ap.pendingLines[lineIdx] = info
+		// Schedule debounced flush with adaptive delay.
 		delay := ap.modeCtrl.CalculateDebounceDelay(
 			writeRate,
 			ap.config.DebounceMinDelay,
@@ -470,14 +490,13 @@ func (ap *AdaptivePersistence) handleWriteLockedWithMeta(lineIdx int64, info *pe
 		ap.scheduleFlushLocked(delay)
 
 	case PersistBestEffort:
-		// Just add to pending; idle monitor will flush
-		ap.pendingLines[lineIdx] = info
+		// Just leave in pending; idle monitor will flush.
 	}
 
-	// Warn if pending line count is getting high
-	pendingCount := len(ap.pendingLines)
+	// Warn if pending op count is getting high.
+	pendingCount := len(ap.pendingOps)
 	if pendingCount > pendingLineWarningThreshold && pendingCount%100 == 0 {
-		debuglog.Printf("[AdaptivePersistence] Warning: %d lines pending flush (mode=%s, rate=%.1f/s)",
+		debuglog.Printf("[AdaptivePersistence] Warning: %d ops pending flush (mode=%s, rate=%.1f/s)",
 			pendingCount, ap.currentMode, writeRate)
 	}
 }
@@ -558,11 +577,11 @@ func (ap *AdaptivePersistence) Metrics() PersistenceMetrics {
 	return ap.metrics
 }
 
-// PendingCount returns the number of lines awaiting flush.
+// PendingCount returns the number of unique lines awaiting flush.
 func (ap *AdaptivePersistence) PendingCount() int {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
-	return len(ap.pendingLines)
+	return len(ap.pendingSet)
 }
 
 // String returns debug information.
@@ -571,7 +590,7 @@ func (ap *AdaptivePersistence) String() string {
 	defer ap.mu.Unlock()
 
 	return fmt.Sprintf("AdaptivePersistence{mode=%s, rate=%.2f/s, pending=%d, writes=%d, flushes=%d}",
-		ap.currentMode, ap.metrics.CurrentWriteRate, len(ap.pendingLines),
+		ap.currentMode, ap.metrics.CurrentWriteRate, len(ap.pendingSet),
 		ap.metrics.TotalWrites, ap.metrics.TotalFlushes)
 }
 
@@ -604,46 +623,51 @@ func (ap *AdaptivePersistence) cancelFlushTimerLocked() {
 // It releases ap.mu during I/O to avoid blocking NotifyWrite on the parse
 // thread. Must be called with ap.mu held; ap.mu is re-held on return.
 func (ap *AdaptivePersistence) flushPendingLocked() error {
-	if len(ap.pendingLines) == 0 && ap.pendingMetadata == nil {
+	if len(ap.pendingOps) == 0 && ap.pendingMetadata == nil {
 		return nil
 	}
 
-	lineCount := len(ap.pendingLines)
+	lineCount := len(ap.pendingOps)
 	startTime := ap.nowFunc()
 
 	ap.metrics.TotalFlushes++
 
 	// --- Collect phase (locked): clone lines and snapshot state ---
+	// Walk the FIFO ops list in enqueue order, skipping dropped entries.
 	type flushEntry struct {
 		lineIdx int64
 		line    *LogicalLine
-		info    *pendingLineInfo
+		ts      time.Time
+		isCmd   bool
 	}
-	entries := make([]flushEntry, 0, len(ap.pendingLines))
-	indices := make([]int64, 0, len(ap.pendingLines))
-	for idx := range ap.pendingLines {
-		indices = append(indices, idx)
-	}
-	slices.Sort(indices)
+	entries := make([]flushEntry, 0, len(ap.pendingOps))
 
-	for _, idx := range indices {
-		info := ap.pendingLines[idx]
-		line := ap.memBuf.GetLine(idx)
+	for _, op := range ap.pendingOps {
+		if op.dropped {
+			continue
+		}
+		if op.kind != opWrite {
+			// opDelete handled by Task 6; skip for now.
+			continue
+		}
+		line := ap.memBuf.GetLine(op.lo)
 		if line == nil {
-			ap.memBuf.ClearDirty(idx)
+			ap.memBuf.ClearDirty(op.lo)
 			continue
 		}
 		entries = append(entries, flushEntry{
-			lineIdx: idx,
+			lineIdx: op.lo,
 			line:    line.Clone(),
-			info:    info,
+			ts:      op.ts,
+			isCmd:   op.isCmd,
 		})
-		ap.memBuf.ClearDirty(idx)
+		ap.memBuf.ClearDirty(op.lo)
 	}
 
 	pendingMeta := ap.pendingMetadata
 	ap.pendingMetadata = nil
-	ap.pendingLines = make(map[int64]*pendingLineInfo)
+	ap.pendingOps = nil
+	ap.pendingSet = make(map[int64]int)
 
 	// --- I/O phase (unlocked): write to WAL without blocking the parser ---
 	// Hold flushIOMu to serialize with any other concurrent flush. Without
@@ -672,8 +696,8 @@ func (ap *AdaptivePersistence) flushPendingLocked() error {
 			continue
 		}
 		ap.metrics.LinesWritten++
-		if ap.OnLineIndexed != nil && e.info != nil {
-			ap.OnLineIndexed(e.lineIdx, e.line, e.info.timestamp, e.info.isCommand)
+		if ap.OnLineIndexed != nil {
+			ap.OnLineIndexed(e.lineIdx, e.line, e.ts, e.isCmd)
 		}
 	}
 
@@ -720,17 +744,28 @@ func (ap *AdaptivePersistence) flushPendingLocked() error {
 }
 
 // flushLineLocked writes a single line to disk (via WAL or direct PageStore).
-// After successful write, calls OnLineIndexed callback for search indexing.
+// This is the WriteThrough fast path: the op was just appended to pendingOps
+// at position pendingSet[lineIdx], so we read the op's metadata from there,
+// write to disk, then mark the op dropped and remove it from pendingSet.
 // Must be called with ap.mu held.
 func (ap *AdaptivePersistence) flushLineLocked(lineIdx int64) error {
-	// Get pending info (may be nil for legacy callers)
-	info := ap.pendingLines[lineIdx]
+	// Get the pending op for this line (set by handleWriteLockedWithMeta just before).
+	opIdx, ok := ap.pendingSet[lineIdx]
+	var ts time.Time
+	var isCmd bool
+	if ok {
+		op := &ap.pendingOps[opIdx]
+		ts = op.ts
+		isCmd = op.isCmd
+		// Mark as dropped so flushPendingLocked won't re-write it.
+		op.dropped = true
+		delete(ap.pendingSet, lineIdx)
+	}
 
 	line := ap.memBuf.GetLine(lineIdx)
 	if line == nil {
 		// Line was evicted from memory - clear dirty and skip
 		ap.memBuf.ClearDirty(lineIdx)
-		delete(ap.pendingLines, lineIdx)
 		return nil
 	}
 
@@ -754,13 +789,12 @@ func (ap *AdaptivePersistence) flushLineLocked(lineIdx int64) error {
 	}
 
 	ap.memBuf.ClearDirty(lineIdx)
-	delete(ap.pendingLines, lineIdx)
 	ap.metrics.LinesWritten++
 
 	// Call search index callback AFTER successful write
 	// This ensures search index only has entries for persisted content
-	if ap.OnLineIndexed != nil && info != nil {
-		ap.OnLineIndexed(lineIdx, lineCopy, info.timestamp, info.isCommand)
+	if ap.OnLineIndexed != nil && ok {
+		ap.OnLineIndexed(lineIdx, lineCopy, ts, isCmd)
 	}
 
 	return nil
@@ -821,7 +855,7 @@ func (ap *AdaptivePersistence) checkIdle() {
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
 
-	if ap.stopped || len(ap.pendingLines) == 0 {
+	if ap.stopped || len(ap.pendingOps) == 0 {
 		return
 	}
 

--- a/apps/texelterm/parser/adaptive_persistence_clearrange_test.go
+++ b/apps/texelterm/parser/adaptive_persistence_clearrange_test.go
@@ -1,0 +1,287 @@
+// Copyright 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: apps/texelterm/parser/adaptive_persistence_clearrange_test.go
+// Summary: Tests for AdaptivePersistence.NotifyClearRange.
+
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+// walOp represents an operation recorded in the WAL for assertion purposes.
+type walOp struct {
+	kind string // "W" for write, "D" for delete
+	lo   int64
+	hi   int64 // meaningful only for deletes
+}
+
+// walOps reads all WAL entries in file order and returns them as walOp values.
+// Writes carry lo==hi==GlobalLineIdx. Deletes carry lo==GlobalLineIdx (the
+// range start) and hi==DeleteHi (the range end, inclusive).
+func walOps(t testing.TB, wal *WriteAheadLog) []walOp {
+	t.Helper()
+	entries, err := wal.readWALEntries()
+	if err != nil {
+		t.Fatalf("readWALEntries: %v", err)
+	}
+	ops := make([]walOp, 0, len(entries))
+	for _, e := range entries {
+		switch e.Type {
+		case EntryTypeLineWrite, EntryTypeLineModify:
+			ops = append(ops, walOp{kind: "W", lo: int64(e.GlobalLineIdx), hi: int64(e.GlobalLineIdx)})
+		case EntryTypeLineDelete:
+			ops = append(ops, walOp{kind: "D", lo: int64(e.GlobalLineIdx), hi: e.DeleteHi})
+		// Skip CHECKPOINT / METADATA / MAIN_SCREEN_STATE entries.
+		}
+	}
+	return ops
+}
+
+// equalWalOps returns true if two slices have the same contents.
+func equalWalOps(a, b []walOp) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// newTestAdaptivePersistenceWriteThrough creates an AdaptivePersistence locked
+// into WriteThrough mode. Writes flush immediately to WAL so they are
+// already committed before a subsequent NotifyClearRange call.
+func newTestAdaptivePersistenceWriteThrough(t testing.TB) (*AdaptivePersistence, *WriteAheadLog) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	walConfig := DefaultWALConfig(tmpDir, "test-writethrough")
+	walConfig.CheckpointInterval = 0
+
+	wal, err := OpenWriteAheadLog(walConfig)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	mb := NewMemoryBuffer(MemoryBufferConfig{MaxLines: 100, EvictionBatch: 10})
+	for i := int64(0); i < 10; i++ {
+		mb.EnsureLine(i)
+		mb.GetLine(i).Cells = []Cell{{Rune: 'X'}}
+	}
+
+	config := DefaultAdaptivePersistenceConfig()
+	// Force WriteThrough mode: rate thresholds set high enough that the
+	// initial rate (0) stays below WriteThroughMaxRate.
+	config.WriteThroughMaxRate = 1000
+	config.DebouncedMaxRate = 2000
+	config.IdleThreshold = 1 * time.Hour
+
+	ap, err := newAdaptivePersistenceWithWAL(config, mb, wal, time.Now)
+	if err != nil {
+		t.Fatalf("newAdaptivePersistenceWithWAL: %v", err)
+	}
+	t.Cleanup(func() { ap.Close() })
+
+	// Explicitly set WriteThrough mode so the test is mode-stable.
+	ap.mu.Lock()
+	ap.currentMode = PersistWriteThrough
+	ap.mu.Unlock()
+
+	return ap, wal
+}
+
+// newTestAdaptivePersistenceDebounced creates an AdaptivePersistence locked
+// into Debounced mode with a very long debounce delay, so writes accumulate
+// in the pending queue and are only flushed on an explicit Flush() call.
+func newTestAdaptivePersistenceDebounced(t testing.TB) (*AdaptivePersistence, *WriteAheadLog) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	walConfig := DefaultWALConfig(tmpDir, "test-debounced")
+	walConfig.CheckpointInterval = 0
+
+	wal, err := OpenWriteAheadLog(walConfig)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	mb := NewMemoryBuffer(MemoryBufferConfig{MaxLines: 100, EvictionBatch: 10})
+	for i := int64(0); i < 10; i++ {
+		mb.EnsureLine(i)
+		mb.GetLine(i).Cells = []Cell{{Rune: 'X'}}
+	}
+
+	config := DefaultAdaptivePersistenceConfig()
+	// Force Debounced mode: WriteThroughMaxRate=0 so any positive rate enters
+	// Debounced, but DebouncedMaxRate is very high so it never reaches BestEffort.
+	config.WriteThroughMaxRate = 0
+	config.DebouncedMaxRate = 1e9
+	// Long delays so the debounce timer never fires during the test.
+	config.DebounceMinDelay = 1 * time.Hour
+	config.DebounceMaxDelay = 1 * time.Hour
+	config.IdleThreshold = 1 * time.Hour
+
+	ap, err := newAdaptivePersistenceWithWAL(config, mb, wal, time.Now)
+	if err != nil {
+		t.Fatalf("newAdaptivePersistenceWithWAL: %v", err)
+	}
+	t.Cleanup(func() { ap.Close() })
+
+	// Explicitly set Debounced mode so writes queue without flushing.
+	ap.mu.Lock()
+	ap.currentMode = PersistDebounced
+	ap.mu.Unlock()
+
+	return ap, wal
+}
+
+// TestAdaptivePersistence_NotifyClearRangeWriteThrough verifies that in
+// WriteThrough mode, writes before NotifyClearRange are already flushed to
+// WAL (immediate flush) and appear in order before the delete tombstone.
+// A write after the clear also appears in order.
+//
+// Call sequence: W5, W6, ClearRange(0,10), W6
+// Since WriteThrough flushes immediately, W5 and W6 hit WAL before the clear
+// sweeps pendingSet (which is already empty). Expected WAL: W5, W6, D0-10, W6.
+func TestAdaptivePersistence_NotifyClearRangeWriteThrough(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceWriteThrough(t)
+
+	ap.NotifyWrite(5)
+	ap.NotifyWrite(6)
+	ap.NotifyClearRange(0, 10)
+	ap.NotifyWrite(6) // new write post-clear should survive
+
+	// WriteThrough flushes each op immediately; no explicit Flush needed.
+	// But call Flush to ensure any pending ops (the last W6 and the delete)
+	// are committed before we read the WAL.
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "W", lo: 5, hi: 5},
+		{kind: "W", lo: 6, hi: 6},
+		{kind: "D", lo: 0, hi: 10},
+		{kind: "W", lo: 6, hi: 6},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangeSweepsQueuedWrite verifies that in
+// a queued mode (Debounced), a write inside the cleared range that has not yet
+// been flushed is marked dropped and does not appear in the WAL.
+//
+// Call sequence: W5, ClearRange(0,10), Flush()
+// W5 is queued but not yet flushed; ClearRange sweeps it. Expected WAL: D0-10.
+func TestAdaptivePersistence_NotifyClearRangeSweepsQueuedWrite(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceDebounced(t)
+
+	ap.NotifyWrite(5)
+	ap.NotifyClearRange(0, 10)
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "D", lo: 0, hi: 10},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangePostWriteSurvives verifies that a
+// write issued AFTER a NotifyClearRange is not swept and does appear in the WAL.
+//
+// Call sequence: W5, ClearRange(0,10), W5, Flush()
+// The first W5 is swept; the second W5 (post-clear) must survive.
+// Expected WAL: D0-10, W5.
+func TestAdaptivePersistence_NotifyClearRangePostWriteSurvives(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceDebounced(t)
+
+	ap.NotifyWrite(5)
+	ap.NotifyClearRange(0, 10)
+	ap.NotifyWrite(5) // new write for same line post-clear; must survive
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "D", lo: 0, hi: 10},
+		{kind: "W", lo: 5, hi: 5},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangeOutsideRangeUnaffected verifies that
+// writes outside [lo, hi] are not swept by NotifyClearRange.
+//
+// Call sequence: W3, W15, ClearRange(5,10), Flush()
+// W3 and W15 are outside [5,10] and must appear in the WAL.
+// Expected WAL: W3, W15, D5-10.
+func TestAdaptivePersistence_NotifyClearRangeOutsideRangeUnaffected(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceDebounced(t)
+
+	// Ensure lines 3 and 15 exist in memory buffer.
+	mb := ap.memBuf.(*MemoryBuffer)
+	mb.EnsureLine(15)
+	mb.GetLine(15).Cells = []Cell{{Rune: 'Y'}}
+
+	ap.NotifyWrite(3)
+	ap.NotifyWrite(15)
+	ap.NotifyClearRange(5, 10)
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "W", lo: 3, hi: 3},
+		{kind: "W", lo: 15, hi: 15},
+		{kind: "D", lo: 5, hi: 10},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangeBestEffortQueues verifies that in
+// BestEffort mode, NotifyClearRange does not flush immediately — the delete op
+// stays pending until an explicit Flush().
+func TestAdaptivePersistence_NotifyClearRangeBestEffortQueues(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceBestEffort(t)
+
+	ap.NotifyWrite(5)
+	ap.NotifyClearRange(0, 10)
+
+	// Before flush: WAL must be empty (nothing written yet).
+	beforeFlush := walOps(t, wal)
+	if len(beforeFlush) != 0 {
+		t.Errorf("before Flush: WAL ops = %v, want empty", beforeFlush)
+	}
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "D", lo: 0, hi: 10},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops after Flush = %v, want %v", got, want)
+	}
+}

--- a/apps/texelterm/parser/adaptive_persistence_clearrange_test.go
+++ b/apps/texelterm/parser/adaptive_persistence_clearrange_test.go
@@ -285,3 +285,102 @@ func TestAdaptivePersistence_NotifyClearRangeBestEffortQueues(t *testing.T) {
 		t.Errorf("WAL ops after Flush = %v, want %v", got, want)
 	}
 }
+
+// TestAdaptivePersistence_NotifyClearRangeSingleLine verifies that a single-line
+// range (lo == hi) deletes exactly that line and leaves adjacent lines intact.
+//
+// Call sequence: W4, W5, W6, ClearRange(5,5), Flush()
+// W4 and W6 are outside [5,5] and must survive in the WAL.
+// W5 is swept by the clear; only the Delete tombstone appears for line 5.
+// Expected WAL: W4, W6, D5-5.
+func TestAdaptivePersistence_NotifyClearRangeSingleLine(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceBestEffort(t)
+
+	ap.NotifyWrite(4)
+	ap.NotifyWrite(5)
+	ap.NotifyWrite(6)
+	ap.NotifyClearRange(5, 5)
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "W", lo: 4, hi: 4},
+		{kind: "W", lo: 6, hi: 6},
+		{kind: "D", lo: 5, hi: 5},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangeInvalidRangeIsNoop verifies that
+// NotifyClearRange is a no-op when given an invalid range (negative lo or hi < lo).
+// No delete op must appear in the WAL after Flush.
+func TestAdaptivePersistence_NotifyClearRangeInvalidRangeIsNoop(t *testing.T) {
+	cases := []struct {
+		name string
+		lo   int64
+		hi   int64
+	}{
+		{"negative lo", -1, 5},
+		{"hi less than lo", 10, 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ap, wal := newTestAdaptivePersistenceBestEffort(t)
+
+			// Seed a write so there is something to not-sweep.
+			ap.NotifyWrite(3)
+			ap.NotifyClearRange(tc.lo, tc.hi)
+
+			if err := ap.Flush(); err != nil {
+				t.Fatalf("Flush: %v", err)
+			}
+
+			got := walOps(t, wal)
+			// The write must appear; no Delete entry must be present.
+			for _, op := range got {
+				if op.kind == "D" {
+					t.Errorf("case %q: unexpected Delete op in WAL: %v (all ops: %v)", tc.name, op, got)
+				}
+			}
+			if len(got) != 1 || got[0].kind != "W" || got[0].lo != 3 {
+				t.Errorf("case %q: WAL ops = %v, want [W(3,3)]", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestAdaptivePersistence_NotifyClearRangeMultipleOverlapping verifies that two
+// overlapping clear ranges both produce Delete tombstones in FIFO order, and that
+// no write ops appear (all three writes are swept by one clear or the other).
+//
+// Call sequence: W5, W6, W7, ClearRange(5,6), ClearRange(6,7), Flush()
+// Both clears overlap on line 6. W5 is swept by first clear, W6 by first clear,
+// W7 by second clear. No writes survive. Expected WAL: D5-6, D6-7.
+func TestAdaptivePersistence_NotifyClearRangeMultipleOverlapping(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceBestEffort(t)
+
+	ap.NotifyWrite(5)
+	ap.NotifyWrite(6)
+	ap.NotifyWrite(7)
+	ap.NotifyClearRange(5, 6)
+	ap.NotifyClearRange(6, 7)
+
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	got := walOps(t, wal)
+	want := []walOp{
+		{kind: "D", lo: 5, hi: 6},
+		{kind: "D", lo: 6, hi: 7},
+	}
+	if !equalWalOps(got, want) {
+		t.Errorf("WAL ops = %v, want %v", got, want)
+	}
+}

--- a/apps/texelterm/parser/adaptive_persistence_test.go
+++ b/apps/texelterm/parser/adaptive_persistence_test.go
@@ -945,6 +945,97 @@ func BenchmarkRateMonitor_CalculateRate(b *testing.B) {
 	}
 }
 
+// --- FIFO flush-order test helpers ---
+
+// newTestAdaptivePersistenceWriteThrough creates an AdaptivePersistence backed
+// by a WAL in a temp directory, locked into BestEffort mode so writes
+// accumulate in the pending list and are only flushed when Flush() is called.
+// This lets tests control exactly when the flush happens and verify flush order.
+// The returned *WriteAheadLog is used by walAppendedOrder to inspect flush order.
+func newTestAdaptivePersistenceWriteThrough(t testing.TB) (*AdaptivePersistence, *WriteAheadLog) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	walConfig := DefaultWALConfig(tmpDir, "test-order")
+	walConfig.CheckpointInterval = 0 // disable auto-checkpoint
+
+	wal, err := OpenWriteAheadLog(walConfig)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	mb := NewMemoryBuffer(MemoryBufferConfig{MaxLines: 100, EvictionBatch: 10})
+	// Ensure lines 0-9 exist in the memory buffer so GetLine returns non-nil.
+	for i := int64(0); i < 10; i++ {
+		mb.EnsureLine(i)
+		mb.GetLine(i).Cells = []Cell{{Rune: 'X'}}
+	}
+
+	config := DefaultAdaptivePersistenceConfig()
+	// Force BestEffort mode so writes accumulate and are only flushed on
+	// explicit Flush() — this exercises flushPendingLocked's ordering.
+	config.WriteThroughMaxRate = 0
+	config.DebouncedMaxRate = 0
+	// Long idle threshold so idle monitor doesn't flush during test.
+	config.IdleThreshold = 1 * time.Hour
+
+	ap, err := newAdaptivePersistenceWithWAL(config, mb, wal, time.Now)
+	if err != nil {
+		t.Fatalf("newAdaptivePersistenceWithWAL: %v", err)
+	}
+	t.Cleanup(func() { ap.Close() })
+
+	// Force BestEffort mode immediately so writes accumulate rather than
+	// flushing individually. Mode normally only changes every 64 writes.
+	ap.mu.Lock()
+	ap.currentMode = PersistBestEffort
+	ap.mu.Unlock()
+
+	return ap, wal
+}
+
+// walAppendedOrder reads the WAL entries in file order and returns their
+// GlobalLineIdx values. This reflects the order lines were flushed to disk.
+func walAppendedOrder(t testing.TB, wal *WriteAheadLog) []int64 {
+	t.Helper()
+	entries, err := wal.readWALEntries()
+	if err != nil {
+		t.Fatalf("readWALEntries: %v", err)
+	}
+	order := make([]int64, 0, len(entries))
+	for _, e := range entries {
+		order = append(order, int64(e.GlobalLineIdx))
+	}
+	return order
+}
+
+// equalInt64 returns true if two slices have the same contents.
+func equalInt64(a, b []int64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAdaptivePersistence_FlushesInCallOrder(t *testing.T) {
+	ap, wal := newTestAdaptivePersistenceWriteThrough(t)
+	ap.NotifyWrite(3)
+	ap.NotifyWrite(7)
+	ap.NotifyWrite(5)
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	got := walAppendedOrder(t, wal)
+	want := []int64{3, 7, 5}
+	if !equalInt64(got, want) {
+		t.Errorf("append order = %v, want %v", got, want)
+	}
+}
+
 // TestMain can be used for setup/teardown if needed
 func TestMain(m *testing.M) {
 	os.Exit(m.Run())

--- a/apps/texelterm/parser/adaptive_persistence_test.go
+++ b/apps/texelterm/parser/adaptive_persistence_test.go
@@ -947,12 +947,12 @@ func BenchmarkRateMonitor_CalculateRate(b *testing.B) {
 
 // --- FIFO flush-order test helpers ---
 
-// newTestAdaptivePersistenceWriteThrough creates an AdaptivePersistence backed
+// newTestAdaptivePersistenceBestEffort creates an AdaptivePersistence backed
 // by a WAL in a temp directory, locked into BestEffort mode so writes
 // accumulate in the pending list and are only flushed when Flush() is called.
 // This lets tests control exactly when the flush happens and verify flush order.
 // The returned *WriteAheadLog is used by walAppendedOrder to inspect flush order.
-func newTestAdaptivePersistenceWriteThrough(t testing.TB) (*AdaptivePersistence, *WriteAheadLog) {
+func newTestAdaptivePersistenceBestEffort(t testing.TB) (*AdaptivePersistence, *WriteAheadLog) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	walConfig := DefaultWALConfig(tmpDir, "test-order")
@@ -1022,7 +1022,7 @@ func equalInt64(a, b []int64) bool {
 }
 
 func TestAdaptivePersistence_FlushesInCallOrder(t *testing.T) {
-	ap, wal := newTestAdaptivePersistenceWriteThrough(t)
+	ap, wal := newTestAdaptivePersistenceBestEffort(t)
 	ap.NotifyWrite(3)
 	ap.NotifyWrite(7)
 	ap.NotifyWrite(5)

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -3,6 +3,15 @@
 
 package parser
 
+// ClearNotifier is the minimal interface the persistence layer must implement
+// so that the MainScreen can propagate range clears (tombstones) to disk.
+// AdaptivePersistence satisfies this interface via its NotifyClearRange method.
+// Defined in the parser package so both the MainScreen interface and its
+// implementations (sparse.Terminal) can reference it without import cycles.
+type ClearNotifier interface {
+	NotifyClearRange(lo, hi int64)
+}
+
 // MainScreen is the interface that sparse.Terminal satisfies. Defined in
 // the parser package to avoid an import cycle (parser -> sparse -> parser).
 // sparse.Terminal is the sole production implementation; VTerm drives the
@@ -30,6 +39,18 @@ type MainScreen interface {
 	// the write window consistent with whatever they mutate.
 	SetLine(globalIdx int64, cells []Cell)
 	ClearRange(lo, hi int64)
+
+	// ClearRangePersistent removes lines [lo, hi] from the in-memory store AND
+	// notifies the persistence layer so the range is tombstoned on disk. Use
+	// this for ED / invalidate operations that must be durable. WriteWindow
+	// scroll / newline / scroll-region clears should use ClearRange (in-memory
+	// only).
+	ClearRangePersistent(lo, hi int64)
+
+	// SetClearNotifier wires the persistence-layer callback for range clears.
+	// Must be called after the persistence layer is created (e.g. in
+	// EnableMemoryBufferWithDisk). Passing nil disables notifications.
+	SetClearNotifier(n ClearNotifier)
 
 	// IL/DL and partial scroll-region operations. cursorRow, marginTop, and
 	// marginBottom are all relative to WriteTop (i.e., viewport-row indices).

--- a/apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
@@ -1,0 +1,136 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
+// Summary: End-to-end regression test for the phantom-Claude-text bug.
+// Simulates a full shell session: OSC 133 anchors set, command output written,
+// ED 2 fired (TUI reset), session closed and reopened. Verifies that the
+// tombstoned rows are absent after reload — i.e. the phantom text does not
+// bleed into the new session's scrollback.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestOSC133_ED2_TombstonesPersistToDisk is the direct regression for the
+// phantom-Claude-text bug: a non-alt-screen TUI (like Claude Code) writes
+// output below the prompt, then issues ED 2 to home its first frame. The
+// rows between CommandStart and WriteBottomHWM should be tombstoned on disk
+// so that after a server restart the phantom text does not appear in
+// scrollback.
+//
+// Sequence under test:
+//  1. OSC 133;A (prompt start) + "$ " prompt text
+//  2. OSC 133;B (prompt end) + "ls" user input + CRLF
+//  3. OSC 133;C (command start)
+//  4. 10 lines of "phantom output line X"
+//  5. ED 2 (ESC[2J) — TUI resets with anchor-rewind + tombstone
+//  6. CloseMemoryBuffer — flushes all ops to disk
+//  7. Reopen from disk
+//  8. Scan every loaded row: none may contain "phantom output"
+func TestOSC133_ED2_TombstonesPersistToDisk(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	// Use a small viewport so that phantom output overflows it and forces
+	// writeTop to advance past the CommandStart anchor. The rewind + tombstone
+	// path is only exercised when writeTop > anchor.
+	const cols, rows = 40, 5
+
+	// --- Session 1: simulate a Claude-style shell interaction ---
+	v := NewVTerm(cols, rows)
+	if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "osc133-tomb-test",
+	}); err != nil {
+		t.Fatalf("EnableMemoryBufferWithDisk: %v", err)
+	}
+	if v.mainScreen == nil {
+		t.Skip("MainScreenFactory not registered; sparse package not imported")
+	}
+
+	p := NewParser(v)
+
+	// OSC 133;A — prompt start (shell emits before drawing prompt)
+	parseString(p, "\x1b]133;A\x07")
+	// Prompt text: "$ "
+	parseString(p, "$ ")
+	// OSC 133;B — prompt end / input start
+	parseString(p, "\x1b]133;B\x07")
+	// User types "ls" then presses Enter
+	parseString(p, "ls\r\n")
+	// OSC 133;C — command start
+	parseString(p, "\x1b]133;C\x07")
+
+	cmdAnchor := v.CommandStartGlobalLine
+	if cmdAnchor < 0 {
+		t.Fatalf("OSC 133;C did not set CommandStartGlobalLine (got %d)", cmdAnchor)
+	}
+
+	// Write 10 lines of phantom output — more than the viewport height (5)
+	// so writeTop advances past cmdAnchor, setting up the rewind condition.
+	for i := 0; i < 10; i++ {
+		parseString(p, fmt.Sprintf("phantom output line %d\r\n", i))
+	}
+
+	hwmBefore := v.mainScreen.WriteBottomHWM()
+
+	// Verify the setup condition: writeTop must have advanced past cmdAnchor
+	// for the rewind + tombstone path to fire.
+	writeTopBeforeED2 := v.mainScreen.WriteTop()
+	if writeTopBeforeED2 <= cmdAnchor {
+		t.Fatalf("setup: writeTop=%d did not advance past cmdAnchor=%d (need viewport overflow)",
+			writeTopBeforeED2, cmdAnchor)
+	}
+
+	// ED 2 — TUI initialises its first frame, clearing the screen.
+	// The anchor-rewind path in mainScreenEraseScreen should:
+	//   1. Rewind writeTop to cmdAnchor
+	//   2. ClearRangePersistent([cmdAnchor, HWM]) — tombstone the phantom rows
+	//   3. EraseDisplay — blank the viewport
+	parseString(p, "\x1b[2J")
+
+	// Quick sanity check: writeTop should have rewound to cmdAnchor.
+	if got := v.mainScreen.WriteTop(); got != cmdAnchor {
+		t.Errorf("writeTop after ED 2: got %d, want %d (CommandStart anchor)", got, cmdAnchor)
+	}
+
+	// Close the session, flushing all write + delete ops to disk.
+	if err := v.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// --- Session 2: reload from disk and verify no phantom text ---
+	v2 := NewVTerm(cols, rows)
+	if err := v2.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "osc133-tomb-test",
+	}); err != nil {
+		t.Fatalf("re-EnableMemoryBufferWithDisk: %v", err)
+	}
+	defer v2.CloseMemoryBuffer()
+
+	if v2.mainScreen == nil {
+		t.Fatal("v2.mainScreen is nil after reload")
+	}
+
+	// Scan every row from globalIdx 0 through hwmBefore (the highest row
+	// any phantom text could have been written to). None may contain
+	// "phantom output".
+	for gi := int64(0); gi <= hwmBefore; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells == nil {
+			continue
+		}
+		var sb strings.Builder
+		for _, c := range cells {
+			if c.Rune != 0 {
+				sb.WriteRune(c.Rune)
+			}
+		}
+		if strings.Contains(sb.String(), "phantom output") {
+			t.Errorf("stale phantom text survived reload at gi=%d: %q", gi, sb.String())
+		}
+	}
+}

--- a/apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
@@ -71,7 +71,7 @@ func TestOSC133_ED2_TombstonesPersistToDisk(t *testing.T) {
 
 	// Write 10 lines of phantom output — more than the viewport height (5)
 	// so writeTop advances past cmdAnchor, setting up the rewind condition.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		parseString(p, fmt.Sprintf("phantom output line %d\r\n", i))
 	}
 

--- a/apps/texelterm/parser/osc133_anchor_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_persistence_test.go
@@ -212,131 +212,95 @@ func TestED2_RewindAfterRestart_UsesRestoredCommandStart(t *testing.T) {
 	}
 }
 
-// TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand guards
-// the "stale frame bleed-through" bug: when a TUI like Claude is running
-// at server shutdown (OSC 133;C fired, no 133;D yet), the sparse store
-// holds the last-drawn frame cells at the restored live range
-// [writeTop, max(writeTop+height-1, HWM)]. On reload, the respawned
-// shell only writes the cells it actually draws (prompt, a new command
-// line), so every untouched cell — blank rows, trailing columns past
-// the command — would show the old TUI frame. The restore path must
-// blank this range so the new session starts on a clean canvas.
-// Scrollback above writeTop must NOT be cleared.
-func TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand(t *testing.T) {
-	dir := t.TempDir()
-	id := "restore-blank-viewport-midcmd"
+// TestED2_ClearsOverflowPastViewport guards the "phantom scrollback"
+// bug: an earlier TUI in the session wrote cells past the current
+// viewport (HWM > writeTop+height-1). When a later "homing" ED 2 fires
+// — the canonical TUI-launch signal — those overflow cells linger as
+// stale scrollback and bleed through once the new frame scrolls or the
+// user scrolls down, even across a server restart that persists them.
+// ED 2 must wipe [writeTop+height, HWM] in addition to the viewport.
+func TestED2_ClearsOverflowPastViewport(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	const cols, rows = 40, 10
+	v := NewVTerm(cols, rows)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
 
-	// --- Session 1: shell session with a running TUI command. ---
-	v1 := newTestVTerm(t, cols, rows, dir, id)
-	p1 := NewParser(v1)
+	// Fill the sparse store with distinctive TUI-style content spanning
+	// well past a single viewport's worth of rows. Plain writes advance
+	// writeTop with the cursor, so HWM stays equal to the viewport
+	// bottom — that's the "no overflow yet" baseline.
+	for i := 0; i < rows*3; i++ {
+		parseString(p, fmt.Sprintf("tui1-row-%02d %s\r\n", i, "yyyyyyy"))
+	}
+	hwmBefore := v.mainScreen.WriteBottomHWM()
 
-	// Scrollback we want preserved.
-	parseString(p1, "scrollback line A\r\n")
-	parseString(p1, "scrollback line B\r\n")
-	scrollbackEnd := v1.mainScreen.WriteTop() + int64(v1.cursorY) - 1
-
-	// Bash prompt + input + command-start (simulates `claude` launching).
-	v1.MarkPromptStart()
-	parseString(p1, "prompt> ")
-	v1.MarkInputStart()
-	parseString(p1, "claude\r\n")
-	v1.MarkCommandStart()
-	if v1.CommandStartGlobalLine < 0 {
-		t.Fatalf("setup: MarkCommandStart did not set CommandStartGlobalLine")
+	// Force writeTop backward to simulate the post-restore condition:
+	// persisted HWM points past the shell's current viewport, so
+	// whatever the old TUI wrote in [rewind+rows, HWM] is now phantom
+	// scrollback the new shell won't overwrite. RewindWriteTop keeps
+	// HWM monotonic — exactly the asymmetry the ED 2 clear must handle.
+	rewindTo := hwmBefore - int64(rows*2)
+	if rewindTo < 0 {
+		t.Fatalf("setup: hwmBefore %d too small to rewind", hwmBefore)
+	}
+	v.mainScreen.RewindWriteTop(rewindTo)
+	writeTop := v.mainScreen.WriteTop()
+	if writeTop != rewindTo {
+		t.Fatalf("setup: writeTop %d != rewindTo %d", writeTop, rewindTo)
+	}
+	if hwm := v.mainScreen.WriteBottomHWM(); hwm <= writeTop+int64(rows)-1 {
+		t.Fatalf("setup: HWM %d not past viewport bottom %d after rewind",
+			hwm, writeTop+int64(rows)-1)
 	}
 
-	// Fill the remaining viewport rows with "TUI" content that must NOT
-	// survive restore — these are cells Claude drew in its last frame.
-	for i := 0; i < rows; i++ {
-		parseString(p1, fmt.Sprintf("tui-frame-row-%02d padded %s\r\n", i, "zzzzzzz"))
-	}
-	writeTopBefore := v1.mainScreen.WriteTop()
-	hwmBefore := v1.mainScreen.WriteBottomHWM()
-	if hwmBefore < writeTopBefore+int64(rows)-1 {
-		t.Fatalf("setup: HWM %d did not reach end of viewport (writeTop=%d, rows=%d)",
-			hwmBefore, writeTopBefore, rows)
-	}
+	// New TUI homes with ED 2. No OSC 133 anchors are set, so the
+	// anchor-rewind branch is a no-op — the overflow clean-slate pass
+	// is the only thing standing between the old TUI's cells and the
+	// user's scrollback.
+	parseString(p, "\x1b[2J")
 
-	if err := v1.CloseMemoryBuffer(); err != nil {
-		t.Fatalf("CloseMemoryBuffer: %v", err)
-	}
-
-	// --- Session 2: reload. ---
-	v2 := newTestVTerm(t, cols, rows, dir, id)
-	defer v2.CloseMemoryBuffer()
-
-	writeTopAfter := v2.mainScreen.WriteTop()
-	if writeTopAfter != writeTopBefore {
-		t.Fatalf("writeTop not restored: got %d, want %d", writeTopAfter, writeTopBefore)
-	}
-
-	// Live range [writeTop, HWM] must be fully blank so the new session
-	// doesn't see stale TUI content bleeding through.
-	for gi := writeTopAfter; gi <= hwmBefore; gi++ {
-		cells := v2.mainScreen.ReadLine(gi)
+	writeTopAfter := v.mainScreen.WriteTop()
+	for gi := writeTopAfter + int64(rows); gi <= hwmBefore; gi++ {
+		cells := v.mainScreen.ReadLine(gi)
 		if cells != nil && lineHasSparseContent(cells) {
-			t.Errorf("live-range line %d still has content after restore: %q",
+			t.Errorf("overflow line %d still has content after ED 2: %q",
 				gi, cellsPreview(cells))
-		}
-	}
-
-	// Scrollback above writeTop must be preserved.
-	for gi := int64(0); gi <= scrollbackEnd; gi++ {
-		cells := v2.mainScreen.ReadLine(gi)
-		if cells == nil || !lineHasSparseContent(cells) {
-			t.Errorf("scrollback line %d was wrongly cleared", gi)
 		}
 	}
 }
 
-// TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell is the
-// counterpart: when no command is running at shutdown (CommandStart
-// < 0), the viewport holds legitimate plain-text output the user wants
-// to see on reload. The restore path must NOT blank it.
-func TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell(t *testing.T) {
-	dir := t.TempDir()
-	id := "restore-preserve-viewport-idle"
+// TestED2_PreservesScrollbackAboveViewport is the counterpart guarantee:
+// only overflow rows *past* the viewport get wiped by ED 2's new
+// clean-slate pass. Legitimate scrollback above writeTop (prior shell
+// output the user wants to see when scrolling up) must stay intact.
+func TestED2_PreservesScrollbackAboveViewport(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	const cols, rows = 40, 10
+	v := NewVTerm(cols, rows)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
 
-	v1 := newTestVTerm(t, cols, rows, dir, id)
-	p1 := NewParser(v1)
-
-	// Plain output — no OSC 133;C. Think `ls` output followed by a
-	// returned shell prompt.
-	const contentLines = 8
-	for i := 0; i < contentLines; i++ {
-		parseString(p1, fmt.Sprintf("output-line-%02d\r\n", i))
+	// Plain scrollback that should survive ED 2. Enough lines to push
+	// writeTop well past 0.
+	const scrollbackLines = 25
+	for i := 0; i < scrollbackLines; i++ {
+		parseString(p, fmt.Sprintf("scroll-%02d\r\n", i))
+	}
+	writeTopBefore := v.mainScreen.WriteTop()
+	if writeTopBefore == 0 {
+		t.Fatalf("setup: writeTop did not advance; test needs scrollback")
 	}
 
-	// Snapshot the populated lines as session 1 saw them so session 2
-	// can be compared cell-for-cell.
-	writeTopBefore := v1.mainScreen.WriteTop()
-	before := make([][]Cell, contentLines)
-	for i := 0; i < contentLines; i++ {
-		before[i] = v1.mainScreen.ReadLine(writeTopBefore + int64(i))
-		if before[i] == nil || !lineHasSparseContent(before[i]) {
-			t.Fatalf("setup: line %d has no content in session 1", i)
-		}
-	}
+	parseString(p, "\x1b[2J")
 
-	if err := v1.CloseMemoryBuffer(); err != nil {
-		t.Fatalf("CloseMemoryBuffer: %v", err)
-	}
-
-	v2 := newTestVTerm(t, cols, rows, dir, id)
-	defer v2.CloseMemoryBuffer()
-
-	if v2.CommandStartGlobalLine >= 0 {
-		t.Fatalf("setup invariant: CommandStartGlobalLine should be -1, got %d",
-			v2.CommandStartGlobalLine)
-	}
-
-	for i := 0; i < contentLines; i++ {
-		got := v2.mainScreen.ReadLine(writeTopBefore + int64(i))
-		if got == nil || !lineHasSparseContent(got) {
-			t.Errorf("idle-shell line %d (globalIdx %d) was wrongly cleared on restore",
-				i, writeTopBefore+int64(i))
+	// Every row above the new writeTop that had content before must
+	// still have content.
+	writeTopAfter := v.mainScreen.WriteTop()
+	for gi := int64(0); gi < writeTopAfter; gi++ {
+		cells := v.mainScreen.ReadLine(gi)
+		if cells == nil || !lineHasSparseContent(cells) {
+			t.Errorf("scrollback line %d wrongly cleared by ED 2", gi)
 		}
 	}
 }

--- a/apps/texelterm/parser/osc133_anchor_persistence_test.go
+++ b/apps/texelterm/parser/osc133_anchor_persistence_test.go
@@ -212,6 +212,154 @@ func TestED2_RewindAfterRestart_UsesRestoredCommandStart(t *testing.T) {
 	}
 }
 
+// TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand guards
+// the "stale frame bleed-through" bug: when a TUI like Claude is running
+// at server shutdown (OSC 133;C fired, no 133;D yet), the sparse store
+// holds the last-drawn frame cells at the restored live range
+// [writeTop, max(writeTop+height-1, HWM)]. On reload, the respawned
+// shell only writes the cells it actually draws (prompt, a new command
+// line), so every untouched cell — blank rows, trailing columns past
+// the command — would show the old TUI frame. The restore path must
+// blank this range so the new session starts on a clean canvas.
+// Scrollback above writeTop must NOT be cleared.
+func TestEnableMemoryBuffer_BlanksLiveViewportOnRestore_MidCommand(t *testing.T) {
+	dir := t.TempDir()
+	id := "restore-blank-viewport-midcmd"
+	const cols, rows = 40, 10
+
+	// --- Session 1: shell session with a running TUI command. ---
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	// Scrollback we want preserved.
+	parseString(p1, "scrollback line A\r\n")
+	parseString(p1, "scrollback line B\r\n")
+	scrollbackEnd := v1.mainScreen.WriteTop() + int64(v1.cursorY) - 1
+
+	// Bash prompt + input + command-start (simulates `claude` launching).
+	v1.MarkPromptStart()
+	parseString(p1, "prompt> ")
+	v1.MarkInputStart()
+	parseString(p1, "claude\r\n")
+	v1.MarkCommandStart()
+	if v1.CommandStartGlobalLine < 0 {
+		t.Fatalf("setup: MarkCommandStart did not set CommandStartGlobalLine")
+	}
+
+	// Fill the remaining viewport rows with "TUI" content that must NOT
+	// survive restore — these are cells Claude drew in its last frame.
+	for i := 0; i < rows; i++ {
+		parseString(p1, fmt.Sprintf("tui-frame-row-%02d padded %s\r\n", i, "zzzzzzz"))
+	}
+	writeTopBefore := v1.mainScreen.WriteTop()
+	hwmBefore := v1.mainScreen.WriteBottomHWM()
+	if hwmBefore < writeTopBefore+int64(rows)-1 {
+		t.Fatalf("setup: HWM %d did not reach end of viewport (writeTop=%d, rows=%d)",
+			hwmBefore, writeTopBefore, rows)
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// --- Session 2: reload. ---
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	writeTopAfter := v2.mainScreen.WriteTop()
+	if writeTopAfter != writeTopBefore {
+		t.Fatalf("writeTop not restored: got %d, want %d", writeTopAfter, writeTopBefore)
+	}
+
+	// Live range [writeTop, HWM] must be fully blank so the new session
+	// doesn't see stale TUI content bleeding through.
+	for gi := writeTopAfter; gi <= hwmBefore; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells != nil && lineHasSparseContent(cells) {
+			t.Errorf("live-range line %d still has content after restore: %q",
+				gi, cellsPreview(cells))
+		}
+	}
+
+	// Scrollback above writeTop must be preserved.
+	for gi := int64(0); gi <= scrollbackEnd; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells == nil || !lineHasSparseContent(cells) {
+			t.Errorf("scrollback line %d was wrongly cleared", gi)
+		}
+	}
+}
+
+// TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell is the
+// counterpart: when no command is running at shutdown (CommandStart
+// < 0), the viewport holds legitimate plain-text output the user wants
+// to see on reload. The restore path must NOT blank it.
+func TestEnableMemoryBuffer_PreservesViewportOnRestore_IdleShell(t *testing.T) {
+	dir := t.TempDir()
+	id := "restore-preserve-viewport-idle"
+	const cols, rows = 40, 10
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	// Plain output — no OSC 133;C. Think `ls` output followed by a
+	// returned shell prompt.
+	const contentLines = 8
+	for i := 0; i < contentLines; i++ {
+		parseString(p1, fmt.Sprintf("output-line-%02d\r\n", i))
+	}
+
+	// Snapshot the populated lines as session 1 saw them so session 2
+	// can be compared cell-for-cell.
+	writeTopBefore := v1.mainScreen.WriteTop()
+	before := make([][]Cell, contentLines)
+	for i := 0; i < contentLines; i++ {
+		before[i] = v1.mainScreen.ReadLine(writeTopBefore + int64(i))
+		if before[i] == nil || !lineHasSparseContent(before[i]) {
+			t.Fatalf("setup: line %d has no content in session 1", i)
+		}
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.CommandStartGlobalLine >= 0 {
+		t.Fatalf("setup invariant: CommandStartGlobalLine should be -1, got %d",
+			v2.CommandStartGlobalLine)
+	}
+
+	for i := 0; i < contentLines; i++ {
+		got := v2.mainScreen.ReadLine(writeTopBefore + int64(i))
+		if got == nil || !lineHasSparseContent(got) {
+			t.Errorf("idle-shell line %d (globalIdx %d) was wrongly cleared on restore",
+				i, writeTopBefore+int64(i))
+		}
+	}
+}
+
+// cellsPreview turns a cell slice into a short printable string for
+// failure messages. Intentionally tiny — we just need to see which TUI
+// content bled through when a test fails.
+func cellsPreview(cells []Cell) string {
+	const max = 20
+	out := make([]rune, 0, max)
+	for i, c := range cells {
+		if i >= max {
+			break
+		}
+		if c.Rune == 0 {
+			out = append(out, ' ')
+		} else {
+			out = append(out, c.Rune)
+		}
+	}
+	return string(out)
+}
+
 // TestEnableMemoryBuffer_DiscardsStaleAnchors verifies that the restore path
 // discards InputStart / CommandStart anchors pointing past the last
 // persisted line, matching the existing PromptStartLine behavior. This

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -635,23 +635,50 @@ func (ps *PageStore) recordIndexEntry(globalIdx int64) {
 	}
 }
 
-// deleteRangeNoWAL removes all pageIndex entries whose globalIdx falls in the
-// closed interval [lo, hi] and decrements totalLineCount. Does NOT emit a WAL
-// entry — that is the caller's responsibility. Used by WriteAheadLog.DeleteRange
-// (after emitting) and by WAL recover() replay (on-disk tombstone already
-// exists). Page-file bytes are not reclaimed; correctness depends on pageIndex
-// absence.
+// deleteRangeNoWAL removes all entries whose globalIdx falls in the closed
+// interval [lo, hi] from both the in-memory pageIndex AND the on-disk page
+// files. Does NOT emit a WAL entry — that is the caller's responsibility.
+// Used by WriteAheadLog.DeleteRange (after emitting) and by WAL recover()
+// replay (on-disk tombstone already exists).
 //
-// Partial-overlap invariant: currentPage entries are in-flight (not yet flushed
-// to disk) and are therefore NEVER present in pageIndex. The two structures are
-// disjoint: pageIndex holds only committed (flushed) lines; currentPage holds
-// only uncommitted lines buffered for the next flush. Deleting a range that
-// straddles the flush boundary requires removing from pageIndex AND discarding
-// currentPage when its full range falls inside [lo, hi].
+// On-disk rewriting is mandatory: rebuildIndex() on reopen rescans raw page
+// files, so phantom bytes left in those files would resurrect deleted lines.
+// For each affected page:
+//   - Fully inside [lo, hi] → the page file is removed.
+//   - Prefix kept, tail deleted → rewritten in place with fewer lines, same
+//     pageID and FirstGlobalIdx.
+//   - Suffix kept, head deleted → rewritten in place, same pageID, with
+//     FirstGlobalIdx advanced to the first surviving line.
+//   - Split (middle deleted) → prefix stays in the original page, suffix
+//     spills into a newly-allocated page with a new pageID.
+//
+// currentPage (in-flight, not yet on disk) is flushed first so the rewrite
+// logic can treat all overlapping regions uniformly as on-disk pages. A
+// fresh empty currentPage is started afterward so subsequent appends have
+// somewhere to go.
 func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
+	if lo < 0 || hi < lo {
+		return nil
+	}
+
+	// Fast path: no content at all.
+	if ps.currentPage == nil && len(ps.pageIndex) == 0 {
+		return nil
+	}
+
+	// Flush currentPage so every line lives in a concrete page file. This
+	// keeps the rewrite logic below purely about on-disk pages.
+	if ps.currentPage != nil && ps.currentPage.Header.LineCount > 0 {
+		if err := ps.flushCurrentPage(); err != nil {
+			return fmt.Errorf("flush current page before delete: %w", err)
+		}
+	}
+	ps.currentPage = nil
+
+	// Collect the distinct pageIDs that contain at least one globalIdx in [lo, hi].
 	start := sort.Search(len(ps.pageIndex), func(i int) bool {
 		return ps.pageIndex[i].globalIdx >= lo
 	})
@@ -659,23 +686,116 @@ func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
 	for end < len(ps.pageIndex) && ps.pageIndex[end].globalIdx <= hi {
 		end++
 	}
-	if end > start {
-		removed := int64(end - start)
-		ps.pageIndex = append(ps.pageIndex[:start], ps.pageIndex[end:]...)
-		ps.totalLineCount -= removed
-		if ps.totalLineCount < 0 {
-			panic("page_store: totalLineCount underflow")
+	if end == start {
+		// Nothing to delete, but we still need a fresh currentPage.
+		return ps.startNewPage()
+	}
+	affectedIDs := make(map[uint64]struct{}, end-start)
+	for i := start; i < end; i++ {
+		affectedIDs[ps.pageIndex[i].pageID] = struct{}{}
+	}
+
+	// Remember nextGlobalIdx before we rebuild the index — globalIdx is
+	// monotonic and must never regress past the high-water mark, even if we
+	// delete the most recently written lines.
+	savedNextGlobalIdx := ps.nextGlobalIdx
+
+	// Rewrite each affected page on disk.
+	for pageID := range affectedIDs {
+		if err := ps.rewritePageForDelete(pageID, lo, hi); err != nil {
+			return fmt.Errorf("rewrite page %d: %w", pageID, err)
 		}
 	}
-	// Drop the current unflushed page if its range falls entirely in [lo, hi].
-	if ps.currentPage != nil && ps.currentPage.Header.LineCount > 0 {
-		first := int64(ps.currentPage.Header.FirstGlobalIdx)
-		last := first + int64(ps.currentPage.Header.LineCount) - 1
-		if first >= lo && last <= hi {
-			ps.currentPage = nil
+
+	// Fully rebuild pageIndex from the new on-disk state. This is simpler
+	// and less error-prone than surgical updates when pages get split into
+	// two files with renumbered offsets.
+	ps.pageIndex = ps.pageIndex[:0]
+	ps.totalLineCount = 0
+	ps.nextGlobalIdx = 0
+	// Note: we do NOT reset nextPageID — rewritePageForDelete already bumped
+	// it for any split pages, and rebuildIndex treats nextPageID as a running
+	// max, so preserving the current value is safe.
+	if err := ps.rebuildIndex(); err != nil {
+		return fmt.Errorf("rebuild index after delete: %w", err)
+	}
+	if savedNextGlobalIdx > ps.nextGlobalIdx {
+		ps.nextGlobalIdx = savedNextGlobalIdx
+	}
+
+	return ps.startNewPage()
+}
+
+// rewritePageForDelete loads the page with pageID, removes any lines whose
+// globalIdx falls inside [lo, hi], and writes the surviving lines back to
+// disk. Caller must hold ps.mu. May allocate a new pageID from ps.nextPageID
+// when a middle-delete splits the page into two.
+func (ps *PageStore) rewritePageForDelete(pageID uint64, lo, hi int64) error {
+	page, err := ps.loadPage(pageID)
+	if err != nil {
+		return err
+	}
+	first := int64(page.Header.FirstGlobalIdx)
+	n := int(page.Header.LineCount)
+	last := first + int64(n) - 1
+	path := ps.pageFilePath(pageID)
+
+	// Fully contained in [lo, hi] → delete the file.
+	if first >= lo && last <= hi {
+		return os.Remove(path)
+	}
+
+	// Local indices of the delete range inside this page.
+	loLocal := max(int(lo-first), 0)
+	hiLocal := min(int(hi-first), n-1)
+	hasPrefix := loLocal > 0
+	hasSuffix := hiLocal < n-1
+
+	switch {
+	case hasPrefix && hasSuffix:
+		// Middle delete: keep prefix in original page, spill suffix to a new one.
+		prefix := buildPageFromRange(page, 0, loLocal, uint64(first), pageID)
+		if err := ps.writePageToDisk(prefix, path); err != nil {
+			return err
+		}
+		suffixPageID := ps.nextPageID
+		ps.nextPageID++
+		suffixFirstGI := uint64(first + int64(hiLocal+1))
+		suffix := buildPageFromRange(page, hiLocal+1, n, suffixFirstGI, suffixPageID)
+		return ps.writePageToDisk(suffix, ps.pageFilePath(suffixPageID))
+	case hasPrefix:
+		// Tail deleted: same pageID, same FirstGlobalIdx, fewer lines.
+		prefix := buildPageFromRange(page, 0, loLocal, uint64(first), pageID)
+		return ps.writePageToDisk(prefix, path)
+	case hasSuffix:
+		// Head deleted: same pageID, FirstGlobalIdx advances past the deletion.
+		survivorFirstGI := uint64(first + int64(hiLocal+1))
+		suffix := buildPageFromRange(page, hiLocal+1, n, survivorFirstGI, pageID)
+		return ps.writePageToDisk(suffix, path)
+	default:
+		// No survivors — handled by the fully-contained branch above.
+		return nil
+	}
+}
+
+// buildPageFromRange returns a new Page containing src.Lines[start:end],
+// anchored at firstGI and numbered pageID. Timestamps and per-line flags are
+// preserved; AddLine re-derives LineFlagFixedWidth from the line itself.
+func buildPageFromRange(src *Page, start, end int, firstGI, pageID uint64) *Page {
+	out := NewPage(pageID, firstGI)
+	for i := start; i < end; i++ {
+		line := src.GetLine(i)
+		if line == nil {
+			continue
+		}
+		ts := src.GetTimestamp(i)
+		flags := src.Index[i].Flags &^ LineFlagFixedWidth
+		if !out.AddLine(line, ts, flags) {
+			// Oversized — AddLine's second call force-adds regardless.
+			out.AddLine(line, ts, flags)
 		}
 	}
-	return nil
+	return out
 }
 
 // findByGlobalIdx does a binary search on pageIndex for the entry matching

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -635,6 +635,44 @@ func (ps *PageStore) recordIndexEntry(globalIdx int64) {
 	}
 }
 
+// deleteRangeNoWAL removes all pageIndex entries whose globalIdx falls in the
+// closed interval [lo, hi] and decrements totalLineCount. Does NOT emit a WAL
+// entry — that is the caller's responsibility. Used by WriteAheadLog.DeleteRange
+// (after emitting) and by WAL recover() replay (on-disk tombstone already
+// exists). Page-file bytes are not reclaimed; correctness depends on pageIndex
+// absence.
+func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
+	if lo < 0 || hi < lo {
+		return fmt.Errorf("invalid delete range [%d, %d]", lo, hi)
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	start := sort.Search(len(ps.pageIndex), func(i int) bool {
+		return ps.pageIndex[i].globalIdx >= lo
+	})
+	end := start
+	for end < len(ps.pageIndex) && ps.pageIndex[end].globalIdx <= hi {
+		end++
+	}
+	if end > start {
+		ps.pageIndex = append(ps.pageIndex[:start], ps.pageIndex[end:]...)
+		ps.totalLineCount -= int64(end - start)
+		if ps.totalLineCount < 0 {
+			ps.totalLineCount = 0
+		}
+	}
+	// Drop the current unflushed page if its range falls entirely in [lo, hi].
+	if ps.currentPage != nil && ps.currentPage.Header.LineCount > 0 {
+		first := int64(ps.currentPage.Header.FirstGlobalIdx)
+		last := first + int64(ps.currentPage.Header.LineCount) - 1
+		if first >= lo && last <= hi {
+			ps.currentPage = nil
+		}
+	}
+	return nil
+}
+
 // findByGlobalIdx does a binary search on pageIndex for the entry matching
 // globalIdx. Returns (entry, true) if found, (zero, false) otherwise.
 // Caller must hold ps.mu (read or write).

--- a/apps/texelterm/parser/page_store.go
+++ b/apps/texelterm/parser/page_store.go
@@ -641,10 +641,14 @@ func (ps *PageStore) recordIndexEntry(globalIdx int64) {
 // (after emitting) and by WAL recover() replay (on-disk tombstone already
 // exists). Page-file bytes are not reclaimed; correctness depends on pageIndex
 // absence.
+//
+// Partial-overlap invariant: currentPage entries are in-flight (not yet flushed
+// to disk) and are therefore NEVER present in pageIndex. The two structures are
+// disjoint: pageIndex holds only committed (flushed) lines; currentPage holds
+// only uncommitted lines buffered for the next flush. Deleting a range that
+// straddles the flush boundary requires removing from pageIndex AND discarding
+// currentPage when its full range falls inside [lo, hi].
 func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
-	if lo < 0 || hi < lo {
-		return fmt.Errorf("invalid delete range [%d, %d]", lo, hi)
-	}
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
@@ -656,10 +660,11 @@ func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
 		end++
 	}
 	if end > start {
+		removed := int64(end - start)
 		ps.pageIndex = append(ps.pageIndex[:start], ps.pageIndex[end:]...)
-		ps.totalLineCount -= int64(end - start)
+		ps.totalLineCount -= removed
 		if ps.totalLineCount < 0 {
-			ps.totalLineCount = 0
+			panic("page_store: totalLineCount underflow")
 		}
 	}
 	// Drop the current unflushed page if its range falls entirely in [lo, hi].

--- a/apps/texelterm/parser/page_store_delete_range_test.go
+++ b/apps/texelterm/parser/page_store_delete_range_test.go
@@ -7,7 +7,7 @@ import (
 
 func seedLines(t *testing.T, ps *PageStore, n int) {
 	t.Helper()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ll := &LogicalLine{Cells: []Cell{{Rune: 'x'}}}
 		if err := ps.AppendLineWithGlobalIdx(int64(i), ll, time.Now()); err != nil {
 			t.Fatalf("seed %d: %v", i, err)

--- a/apps/texelterm/parser/page_store_delete_range_test.go
+++ b/apps/texelterm/parser/page_store_delete_range_test.go
@@ -1,0 +1,109 @@
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+func seedLines(t *testing.T, ps *PageStore, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		ll := &LogicalLine{Cells: []Cell{{Rune: 'x'}}}
+		if err := ps.AppendLineWithGlobalIdx(int64(i), ll, time.Now()); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	if err := ps.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestPageStore_DeleteRangeMiddle(t *testing.T) {
+	dir := t.TempDir()
+	ps, err := CreatePageStore(DefaultPageStoreConfig(dir, "term-x"))
+	if err != nil {
+		t.Fatalf("CreatePageStore: %v", err)
+	}
+	defer ps.Close()
+	seedLines(t, ps, 10)
+	if err := ps.deleteRangeNoWAL(3, 7); err != nil {
+		t.Fatalf("deleteRangeNoWAL: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 5 {
+		t.Errorf("StoredLineCount = %d, want 5", got)
+	}
+	want := []int64{0, 1, 2, 8, 9}
+	for i, w := range want {
+		if got := ps.GlobalIdxAtStoredPosition(int64(i)); got != w {
+			t.Errorf("pos %d: got %d want %d", i, got, w)
+		}
+	}
+}
+
+func TestPageStore_DeleteRangeEmpty(t *testing.T) {
+	dir := t.TempDir()
+	ps, err := CreatePageStore(DefaultPageStoreConfig(dir, "term-x"))
+	if err != nil {
+		t.Fatalf("CreatePageStore: %v", err)
+	}
+	defer ps.Close()
+	seedLines(t, ps, 3)
+	if err := ps.deleteRangeNoWAL(100, 200); err != nil {
+		t.Fatalf("deleteRangeNoWAL empty: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 3 {
+		t.Errorf("StoredLineCount = %d, want 3", got)
+	}
+}
+
+func TestPageStore_DeleteRangeWholeStore(t *testing.T) {
+	dir := t.TempDir()
+	ps, err := CreatePageStore(DefaultPageStoreConfig(dir, "term-x"))
+	if err != nil {
+		t.Fatalf("CreatePageStore: %v", err)
+	}
+	defer ps.Close()
+	seedLines(t, ps, 4)
+	if err := ps.deleteRangeNoWAL(0, 3); err != nil {
+		t.Fatalf("deleteRangeNoWAL: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 0 {
+		t.Errorf("StoredLineCount = %d, want 0", got)
+	}
+}
+
+func TestPageStore_DeleteRangeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	ps, err := CreatePageStore(DefaultPageStoreConfig(dir, "term-x"))
+	if err != nil {
+		t.Fatalf("CreatePageStore: %v", err)
+	}
+	defer ps.Close()
+	if err := ps.deleteRangeNoWAL(5, 3); err == nil {
+		t.Error("deleteRangeNoWAL(5, 3) = nil, want error")
+	}
+	if err := ps.deleteRangeNoWAL(-1, 3); err == nil {
+		t.Error("deleteRangeNoWAL(-1, 3) = nil, want error")
+	}
+}
+
+func TestWAL_DeleteRangeEmitsAndApplies(t *testing.T) {
+	// Verifies WriteAheadLog.DeleteRange both emits a WAL entry and mutates
+	// PageStore state.
+	dir := t.TempDir()
+	cfg := DefaultWALConfig(dir, "wal-delete-term")
+	cfg.CheckpointInterval = 0
+	wal, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("NewWAL: %v", err)
+	}
+	defer wal.Close()
+	ps := wal.PageStore()
+	seedLines(t, ps, 6)
+	if err := wal.DeleteRange(1, 3); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 3 {
+		t.Errorf("StoredLineCount = %d, want 3 (kept: 0, 4, 5)", got)
+	}
+}

--- a/apps/texelterm/parser/page_store_delete_range_test.go
+++ b/apps/texelterm/parser/page_store_delete_range_test.go
@@ -73,17 +73,21 @@ func TestPageStore_DeleteRangeWholeStore(t *testing.T) {
 }
 
 func TestPageStore_DeleteRangeInvalid(t *testing.T) {
+	// Validation lives in AppendDelete / DeleteRange (public entry points),
+	// not in deleteRangeNoWAL. Use the WAL.DeleteRange path to exercise it.
 	dir := t.TempDir()
-	ps, err := CreatePageStore(DefaultPageStoreConfig(dir, "term-x"))
+	cfg := DefaultWALConfig(dir, "term-invalid")
+	cfg.CheckpointInterval = 0
+	wal, err := OpenWriteAheadLog(cfg)
 	if err != nil {
-		t.Fatalf("CreatePageStore: %v", err)
+		t.Fatalf("OpenWriteAheadLog: %v", err)
 	}
-	defer ps.Close()
-	if err := ps.deleteRangeNoWAL(5, 3); err == nil {
-		t.Error("deleteRangeNoWAL(5, 3) = nil, want error")
+	defer wal.Close()
+	if err := wal.DeleteRange(5, 3); err == nil {
+		t.Error("DeleteRange(5, 3) = nil, want error")
 	}
-	if err := ps.deleteRangeNoWAL(-1, 3); err == nil {
-		t.Error("deleteRangeNoWAL(-1, 3) = nil, want error")
+	if err := wal.DeleteRange(-1, 3); err == nil {
+		t.Error("DeleteRange(-1, 3) = nil, want error")
 	}
 }
 

--- a/apps/texelterm/parser/sparse/persistence_clear_production_test.go
+++ b/apps/texelterm/parser/sparse/persistence_clear_production_test.go
@@ -1,0 +1,107 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// TestLoadStore_TombstoneSurvivesCheckpointAfterFlush is the production-bug
+// regression test. It reproduces the sequence the running texel-server hits
+// in real life:
+//
+//  1. Phantom writes are flushed to on-disk .page files (via a periodic
+//     checkpoint — default 30s).
+//  2. ED 2 anchor-rewind emits a DeleteRange tombstone into the WAL.
+//  3. Shutdown triggers a final Close() checkpoint. The checkpoint sees ONLY
+//     the delete entry (writes were already flushed and WAL truncated).
+//  4. deleteRangeNoWAL removes the entries from the in-memory pageIndex but
+//     the raw page file bytes on disk are never touched, then the WAL is
+//     truncated.
+//  5. On reopen, rebuildIndex() rescans the page files and repopulates
+//     pageIndex from their headers — resurrecting the phantom rows.
+//
+// Distinct from TestLoadStore_TombstoneSurvivesCheckpoint: that test appends
+// all 20 writes + the delete inside a single checkpoint cycle, which the
+// two-pass epoch approach handles by shadowing writes BEFORE they hit
+// PageStore. This test proves the bug remains when writes are flushed to
+// disk BEFORE the delete is emitted.
+func TestLoadStore_TombstoneSurvivesCheckpointAfterFlush(t *testing.T) {
+	baseDir := t.TempDir()
+	terminalID := "test-tombstone-prod"
+
+	cfg := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg.CheckpointInterval = 0 // disable auto-checkpoint; we drive it by hand
+
+	wal1, err := parser.OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	// Append 20 lines (gi 0–19).
+	for i := range 20 {
+		cells := []parser.Cell{{Rune: rune('A' + i)}}
+		line := &parser.LogicalLine{Cells: cells}
+		if err := wal1.Append(int64(i), line, now); err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+	}
+
+	// FORCE a checkpoint BEFORE the delete. This flushes all writes to the
+	// .page files and truncates the WAL. This is the critical step that
+	// distinguishes the production scenario from the existing checkpoint
+	// test: writes now live on disk as raw bytes in page files.
+	if err := wal1.Checkpoint(); err != nil {
+		t.Fatalf("pre-delete Checkpoint: %v", err)
+	}
+
+	// NOW emit the delete tombstone.
+	if err := wal1.DeleteRange(5, 10); err != nil {
+		t.Fatalf("DeleteRange(5, 10): %v", err)
+	}
+
+	// Final close triggers a second checkpoint. This checkpoint's replay
+	// sees ONLY the delete entry (writes were flushed in the earlier
+	// checkpoint). The fix must actually remove those bytes from the page
+	// files on disk — not just from the in-memory pageIndex — or reopen
+	// will resurrect them via rebuildIndex.
+	if err := wal1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen. rebuildIndex() will re-scan every .page file from disk.
+	cfg2 := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg2.CheckpointInterval = 0
+	wal2, err := parser.OpenWriteAheadLog(cfg2)
+	if err != nil {
+		t.Fatalf("reopen OpenWriteAheadLog: %v", err)
+	}
+	defer wal2.Close()
+
+	ps2 := wal2.PageStore()
+
+	store := NewStore(80)
+	if err := LoadStore(store, ps2); err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	// Tombstoned range must not resurrect from page files.
+	for gi := int64(5); gi <= 10; gi++ {
+		if got := store.GetLine(gi); got != nil {
+			t.Errorf("GetLine(%d) = %v, want nil (page bytes must be removed, not just pageIndex)", gi, got)
+		}
+	}
+
+	// Untouched rows must still be present.
+	for _, gi := range []int64{0, 4, 11, 19} {
+		if got := store.GetLine(gi); got == nil {
+			t.Errorf("GetLine(%d) = nil, want non-nil", gi)
+		}
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go
+++ b/apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go
@@ -1,0 +1,93 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+// TestLoadStore_SkipsTombstonedRange verifies that lines deleted via
+// WriteAheadLog.DeleteRange are absent from a sparse.Store after a
+// close-and-reopen cycle.
+//
+// Sequence:
+//  1. Open a WAL, append 20 lines (gi 0–19) via wal.Append.
+//  2. Call wal.DeleteRange(5, 10) — emits a tombstone and removes [5,10]
+//     from the in-memory PageStore index.
+//  3. SyncWAL() — flush WAL entries to disk without checkpointing (so the
+//     tombstone survives on disk for recovery).
+//  4. Reopen the WAL on the same directory — recover() replays all line
+//     writes then applies the delete tombstone.
+//  5. LoadStore into a fresh sparse.Store.
+//  6. Assert GetLine returns nil for gi ∈ [5,10] and non-nil for gi ∈ {0,4,11,19}.
+func TestLoadStore_SkipsTombstonedRange(t *testing.T) {
+	baseDir := t.TempDir()
+	terminalID := "test-tombstone"
+
+	cfg := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg.CheckpointInterval = 0 // disable auto-checkpoint
+
+	// Open the first WAL.
+	wal1, err := parser.OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	// Append 20 lines (gi 0–19) to the WAL.
+	for i := range 20 {
+		cells := []parser.Cell{{Rune: rune('A' + i)}}
+		line := &parser.LogicalLine{Cells: cells}
+		if err := wal1.Append(int64(i), line, now); err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+	}
+
+	// Delete gi range [5, 10] inclusive.
+	if err := wal1.DeleteRange(5, 10); err != nil {
+		t.Fatalf("DeleteRange(5, 10): %v", err)
+	}
+
+	// Flush WAL to disk without checkpointing so the tombstone survives.
+	if err := wal1.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	// Intentionally do NOT call wal1.Close() — that would checkpoint and lose
+	// the delete tombstone.  The reopen path's recover() must replay it.
+
+	// Reopen the WAL on the same path; recover() replays line writes + tombstone.
+	cfg2 := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg2.CheckpointInterval = 0
+	wal2, err := parser.OpenWriteAheadLog(cfg2)
+	if err != nil {
+		t.Fatalf("reopen OpenWriteAheadLog: %v", err)
+	}
+	defer wal2.Close()
+
+	ps2 := wal2.PageStore()
+
+	// Load the PageStore into a fresh sparse.Store.
+	store := NewStore(80)
+	if err := LoadStore(store, ps2); err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	// Lines in [5, 10] must be absent (tombstoned).
+	for gi := int64(5); gi <= 10; gi++ {
+		if got := store.GetLine(gi); got != nil {
+			t.Errorf("GetLine(%d) = %v, want nil (tombstoned)", gi, got)
+		}
+	}
+
+	// Lines outside the deleted range must be present.
+	for _, gi := range []int64{0, 4, 11, 19} {
+		if got := store.GetLine(gi); got == nil {
+			t.Errorf("GetLine(%d) = nil, want non-nil (not tombstoned)", gi)
+		}
+	}
+}

--- a/apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go
+++ b/apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go
@@ -91,3 +91,85 @@ func TestLoadStore_SkipsTombstonedRange(t *testing.T) {
 		}
 	}
 }
+
+// TestLoadStore_TombstoneSurvivesCheckpoint is the checkpoint-path companion to
+// TestLoadStore_SkipsTombstonedRange.  It exercises the bug where
+// checkpointLocked() skipped EntryTypeLineDelete entries, causing tombstoned
+// lines to be resurrected after a normal WAL.Close() cycle.
+//
+// The only difference from TestLoadStore_SkipsTombstonedRange is that the WAL
+// is closed with wal1.Close() instead of wal1.SyncWAL().  Close() triggers a
+// final checkpoint (WAL entries flushed → PageStore → WAL truncated), so the
+// tombstone must be applied to the PageStore before truncation — otherwise it
+// is silently dropped and the deleted lines reappear on the next reopen.
+//
+// This test FAILS without the fix and PASSES with it.
+func TestLoadStore_TombstoneSurvivesCheckpoint(t *testing.T) {
+	baseDir := t.TempDir()
+	terminalID := "test-tombstone-checkpoint"
+
+	cfg := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg.CheckpointInterval = 0 // disable auto-checkpoint
+
+	// Open the first WAL.
+	wal1, err := parser.OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+
+	// Append 20 lines (gi 0–19) to the WAL.
+	for i := range 20 {
+		cells := []parser.Cell{{Rune: rune('A' + i)}}
+		line := &parser.LogicalLine{Cells: cells}
+		if err := wal1.Append(int64(i), line, now); err != nil {
+			t.Fatalf("Append(%d): %v", i, err)
+		}
+	}
+
+	// Delete gi range [5, 10] inclusive.
+	if err := wal1.DeleteRange(5, 10); err != nil {
+		t.Fatalf("DeleteRange(5, 10): %v", err)
+	}
+
+	// Close() forces a final checkpoint: WAL entries (including the tombstone)
+	// are replayed into the PageStore, PageStore is flushed, WAL is truncated.
+	// The tombstone must survive this so that the reopen sees deleted lines as
+	// absent.
+	if err := wal1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen the WAL on the same path.
+	cfg2 := parser.DefaultWALConfig(baseDir, terminalID)
+	cfg2.CheckpointInterval = 0
+	wal2, err := parser.OpenWriteAheadLog(cfg2)
+	if err != nil {
+		t.Fatalf("reopen OpenWriteAheadLog: %v", err)
+	}
+	defer wal2.Close()
+
+	ps2 := wal2.PageStore()
+
+	// Load the PageStore into a fresh sparse.Store.
+	store := NewStore(80)
+	if err := LoadStore(store, ps2); err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+
+	// Lines in [5, 10] must be absent (tombstoned) — they must NOT be
+	// resurrected from the page files after checkpoint.
+	for gi := int64(5); gi <= 10; gi++ {
+		if got := store.GetLine(gi); got != nil {
+			t.Errorf("GetLine(%d) = %v, want nil (tombstoned; checkpoint should have applied delete)", gi, got)
+		}
+	}
+
+	// Lines outside the deleted range must be present.
+	for _, gi := range []int64{0, 4, 11, 19} {
+		if got := store.GetLine(gi); got == nil {
+			t.Errorf("GetLine(%d) = nil, want non-nil (not tombstoned)", gi)
+		}
+	}
+}

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -5,13 +5,14 @@ package sparse
 
 import "github.com/framegrace/texelation/apps/texelterm/parser"
 
-// ClearNotifier is the minimal interface the sparse Terminal needs to propagate
-// range clears to the persistence layer. AdaptivePersistence in the parser
-// package satisfies it. Defined here so Terminal doesn't import parser
-// (it already does, but keeping this interface-based keeps seams explicit).
-type ClearNotifier interface {
-	NotifyClearRange(lo, hi int64)
-}
+// ClearNotifier is an alias for parser.ClearNotifier, re-exported from the
+// sparse package so callers that work exclusively with sparse types do not need
+// to import the parser package just to pass a notifier. Both types are
+// structurally identical; Go's structural typing means any value that satisfies
+// one also satisfies the other.
+//
+// Deprecated: prefer parser.ClearNotifier in new code.
+type ClearNotifier = parser.ClearNotifier
 
 // Terminal is a thin composition of Store, WriteWindow, and ViewWindow. It
 // exposes the API that VTerm's main-screen path calls into.
@@ -23,7 +24,7 @@ type Terminal struct {
 	store    *Store
 	write    *WriteWindow
 	view     *ViewWindow
-	notifier ClearNotifier
+	notifier parser.ClearNotifier
 }
 
 // NewTerminal creates a Terminal with the given dimensions. ViewWindow starts
@@ -201,7 +202,7 @@ func (t *Terminal) ClearRange(lo, hi int64) {
 // Passing nil disables notifications. Thread-safety: callers must not race
 // with ClearRangePersistent; in practice this is set once during VTerm
 // EnableMemoryBuffer.
-func (t *Terminal) SetClearNotifier(n ClearNotifier) {
+func (t *Terminal) SetClearNotifier(n parser.ClearNotifier) {
 	t.notifier = n
 }
 

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -5,6 +5,14 @@ package sparse
 
 import "github.com/framegrace/texelation/apps/texelterm/parser"
 
+// ClearNotifier is the minimal interface the sparse Terminal needs to propagate
+// range clears to the persistence layer. AdaptivePersistence in the parser
+// package satisfies it. Defined here so Terminal doesn't import parser
+// (it already does, but keeping this interface-based keeps seams explicit).
+type ClearNotifier interface {
+	NotifyClearRange(lo, hi int64)
+}
+
 // Terminal is a thin composition of Store, WriteWindow, and ViewWindow. It
 // exposes the API that VTerm's main-screen path calls into.
 //
@@ -12,9 +20,10 @@ import "github.com/framegrace/texelation/apps/texelterm/parser"
 // that no method has to lazy-init anything. This keeps the locking strategy
 // simple — reads never upgrade to writes.
 type Terminal struct {
-	store *Store
-	write *WriteWindow
-	view  *ViewWindow
+	store    *Store
+	write    *WriteWindow
+	view     *ViewWindow
+	notifier ClearNotifier
 }
 
 // NewTerminal creates a Terminal with the given dimensions. ViewWindow starts
@@ -186,6 +195,25 @@ func (t *Terminal) SetLine(globalIdx int64, cells []parser.Cell) {
 // write window), and scroll-region rejoin that collapses logical lines.
 func (t *Terminal) ClearRange(lo, hi int64) {
 	t.store.ClearRange(lo, hi)
+}
+
+// SetClearNotifier wires a persistence-layer callback for range clears.
+// Passing nil disables notifications. Thread-safety: callers must not race
+// with ClearRangePersistent; in practice this is set once during VTerm
+// EnableMemoryBuffer.
+func (t *Terminal) SetClearNotifier(n ClearNotifier) {
+	t.notifier = n
+}
+
+// ClearRangePersistent removes lines [lo, hi] from the in-memory store AND
+// notifies the persistence layer so the range is tombstoned on disk. Used by
+// VTerm ED 0/1/2 and single-line invalidate. WriteWindow scroll / newline /
+// scroll-region clears keep calling ClearRange (in-memory only).
+func (t *Terminal) ClearRangePersistent(lo, hi int64) {
+	t.store.ClearRange(lo, hi)
+	if t.notifier != nil {
+		t.notifier.NotifyClearRange(lo, hi)
+	}
 }
 
 // ReadLine returns a copy of the cells at globalIdx. Returns nil for gaps.

--- a/apps/texelterm/parser/sparse/terminal_clear_persistent_test.go
+++ b/apps/texelterm/parser/sparse/terminal_clear_persistent_test.go
@@ -1,0 +1,52 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+type stubNotifier struct {
+	ranges [][2]int64
+}
+
+func (s *stubNotifier) NotifyClearRange(lo, hi int64) {
+	s.ranges = append(s.ranges, [2]int64{lo, hi})
+}
+
+// makeTestRow creates a row of width `w` filled with rune `r`.
+func makeTestRow(w int, r rune) []parser.Cell {
+	row := make([]parser.Cell, w)
+	for i := 0; i < w; i++ {
+		row[i] = parser.Cell{Rune: r}
+	}
+	return row
+}
+
+func TestTerminal_ClearRangePersistent_ClearsAndNotifies(t *testing.T) {
+	term := NewTerminal(80, 24)
+	// Seed a line at gi=5 so we can assert in-memory removal.
+	term.SetLine(5, makeTestRow(80, 'x'))
+	n := &stubNotifier{}
+	term.SetClearNotifier(n)
+	term.ClearRangePersistent(3, 7)
+	if got := term.ReadLine(5); got != nil {
+		t.Errorf("in-memory line 5 still present after clear: %v", got)
+	}
+	if len(n.ranges) != 1 || n.ranges[0] != [2]int64{3, 7} {
+		t.Errorf("notifier ranges = %v, want [[3 7]]", n.ranges)
+	}
+}
+
+func TestTerminal_ClearRangePersistent_NoNotifierIsFine(t *testing.T) {
+	term := NewTerminal(80, 24)
+	term.SetLine(5, makeTestRow(80, 'x'))
+	// No SetClearNotifier call — ClearRangePersistent must not panic.
+	term.ClearRangePersistent(3, 7)
+	if got := term.ReadLine(5); got != nil {
+		t.Error("in-memory line 5 still present")
+	}
+}

--- a/apps/texelterm/parser/vterm_erase.go
+++ b/apps/texelterm/parser/vterm_erase.go
@@ -65,7 +65,7 @@ func (v *VTerm) ClearScreenMode(mode int) {
 			// Clear all history lines before the write window.
 			writeTop := v.mainScreen.WriteTop()
 			if writeTop > 0 {
-				v.mainScreen.ClearRange(0, writeTop-1)
+				v.mainScreen.ClearRangePersistent(0, writeTop-1)
 			}
 			v.MarkAllDirty()
 		}

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -60,9 +60,7 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// than propagating it into a new session.
 	recoveredMeta := wal.RecoveredMainScreenState()
 	pageStoreLineCount := pageStore.LineCount()
-	restored := false
 	if recoveredMeta != nil && recoveredMeta.WriteTop <= pageStoreLineCount && recoveredMeta.CursorGlobalIdx <= pageStoreLineCount+int64(v.height) {
-		restored = true
 		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol, recoveredMeta.WriteBottomHWM)
 		// Discard a stale PromptStartLine that points past the last persisted
 		// line. The prompt position is only meaningful if the referenced line
@@ -114,27 +112,6 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// Load historical lines from PageStore into sparse store.
 	if err := v.mainScreen.LoadFromPageStore(pageStore); err != nil {
 		log.Printf("[MAIN_SCREEN] LoadFromPageStore failed: %v", err)
-	}
-
-	// If a foreground command was running at shutdown (OSC 133;C fired,
-	// no 133;D yet), the live range [writeTop, max(writeTop+height-1,
-	// HWM)] holds that command's in-flight frame. After a server restart
-	// the command (Claude, htop, vim, ...) is gone; the respawned shell
-	// only writes cells for its new prompt, so everything the shell
-	// doesn't overwrite would show the stale frame bleeding through.
-	// Blank the live range so the new session starts on a clean canvas.
-	// Scrollback above writeTop is preserved.
-	//
-	// Idle / between-commands sessions (CommandStart < 0) keep viewport
-	// content intact — that path is a plain-text scrollback of the prior
-	// session's output that users legitimately want to see on reload.
-	if restored && v.CommandStartGlobalLine >= 0 {
-		writeTop := v.mainScreen.WriteTop()
-		hi := writeTop + int64(v.height) - 1
-		if hwm := v.mainScreen.WriteBottomHWM(); hwm > hi {
-			hi = hwm
-		}
-		v.mainScreen.ClearRange(writeTop, hi)
 	}
 
 	// Create persistence adapter.
@@ -416,6 +393,21 @@ func (v *VTerm) mainScreenEraseScreen(mode int) {
 					// user scrolls up through the just-rewound area.
 					v.mainScreen.ClearRange(anchor, v.mainScreen.WriteBottomHWM())
 				}
+			}
+			// ED 2 from a non-alt-screen TUI is the canonical "homing"
+			// signal: the caller is about to redraw a full frame from
+			// scratch. Blank any overflow rows past the current viewport
+			// up to HWM — they hold cells drawn by an earlier TUI or
+			// command in this session, and if they survive they'll bleed
+			// through once the new frame scrolls or the user scrolls down.
+			// EraseDisplay below only covers [writeTop, writeTop+height-1];
+			// this line extends the clean-slate guarantee past the viewport
+			// so whatever the new TUI doesn't repaint ends up as empty
+			// scrollback rather than a stale frame.
+			wt := v.mainScreen.WriteTop()
+			vpBot := wt + int64(v.height) - 1
+			if hwm := v.mainScreen.WriteBottomHWM(); hwm > vpBot {
+				v.mainScreen.ClearRange(vpBot+1, hwm)
 			}
 		}
 		v.mainScreen.EraseDisplay()

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -349,11 +349,11 @@ func (v *VTerm) mainScreenEraseScreen(mode int) {
 	case 0: // cursor to end of screen
 		v.mainScreen.EraseToEndOfLine(v.cursorX)
 		if v.cursorY < v.height-1 {
-			v.mainScreen.ClearRange(writeTop+int64(v.cursorY+1), writeTop+int64(v.height-1))
+			v.mainScreen.ClearRangePersistent(writeTop+int64(v.cursorY+1), writeTop+int64(v.height-1))
 		}
 	case 1: // start of screen to cursor
 		if v.cursorY > 0 {
-			v.mainScreen.ClearRange(writeTop, writeTop+int64(v.cursorY-1))
+			v.mainScreen.ClearRangePersistent(writeTop, writeTop+int64(v.cursorY-1))
 		}
 		v.mainScreen.EraseFromStartOfLine(v.cursorX)
 	case 2: // entire screen
@@ -392,7 +392,7 @@ func (v *VTerm) mainScreenEraseScreen(mode int) {
 					// Clear [anchor, HWM] so leftover rows from the previous
 					// repaint's overflow don't linger in scrollback once the
 					// user scrolls up through the just-rewound area.
-					v.mainScreen.ClearRange(anchor, v.mainScreen.WriteBottomHWM())
+					v.mainScreen.ClearRangePersistent(anchor, v.mainScreen.WriteBottomHWM())
 				}
 			}
 			// ED 2 from a non-alt-screen TUI is the canonical "homing"
@@ -408,13 +408,13 @@ func (v *VTerm) mainScreenEraseScreen(mode int) {
 			wt := v.mainScreen.WriteTop()
 			vpBot := wt + int64(v.height) - 1
 			if hwm := v.mainScreen.WriteBottomHWM(); hwm > vpBot {
-				v.mainScreen.ClearRange(vpBot+1, hwm)
+				v.mainScreen.ClearRangePersistent(vpBot+1, hwm)
 			}
 		}
 		v.mainScreen.EraseDisplay()
 	case 3: // clear scrollback
 		if writeTop > 0 {
-			v.mainScreen.ClearRange(0, writeTop-1)
+			v.mainScreen.ClearRangePersistent(0, writeTop-1)
 		}
 	}
 }
@@ -505,7 +505,7 @@ func (v *VTerm) mainScreenEraseHistoryLine(globalIdx int) {
 	if v.mainScreen == nil {
 		return
 	}
-	v.mainScreen.ClearRange(int64(globalIdx), int64(globalIdx))
+	v.mainScreen.ClearRangePersistent(int64(globalIdx), int64(globalIdx))
 }
 
 // mainScreenGetTopHistoryLine returns the globalIdx at the top of the write window.

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -124,6 +124,7 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 		return nil
 	}
 	v.mainScreenPersistence = persistence
+	v.mainScreen.SetClearNotifier(persistence)
 
 	log.Printf("[MAIN_SCREEN] Persistence enabled, history lines=%d", pageStore.LineCount())
 	return nil

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -60,7 +60,9 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// than propagating it into a new session.
 	recoveredMeta := wal.RecoveredMainScreenState()
 	pageStoreLineCount := pageStore.LineCount()
+	restored := false
 	if recoveredMeta != nil && recoveredMeta.WriteTop <= pageStoreLineCount && recoveredMeta.CursorGlobalIdx <= pageStoreLineCount+int64(v.height) {
+		restored = true
 		v.mainScreen.RestoreState(recoveredMeta.WriteTop, recoveredMeta.CursorGlobalIdx, recoveredMeta.CursorCol, recoveredMeta.WriteBottomHWM)
 		// Discard a stale PromptStartLine that points past the last persisted
 		// line. The prompt position is only meaningful if the referenced line
@@ -112,6 +114,27 @@ func (v *VTerm) EnableMemoryBufferWithDisk(diskPath string, opts MemoryBufferOpt
 	// Load historical lines from PageStore into sparse store.
 	if err := v.mainScreen.LoadFromPageStore(pageStore); err != nil {
 		log.Printf("[MAIN_SCREEN] LoadFromPageStore failed: %v", err)
+	}
+
+	// If a foreground command was running at shutdown (OSC 133;C fired,
+	// no 133;D yet), the live range [writeTop, max(writeTop+height-1,
+	// HWM)] holds that command's in-flight frame. After a server restart
+	// the command (Claude, htop, vim, ...) is gone; the respawned shell
+	// only writes cells for its new prompt, so everything the shell
+	// doesn't overwrite would show the stale frame bleeding through.
+	// Blank the live range so the new session starts on a clean canvas.
+	// Scrollback above writeTop is preserved.
+	//
+	// Idle / between-commands sessions (CommandStart < 0) keep viewport
+	// content intact — that path is a plain-text scrollback of the prior
+	// session's output that users legitimately want to see on reload.
+	if restored && v.CommandStartGlobalLine >= 0 {
+		writeTop := v.mainScreen.WriteTop()
+		hi := writeTop + int64(v.height) - 1
+		if hwm := v.mainScreen.WriteBottomHWM(); hwm > hi {
+			hi = hwm
+		}
+		v.mainScreen.ClearRange(writeTop, hi)
 	}
 
 	// Create persistence adapter.

--- a/apps/texelterm/parser/vterm_main_screen_persistence_test.go
+++ b/apps/texelterm/parser/vterm_main_screen_persistence_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package parser
+
+import (
+	"testing"
+)
+
+// TestEnableMemoryBuffer_WiresClearNotifier verifies that after
+// EnableMemoryBufferWithDisk, ClearRangePersistent on mainScreen propagates
+// a delete op to the AdaptivePersistence layer. Before the wiring (Task 9),
+// mainScreen.SetClearNotifier is never called, so ClearRangePersistent has no
+// notifier and the persistence layer sees no ops. After wiring, the delete op
+// is enqueued (checked in BestEffort mode where ops are not flushed eagerly).
+func TestEnableMemoryBuffer_WiresClearNotifier(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	v := NewVTerm(80, 24)
+	dir := t.TempDir()
+	if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "wiring-test",
+	}); err != nil {
+		t.Fatalf("EnableMemoryBufferWithDisk: %v", err)
+	}
+	defer v.CloseMemoryBuffer()
+
+	if v.mainScreen == nil {
+		t.Skip("MainScreenFactory not registered; sparse package not imported")
+	}
+	if v.mainScreenPersistence == nil {
+		t.Fatal("mainScreenPersistence is nil after EnableMemoryBufferWithDisk")
+	}
+
+	// Force BestEffort mode so NotifyClearRange enqueues the op without an
+	// immediate flush (WriteThrough would flush to zero before we can observe).
+	v.mainScreenPersistence.mu.Lock()
+	v.mainScreenPersistence.currentMode = PersistBestEffort
+	v.mainScreenPersistence.mu.Unlock()
+
+	// Trigger a clear via the public MainScreen API.
+	v.mainScreen.ClearRangePersistent(0, 5)
+
+	// If the notifier is wired, the AdaptivePersistence layer must hold at
+	// least one pending op (the delete tombstone for [0, 5]).
+	if n := v.mainScreenPersistence.PendingOpCount(); n == 0 {
+		t.Error("no pending op after ClearRangePersistent; notifier not wired")
+	}
+}

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -1099,19 +1099,46 @@ func (w *WriteAheadLog) checkpointLocked() error {
 		return fmt.Errorf("failed to read WAL entries: %w", err)
 	}
 
-	// Replay entries to PageStore in WAL order using the unified write
-	// path. AppendLineWithGlobalIdx now supports out-of-order inserts and
-	// updates, so the previous "Pass 1: appends, Pass 2: modifies" split
-	// is unnecessary. Replaying in WAL order means the LATEST entry for
-	// each globalIdx wins, which is the correct semantic.
-	for _, entry := range entries {
-		if entry.Line == nil {
+	// Build a map: globalIdx → WAL position of the most recent delete that
+	// covers it. A delete entry at position P marks all globalIdxs in [lo, hi]
+	// as deleted-at-P. A write entry at position Q > P for the same globalIdx
+	// "un-deletes" it (the write wins and will be replayed). Writes at Q ≤ P
+	// are shadowed by the tombstone and must be skipped.
+	//
+	// deleteRangeNoWAL only removes from the in-memory pageIndex. It does NOT
+	// remove data from currentPage, so when all replay-writes land in a single
+	// in-flight currentPage (common for small sessions), partial-overlap deletes
+	// leave the deleted data in currentPage, and Flush() bakes it onto disk.
+	// rebuildIndex() then resurrects those lines on the next reopen.
+	// Filtering writes at the source is simpler and more robust.
+	deleteEpoch := make(map[int64]int) // globalIdx → entry-slice index of last delete that covers it
+	for i, entry := range entries {
+		if entry.Type != EntryTypeLineDelete {
 			continue
 		}
+		lo := int64(entry.GlobalLineIdx)
+		hi := entry.DeleteHi
+		for gi := lo; gi <= hi; gi++ {
+			deleteEpoch[gi] = i
+		}
+	}
+
+	// Replay entries to PageStore in WAL order. For each write, check whether a
+	// later delete tombstone covers the same globalIdx — if so, skip it. If the
+	// write was emitted AFTER the last delete that covers its idx (entry index >
+	// deleteEpoch[idx]), the write is alive and must be replayed.
+	for i, entry := range entries {
 		if entry.Type != EntryTypeLineWrite && entry.Type != EntryTypeLineModify {
 			continue
 		}
+		if entry.Line == nil {
+			continue
+		}
 		lineIdx := int64(entry.GlobalLineIdx)
+		// Skip if a later (or same-position) delete tombstone covers this idx.
+		if epoch, deleted := deleteEpoch[lineIdx]; deleted && i <= epoch {
+			continue
+		}
 		if err := w.pageStore.AppendLineWithGlobalIdx(lineIdx, entry.Line, entry.Timestamp); err != nil {
 			return fmt.Errorf("failed to write line %d to PageStore: %w", entry.GlobalLineIdx, err)
 		}

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -98,9 +98,10 @@ type WALEntry struct {
 	Type            uint8
 	GlobalLineIdx   uint64
 	Timestamp       time.Time
-	Line            *LogicalLine     // nil for CHECKPOINT and METADATA entries
+	Line            *LogicalLine     // nil for CHECKPOINT / METADATA / DELETE entries
 	Metadata        *ViewportState   // nil for non-METADATA entries
 	MainScreenState *MainScreenState // nil for non-MAIN_SCREEN_STATE entries
+	DeleteHi        int64            // valid only for EntryTypeLineDelete (inclusive upper bound)
 }
 
 // WriteAheadLog provides crash recovery for terminal history.
@@ -428,6 +429,48 @@ func (w *WriteAheadLog) Append(lineIdx int64, line *LogicalLine, timestamp time.
 	}
 
 	return nil
+}
+
+// AppendDelete writes a range-delete tombstone [lo, hi] to the WAL. Emits one
+// entry, not one per line. Caller (PageStore.DeleteRange) applies the delete
+// to the in-memory page index after this returns successfully.
+func (w *WriteAheadLog) AppendDelete(lo, hi int64, timestamp time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.stopped {
+		return fmt.Errorf("WAL is closed")
+	}
+	if lo < 0 || hi < lo {
+		return fmt.Errorf("invalid delete range [%d, %d]", lo, hi)
+	}
+
+	entryData, err := w.encodeDeleteEntry(uint64(lo), uint64(hi), timestamp)
+	if err != nil {
+		return fmt.Errorf("failed to encode delete entry: %w", err)
+	}
+	if _, err := w.walFile.Write(entryData); err != nil {
+		return fmt.Errorf("failed to write delete entry: %w", err)
+	}
+	w.walSize += int64(len(entryData))
+	w.entriesWritten++
+	return nil
+}
+
+// encodeDeleteEntry builds a 33-byte WAL entry for a range tombstone:
+// type(1) + lo(8, GlobalLineIdx) + timestamp(8) + dataLen(4, =8) + hi(8) + crc32(4).
+func (w *WriteAheadLog) encodeDeleteEntry(lo, hi uint64, timestamp time.Time) ([]byte, error) {
+	const dataLen = 8
+	totalSize := WALEntryBase + dataLen
+	buf := make([]byte, totalSize)
+	buf[0] = EntryTypeLineDelete
+	binary.LittleEndian.PutUint64(buf[1:9], lo)
+	binary.LittleEndian.PutUint64(buf[9:17], uint64(timestamp.UnixNano()))
+	binary.LittleEndian.PutUint32(buf[17:21], dataLen)
+	binary.LittleEndian.PutUint64(buf[21:29], hi)
+	crc := crc32.ChecksumIEEE(buf[:totalSize-4])
+	binary.LittleEndian.PutUint32(buf[totalSize-4:], crc)
+	return buf, nil
 }
 
 // WriteMetadata writes viewport state (scroll position, cursor) to the WAL.
@@ -985,6 +1028,17 @@ func (w *WriteAheadLog) readEntry(r *bufio.Reader) (WALEntry, int, error) {
 		}
 	case EntryTypeCheckpoint:
 		// No data to decode
+	case EntryTypeLineDelete:
+		if dataLen != 8 {
+			return WALEntry{}, totalSize, fmt.Errorf("delete entry dataLen = %d, want 8", dataLen)
+		}
+		hi := int64(binary.LittleEndian.Uint64(lineData))
+		return WALEntry{
+			Type:          entryType,
+			GlobalLineIdx: lineIdx,
+			Timestamp:     timestamp,
+			DeleteHi:      hi,
+		}, totalSize, nil
 	}
 
 	return WALEntry{

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -459,6 +459,14 @@ func (w *WriteAheadLog) AppendDelete(lo, hi int64, timestamp time.Time) error {
 
 // DeleteRange emits a range-delete tombstone to the WAL and applies the delete
 // to the owned PageStore. One WAL entry per range, not one per line.
+//
+// Locking note: AppendDelete acquires and releases w.mu; deleteRangeNoWAL
+// acquires and releases ps.mu separately. The two locks are never held
+// simultaneously. This matches the established pattern used by Append
+// (w.mu) + AppendLineWithGlobalIdx (ps.mu): the WAL journal and the
+// PageStore state advance sequentially, not atomically. A crash between the
+// two steps is safe because recover() replays the WAL tombstone and
+// re-applies it to PageStore on the next open.
 func (w *WriteAheadLog) DeleteRange(lo, hi int64) error {
 	if err := w.AppendDelete(lo, hi, w.nowFunc()); err != nil {
 		return err

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -457,6 +457,15 @@ func (w *WriteAheadLog) AppendDelete(lo, hi int64, timestamp time.Time) error {
 	return nil
 }
 
+// DeleteRange emits a range-delete tombstone to the WAL and applies the delete
+// to the owned PageStore. One WAL entry per range, not one per line.
+func (w *WriteAheadLog) DeleteRange(lo, hi int64) error {
+	if err := w.AppendDelete(lo, hi, w.nowFunc()); err != nil {
+		return err
+	}
+	return w.pageStore.deleteRangeNoWAL(lo, hi)
+}
+
 // encodeDeleteEntry builds a 33-byte WAL entry for a range tombstone:
 // type(1) + lo(8, GlobalLineIdx) + timestamp(8) + dataLen(4, =8) + hi(8) + crc32(4).
 func (w *WriteAheadLog) encodeDeleteEntry(lo, hi uint64, timestamp time.Time) ([]byte, error) {
@@ -919,15 +928,21 @@ func (w *WriteAheadLog) recover() error {
 	// AppendLineWithGlobalIdx handles append, update-in-place, and out-of-order
 	// insert in one operation, so the LATEST WAL entry for each globalIdx wins.
 	for _, entry := range entries {
-		if entry.Line == nil {
-			continue
-		}
-		if entry.Type != EntryTypeLineWrite && entry.Type != EntryTypeLineModify {
-			continue
-		}
-		lineIdx := int64(entry.GlobalLineIdx)
-		if err := w.pageStore.AppendLineWithGlobalIdx(lineIdx, entry.Line, entry.Timestamp); err != nil {
-			return fmt.Errorf("failed to replay line %d: %w", entry.GlobalLineIdx, err)
+		switch entry.Type {
+		case EntryTypeLineWrite, EntryTypeLineModify:
+			if entry.Line == nil {
+				continue
+			}
+			lineIdx := int64(entry.GlobalLineIdx)
+			if err := w.pageStore.AppendLineWithGlobalIdx(lineIdx, entry.Line, entry.Timestamp); err != nil {
+				return fmt.Errorf("failed to replay line %d: %w", entry.GlobalLineIdx, err)
+			}
+		case EntryTypeLineDelete:
+			lo := int64(entry.GlobalLineIdx)
+			hi := entry.DeleteHi
+			if err := w.pageStore.deleteRangeNoWAL(lo, hi); err != nil {
+				return fmt.Errorf("failed to replay delete [%d, %d]: %w", lo, hi, err)
+			}
 		}
 	}
 

--- a/apps/texelterm/parser/write_ahead_log.go
+++ b/apps/texelterm/parser/write_ahead_log.go
@@ -7,12 +7,12 @@
 // WAL Format:
 //   Header (32 bytes):
 //     Magic: "TXWAL001" (8 bytes)
-//     Version: uint32 (4 bytes) - value 1
+//     Version: uint32 (4 bytes) - value 2
 //     TerminalID: [16]byte (UUID bytes)
 //     LastCheckpoint: uint64 (8 bytes) - global line index
 //
 //   Entry (variable, repeated):
-//     EntryType: uint8 (1 byte) - LINE_WRITE=0x01, LINE_MODIFY=0x02, CHECKPOINT=0x03
+//     EntryType: uint8 (1 byte) - LINE_WRITE=0x01, LINE_MODIFY=0x02, CHECKPOINT=0x03, METADATA=0x04, MAIN_SCREEN_STATE=0x05, LINE_DELETE=0x06
 //     GlobalLineIdx: uint64 (8 bytes)
 //     Timestamp: int64 (8 bytes) - UnixNano
 //     DataLen: uint32 (4 bytes)
@@ -39,18 +39,19 @@ import (
 // WAL format constants
 const (
 	WALMagic      = "TXWAL001"
-	WALVersion    = uint32(1)
+	WALVersion    = uint32(2)
 	WALHeaderSize = 32
 	WALEntryBase  = 1 + 8 + 8 + 4 + 4 // type + lineIdx + timestamp + dataLen + crc32 (no data)
 )
 
 // WAL entry types
 const (
-	EntryTypeLineWrite        uint8 = 0x01
-	EntryTypeLineModify       uint8 = 0x02
-	EntryTypeCheckpoint       uint8 = 0x03
-	EntryTypeMetadata         uint8 = 0x04 // Legacy ViewportState (scroll position, cursor)
-	EntryTypeMainScreenState  uint8 = 0x05 // Sparse MainScreenState (writeTop, cursor globalIdx)
+	EntryTypeLineWrite       uint8 = 0x01
+	EntryTypeLineModify      uint8 = 0x02
+	EntryTypeCheckpoint      uint8 = 0x03
+	EntryTypeMetadata        uint8 = 0x04 // Legacy ViewportState (scroll position, cursor)
+	EntryTypeMainScreenState uint8 = 0x05 // Sparse MainScreenState (writeTop, cursor globalIdx)
+	EntryTypeLineDelete      uint8 = 0x06 // Range tombstone: [lo, hi] inclusive
 )
 
 // WALConfig holds configuration for the write-ahead log.

--- a/apps/texelterm/parser/write_ahead_log_delete_test.go
+++ b/apps/texelterm/parser/write_ahead_log_delete_test.go
@@ -112,8 +112,15 @@ func TestWAL_CorruptDeleteEntryTruncates(t *testing.T) {
 }
 
 func TestWAL_RecoverAppliesDelete(t *testing.T) {
-	wal, walPath, baseDir := newDeleteTestWAL(t)
-	// Seed 5 lines and append a tombstone for [1, 3] BEFORE any checkpoint.
+	_, _, baseDir := newDeleteTestWAL(t)
+	// Open a fresh WAL, seed 5 lines, and append a tombstone for [1, 3]
+	// BEFORE any checkpoint.
+	cfg := DefaultWALConfig(baseDir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
 	ll := func(text string) *LogicalLine {
 		cells := make([]Cell, len(text))
 		for i, r := range text {
@@ -129,18 +136,18 @@ func TestWAL_RecoverAppliesDelete(t *testing.T) {
 	if err := wal.AppendDelete(1, 3, time.Now()); err != nil {
 		t.Fatalf("AppendDelete: %v", err)
 	}
-	// Flush bytes to disk but DO NOT Close (Close checkpoints which rewrites WAL).
+	// SyncWAL flushes all entries to disk. Skipping Close() simulates a crash:
+	// the WAL entries survive on disk but no checkpoint/truncation happens.
 	if err := wal.SyncWAL(); err != nil {
 		t.Fatalf("SyncWAL: %v", err)
 	}
-	// Abandon the WAL without closing — simulate crash.
-	wal.walFile.Close()
-	_ = walPath
+	// Do not call wal.Close() — opening a second WAL on the same path exercises
+	// the recover() path, which must replay both line writes and the tombstone.
 
-	// Reopen; recover should replay writes + delete.
-	cfg := DefaultWALConfig(baseDir, "test-term")
-	cfg.CheckpointInterval = 0
-	wal2, err := OpenWriteAheadLog(cfg)
+	// Reopen on the same path; recover should replay writes + delete.
+	cfg2 := DefaultWALConfig(baseDir, "test-term")
+	cfg2.CheckpointInterval = 0
+	wal2, err := OpenWriteAheadLog(cfg2)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}

--- a/apps/texelterm/parser/write_ahead_log_delete_test.go
+++ b/apps/texelterm/parser/write_ahead_log_delete_test.go
@@ -128,7 +128,7 @@ func TestWAL_RecoverAppliesDelete(t *testing.T) {
 		}
 		return &LogicalLine{Cells: cells}
 	}
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		if err := wal.Append(int64(i), ll("line"), time.Now()); err != nil {
 			t.Fatalf("Append %d: %v", i, err)
 		}

--- a/apps/texelterm/parser/write_ahead_log_delete_test.go
+++ b/apps/texelterm/parser/write_ahead_log_delete_test.go
@@ -110,3 +110,49 @@ func TestWAL_CorruptDeleteEntryTruncates(t *testing.T) {
 		t.Errorf("WAL size after corrupted-entry recover = %d, want %d (header only)", info2.Size(), WALHeaderSize)
 	}
 }
+
+func TestWAL_RecoverAppliesDelete(t *testing.T) {
+	wal, walPath, baseDir := newDeleteTestWAL(t)
+	// Seed 5 lines and append a tombstone for [1, 3] BEFORE any checkpoint.
+	ll := func(text string) *LogicalLine {
+		cells := make([]Cell, len(text))
+		for i, r := range text {
+			cells[i] = Cell{Rune: r}
+		}
+		return &LogicalLine{Cells: cells}
+	}
+	for i := 0; i < 5; i++ {
+		if err := wal.Append(int64(i), ll("line"), time.Now()); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	if err := wal.AppendDelete(1, 3, time.Now()); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	// Flush bytes to disk but DO NOT Close (Close checkpoints which rewrites WAL).
+	if err := wal.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	// Abandon the WAL without closing — simulate crash.
+	wal.walFile.Close()
+	_ = walPath
+
+	// Reopen; recover should replay writes + delete.
+	cfg := DefaultWALConfig(baseDir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal2, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer wal2.Close()
+	ps := wal2.PageStore()
+	if got := ps.StoredLineCount(); got != 2 {
+		t.Errorf("StoredLineCount = %d, want 2 (lines 0 and 4)", got)
+	}
+	if gi := ps.GlobalIdxAtStoredPosition(0); gi != 0 {
+		t.Errorf("first stored globalIdx = %d, want 0", gi)
+	}
+	if gi := ps.GlobalIdxAtStoredPosition(1); gi != 4 {
+		t.Errorf("second stored globalIdx = %d, want 4", gi)
+	}
+}

--- a/apps/texelterm/parser/write_ahead_log_delete_test.go
+++ b/apps/texelterm/parser/write_ahead_log_delete_test.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newDeleteTestWAL creates a temporary WAL for delete-entry tests.
+// Returns the WAL, the path to wal.log, and the baseDir used for DefaultWALConfig.
+func newDeleteTestWAL(t *testing.T) (*WriteAheadLog, string, string) {
+	t.Helper()
+	baseDir := t.TempDir()
+	cfg := DefaultWALConfig(baseDir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("OpenWriteAheadLog: %v", err)
+	}
+	walPath := filepath.Join(cfg.WALDir, "wal.log")
+	return wal, walPath, baseDir
+}
+
+func TestWAL_AppendDeleteRoundTrip(t *testing.T) {
+	wal, walPath, _ := newDeleteTestWAL(t)
+	ts := time.Unix(1700000000, 0)
+	if err := wal.AppendDelete(5, 10, ts); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	// Sync to disk without triggering a checkpoint (which would truncate the WAL).
+	if err := wal.SyncWAL(); err != nil {
+		t.Fatalf("SyncWAL: %v", err)
+	}
+	defer wal.Close()
+
+	// Read the raw entry off disk via readEntry.
+	f, err := os.Open(walPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Seek(int64(WALHeaderSize), 0); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	entry, _, err := (&WriteAheadLog{}).readEntry(bufio.NewReader(f))
+	if err != nil {
+		t.Fatalf("readEntry: %v", err)
+	}
+	if entry.Type != EntryTypeLineDelete {
+		t.Errorf("Type = %#x, want %#x", entry.Type, EntryTypeLineDelete)
+	}
+	if entry.GlobalLineIdx != 5 {
+		t.Errorf("lo = %d, want 5", entry.GlobalLineIdx)
+	}
+	if entry.DeleteHi != 10 {
+		t.Errorf("hi = %d, want 10", entry.DeleteHi)
+	}
+}
+
+func TestWAL_CorruptDeleteEntryTruncates(t *testing.T) {
+	wal, walPath, baseDir := newDeleteTestWAL(t)
+	ts := time.Unix(1700000000, 0)
+	if err := wal.AppendDelete(5, 10, ts); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	if err := wal.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Corrupt the CRC (last 4 bytes of the file)
+	info, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	f, err := os.OpenFile(walPath, os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := f.WriteAt([]byte{0xDE, 0xAD, 0xBE, 0xEF}, info.Size()-4); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	f.Close()
+
+	// Reopen — recover should truncate the corrupted entry and succeed.
+	cfg := DefaultWALConfig(baseDir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal2, err := OpenWriteAheadLog(cfg)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer wal2.Close()
+	info2, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("Stat after recover: %v", err)
+	}
+	if info2.Size() != int64(WALHeaderSize) {
+		t.Errorf("WAL size after corrupted-entry recover = %d, want %d (header only)", info2.Size(), WALHeaderSize)
+	}
+}

--- a/apps/texelterm/parser/write_ahead_log_delete_test.go
+++ b/apps/texelterm/parser/write_ahead_log_delete_test.go
@@ -24,38 +24,50 @@ func newDeleteTestWAL(t *testing.T) (*WriteAheadLog, string, string) {
 }
 
 func TestWAL_AppendDeleteRoundTrip(t *testing.T) {
-	wal, walPath, _ := newDeleteTestWAL(t)
-	ts := time.Unix(1700000000, 0)
-	if err := wal.AppendDelete(5, 10, ts); err != nil {
-		t.Fatalf("AppendDelete: %v", err)
+	tests := []struct {
+		name   string
+		lo, hi int64
+	}{
+		{"multi-line", 5, 10},
+		{"single-line", 5, 5},
 	}
-	// Sync to disk without triggering a checkpoint (which would truncate the WAL).
-	if err := wal.SyncWAL(); err != nil {
-		t.Fatalf("SyncWAL: %v", err)
-	}
-	defer wal.Close()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wal, walPath, _ := newDeleteTestWAL(t)
+			defer wal.Close()
 
-	// Read the raw entry off disk via readEntry.
-	f, err := os.Open(walPath)
-	if err != nil {
-		t.Fatalf("Open: %v", err)
-	}
-	defer f.Close()
-	if _, err := f.Seek(int64(WALHeaderSize), 0); err != nil {
-		t.Fatalf("Seek: %v", err)
-	}
-	entry, _, err := (&WriteAheadLog{}).readEntry(bufio.NewReader(f))
-	if err != nil {
-		t.Fatalf("readEntry: %v", err)
-	}
-	if entry.Type != EntryTypeLineDelete {
-		t.Errorf("Type = %#x, want %#x", entry.Type, EntryTypeLineDelete)
-	}
-	if entry.GlobalLineIdx != 5 {
-		t.Errorf("lo = %d, want 5", entry.GlobalLineIdx)
-	}
-	if entry.DeleteHi != 10 {
-		t.Errorf("hi = %d, want 10", entry.DeleteHi)
+			ts := time.Unix(1700000000, 0)
+			if err := wal.AppendDelete(tc.lo, tc.hi, ts); err != nil {
+				t.Fatalf("AppendDelete: %v", err)
+			}
+			// Sync to disk without triggering a checkpoint (which would truncate the WAL).
+			if err := wal.SyncWAL(); err != nil {
+				t.Fatalf("SyncWAL: %v", err)
+			}
+
+			// Read the raw entry off disk via readEntry.
+			f, err := os.Open(walPath)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer f.Close()
+			if _, err := f.Seek(int64(WALHeaderSize), 0); err != nil {
+				t.Fatalf("Seek: %v", err)
+			}
+			entry, _, err := (&WriteAheadLog{}).readEntry(bufio.NewReader(f))
+			if err != nil {
+				t.Fatalf("readEntry: %v", err)
+			}
+			if entry.Type != EntryTypeLineDelete {
+				t.Errorf("Type = %#x, want %#x", entry.Type, EntryTypeLineDelete)
+			}
+			if int64(entry.GlobalLineIdx) != tc.lo {
+				t.Errorf("lo = %d, want %d", entry.GlobalLineIdx, tc.lo)
+			}
+			if entry.DeleteHi != tc.hi {
+				t.Errorf("hi = %d, want %d", entry.DeleteHi, tc.hi)
+			}
+		})
 	}
 }
 

--- a/apps/texelterm/parser/write_ahead_log_test.go
+++ b/apps/texelterm/parser/write_ahead_log_test.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+func TestWAL_HeaderVersionIs2(t *testing.T) {
+	if WALVersion != 2 {
+		t.Errorf("WALVersion = %d, want 2", WALVersion)
+	}
+}
+
 func TestWAL_CreateAndClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := DefaultWALConfig(tmpDir, "test-terminal-123")

--- a/docs/superpowers/plans/2026-04-19-ed-clear-tombstone.md
+++ b/docs/superpowers/plans/2026-04-19-ed-clear-tombstone.md
@@ -1,0 +1,1403 @@
+# ED-Clear Tombstone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Propagate sparse `ClearRange` ops (ED 0/1/2 + single-line invalidate) to disk via WAL tombstones + PageStore range deletes, so persisted history never re-emits cells the live session has already cleared.
+
+**Architecture:** Add WAL op `EntryTypeLineDelete = 0x06`, bump WAL version 1→2. Add `PageStore.DeleteRange`. Refactor `AdaptivePersistence` pending state from a write-only map to a FIFO op list (writes + deletes) with sweep-on-delete so call order is preserved across a flush. Add `sparse.Terminal.ClearRangePersistent` + `ClearNotifier` callback. Switch 7 VTerm ED/invalidate call sites; `WriteWindow` scroll/newline clears stay in-memory.
+
+**Tech Stack:** Go 1.24.3, existing `apps/texelterm/parser/` sparse stack. No new deps.
+
+---
+
+## File Structure
+
+### Files to modify
+
+- `apps/texelterm/parser/write_ahead_log.go` — bump version constant, add `EntryTypeLineDelete`, add `WALEntry.DeleteHi` field, add `AppendDelete`, extend `readEntry` + `recover`.
+- `apps/texelterm/parser/page_store.go` — add `DeleteRange`.
+- `apps/texelterm/parser/adaptive_persistence.go` — refactor `pendingLines` to `pendingOps` FIFO list; add `NotifyClearRange`; update `flushPendingLocked`.
+- `apps/texelterm/parser/sparse/terminal.go` — add `ClearNotifier` interface, `SetClearNotifier`, `ClearRangePersistent`.
+- `apps/texelterm/parser/main_screen.go` — add `ClearRangePersistent` to `MainScreen` interface.
+- `apps/texelterm/parser/vterm_main_screen.go` — wire persistence as `ClearNotifier` on mainScreen; migrate 6 ED/invalidate call sites.
+- `apps/texelterm/parser/vterm_erase.go` — migrate 1 ED call site.
+
+### Files to create
+
+- `apps/texelterm/parser/write_ahead_log_delete_test.go` — WAL delete round-trip + CRC corruption tests.
+- `apps/texelterm/parser/page_store_delete_range_test.go` — `DeleteRange` edge-case tests.
+- `apps/texelterm/parser/adaptive_persistence_clearrange_test.go` — FIFO ordering tests.
+- `apps/texelterm/parser/sparse/terminal_clear_persistent_test.go` — notifier fan-out test.
+- `apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go` — reload-skips-cleared test.
+- `apps/texelterm/parser/osc133_anchor_clear_persistence_test.go` — end-to-end regression test.
+
+---
+
+## Task 1: Bump WAL version constant to 2
+
+**Files:**
+- Modify: `apps/texelterm/parser/write_ahead_log.go:40-54`
+- Test: reuses existing `write_ahead_log_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/texelterm/parser/write_ahead_log_test.go`:
+
+```go
+func TestWAL_HeaderVersionIs2(t *testing.T) {
+	if WALVersion != 2 {
+		t.Errorf("WALVersion = %d, want 2", WALVersion)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd /home/marc/projects/texel/texelation-sparse && go test ./apps/texelterm/parser/ -run TestWAL_HeaderVersionIs2 -count=1`
+Expected: FAIL (`WALVersion = 1, want 2`).
+
+- [ ] **Step 3: Bump the version constant and add delete op code**
+
+Edit `apps/texelterm/parser/write_ahead_log.go:40-54`:
+
+```go
+// WAL format constants
+const (
+	WALMagic      = "TXWAL001"
+	WALVersion    = uint32(2)
+	WALHeaderSize = 32
+	WALEntryBase  = 1 + 8 + 8 + 4 + 4 // type + lineIdx + timestamp + dataLen + crc32 (no data)
+)
+
+// WAL entry types
+const (
+	EntryTypeLineWrite       uint8 = 0x01
+	EntryTypeLineModify      uint8 = 0x02
+	EntryTypeCheckpoint      uint8 = 0x03
+	EntryTypeMetadata        uint8 = 0x04 // Legacy ViewportState
+	EntryTypeMainScreenState uint8 = 0x05 // Sparse MainScreenState
+	EntryTypeLineDelete      uint8 = 0x06 // Range tombstone: [lo, hi] inclusive
+)
+```
+
+Also update the header doc-comment at `write_ahead_log.go:7-20` to list `LINE_DELETE=0x06` and bump `Version: uint32 (4 bytes) - value 2`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_HeaderVersionIs2 -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full WAL test suite to catch version regressions**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL -count=1`
+Expected: PASS. Any test that writes-then-reopens a WAL must still work because we upgraded both the writer and reader in the same change; tests that embed a hard-coded v1 magic will need adjustment — fix them to use `WALVersion` rather than literal `1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/write_ahead_log.go apps/texelterm/parser/write_ahead_log_test.go
+git commit -m "wal: bump version to 2 and reserve EntryTypeLineDelete"
+```
+
+---
+
+## Task 2: `WriteAheadLog.AppendDelete` — encode+append one tombstone entry
+
+**Files:**
+- Modify: `apps/texelterm/parser/write_ahead_log.go` (add method near `Append` at line 390; add `DeleteHi` field on `WALEntry` at line 96)
+- Test: `apps/texelterm/parser/write_ahead_log_delete_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/parser/write_ahead_log_delete_test.go`:
+
+```go
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestWAL(t *testing.T) (*WriteAheadLog, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := DefaultWALConfig(dir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal, err := NewWriteAheadLog(cfg, time.Now)
+	if err != nil {
+		t.Fatalf("NewWriteAheadLog: %v", err)
+	}
+	return wal, filepath.Join(cfg.WALDir, "wal.log")
+}
+
+func TestWAL_AppendDeleteRoundTrip(t *testing.T) {
+	wal, walPath := newTestWAL(t)
+	ts := time.Unix(1700000000, 0)
+	if err := wal.AppendDelete(5, 10, ts); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	if err := wal.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen and walk entries using readEntryStandalone semantics via recover.
+	// We use the low-level reader to verify the bytes on disk.
+	f, err := os.Open(walPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Seek(int64(WALHeaderSize), 0); err != nil {
+		t.Fatalf("Seek: %v", err)
+	}
+	entry, _, err := (&WriteAheadLog{}).readEntry(bufioNewReaderForTest(f))
+	if err != nil {
+		t.Fatalf("readEntry: %v", err)
+	}
+	if entry.Type != EntryTypeLineDelete {
+		t.Errorf("Type = %#x, want %#x", entry.Type, EntryTypeLineDelete)
+	}
+	if entry.GlobalLineIdx != 5 {
+		t.Errorf("lo = %d, want 5", entry.GlobalLineIdx)
+	}
+	if entry.DeleteHi != 10 {
+		t.Errorf("hi = %d, want 10", entry.DeleteHi)
+	}
+}
+```
+
+Also add a tiny helper near the top of the file (same file is fine; keep local to test package):
+
+```go
+import "bufio"
+
+func bufioNewReaderForTest(f *os.File) *bufio.Reader { return bufio.NewReader(f) }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_AppendDeleteRoundTrip -count=1`
+Expected: FAIL — `AppendDelete` / `DeleteHi` undefined.
+
+- [ ] **Step 3: Add `DeleteHi` field on `WALEntry`**
+
+Edit `apps/texelterm/parser/write_ahead_log.go:95-103`:
+
+```go
+// WALEntry represents a single entry in the WAL.
+type WALEntry struct {
+	Type            uint8
+	GlobalLineIdx   uint64
+	Timestamp       time.Time
+	Line            *LogicalLine     // nil for CHECKPOINT / METADATA / DELETE entries
+	Metadata        *ViewportState   // nil for non-METADATA entries
+	MainScreenState *MainScreenState // nil for non-MAIN_SCREEN_STATE entries
+	DeleteHi        int64            // valid only for EntryTypeLineDelete (inclusive upper bound)
+}
+```
+
+- [ ] **Step 4: Add `AppendDelete` method**
+
+Add to `apps/texelterm/parser/write_ahead_log.go` (place it directly after `Append` at line 430):
+
+```go
+// AppendDelete writes a range-delete tombstone [lo, hi] to the WAL. Emits one
+// entry, not one per line. Caller (PageStore.DeleteRange) applies the delete
+// to the in-memory page index after this returns successfully.
+func (w *WriteAheadLog) AppendDelete(lo, hi int64, timestamp time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.stopped {
+		return fmt.Errorf("WAL is closed")
+	}
+	if lo < 0 || hi < lo {
+		return fmt.Errorf("invalid delete range [%d, %d]", lo, hi)
+	}
+
+	entryData, err := w.encodeDeleteEntry(uint64(lo), uint64(hi), timestamp)
+	if err != nil {
+		return fmt.Errorf("failed to encode delete entry: %w", err)
+	}
+	if _, err := w.walFile.Write(entryData); err != nil {
+		return fmt.Errorf("failed to write delete entry: %w", err)
+	}
+	w.walSize += int64(len(entryData))
+	w.entriesWritten++
+	return nil
+}
+
+// encodeDeleteEntry builds a 33-byte WAL entry for a range tombstone:
+// type(1) + lo(8, GlobalLineIdx) + timestamp(8) + dataLen(4, =8) + hi(8) + crc32(4).
+func (w *WriteAheadLog) encodeDeleteEntry(lo, hi uint64, timestamp time.Time) ([]byte, error) {
+	const dataLen = 8
+	totalSize := WALEntryBase + dataLen
+	buf := make([]byte, totalSize)
+	buf[0] = EntryTypeLineDelete
+	binary.LittleEndian.PutUint64(buf[1:9], lo)
+	binary.LittleEndian.PutUint64(buf[9:17], uint64(timestamp.UnixNano()))
+	binary.LittleEndian.PutUint32(buf[17:21], dataLen)
+	binary.LittleEndian.PutUint64(buf[21:29], hi)
+	crc := crc32.ChecksumIEEE(buf[:totalSize-4])
+	binary.LittleEndian.PutUint32(buf[totalSize-4:], crc)
+	return buf, nil
+}
+```
+
+- [ ] **Step 5: Extend `readEntry` to decode delete entries**
+
+Edit `apps/texelterm/parser/write_ahead_log.go:963-987` — add a new case inside the `switch entryType` block (right after `case EntryTypeCheckpoint:`):
+
+```go
+	case EntryTypeLineDelete:
+		if dataLen != 8 {
+			return WALEntry{}, totalSize, fmt.Errorf("delete entry dataLen = %d, want 8", dataLen)
+		}
+		hi := int64(binary.LittleEndian.Uint64(lineData))
+		return WALEntry{
+			Type:          entryType,
+			GlobalLineIdx: lineIdx,
+			Timestamp:     timestamp,
+			DeleteHi:      hi,
+		}, totalSize, nil
+```
+
+(The existing final `return WALEntry{...}` at line 989-996 stays intact for the non-delete path.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_AppendDeleteRoundTrip -count=1`
+Expected: PASS.
+
+- [ ] **Step 7: Add a CRC-corruption regression test**
+
+Append to `write_ahead_log_delete_test.go`:
+
+```go
+func TestWAL_CorruptDeleteEntryTruncates(t *testing.T) {
+	wal, walPath := newTestWAL(t)
+	ts := time.Unix(1700000000, 0)
+	if err := wal.AppendDelete(5, 10, ts); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	if err := wal.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Corrupt the CRC (last 4 bytes of the file)
+	info, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	f, err := os.OpenFile(walPath, os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := f.WriteAt([]byte{0xDE, 0xAD, 0xBE, 0xEF}, info.Size()-4); err != nil {
+		t.Fatalf("WriteAt: %v", err)
+	}
+	f.Close()
+
+	// Reopen — recover should truncate and succeed.
+	cfg := DefaultWALConfig(filepath.Dir(filepath.Dir(walPath)), "test-term")
+	cfg.CheckpointInterval = 0
+	wal2, err := NewWriteAheadLog(cfg, time.Now)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer wal2.Close()
+	info2, err := os.Stat(walPath)
+	if err != nil {
+		t.Fatalf("Stat after recover: %v", err)
+	}
+	if info2.Size() != int64(WALHeaderSize) {
+		t.Errorf("WAL size after corrupted-entry recover = %d, want %d (header only)", info2.Size(), WALHeaderSize)
+	}
+}
+```
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_CorruptDeleteEntryTruncates -count=1`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/texelterm/parser/write_ahead_log.go apps/texelterm/parser/write_ahead_log_delete_test.go
+git commit -m "wal: add AppendDelete for range tombstones"
+```
+
+---
+
+## Task 3: WAL `recover` applies delete entries to PageStore
+
+**Files:**
+- Modify: `apps/texelterm/parser/write_ahead_log.go:825-888` (recover loop)
+- Test: `write_ahead_log_delete_test.go` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/texelterm/parser/write_ahead_log_delete_test.go`:
+
+```go
+func TestWAL_RecoverAppliesDelete(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultWALConfig(dir, "test-term")
+	cfg.CheckpointInterval = 0
+	wal, err := NewWriteAheadLog(cfg, time.Now)
+	if err != nil {
+		t.Fatalf("NewWAL: %v", err)
+	}
+	// Write 5 lines, then tombstone lines 1..3.
+	ll := func(text string) *LogicalLine {
+		cells := make([]Cell, len(text))
+		for i, r := range text {
+			cells[i] = Cell{Rune: r}
+		}
+		return &LogicalLine{Cells: cells}
+	}
+	for i := 0; i < 5; i++ {
+		if err := wal.Append(int64(i), ll("line"), time.Now()); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	if err := wal.AppendDelete(1, 3, time.Now()); err != nil {
+		t.Fatalf("AppendDelete: %v", err)
+	}
+	// Do NOT checkpoint; close so the WAL keeps its entries.
+	if err := wal.walFile.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	wal.walFile.Close()
+
+	// Reopen; recover should replay both writes and the delete.
+	wal2, err := NewWriteAheadLog(cfg, time.Now)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer wal2.Close()
+	ps := wal2.PageStore()
+	if got := ps.StoredLineCount(); got != 2 {
+		t.Errorf("StoredLineCount = %d, want 2 (lines 0 and 4)", got)
+	}
+	if gi := ps.GlobalIdxAtStoredPosition(0); gi != 0 {
+		t.Errorf("first stored globalIdx = %d, want 0", gi)
+	}
+	if gi := ps.GlobalIdxAtStoredPosition(1); gi != 4 {
+		t.Errorf("second stored globalIdx = %d, want 4", gi)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_RecoverAppliesDelete -count=1`
+Expected: FAIL — deletes not replayed, `StoredLineCount` returns 5.
+
+- [ ] **Step 3: Make `recover` apply delete entries**
+
+Edit `apps/texelterm/parser/write_ahead_log.go:826-853`. Replace the entry-classification loop so delete entries are kept in the replay list. Change:
+
+```go
+		} else if entry.Type == EntryTypeMetadata {
+			lastMetadata = entry.Metadata
+		} else if entry.Type == EntryTypeMainScreenState {
+			lastMainScreenState = entry.MainScreenState
+		} else {
+			entries = append(entries, entry)
+		}
+```
+
+to:
+
+```go
+		} else if entry.Type == EntryTypeMetadata {
+			lastMetadata = entry.Metadata
+		} else if entry.Type == EntryTypeMainScreenState {
+			lastMainScreenState = entry.MainScreenState
+		} else if entry.Type == EntryTypeLineDelete {
+			entries = append(entries, entry)
+		} else {
+			entries = append(entries, entry)
+		}
+```
+
+(Two branches kept separate for clarity; a linter merge is fine.)
+
+Now edit the replay loop at `write_ahead_log.go:877-888`. Replace:
+
+```go
+	for _, entry := range entries {
+		if entry.Line == nil {
+			continue
+		}
+		if entry.Type != EntryTypeLineWrite && entry.Type != EntryTypeLineModify {
+			continue
+		}
+		lineIdx := int64(entry.GlobalLineIdx)
+		if err := w.pageStore.AppendLineWithGlobalIdx(lineIdx, entry.Line, entry.Timestamp); err != nil {
+			return fmt.Errorf("failed to replay line %d: %w", entry.GlobalLineIdx, err)
+		}
+	}
+```
+
+with:
+
+```go
+	for _, entry := range entries {
+		switch entry.Type {
+		case EntryTypeLineWrite, EntryTypeLineModify:
+			if entry.Line == nil {
+				continue
+			}
+			lineIdx := int64(entry.GlobalLineIdx)
+			if err := w.pageStore.AppendLineWithGlobalIdx(lineIdx, entry.Line, entry.Timestamp); err != nil {
+				return fmt.Errorf("failed to replay line %d: %w", entry.GlobalLineIdx, err)
+			}
+		case EntryTypeLineDelete:
+			lo := int64(entry.GlobalLineIdx)
+			hi := entry.DeleteHi
+			if err := w.pageStore.deleteRangeNoWAL(lo, hi); err != nil {
+				return fmt.Errorf("failed to replay delete [%d, %d]: %w", lo, hi, err)
+			}
+		}
+	}
+```
+
+(`deleteRangeNoWAL` is the bypass helper we add in Task 4. Replay must NOT re-emit a WAL entry.)
+
+- [ ] **Step 4: Run the test to verify it still fails with a clear signal**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_RecoverAppliesDelete -count=1`
+Expected: FAIL because `deleteRangeNoWAL` doesn't exist yet. That's the correct next-step shape — we wire replay before the target method to drive the Task 4 contract.
+
+- [ ] **Step 5: Commit the replay wiring**
+
+Leave the test failing until Task 4 lands. Commit only the WAL changes:
+
+```bash
+git add apps/texelterm/parser/write_ahead_log.go
+git commit -m "wal: replay EntryTypeLineDelete during recover"
+```
+
+---
+
+## Task 4: `PageStore.DeleteRange` — remove pageIndex entries in [lo, hi]
+
+**Files:**
+- Modify: `apps/texelterm/parser/page_store.go` (add near `AppendLineWithGlobalIdx` around line 548)
+- Test: `apps/texelterm/parser/page_store_delete_range_test.go` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/texelterm/parser/page_store_delete_range_test.go`:
+
+```go
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+func seedLines(t *testing.T, ps *PageStore, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		ll := &LogicalLine{Cells: []Cell{{Rune: 'x'}}}
+		if err := ps.AppendLineWithGlobalIdx(int64(i), ll, time.Now()); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	if err := ps.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestPageStore_DeleteRangeMiddle(t *testing.T) {
+	dir := t.TempDir()
+	ps, err := NewPageStore(DefaultPageStoreConfig(dir, "term-x"))
+	if err != nil {
+		t.Fatalf("NewPageStore: %v", err)
+	}
+	defer ps.Close()
+	seedLines(t, ps, 10)
+	if err := ps.DeleteRange(3, 7); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 5 {
+		t.Errorf("StoredLineCount = %d, want 5", got)
+	}
+	// Remaining globalIdxs, in stored order: 0, 1, 2, 8, 9.
+	want := []int64{0, 1, 2, 8, 9}
+	for i, w := range want {
+		if got := ps.GlobalIdxAtStoredPosition(i); got != w {
+			t.Errorf("pos %d: got %d want %d", i, got, w)
+		}
+	}
+}
+
+func TestPageStore_DeleteRangeEmpty(t *testing.T) {
+	dir := t.TempDir()
+	ps, _ := NewPageStore(DefaultPageStoreConfig(dir, "term-x"))
+	defer ps.Close()
+	seedLines(t, ps, 3)
+	// Range contains no entries.
+	if err := ps.DeleteRange(100, 200); err != nil {
+		t.Fatalf("DeleteRange empty: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 3 {
+		t.Errorf("StoredLineCount = %d, want 3", got)
+	}
+}
+
+func TestPageStore_DeleteRangeWholeStore(t *testing.T) {
+	dir := t.TempDir()
+	ps, _ := NewPageStore(DefaultPageStoreConfig(dir, "term-x"))
+	defer ps.Close()
+	seedLines(t, ps, 4)
+	if err := ps.DeleteRange(0, 3); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if got := ps.StoredLineCount(); got != 0 {
+		t.Errorf("StoredLineCount = %d, want 0", got)
+	}
+}
+
+func TestPageStore_DeleteRangeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	ps, _ := NewPageStore(DefaultPageStoreConfig(dir, "term-x"))
+	defer ps.Close()
+	if err := ps.DeleteRange(5, 3); err == nil {
+		t.Error("DeleteRange(5, 3) = nil, want error")
+	}
+	if err := ps.DeleteRange(-1, 3); err == nil {
+		t.Error("DeleteRange(-1, 3) = nil, want error")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./apps/texelterm/parser/ -run TestPageStore_DeleteRange -count=1`
+Expected: FAIL — `DeleteRange` undefined.
+
+- [ ] **Step 3: Implement `DeleteRange` and the no-WAL internal helper**
+
+Add to `apps/texelterm/parser/page_store.go` (directly after `AppendLineWithGlobalIdx`):
+
+```go
+// DeleteRange removes all pageIndex entries whose globalIdx falls in the closed
+// interval [lo, hi], emits one WAL tombstone (EntryTypeLineDelete), and
+// decrements totalLineCount. Page-file bytes are NOT reclaimed; correctness
+// depends on pageIndex absence. Safe no-op for empty ranges — the WAL entry is
+// still emitted so recovery ordering is deterministic.
+func (ps *PageStore) DeleteRange(lo, hi int64) error {
+	if lo < 0 || hi < lo {
+		return fmt.Errorf("invalid delete range [%d, %d]", lo, hi)
+	}
+	if ps.wal != nil {
+		if err := ps.wal.AppendDelete(lo, hi, time.Now()); err != nil {
+			return fmt.Errorf("wal append delete: %w", err)
+		}
+	}
+	return ps.deleteRangeNoWAL(lo, hi)
+}
+
+// deleteRangeNoWAL mutates pageIndex + totalLineCount without emitting a WAL
+// entry. Used by DeleteRange after it emits, and by WAL.recover() replay (the
+// on-disk tombstone already exists).
+func (ps *PageStore) deleteRangeNoWAL(lo, hi int64) error {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	// Binary search for first entry with globalIdx >= lo.
+	start := sort.Search(len(ps.pageIndex), func(i int) bool {
+		return ps.pageIndex[i].globalIdx >= lo
+	})
+	// Scan forward while globalIdx <= hi.
+	end := start
+	for end < len(ps.pageIndex) && ps.pageIndex[end].globalIdx <= hi {
+		end++
+	}
+	if end > start {
+		ps.pageIndex = append(ps.pageIndex[:start], ps.pageIndex[end:]...)
+		ps.totalLineCount -= int64(end - start)
+		if ps.totalLineCount < 0 {
+			ps.totalLineCount = 0
+		}
+	}
+	// Drop the current unflushed page if its range falls entirely inside [lo, hi].
+	if ps.currentPage != nil && len(ps.currentPage.entries) > 0 {
+		first := ps.currentPage.entries[0].globalIdx
+		last := ps.currentPage.entries[len(ps.currentPage.entries)-1].globalIdx
+		if first >= lo && last <= hi {
+			ps.currentPage = nil
+		}
+	}
+	return nil
+}
+```
+
+Imports: make sure `"sort"` and `"time"` are present in `page_store.go`'s import block — they likely already are. `fmt` is already imported.
+
+**Note on `ps.wal` field:** `PageStore` currently does not hold a `*WriteAheadLog` reference (the WAL owns the PageStore, not the other way around). This would force `DeleteRange` into the WAL itself. **Verify before implementing:** read `page_store.go`'s struct definition (around line 192) to confirm. If `ps.wal` does not exist, instead:
+
+- Move `DeleteRange` onto `WriteAheadLog` as `DeleteRange(lo, hi int64) error`, which internally does `w.AppendDelete(lo, hi, time.Now())` followed by `w.pageStore.deleteRangeNoWAL(lo, hi)`.
+- Callers (AdaptivePersistence flush path) use `wal.DeleteRange`.
+- The test above changes to call `wal.DeleteRange` instead of `ps.DeleteRange`.
+
+Pick the option that matches the existing ownership direction after reading the struct. Keep `deleteRangeNoWAL` as a `PageStore` method either way — `WAL.recover` calls it directly.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/ -run TestPageStore_DeleteRange -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Re-run the Task 3 recover test**
+
+Run: `go test ./apps/texelterm/parser/ -run TestWAL_RecoverAppliesDelete -count=1`
+Expected: PASS. This closes the loop opened in Task 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/page_store.go apps/texelterm/parser/page_store_delete_range_test.go
+git commit -m "page_store: add DeleteRange + deleteRangeNoWAL"
+```
+
+---
+
+## Task 5: `AdaptivePersistence` FIFO ops list refactor (no behaviour change yet)
+
+**Files:**
+- Modify: `apps/texelterm/parser/adaptive_persistence.go:109-200` (struct), `324-410` (NotifyWrite), `606-680` (flushPendingLocked)
+- Test: extend `apps/texelterm/parser/adaptive_persistence_test.go` with a strict ordering test that still passes after the refactor.
+
+- [ ] **Step 1: Write the behaviour-preserving test**
+
+Add to `adaptive_persistence_test.go`:
+
+```go
+func TestAdaptivePersistence_FlushesInCallOrder(t *testing.T) {
+	ap, store := newTestAdaptivePersistenceWriteThrough(t) // existing helper; reuse or adapt
+	ap.NotifyWrite(3)
+	ap.NotifyWrite(7)
+	ap.NotifyWrite(5)
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	got := store.AppendedOrder() // existing test-helper; returns []int64
+	want := []int64{3, 7, 5}
+	if !equalInt64(got, want) {
+		t.Errorf("append order = %v, want %v", got, want)
+	}
+}
+```
+
+If `newTestAdaptivePersistenceWriteThrough` / `AppendedOrder` / `equalInt64` do not yet exist, add them in this same test file; base them on the existing test scaffolding at the top of `adaptive_persistence_test.go`.
+
+- [ ] **Step 2: Run the test to verify it passes on current implementation**
+
+Run: `go test ./apps/texelterm/parser/ -run TestAdaptivePersistence_FlushesInCallOrder -count=1`
+Expected: PASS (current code sorts by lineIdx at flush — fortunately 3<5<7, but `3,7,5` will surface the order mismatch). **If it passes on current code**, the test is not strict enough; the ordering check above should FAIL on the current `sort.Slice`-based flush. That failure is the signal to refactor.
+
+- [ ] **Step 3: Refactor pending state to an ops list**
+
+Edit `adaptive_persistence.go` struct definition (around line 109-200). Replace the `pendingLines map[int64]*pendingLineInfo` field with:
+
+```go
+type opKind uint8
+
+const (
+	opWrite  opKind = 1
+	opDelete opKind = 2
+)
+
+type pendingOp struct {
+	kind    opKind
+	lo, hi  int64     // for writes: lo == hi == lineIdx
+	ts      time.Time
+	isCmd   bool      // writes only
+	dropped bool      // superseded by a later write or swallowed by a delete
+}
+
+type AdaptivePersistence struct {
+	// ... existing fields up through timers/config ...
+	pendingOps []pendingOp
+	pendingSet map[int64]int // lineIdx -> index in pendingOps for the most recent write
+	// ... existing fields below ...
+}
+```
+
+Update the constructor (`newAdaptivePersistenceWithWAL` / `NewAdaptivePersistence`) to initialise `pendingSet: make(map[int64]int)` instead of `pendingLines: make(map[int64]*pendingLineInfo)`. Remove the `pendingLineInfo` type declaration if nothing else consumes it.
+
+- [ ] **Step 4: Rewrite `NotifyWrite` / `NotifyWriteWithMeta`**
+
+Current code (around line 324-380) updates the map. Replace with an append-plus-supersede pattern:
+
+```go
+func (ap *AdaptivePersistence) NotifyWrite(lineIdx int64) {
+	ap.NotifyWriteWithMeta(lineIdx, false)
+}
+
+func (ap *AdaptivePersistence) NotifyWriteWithMeta(lineIdx int64, isCmd bool) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	if prev, ok := ap.pendingSet[lineIdx]; ok {
+		ap.pendingOps[prev].dropped = true
+	}
+	ap.pendingOps = append(ap.pendingOps, pendingOp{
+		kind:  opWrite,
+		lo:    lineIdx,
+		hi:    lineIdx,
+		ts:    ap.nowFunc(),
+		isCmd: isCmd,
+	})
+	ap.pendingSet[lineIdx] = len(ap.pendingOps) - 1
+
+	ap.scheduleFlushLocked() // existing helper or inlined timer arm
+}
+```
+
+- [ ] **Step 5: Rewrite `flushPendingLocked`**
+
+Replace the body (around line 606-680) with:
+
+```go
+func (ap *AdaptivePersistence) flushPendingLocked() error {
+	if len(ap.pendingOps) == 0 {
+		return nil
+	}
+	ops := ap.pendingOps
+	ap.pendingOps = nil
+	ap.pendingSet = make(map[int64]int)
+
+	for _, op := range ops {
+		if op.dropped {
+			continue
+		}
+		switch op.kind {
+		case opWrite:
+			cells := ap.store.GetLine(op.lo) // LineStore interface
+			if cells == nil {
+				continue
+			}
+			clone := cloneCells(cells) // existing helper
+			ll := &LogicalLine{Cells: clone}
+			if err := ap.wal.Append(op.lo, ll, op.ts); err != nil {
+				return err
+			}
+		case opDelete:
+			if err := ap.wal.DeleteRange(op.lo, op.hi); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+```
+
+(`ap.wal.DeleteRange` was added in Task 4's fallback option. If you went with `ps.DeleteRange`, substitute `ap.wal.pageStore.DeleteRange(...)` or expose a matching method.)
+
+- [ ] **Step 6: Run the full AdaptivePersistence test suite**
+
+Run: `go test ./apps/texelterm/parser/ -run TestAdaptivePersistence -count=1`
+Expected: PASS. The `TestAdaptivePersistence_FlushesInCallOrder` added in Step 1 is the canary for ordering.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/texelterm/parser/adaptive_persistence.go apps/texelterm/parser/adaptive_persistence_test.go
+git commit -m "adaptive_persistence: refactor pending state to FIFO ops list"
+```
+
+---
+
+## Task 6: `AdaptivePersistence.NotifyClearRange` + sweep-on-delete
+
+**Files:**
+- Modify: `apps/texelterm/parser/adaptive_persistence.go` (add method)
+- Test: `apps/texelterm/parser/adaptive_persistence_clearrange_test.go` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/texelterm/parser/adaptive_persistence_clearrange_test.go`:
+
+```go
+package parser
+
+import (
+	"testing"
+)
+
+func TestAdaptivePersistence_NotifyClearRangeDropsQueuedWrites(t *testing.T) {
+	ap, store := newTestAdaptivePersistenceWriteThrough(t)
+	ap.NotifyWrite(5)
+	ap.NotifyWrite(6)
+	ap.NotifyClearRange(0, 10)
+	ap.NotifyWrite(6) // new write post-clear should survive
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	opOrder := store.RecordedOps() // []string like {"W5","W6","D0-10","W6"}
+	want := []string{"W5", "W6", "D0-10", "W6"}
+	if !equalStrings(opOrder, want) {
+		t.Errorf("ops = %v, want %v", opOrder, want)
+	}
+}
+
+func TestAdaptivePersistence_NotifyClearRangeSweepsSupersededWrite(t *testing.T) {
+	// Writes inside the cleared range that were queued but not yet flushed
+	// must be marked dropped so they don't flush at all.
+	ap, store := newTestAdaptivePersistenceDebounced(t) // writes don't flush immediately
+	ap.NotifyWrite(5)
+	ap.NotifyClearRange(0, 10)
+	if err := ap.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	opOrder := store.RecordedOps()
+	want := []string{"D0-10"} // W5 swept
+	if !equalStrings(opOrder, want) {
+		t.Errorf("ops = %v, want %v", opOrder, want)
+	}
+}
+```
+
+Add test helpers (`RecordedOps`, `newTestAdaptivePersistenceDebounced`, `equalStrings`) to whatever test-scaffolding file already exists for adaptive_persistence.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./apps/texelterm/parser/ -run TestAdaptivePersistence_NotifyClearRange -count=1`
+Expected: FAIL — `NotifyClearRange` undefined.
+
+- [ ] **Step 3: Implement `NotifyClearRange`**
+
+Add to `adaptive_persistence.go`:
+
+```go
+// NotifyClearRange records a [lo, hi] tombstone. Sweeps pendingSet for any
+// queued writes inside the range (marks them dropped and removes them from
+// pendingSet), then enqueues an opDelete. Flush semantics match the current
+// mode: WriteThrough flushes now; Debounced / BestEffort queue.
+func (ap *AdaptivePersistence) NotifyClearRange(lo, hi int64) {
+	if lo < 0 || hi < lo {
+		return
+	}
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	for gi, opIdx := range ap.pendingSet {
+		if gi >= lo && gi <= hi {
+			ap.pendingOps[opIdx].dropped = true
+			delete(ap.pendingSet, gi)
+		}
+	}
+	ap.pendingOps = append(ap.pendingOps, pendingOp{
+		kind: opDelete,
+		lo:   lo,
+		hi:   hi,
+		ts:   ap.nowFunc(),
+	})
+
+	ap.scheduleFlushLocked()
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/ -run TestAdaptivePersistence_NotifyClearRange -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/adaptive_persistence.go apps/texelterm/parser/adaptive_persistence_clearrange_test.go
+git commit -m "adaptive_persistence: add NotifyClearRange with sweep-on-delete"
+```
+
+---
+
+## Task 7: `sparse.Terminal.ClearRangePersistent` + `ClearNotifier` interface
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/terminal.go` (add interface, field, setter, method)
+- Test: `apps/texelterm/parser/sparse/terminal_clear_persistent_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/parser/sparse/terminal_clear_persistent_test.go`:
+
+```go
+package sparse
+
+import "testing"
+
+type stubNotifier struct {
+	ranges [][2]int64
+}
+
+func (s *stubNotifier) NotifyClearRange(lo, hi int64) {
+	s.ranges = append(s.ranges, [2]int64{lo, hi})
+}
+
+func TestTerminal_ClearRangePersistent_ClearsAndNotifies(t *testing.T) {
+	term := NewTerminal(80, 24)
+	// Seed a line at gi=5 so we can assert in-memory removal.
+	term.SetLine(5, makeTestRow(80, 'x'))
+	n := &stubNotifier{}
+	term.SetClearNotifier(n)
+	term.ClearRangePersistent(3, 7)
+	if got := term.ReadLine(5); got != nil {
+		t.Errorf("in-memory line 5 still present after clear: %v", got)
+	}
+	if len(n.ranges) != 1 || n.ranges[0] != [2]int64{3, 7} {
+		t.Errorf("notifier ranges = %v, want [[3 7]]", n.ranges)
+	}
+}
+
+func TestTerminal_ClearRangePersistent_NoNotifierIsFine(t *testing.T) {
+	term := NewTerminal(80, 24)
+	term.SetLine(5, makeTestRow(80, 'x'))
+	// No SetClearNotifier call — ClearRangePersistent must not panic.
+	term.ClearRangePersistent(3, 7)
+	if got := term.ReadLine(5); got != nil {
+		t.Error("in-memory line 5 still present")
+	}
+}
+```
+
+`makeTestRow` already exists in the sparse test utilities; if not, mirror the helper used by `store_test.go`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./apps/texelterm/parser/sparse/ -run TestTerminal_ClearRangePersistent -count=1`
+Expected: FAIL — `SetClearNotifier` / `ClearRangePersistent` undefined.
+
+- [ ] **Step 3: Add the interface, field, setter, and method**
+
+Edit `apps/texelterm/parser/sparse/terminal.go`. Add near the top (under the existing `type Terminal struct`):
+
+```go
+// ClearNotifier is the minimal interface the sparse Terminal needs to propagate
+// range clears to the persistence layer. AdaptivePersistence in the parser
+// package satisfies it. Defined here so Terminal doesn't import parser
+// (it already does, but keeping this interface-based keeps seams explicit).
+type ClearNotifier interface {
+	NotifyClearRange(lo, hi int64)
+}
+```
+
+Add a field to the struct (line 14-18):
+
+```go
+type Terminal struct {
+	store    *Store
+	write    *WriteWindow
+	view     *ViewWindow
+	notifier ClearNotifier
+}
+```
+
+Add the setter and method (near the existing `ClearRange` at line 187):
+
+```go
+// SetClearNotifier wires a persistence-layer callback for range clears.
+// Passing nil disables notifications. Thread-safety: callers must not race
+// with ClearRangePersistent; in practice this is set once during VTerm
+// EnableMemoryBuffer.
+func (t *Terminal) SetClearNotifier(n ClearNotifier) {
+	t.notifier = n
+}
+
+// ClearRangePersistent removes lines [lo, hi] from the in-memory store AND
+// notifies the persistence layer so the range is tombstoned on disk. Used by
+// VTerm ED 0/1/2 and single-line invalidate. WriteWindow scroll / newline /
+// scroll-region clears keep calling ClearRange (in-memory only).
+func (t *Terminal) ClearRangePersistent(lo, hi int64) {
+	t.store.ClearRange(lo, hi)
+	if t.notifier != nil {
+		t.notifier.NotifyClearRange(lo, hi)
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./apps/texelterm/parser/sparse/ -run TestTerminal_ClearRangePersistent -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/terminal.go apps/texelterm/parser/sparse/terminal_clear_persistent_test.go
+git commit -m "sparse: add Terminal.ClearRangePersistent with ClearNotifier"
+```
+
+---
+
+## Task 8: Extend `MainScreen` interface with `ClearRangePersistent`
+
+**Files:**
+- Modify: `apps/texelterm/parser/main_screen.go` (interface line 10+)
+
+- [ ] **Step 1: Add the method to the interface**
+
+Edit `apps/texelterm/parser/main_screen.go`. Locate the `MainScreen` interface (line 10+). Under the existing `ClearRange(lo, hi int64)` line, add:
+
+```go
+	ClearRangePersistent(lo, hi int64)
+	SetClearNotifier(n interface {
+		NotifyClearRange(lo, hi int64)
+	})
+```
+
+(Second method uses an inline interface to avoid a new named type in `parser`. Alternatively: define `type ClearNotifier interface { NotifyClearRange(lo, hi int64) }` in `main_screen.go` and reuse.)
+
+- [ ] **Step 2: Verify the package still compiles**
+
+Run: `go build ./apps/texelterm/parser/...`
+Expected: PASS. `sparse.Terminal` already satisfies the new methods from Task 7.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/main_screen.go
+git commit -m "parser: extend MainScreen interface with ClearRangePersistent"
+```
+
+---
+
+## Task 9: Wire `mainScreenPersistence` as the `ClearNotifier` on `mainScreen`
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm_main_screen.go:118-126` (persistence setup)
+
+- [ ] **Step 1: Write a focused wiring test**
+
+Add to an appropriate existing test file (e.g. `vterm_main_screen_persistence_test.go`; create if missing):
+
+```go
+func TestEnableMemoryBuffer_WiresClearNotifier(t *testing.T) {
+	v := NewVTerm(80, 24)
+	dir := t.TempDir()
+	if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "wiring-test",
+	}); err != nil {
+		t.Fatalf("EnableMemoryBufferWithDisk: %v", err)
+	}
+	defer v.CloseMemoryBuffer()
+
+	// Trigger a clear via the public API; if the notifier is wired, the
+	// AdaptivePersistence layer should observe a pending delete op.
+	v.mainScreen.ClearRangePersistent(0, 5)
+	if n := v.mainScreenPersistence.PendingOpCount(); n == 0 {
+		t.Error("no pending op after ClearRangePersistent; notifier not wired")
+	}
+}
+```
+
+Add a small test-only introspection helper on `AdaptivePersistence`:
+
+```go
+// PendingOpCount returns the number of queued ops. Test-only.
+func (ap *AdaptivePersistence) PendingOpCount() int {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	return len(ap.pendingOps)
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./apps/texelterm/parser/ -run TestEnableMemoryBuffer_WiresClearNotifier -count=1`
+Expected: FAIL — notifier not wired; `PendingOpCount` == 0.
+
+- [ ] **Step 3: Wire the notifier**
+
+Edit `apps/texelterm/parser/vterm_main_screen.go:118-126`. After `v.mainScreenPersistence = persistence`, add:
+
+```go
+	v.mainScreen.SetClearNotifier(persistence)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./apps/texelterm/parser/ -run TestEnableMemoryBuffer_WiresClearNotifier -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm_main_screen.go apps/texelterm/parser/adaptive_persistence.go apps/texelterm/parser/vterm_main_screen_persistence_test.go
+git commit -m "vterm: wire AdaptivePersistence as ClearNotifier on mainScreen"
+```
+
+---
+
+## Task 10: Migrate VTerm call sites from `ClearRange` to `ClearRangePersistent`
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm_main_screen.go:351, 355, 394, 410, 416, 507`
+- Modify: `apps/texelterm/parser/vterm_erase.go:68`
+
+Seven call sites total. Each change is a rename.
+
+- [ ] **Step 1: Migrate `vterm_main_screen.go:351` (ED 0 cursor → screen bottom)**
+
+Edit — change `v.mainScreen.ClearRange(` to `v.mainScreen.ClearRangePersistent(` at line 351.
+
+- [ ] **Step 2: Migrate `vterm_main_screen.go:355` (ED 1 screen top → cursor)**
+
+Same rename at line 355.
+
+- [ ] **Step 3: Migrate `vterm_main_screen.go:394` (ED 2 anchor-rewind)**
+
+Same rename at line 394.
+
+- [ ] **Step 4: Migrate `vterm_main_screen.go:410` (ED 2 overflow-past-viewport)**
+
+Same rename at line 410.
+
+- [ ] **Step 5: Migrate `vterm_main_screen.go:416` (ED 2 no-scrollback)**
+
+Same rename at line 416.
+
+- [ ] **Step 6: Migrate `vterm_main_screen.go:507` (`MainScreenInvalidateLine`)**
+
+Same rename at line 507.
+
+- [ ] **Step 7: Migrate `vterm_erase.go:68` (alt-screen ED 2)**
+
+Same rename at line 68.
+
+- [ ] **Step 8: Run the full parser test suite**
+
+Run: `go test ./apps/texelterm/parser/... -count=1`
+Expected: PASS. Any test relying on pre-migration behaviour (ED clears leaving on-disk data) should now fail — treat that as evidence the migration is working. Update assertions in those tests to match the new behaviour.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm_main_screen.go apps/texelterm/parser/vterm_erase.go
+git commit -m "vterm: route ED + invalidate through ClearRangePersistent"
+```
+
+---
+
+## Task 11: Sparse reload round-trip test
+
+**Files:**
+- Create: `apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go`:
+
+```go
+package sparse
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestLoadStore_SkipsTombstonedRange(t *testing.T) {
+	dir := t.TempDir()
+	ps1, err := parser.NewPageStore(parser.DefaultPageStoreConfig(dir, "rt-term"))
+	if err != nil {
+		t.Fatalf("NewPageStore: %v", err)
+	}
+	// Seed 20 lines.
+	for i := 0; i < 20; i++ {
+		ll := &parser.LogicalLine{Cells: []parser.Cell{{Rune: 'x'}}}
+		if err := ps1.AppendLineWithGlobalIdx(int64(i), ll, timeNowForTest()); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	if err := ps1.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	// Tombstone [5, 10].
+	if err := ps1.DeleteRange(5, 10); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := ps1.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen and LoadStore.
+	ps2, err := parser.NewPageStore(parser.DefaultPageStoreConfig(dir, "rt-term"))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer ps2.Close()
+	store := NewStore(80)
+	if err := LoadStore(store, ps2); err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	for gi := int64(5); gi <= 10; gi++ {
+		if got := store.GetLine(gi); got != nil {
+			t.Errorf("gi %d loaded after tombstone: %v", gi, got)
+		}
+	}
+	for _, gi := range []int64{0, 4, 11, 19} {
+		if got := store.GetLine(gi); got == nil {
+			t.Errorf("gi %d missing after reload", gi)
+		}
+	}
+}
+
+func timeNowForTest() time.Time { return time.Unix(1700000000, 0) }
+```
+
+Imports: add `"time"` and `"github.com/framegrace/texelation/apps/texelterm/parser"`.
+
+- [ ] **Step 2: Run the test to verify it passes immediately**
+
+Run: `go test ./apps/texelterm/parser/sparse/ -run TestLoadStore_SkipsTombstonedRange -count=1`
+Expected: PASS on first try (no code changes needed — `LoadStore` reads from `pageIndex`, which `DeleteRange` already mutates).
+
+If it fails, investigate `LoadStore` at `sparse/persistence.go:80` — the likely cause is iterating a stale index.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/persistence_clear_roundtrip_test.go
+git commit -m "sparse: test LoadStore skips tombstoned lines on reload"
+```
+
+---
+
+## Task 12: End-to-end OSC 133 + ED 2 regression test
+
+**Files:**
+- Create: `apps/texelterm/parser/osc133_anchor_clear_persistence_test.go`
+
+This is the direct regression for the phantom-Claude-text bug that motivated the whole feature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/parser/osc133_anchor_clear_persistence_test.go`:
+
+```go
+package parser
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Simulates: prompt rendered → Claude writes output → ED 2 (TUI reset) →
+// close → reopen → verify rewound range has no stale cells.
+func TestOSC133_ED2_TombstonesPersistToDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	v := NewVTerm(80, 24)
+	if err := v.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "osc133-tomb-test",
+	}); err != nil {
+		t.Fatalf("EnableMemoryBufferWithDisk: %v", err)
+	}
+
+	// Emit OSC 133;A (prompt start) + prompt text + OSC 133;B (prompt end) +
+	// user input + OSC 133;C (command start) + command output + ED 2.
+	input := bytes.NewBuffer(nil)
+	input.WriteString("\x1b]133;A\x07$ \x1b]133;B\x07ls\r\n\x1b]133;C\x07")
+	for i := 0; i < 10; i++ {
+		input.WriteString("phantom output line ")
+		input.WriteByte('0' + byte(i))
+		input.WriteString("\r\n")
+	}
+	// TUI resets with ED 2.
+	input.WriteString("\x1b[2J")
+	if _, err := v.Write(input.Bytes()); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := v.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	// Reopen.
+	v2 := NewVTerm(80, 24)
+	if err := v2.EnableMemoryBufferWithDisk(dir, MemoryBufferOptions{
+		TerminalID: "osc133-tomb-test",
+	}); err != nil {
+		t.Fatalf("re-EnableMemoryBufferWithDisk: %v", err)
+	}
+	defer v2.CloseMemoryBuffer()
+
+	// Scan every loaded row for "phantom output"; none should remain.
+	hwm := v2.mainScreen.WriteBottomHWM()
+	for gi := int64(0); gi <= hwm; gi++ {
+		cells := v2.mainScreen.ReadLine(gi)
+		if cells == nil {
+			continue
+		}
+		var sb strings.Builder
+		for _, c := range cells {
+			if c.Rune != 0 {
+				sb.WriteRune(c.Rune)
+			}
+		}
+		if strings.Contains(sb.String(), "phantom output") {
+			t.Errorf("stale phantom text at gi=%d: %q", gi, sb.String())
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./apps/texelterm/parser/ -run TestOSC133_ED2_TombstonesPersistToDisk -count=1`
+Expected: PASS. If it fails, the most common causes are:
+- The VTerm isn't routing ED 2 through the anchor-rewind path for this particular prompt layout. Inspect `vterm_main_screen.go:387-416` and confirm the anchor is set.
+- The persistence layer is still in `BestEffort` mode and never flushes. Force a `Flush()` on close (`CloseMemoryBuffer` already does this — verify).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/osc133_anchor_clear_persistence_test.go
+git commit -m "test: OSC133 + ED2 tombstone persistence regression"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full test suite**
+
+```bash
+cd /home/marc/projects/texel/texelation-sparse
+go test ./apps/texelterm/parser/... -count=1
+```
+Expected: PASS.
+
+- [ ] **Build all binaries**
+
+```bash
+make build
+```
+Expected: success.
+
+- [ ] **Manual smoke test (optional)**
+
+With a pre-existing v1 WAL file in place, launch `./bin/texelation`. The terminal should log `unsupported WAL version: 1`, start with empty scrollback, and create a fresh v2 WAL. This confirms the downgrade-safety contract from the spec.
+
+- [ ] **Document the WAL-version bump in the PR description**
+
+First launch after merge reports "unsupported WAL version" for pre-existing per-terminal WAL files; history resets. Call this out explicitly in the PR body so the expected empty-scrollback on first launch isn't mistaken for data loss.
+
+---
+
+## Notes on task ordering and model choice
+
+- **Tasks 1–4** are mostly mechanical (constants, encoding, binary search). Fast model is fine.
+- **Task 5** (FIFO refactor) touches hot persistence code paths — use a standard model and review carefully.
+- **Task 6** (sweep-on-delete) has a subtle invariant (superseded writes must be dropped before the delete); standard model.
+- **Tasks 7–10** (sparse Terminal + call-site migration) are mechanical — fast model.
+- **Tasks 11–12** (reload + E2E regression) are the quality gates — run under the same model as implementation and verify by hand if anything is murky.

--- a/docs/superpowers/specs/2026-04-19-ed-clear-tombstone-design.md
+++ b/docs/superpowers/specs/2026-04-19-ed-clear-tombstone-design.md
@@ -1,0 +1,189 @@
+# ED-Clear Tombstones for Persistent Sparse Store
+
+**Status**: Design
+**Date**: 2026-04-19
+**Relates to**: `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`, `docs/superpowers/specs/2026-04-07-sparse-pagestore-design.md`
+**Implements fix for**: phantom Claude text bleeding through on reload after OSC 133 anchor persistence (PR #190, follow-up to #189)
+
+## Background
+
+The sparse persistence stack (`sparse.Store` + WAL + `PageStore`) treats the on-disk store as append-only. `sparse.Store.ClearRange(lo, hi)` (`apps/texelterm/parser/sparse/store.go:201`) deletes entries from the in-memory `lines` map only — no notification reaches `AdaptivePersistence`, the WAL, or the `PageStore` index. On restart, `LoadStore` iterates every persisted position via `StoredLineCount` + `GlobalIdxAtStoredPosition` and re-materializes every cell that was ever written, including cells that an in-session ED 2 (or other erase op) had already cleared.
+
+User-visible symptom: after an in-session `/compact` or similar TUI reset, Claude issues ED 2 (`ESC[2J`), which our VTerm resolves via anchor-rewind to `CommandStart` / `InputStart+1` / `PromptStart+1` and calls `sparse.Terminal.ClearRange` on the stale range. The in-session grid looks correct. But on the next restart the stale range returns verbatim from disk and shows through any cells the respawned shell does not overwrite.
+
+A prior attempt (b75073c on `fix/clear-viewport-on-restore`) patched this at restore time by gating on `CommandStartGlobalLine >= 0` and clearing cells after `LoadStore`. It was fragile (depended on a command being in-flight at crash time) and was reverted. This spec addresses the problem at its origin: the clear needs to propagate to disk.
+
+## Goals
+
+- ED erase ops (`ED 0`, `ED 1`, `ED 2`, single-line invalidate) that clear a range on the sparse store also remove that range from the on-disk `PageStore` index, so `LoadStore` never re-emits the cleared cells.
+- One WAL entry per range clear, not one per line.
+- Ordering: a clear that follows queued writes in the same session must beat those writes in the end state — no zombies.
+- Crash safety: if the process dies between emitting the WAL delete op and applying it to `pageIndex`, WAL replay re-applies the delete.
+- Downgrade safety: an older binary opening a new-format WAL must fail loudly, not silently truncate.
+
+## Non-goals
+
+- Tombstones for `WriteWindow` scroll / newline / scroll-region ops. Those clears are always immediately overwritten by subsequent writes, so tombstoning them produces churn with no correctness gain.
+- Page-file byte reclamation / compaction. Tombstoned bytes remain in page files until natural rotation. Correctness depends on `pageIndex` absence, not byte-level erasure.
+- Multi-version WAL replay (skip-unknown op codes). WAL stays strict: any unknown op triggers recovery-truncate as today.
+- Automatic v1 → v2 WAL migration. On first launch with v2 code, a pre-existing v1 WAL will be rejected and history will appear empty. Documented in the PR description so the upgrade path is explicit.
+
+## The Approach
+
+### Architecture
+
+```
+vterm_main_screen.go / vterm_erase.go  (ED 0/1/2 + MainScreenInvalidateLine)
+    │ call sparse.Terminal.ClearRangePersistent(lo, hi)
+    ▼
+sparse.Terminal.ClearRangePersistent  (new)
+    • calls store.ClearRange(lo, hi)            — in-memory delete (existing)
+    • calls persistence.NotifyClearRange(lo, hi) — new persistence hook
+    ▼
+AdaptivePersistence.NotifyClearRange  (new)
+    • sweeps pendingLines for gi in [lo, hi]    — drops queued writes
+    • enqueues a Delete op in the FIFO ops queue
+    • WriteThrough mode: flushes immediately
+    • Debounced / BestEffort: flushes in FIFO order at the next flush
+    ▼
+WAL.AppendDelete(lo, hi, timestamp)  (new)       — one entry per range
+PageStore.DeleteRange(lo, hi)        (new)       — pageIndex slice-out
+```
+
+Scroll, newline, and scroll-region clears in `write_window.go` keep calling `sparse.Store.ClearRange` directly and stay in-memory only.
+
+### WAL format
+
+**Version bump:** header `Version uint32` goes from 1 to 2. Magic stays `TXWAL001`. `readHeader` already rejects mismatched versions with an error; an old binary opening a v2 WAL fails cleanly.
+
+**New op code:** `EntryTypeLineDelete = 0x06`. Current ops 0x01–0x05 unchanged.
+
+**Entry framing:** reuses the standard 25-byte entry header.
+
+| Field | Size | Value for delete ops |
+|-------|------|----------------------|
+| Type | 1 byte | `0x06` |
+| GlobalLineIdx | 8 bytes | `lo` (int64, inclusive) |
+| Timestamp | 8 bytes | wall-clock at the time of the ED op |
+| DataLen | 4 bytes | `8` |
+| Data | 8 bytes | `hi` (int64, inclusive, big-endian) |
+| CRC32 | 4 bytes | over all prior fields |
+
+**Validity:** `lo ≥ 0`, `lo ≤ hi`. Malformed entries fall through to the existing corruption path (WAL truncated to the last valid entry, execution continues).
+
+**Checkpointing:** unchanged. A tombstone applied before a checkpoint is reflected in the post-checkpoint `pageIndex` state, so the existing checkpoint-truncation logic works without modification.
+
+### PageStore
+
+**New method:**
+
+```go
+// DeleteRange removes all pageIndex entries in the closed interval [lo, hi].
+// Emits one WAL entry (EntryTypeLineDelete), then mutates pageIndex and
+// totalLineCount. Page-file bytes are not reclaimed. Safe no-op if the
+// range contains no stored entries (the WAL entry is still emitted so
+// on-disk ordering matches caller order; this keeps replay deterministic).
+func (ps *PageStore) DeleteRange(lo, hi int64) error
+```
+
+**Implementation sketch:**
+1. Validate `lo ≤ hi` and both non-negative.
+2. Emit `wal.AppendDelete(lo, hi, time.Now())`.
+3. Binary-search `pageIndex` for the first entry with `globalIdx ≥ lo`.
+4. Scan forward while `globalIdx ≤ hi`; record the end index.
+5. `pageIndex = append(pageIndex[:start], pageIndex[end:]...)`.
+6. `totalLineCount -= (end - start)`.
+7. If the current unflushed page falls entirely inside the range, discard it (reset `currentPage` to `nil`).
+
+**WAL replay:** the recovery path at `write_ahead_log.go:885` dispatches by op code; a new case for `EntryTypeLineDelete` calls `PageStore.DeleteRange` directly (bypassing the WAL-emit step — replay is idempotent).
+
+### AdaptivePersistence
+
+**New method:**
+
+```go
+// NotifyClearRange records a tombstone for [lo, hi]. Drops any queued
+// writes in that range from pendingLines, then enqueues a Delete op in
+// the FIFO ops queue. Flush semantics match the current mode:
+//
+//   WriteThrough: flush synchronously.
+//   Debounced:    arm debounce timer (or flush if already armed); ordering
+//                 preserved by the FIFO queue.
+//   BestEffort:   queue only; flush on idle or Close.
+func (ap *AdaptivePersistence) NotifyClearRange(lo, hi int64)
+```
+
+**FIFO ops queue.** Replaces (or wraps) the current `pendingLines` map with an ordered sequence of operations so writes and deletes flush in call order. Shape:
+
+```go
+type pendingOp struct {
+    kind    opKind       // opWrite | opDelete
+    lo, hi  int64        // for deletes; for writes, lo == hi == lineIdx
+    ts      time.Time
+    isCmd   bool         // writes only
+}
+
+type AdaptivePersistence struct {
+    // ...existing fields...
+    pendingOps []pendingOp     // ordered list
+    pendingSet map[int64]int   // lineIdx -> index into pendingOps (for dedup)
+}
+```
+
+`NotifyWrite` always appends a new `opWrite` entry and sets `pendingSet[gi]` to the new entry's index. `NotifyClearRange` sweeps `pendingSet` for any `gi` in `[lo, hi]`, marks those `pendingOps` entries as dropped (or removes them), clears the matching `pendingSet` keys, then appends an `opDelete`. Flush drains `pendingOps` in order: for each write, skip if `pendingSet[gi]` points to a later entry (superseded by a newer write); otherwise call `PageStore.AppendLineWithGlobalIdx`. For each delete, call `PageStore.DeleteRange`. This preserves call order between writes and deletes while deduping successive writes to the same line.
+
+**Pre-evict callback:** unchanged. Eviction still reads the current in-memory state; if a cell has been tombstoned before eviction triggers, the eviction simply sees nothing to flush for that `gi`.
+
+### sparse.Terminal
+
+**New method:**
+
+```go
+// ClearRangePersistent removes lines [lo, hi] from the in-memory store
+// and tombstones the range on disk. Used by VTerm ED ops and single-line
+// invalidation; not used by WriteWindow scroll / newline / scroll-region
+// (those stay transient).
+func (t *Terminal) ClearRangePersistent(lo, hi int64)
+```
+
+Implementation:
+1. `t.store.ClearRange(lo, hi)`.
+2. If `t.persistence != nil`, `t.persistence.NotifyClearRange(lo, hi)`.
+
+### Call-site changes
+
+Switch these sites from `ClearRange` to `ClearRangePersistent`:
+
+- `apps/texelterm/parser/vterm_main_screen.go:351` (ED 0 cursor → screen bottom)
+- `apps/texelterm/parser/vterm_main_screen.go:355` (ED 1 screen top → cursor)
+- `apps/texelterm/parser/vterm_main_screen.go:394` (ED 2 anchor-rewind)
+- `apps/texelterm/parser/vterm_main_screen.go:410` (ED 2 overflow-past-viewport)
+- `apps/texelterm/parser/vterm_main_screen.go:416` (ED 2 no-scrollback)
+- `apps/texelterm/parser/vterm_main_screen.go:507` (`MainScreenInvalidateLine`)
+- `apps/texelterm/parser/vterm_erase.go:68` (ED 2 alt-screen / no-scrollback path)
+
+Leave unchanged (in-memory only):
+
+- `apps/texelterm/parser/sparse/write_window.go:272, 280, 328, 358, 383`
+
+## Error handling
+
+- `WAL.AppendDelete` failure: propagate up from `PageStore.DeleteRange`. Caller (`AdaptivePersistence` flush path) logs and continues; this matches the existing policy for `AppendLineWithGlobalIdx` errors.
+- Malformed WAL delete entry on replay: falls into the existing corruption path (`write_ahead_log.go:913-997`) — WAL truncates to last valid entry.
+- `DeleteRange` called with `lo > hi` or negative values: return an error without emitting a WAL entry.
+- Downgrade (v2 WAL + v1 binary): `readHeader` returns `fmt.Errorf("unsupported WAL version %d")`; the terminal starts with empty history.
+
+## Testing
+
+1. **WAL round-trip** (`write_ahead_log_test.go`). Append a mix of writes and deletes; recover; verify entry order and payloads. Corrupt a delete entry's CRC; verify truncation at the entry boundary.
+2. **PageStore range delete** (`page_store_test.go`). Seed 10 lines at `gi=0..9`. `DeleteRange(3,7)`; assert `StoredLineCount == 5`, `GlobalIdxAtStoredPosition(3) == 8`, `ReadLine(4)` returns not-found. Edges: empty range (no entries in `[lo,hi]`), single-line range, whole-store range, range straddling the current unflushed page.
+3. **AdaptivePersistence FIFO ordering** (`adaptive_persistence_test.go`). WriteThrough: `NotifyWrite(5); NotifyClearRange(0,10); NotifyWrite(6)` → WAL records write-delete-write; `pendingOps` for gi=5 dropped at the delete. Debounced: same sequence queued, single flush emits in FIFO order.
+4. **Sparse reload round-trip** (`sparse/persistence_test.go`). Persist 20 lines, `ClearRangePersistent(5, 10)`, close, reopen, verify `LoadStore` skips the cleared range and the in-memory store after load has no entries in `[5,10]`.
+5. **End-to-end ED 2 regression** (`osc133_anchor_persistence_test.go`). Drive VTerm through a simulated TUI session that issues ED 2 with anchor rewind; close; reopen; verify no stale cells in the rewound range. This is the direct regression test for the bug motivating the whole feature.
+
+## Rollout
+
+- Branch: `fix/clear-viewport-on-restore` (current). Rename to `feat/persistent-clear-range` is optional — cosmetic.
+- Squash history on the branch to drop the reverted b75073c restore-time approach; keep the ED-in-session anchor clear commit (1c86537) plus the new tombstone commits.
+- PR #190 description rewritten around tombstones.
+- First launch after merge will report "unsupported WAL version" for pre-existing per-terminal WAL files and start with empty history. Acceptable given the single-user situation; documented in the PR body.


### PR DESCRIPTION
## Summary

- Fixes phantom TUI output (e.g. Claude Code frames) persisting into scrollback after a server restart.
- On ED 2 anchor-rewind, emits a WAL `EntryTypeLineDelete` tombstone for the range between the command-start anchor and the write high-water mark.
- Checkpoint replay shadows writes covered by a later tombstone in the same cycle, and `deleteRangeNoWAL` now rewrites `.page` files on disk so the deletion survives across checkpoints.

## The two-part fix

**Same-cycle shadowing** (earlier commits on this branch): `checkpointLocked()` builds a per-line `deleteEpoch` map in pass 1 and skips any write at an index ≤ the max covering delete in pass 2. This handles the case where writes and deletes live in the same WAL replay.

**Cross-cycle byte reclamation** (final commit): The epoch pass isn't enough in production. With the default 30s auto-checkpoint, phantom writes land in `.page` files BEFORE the ED 2 tombstone is emitted. The next checkpoint sees only the delete — the old `deleteRangeNoWAL` only mutated the in-memory `pageIndex`, leaving phantom bytes on disk; `rebuildIndex()` on reopen resurrected them. `deleteRangeNoWAL` now actually rewrites page files:
- Fully-contained pages → `os.Remove`
- Prefix or suffix kept → rewrite in place
- Middle delete → split into prefix (same pageID) + suffix (new pageID)

currentPage is flushed first so the rewrite path is uniformly on-disk; `nextGlobalIdx` is preserved across the rebuild (must not regress past HWM).

## Test plan

- [x] `go test ./apps/texelterm/parser/...` — full suite passes (~53s)
- [x] `TestLoadStore_TombstoneSurvivesCheckpoint` — same-cycle (writes + delete before Close)
- [x] `TestLoadStore_TombstoneSurvivesCheckpointAfterFlush` — production-shaped (checkpoint BETWEEN writes and delete)
- [x] `TestOSC133_ED2_TombstonesPersistToDisk` — end-to-end vterm flow
- [x] Manual: reproduced the phantom scenario with `claude` in a pane, restart server, phantom text no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)