### PR TITLE
Wire LastPromptLine/LastPromptHeight to OSC 133 anchors (#188)

### DIFF
--- a/apps/texelterm/parser/prompt_overwrite_recovery_test.go
+++ b/apps/texelterm/parser/prompt_overwrite_recovery_test.go
@@ -1,0 +1,222 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: apps/texelterm/parser/prompt_overwrite_recovery_test.go
+// Summary: Regression for issue #188. After closing a VTerm with a stored
+// OSC 133;A prompt and reopening, RepositionForPromptOverwrite must place
+// the cursor at column 0 of the prompt's global line so the freshly-spawned
+// shell's first PS1 prompt overwrites the stored prompt 1:1 instead of
+// rendering below it.
+
+package parser
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestRepositionForPromptOverwrite_ViewportHoldsPrompt covers the common
+// case where the whole history still fits in the viewport after reload
+// (writeTop stays at 0). The cursor must move onto the prompt row — NOT
+// rewinding writeTop, which would invalidate the rows above the prompt.
+func TestRepositionForPromptOverwrite_ViewportHoldsPrompt(t *testing.T) {
+	dir := t.TempDir()
+	id := "prompt-overwrite-viewport"
+	const cols, rows = 40, 10
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	parseString(p1, "banner\r\n")
+	v1.MarkPromptStart()
+	parseString(p1, "$ ")
+	v1.MarkInputStart()
+	parseString(p1, "echo hi\r\n")
+	v1.MarkCommandStart()
+	parseString(p1, "hi\r\n")
+
+	storedPrompt := v1.PromptStartGlobalLine
+	if storedPrompt < 0 {
+		t.Fatalf("setup: MarkPromptStart did not set PromptStartGlobalLine")
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.LastPromptLine() != storedPrompt {
+		t.Fatalf("LastPromptLine after reload: got %d, want %d", v2.LastPromptLine(), storedPrompt)
+	}
+	if got := v2.LastPromptHeight(); got != 1 {
+		t.Errorf("LastPromptHeight single-line: got %d, want 1", got)
+	}
+
+	topBefore := v2.mainScreen.WriteTop()
+	if topBefore > storedPrompt {
+		t.Fatalf("setup: expected writeTop (%d) <= storedPrompt (%d) for in-viewport case", topBefore, storedPrompt)
+	}
+
+	v2.RepositionForPromptOverwrite(storedPrompt)
+
+	if got := v2.mainScreen.WriteTop(); got != topBefore {
+		t.Errorf("writeTop should not move when prompt is already in viewport: got %d, want %d", got, topBefore)
+	}
+	wantRow := int(storedPrompt - topBefore)
+	if v2.cursorY != wantRow || v2.cursorX != 0 {
+		t.Errorf("cursor: got (%d, %d), want (%d, 0)", v2.cursorY, v2.cursorX, wantRow)
+	}
+}
+
+// TestRepositionForPromptOverwrite_PromptAboveWriteTop covers the
+// scrollback-overflow case where the stored prompt is older than the
+// current viewport. writeTop must rewind to the prompt line and the
+// cursor must land at row 0.
+func TestRepositionForPromptOverwrite_PromptAboveWriteTop(t *testing.T) {
+	dir := t.TempDir()
+	id := "prompt-overwrite-scrolled"
+	const cols, rows = 40, 5
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	v1.MarkPromptStart()
+	parseString(p1, "$ ")
+	v1.MarkInputStart()
+	parseString(p1, "cmd\r\n")
+	v1.MarkCommandStart()
+
+	// Push past the viewport so writeTop advances past the stored prompt.
+	for i := range rows * 3 {
+		parseString(p1, fmt.Sprintf("output line %d\r\n", i))
+	}
+
+	storedPrompt := v1.PromptStartGlobalLine
+	if storedPrompt < 0 {
+		t.Fatalf("setup: PromptStartGlobalLine not set")
+	}
+	if v1.mainScreen.WriteTop() <= storedPrompt {
+		t.Fatalf("setup: writeTop (%d) did not advance past storedPrompt (%d)",
+			v1.mainScreen.WriteTop(), storedPrompt)
+	}
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if v2.mainScreen.WriteTop() <= storedPrompt {
+		t.Fatalf("setup: reloaded writeTop (%d) should be past storedPrompt (%d)",
+			v2.mainScreen.WriteTop(), storedPrompt)
+	}
+
+	v2.RepositionForPromptOverwrite(storedPrompt)
+
+	if got := v2.mainScreen.WriteTop(); got != storedPrompt {
+		t.Errorf("writeTop should rewind to prompt: got %d, want %d", got, storedPrompt)
+	}
+	if v2.cursorY != 0 || v2.cursorX != 0 {
+		t.Errorf("cursor after rewind: got (%d, %d), want (0, 0)", v2.cursorY, v2.cursorX)
+	}
+}
+
+// TestRepositionForPromptOverwrite_MultiLinePromptHeight verifies
+// LastPromptHeight reflects the span between PromptStart and InputStart.
+// Repositioning always targets PromptStart (the top of the prompt); bash
+// will redraw every subsequent row of its own multi-line prompt.
+func TestRepositionForPromptOverwrite_MultiLinePromptHeight(t *testing.T) {
+	dir := t.TempDir()
+	id := "prompt-overwrite-multi"
+	const cols, rows = 40, 10
+
+	v1 := newTestVTerm(t, cols, rows, dir, id)
+	p1 := NewParser(v1)
+
+	parseString(p1, "banner\r\n")
+	v1.MarkPromptStart()
+	parseString(p1, "line1 of prompt\r\n")
+	parseString(p1, "line2 of prompt $ ")
+	v1.MarkInputStart()
+	parseString(p1, "cmd\r\n")
+	v1.MarkCommandStart()
+
+	promptStart := v1.PromptStartGlobalLine
+	inputStart := v1.InputStartGlobalLine
+	if promptStart < 0 || inputStart < promptStart {
+		t.Fatalf("setup: anchors invalid, prompt=%d input=%d", promptStart, inputStart)
+	}
+	wantHeight := int(inputStart-promptStart) + 1
+
+	if err := v1.CloseMemoryBuffer(); err != nil {
+		t.Fatalf("CloseMemoryBuffer: %v", err)
+	}
+
+	v2 := newTestVTerm(t, cols, rows, dir, id)
+	defer v2.CloseMemoryBuffer()
+
+	if got := v2.LastPromptHeight(); got != wantHeight {
+		t.Errorf("LastPromptHeight multi-line: got %d, want %d", got, wantHeight)
+	}
+
+	topBefore := v2.mainScreen.WriteTop()
+	v2.RepositionForPromptOverwrite(v2.LastPromptLine())
+
+	wantRow := max(int(promptStart-topBefore), 0)
+	if v2.cursorY != wantRow || v2.cursorX != 0 {
+		t.Errorf("cursor: got (%d, %d), want (%d, 0)", v2.cursorY, v2.cursorX, wantRow)
+	}
+}
+
+// TestRepositionForPromptOverwrite_UnknownPromptNoOp verifies the
+// repositioning is a no-op when the prompt line is unknown. Without this,
+// a stray call from a shell that doesn't emit OSC 133;A would wipe state.
+func TestRepositionForPromptOverwrite_UnknownPromptNoOp(t *testing.T) {
+	dir := t.TempDir()
+	id := "prompt-overwrite-noop"
+	const cols, rows = 40, 10
+
+	v := newTestVTerm(t, cols, rows, dir, id)
+	defer v.CloseMemoryBuffer()
+	p := NewParser(v)
+
+	parseString(p, "line1\r\nline2\r\nline3\r\n")
+	topBefore := v.mainScreen.WriteTop()
+	cx, cy := v.cursorX, v.cursorY
+
+	v.RepositionForPromptOverwrite(-1)
+
+	if got := v.mainScreen.WriteTop(); got != topBefore {
+		t.Errorf("writeTop after no-op: got %d, want %d", got, topBefore)
+	}
+	if v.cursorX != cx || v.cursorY != cy {
+		t.Errorf("cursor after no-op: got (%d, %d), want (%d, %d)", v.cursorY, v.cursorX, cy, cx)
+	}
+}
+
+// TestRepositionForPromptOverwrite_PromptPastViewportBottom is a defensive
+// no-op when the stored prompt somehow refers to a row below the current
+// viewport — a malformed state that callers shouldn't synthesize but that
+// the helper must survive without corrupting cursor coordinates.
+func TestRepositionForPromptOverwrite_PromptPastViewportBottom(t *testing.T) {
+	dir := t.TempDir()
+	id := "prompt-overwrite-past-bottom"
+	const cols, rows = 40, 5
+
+	v := newTestVTerm(t, cols, rows, dir, id)
+	defer v.CloseMemoryBuffer()
+	p := NewParser(v)
+
+	parseString(p, "a\r\n")
+	topBefore := v.mainScreen.WriteTop()
+
+	// Target a line well past writeTop + height-1.
+	v.RepositionForPromptOverwrite(topBefore + int64(rows) + 10)
+
+	if got := v.mainScreen.WriteTop(); got != topBefore {
+		t.Errorf("writeTop must not move on past-bottom target: got %d, want %d", got, topBefore)
+	}
+}

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -1060,14 +1060,50 @@ func (v *VTerm) GlobalEnd() int64 {
 	return v.mainScreen.ContentEnd()
 }
 
-// LastPromptLine returns the line index of the last shell prompt.
+// LastPromptLine returns the global line index of the last shell prompt,
+// tracked via OSC 133;A. Returns -1 if unknown.
 func (v *VTerm) LastPromptLine() int64 {
-	return -1
+	return v.PromptStartGlobalLine
 }
 
-// LastPromptHeight returns the height of the last prompt in lines.
+// LastPromptHeight returns the number of rows spanned by the last prompt,
+// derived from OSC 133 anchors: InputStart - PromptStart + 1. Defaults to 1
+// when anchors are unknown or inconsistent.
 func (v *VTerm) LastPromptHeight() int {
+	if v.PromptStartGlobalLine >= 0 && v.InputStartGlobalLine >= v.PromptStartGlobalLine {
+		return int(v.InputStartGlobalLine-v.PromptStartGlobalLine) + 1
+	}
 	return 1
+}
+
+// RepositionForPromptOverwrite positions the cursor at `promptLine` column 0
+// so a freshly-spawned shell's first prompt overwrites the stored prompt 1:1
+// instead of rendering on the row where the previous session left off. When
+// `promptLine` is at or past the current writeTop and within the viewport,
+// the cursor is moved in place. When it's above writeTop (viewport-capped
+// history), writeTop is rewound so the prompt line lands at row 0. No-op
+// if the main screen is absent, `promptLine` is unknown (<0), or the target
+// lies below the bottom of the current viewport.
+func (v *VTerm) RepositionForPromptOverwrite(promptLine int64) {
+	if v.mainScreen == nil || promptLine < 0 {
+		return
+	}
+	curTop := v.mainScreen.WriteTop()
+	var targetRow int
+	switch {
+	case promptLine < curTop:
+		v.mainScreen.RewindWriteTop(promptLine)
+		targetRow = 0
+	case promptLine >= curTop+int64(v.height):
+		// Prompt sits past the viewport bottom — nothing sensible to do.
+		return
+	default:
+		targetRow = int(promptLine - curTop)
+	}
+	v.cursorX = 0
+	v.cursorY = targetRow
+	v.wrapNext = false
+	v.MarkAllDirty()
 }
 
 // sparseLineStoreAdapter implements LineStore using MainScreen.

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -2277,13 +2277,19 @@ func (a *TexelTerm) populateFromHistoryLocked(savedState terminalState) {
 
 	// With MemoryBuffer, history is automatically loaded from disk if available.
 	// The scroll offset is restored in applyRestoredStateLocked.
-	if a.renderDebugLog != nil {
-		if savedState.LastPromptLine >= 0 {
-			a.renderDebugLog("[RECOVERY] Saved prompt line=%d, height=%d",
+	if savedState.LastPromptLine >= 0 {
+		// Rewind the write window to the stored prompt so the freshly-spawned
+		// shell's first PS1 prompt lands at col 0 of the same global line and
+		// overwrites the previous prompt instead of rendering below it. Works
+		// for both single- and multi-line prompts: bash will redraw every row
+		// of its prompt starting at PromptStart.
+		a.vterm.RepositionForPromptOverwrite(savedState.LastPromptLine)
+		if a.renderDebugLog != nil {
+			a.renderDebugLog("[RECOVERY] Repositioned to prompt line=%d, height=%d",
 				savedState.LastPromptLine, savedState.LastPromptHeight)
-		} else {
-			a.renderDebugLog("[RECOVERY] No saved prompt line")
 		}
+	} else if a.renderDebugLog != nil {
+		a.renderDebugLog("[RECOVERY] No saved prompt line")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces the `LastPromptLine` / `LastPromptHeight` stubs with real readouts of `PromptStartGlobalLine` / `InputStartGlobalLine`
- Adds `VTerm.RepositionForPromptOverwrite(promptLine)` and calls it from `populateFromHistoryLocked` so a freshly-spawned shell's first PS1 prompt overwrites the stored prompt 1:1 instead of rendering below it

Fixes #188. Unblocks the full user-visible fix now that #186 has landed (anchors persist across restart).

## Behavior

- Prompt still inside the viewport (small history): cursor moves onto the prompt row; `writeTop` does not change.
- Prompt above the viewport (scrolled out): `writeTop` rewinds to the prompt line and cursor lands at row 0.
- Multi-line prompt: repositioning targets PromptStart; bash's own PS1 redraws the subsequent rows. Height is still exposed via `LastPromptHeight()` for callers that care.
- `LastPromptLine < 0` (unknown prompt, or shell without OSC 133;A): no-op.
- Prompt past viewport bottom (malformed): defensive no-op.

## Test plan

- [x] New: `TestRepositionForPromptOverwrite_ViewportHoldsPrompt`
- [x] New: `TestRepositionForPromptOverwrite_PromptAboveWriteTop`
- [x] New: `TestRepositionForPromptOverwrite_MultiLinePromptHeight`
- [x] New: `TestRepositionForPromptOverwrite_UnknownPromptNoOp`
- [x] New: `TestRepositionForPromptOverwrite_PromptPastViewportBottom`
- [x] `make test` (full suite, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)