### PR TITLE
Track written cells to fix prompt reflow on resize (#193, #197)

### DIFF
--- a/apps/texelterm/parser/issue193_prompt_resize_test.go
+++ b/apps/texelterm/parser/issue193_prompt_resize_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 // powerlineTailFromCapture is the byte-for-byte tail of the right-aligned
-// prompt segment from /tmp/prompt-resize.txrec.bytes (offsets 0x110..0x186):
+// prompt segment from /tmp/prompt-resize.txrec.bytes (offsets 0x110..0x186),
+// trailing CR/CR/LF included exactly as the shell emitted them.
 //
 //	ESC[500C ESC[17D <SGR> <chevron> <SGR> " 21:45:14 " <SGR>
 //	<SGR> <chevron> <SGR> " marc " <SGR><SGR><SGR> CR CR LF
@@ -28,11 +29,14 @@ const powerlineTailFromCapture = "\x1b[500C\x1b[17D" +
 	"\x1b[38;5;240m\ue0b2\x1b[0m" +
 	"\x1b[48;5;240m 21:45:14 \x1b[0m\x1b[m\x1b[0m" +
 	"\x1b[38;5;32;48;5;240m\ue0b2\x1b[0m" +
-	"\x1b[48;5;32m marc \x1b[0m\x1b[m\x1b[0m\r\r\n"
+	"\x1b[48;5;32m marc \x1b[0m\x1b[m\x1b[0m" +
+	"\r\r\n"
 
 // TestIssue193_PowerlinePromptDoesNotWrapOnShrink: write a powerline
 // right-aligned prompt at width 107, then resize narrower. The single
-// logical row must stay a single physical row.
+// logical row must stay a single physical row regardless of where the
+// cursor ends up — the row's positional gap (cells 0..88 unwritten,
+// 89..106 written) is detected from the row itself.
 func TestIssue193_PowerlinePromptDoesNotWrapOnShrink(t *testing.T) {
 	const initialWidth = 107
 	const height = 36
@@ -43,6 +47,8 @@ func TestIssue193_PowerlinePromptDoesNotWrapOnShrink(t *testing.T) {
 
 	parseString(p, powerlineTailFromCapture)
 
+	// The trailing CR/LF moves the cursor down one row; the prompt row is
+	// the row above the cursor.
 	gi, _ := v.CursorGlobalIdx()
 	promptRow := gi - 1
 	cells := v.mainScreen.ReadLine(promptRow)
@@ -50,7 +56,7 @@ func TestIssue193_PowerlinePromptDoesNotWrapOnShrink(t *testing.T) {
 		t.Fatalf("prompt row %d empty after write", promptRow)
 	}
 	if cells[len(cells)-1].Wrapped {
-		t.Errorf("prompt row %d last cell has Wrapped=true after CR/LF (should be cleared)", promptRow)
+		t.Errorf("prompt row %d last cell has Wrapped=true; the powerline write should not have set Wrapped on its tail cell", promptRow)
 	}
 	t.Logf("prompt row %d: %d cells, last.Wrapped=%v", promptRow, len(cells), cells[len(cells)-1].Wrapped)
 

--- a/apps/texelterm/parser/issue197_cursor_pin_test.go
+++ b/apps/texelterm/parser/issue197_cursor_pin_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Issue #197: cursor row drifts up on widen instead of staying pinned at
+// the viewport bottom. When content above the cursor reflows into fewer
+// physical rows (because chains unwrap on widen), RecomputeLiveAnchor
+// clamps the backward walk at writeTop and falls through to anchoring
+// at writeTop with offset 0. Render fills `accumulated` rows and pads
+// the bottom with blanks — the cursor row ends up mid-viewport.
+
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestIssue197_CursorPinnedAtBottomOnWiden writes content that wraps at
+// the initial width, then widens and verifies the cursor row stays at the
+// bottom of the viewport.
+func TestIssue197_CursorPinnedAtBottomOnWiden(t *testing.T) {
+	const initialWidth = 40
+	const height = 20
+	const widerWidth = 120
+
+	v := NewVTerm(initialWidth, height)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Write 30 lines of ~80-char content. At width 40 each line autowraps
+	// into 2 physical rows; at width 120 each line fits on 1 row. So
+	// widening should reduce content from ~60 physical rows to ~30, leaving
+	// scrollback rows that need to be pulled in to refill the viewport top.
+	for i := 0; i < 30; i++ {
+		tag := fmt.Sprintf("L%05d ", i)
+		body := strings.Repeat("xy", (80-len(tag))/2)
+		parseString(p, tag+body+"\r\n")
+	}
+
+	v.Resize(widerWidth, height)
+	grid := v.Grid()
+
+	lastNonBlank := -1
+	for i, row := range grid {
+		if hasVisibleContent(row) {
+			lastNonBlank = i
+		}
+	}
+
+	// After widen, the cursor sits at the row after the last written line
+	// (where the next prompt would render). The expected behavior is that
+	// the cursor row — the last visible content row plus zero or one blank
+	// row — stays at the bottom of the viewport. If RecomputeLiveAnchor
+	// failed to pull in scrollback to refill the top, the cursor row
+	// drifts up and the bottom of the viewport is blank.
+	cursorY := getCursorY(v)
+	t.Logf("after widen: cursorY=%d, lastNonBlank=%d, height=%d", cursorY, lastNonBlank, height)
+	if cursorY < height-1 {
+		// Acceptable iff there's no scrollback to pull in. Here we wrote
+		// 30 lines × 2 rows = 60 physical rows of history, far more than
+		// height=20 — so there's plenty to pull from.
+		t.Errorf("cursor at row %d after widen (want %d, the bottom of the viewport); blank rows below cursor indicate the live anchor failed to pull scrollback in to refill the top", cursorY, height-1)
+		dumpGrid(t, grid)
+	}
+}
+
+// getCursorY returns the cursor's viewport row. Tries CursorToView first;
+// falls back to "row after the last visible content row" since the cursor
+// sits on the row immediately after the last written line.
+func getCursorY(v *VTerm) int {
+	if row, _, ok := v.mainScreen.CursorToView(); ok {
+		return row
+	}
+	grid := v.Grid()
+	last := -1
+	for i, row := range grid {
+		if hasVisibleContent(row) {
+			last = i
+		}
+	}
+	return last + 1
+}

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -12,9 +12,20 @@ import (
 // storeLine is the wrapper around a row of cells in the sparse Store.
 // A missing map entry represents "no content at this globalIdx" — reads of
 // missing globalIdxs return blank cells.
+//
+// written tracks which cells were placed by an explicit write (Set or SetLine
+// with content from the shell) versus filled implicitly when Set extended the
+// slice past its old length. This distinguishes typed content from positional
+// gaps left by CUF/CUP cursor jumps and lets the reflow logic skip slicing
+// rows whose only "wide" extent is positional padding (issue #193 / #197).
+//
+// written and cells are kept the same length. WrittenCount caches the popcount
+// for O(1) WrittenExtent queries.
 type storeLine struct {
-	cells  []parser.Cell
-	nowrap bool
+	cells        []parser.Cell
+	written      []bool
+	writtenCount int
+	nowrap       bool
 }
 
 // Store is a sparse, globalIdx-keyed cell storage.
@@ -71,7 +82,9 @@ func (s *Store) Get(globalIdx int64, col int) parser.Cell {
 }
 
 // Set writes a single Cell at (globalIdx, col). The target line is
-// automatically extended to cover col if it did not already.
+// automatically extended to cover col if it did not already; intermediate
+// cells (positional gap from a cursor jump) stay marked unwritten so the
+// reflow layer can distinguish them from typed content.
 func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
 	if col < 0 {
 		return
@@ -99,8 +112,15 @@ func (s *Store) Set(globalIdx int64, col int, cell parser.Cell) {
 		grown := make([]parser.Cell, needed, newCap)
 		copy(grown, line.cells)
 		line.cells = grown
+		grownWritten := make([]bool, needed, newCap)
+		copy(grownWritten, line.written)
+		line.written = grownWritten
 	}
 	line.cells[col] = cell
+	if !line.written[col] {
+		line.written[col] = true
+		line.writtenCount++
+	}
 	if globalIdx > s.contentEnd {
 		s.contentEnd = globalIdx
 	}
@@ -127,6 +147,10 @@ func (s *Store) GetLine(globalIdx int64) []parser.Cell {
 // preserved — use SetLineWithNoWrap to set an explicit flag value.
 // To preserve alignment with column 0, callers must pass cells starting at
 // column 0.
+//
+// Every cell in the replacement is marked written — SetLine is the bulk-replace
+// API used by reflow shifts and persistence reload, neither of which produce
+// positional gaps.
 func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -137,6 +161,11 @@ func (s *Store) SetLine(globalIdx int64, cells []parser.Cell) {
 	}
 	line.cells = make([]parser.Cell, len(cells))
 	copy(line.cells, cells)
+	line.written = make([]bool, len(cells))
+	for i := range line.written {
+		line.written[i] = true
+	}
+	line.writtenCount = len(cells)
 	if globalIdx > s.contentEnd {
 		s.contentEnd = globalIdx
 	}
@@ -178,7 +207,8 @@ func (s *Store) SetRowNoWrap(globalIdx int64, nowrap bool) {
 
 // SetLineWithNoWrap replaces both cells and the NoWrap flag at globalIdx.
 // Used by IL/DL/scroll shifts that move a row (and its NoWrap semantics)
-// from one globalIdx to another.
+// from one globalIdx to another. Like SetLine, every replacement cell is
+// marked written.
 func (s *Store) SetLineWithNoWrap(globalIdx int64, cells []parser.Cell, nowrap bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -189,9 +219,64 @@ func (s *Store) SetLineWithNoWrap(globalIdx int64, cells []parser.Cell, nowrap b
 	}
 	line.cells = make([]parser.Cell, len(cells))
 	copy(line.cells, cells)
+	line.written = make([]bool, len(cells))
+	for i := range line.written {
+		line.written[i] = true
+	}
+	line.writtenCount = len(cells)
 	line.nowrap = nowrap
 	if globalIdx > s.contentEnd {
 		s.contentEnd = globalIdx
+	}
+}
+
+// WrittenExtent returns (writtenCount, lastWrittenCol) for the row at
+// globalIdx. writtenCount is the number of cells placed by Set or SetLine;
+// lastWrittenCol is the highest column index that was written, or -1 when
+// no cells were written. Missing rows return (0, -1).
+//
+// rowHasPositionalGap uses this to detect rows with cursor-positioned
+// fillers — cells whose len(cells) extends past actual typed content.
+func (s *Store) WrittenExtent(globalIdx int64) (count int, lastCol int) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return 0, -1
+	}
+	last := -1
+	for i := len(line.written) - 1; i >= 0; i-- {
+		if line.written[i] {
+			last = i
+			break
+		}
+	}
+	return line.writtenCount, last
+}
+
+// EraseCell clears the cell at (globalIdx, col), unmarking it as written.
+// Unlike Set, EraseCell never extends the row past its current length —
+// erasing a column that was never written is a no-op. The supplied cell
+// value is stored verbatim (so callers can preserve a colored background)
+// but the written bit is cleared so reflow's gap detector treats the cell
+// as positional padding rather than typed content.
+func (s *Store) EraseCell(globalIdx int64, col int, cell parser.Cell) {
+	if col < 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	line, ok := s.lines[globalIdx]
+	if !ok {
+		return
+	}
+	if col >= len(line.cells) {
+		return
+	}
+	line.cells[col] = cell
+	if line.written[col] {
+		line.written[col] = false
+		line.writtenCount--
 	}
 }
 

--- a/apps/texelterm/parser/sparse/view_reflow.go
+++ b/apps/texelterm/parser/sparse/view_reflow.go
@@ -41,22 +41,21 @@ func walkChain(s *Store, startGI int64, maxSteps int) (end int64, nowrap bool) {
 // any content has been written) are emitted as explicit blank rows so the
 // chain's reflowed row count matches its physical-row footprint.
 //
-// Single-row "chains" whose last cell is NOT Wrapped (i.e., the row never
-// auto-wrapped) render as exactly one row. This handles content placed past
-// the previous cursor via CUF/CUP — e.g., a powerline prompt's right-aligned
-// segment via `ESC[500C ESC[17D` writes cells past the visible viewport
-// when the terminal later shrinks. Without this guard, the row's stored
-// cell count would be sliced into multiple physical rows on shrink, scrolling
-// older content up by an extra row each event (issue #193).
+// A single-row chain whose stored cells contain a positional gap (some cell
+// before the last-written col is unwritten — e.g., a powerline prompt that
+// jumped via `ESC[500C ESC[17D` and wrote at col 89 with cols 0..88 still
+// unwritten) renders as exactly one row at the cells' original positions.
+// Off-viewport cells clip naturally via clipRow. Without this, the stored
+// cell count would be sliced into multiple physical rows on shrink, surfacing
+// the right-side content on a NEW row (issue #193). Lines without gaps
+// (everything autowrap or shell-typed contiguously from col 0) reflow
+// normally — `ls -l` output etc. continues to wrap on shrink (issue #197).
 func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell {
 	if viewWidth <= 0 {
 		return nil
 	}
-	if startGI == endGI {
-		cells := s.GetLine(startGI)
-		if len(cells) == 0 || !cells[len(cells)-1].Wrapped {
-			return [][]parser.Cell{cells}
-		}
+	if startGI == endGI && rowHasPositionalGap(s, startGI) {
+		return [][]parser.Cell{s.GetLine(startGI)}
 	}
 	var logical []parser.Cell
 	for gi := startGI; gi <= endGI; gi++ {
@@ -100,15 +99,14 @@ func trailingEmptyRows(s *Store, start, end int64) int {
 // chainReflowedRowCount returns the number of physical rows the chain
 // [start..end] occupies when reflowed at width. Matches reflowChain's output
 // row count, including trailing empty continuation rows.
+//
+// See reflowChain for the positional-gap rationale (issue #193 / #197).
 func chainReflowedRowCount(s *Store, start, end int64, width int, nowrap bool) int {
 	if nowrap {
 		return int(end - start + 1)
 	}
-	if start == end {
-		cells := s.GetLine(start)
-		if len(cells) == 0 || !cells[len(cells)-1].Wrapped {
-			return 1
-		}
+	if start == end && rowHasPositionalGap(s, start) {
+		return 1
 	}
 	total := 0
 	for r := start; r <= end; r++ {
@@ -145,6 +143,24 @@ func findChainStart(s *Store, gi int64, maxSteps int) int64 {
 		start = prev
 	}
 	return start
+}
+
+// rowHasPositionalGap reports whether the row at gi was placed via cursor
+// positioning (CUF/CUP) past existing content rather than written contiguously
+// from col 0. Concretely: the count of cells actually written via WriteCell
+// is less than (lastWrittenCol + 1), i.e. there's at least one unwritten cell
+// before the last-written cell. Such rows must NOT be sliced into multiple
+// physical rows on shrink — the unwritten cells aren't real content and
+// shouldn't drag content past the viewport edge onto a new physical row.
+//
+// An empty row (no cells) and a row with no written cells are not "positional"
+// — they're just blank.
+func rowHasPositionalGap(s *Store, gi int64) bool {
+	written, lastCol := s.WrittenExtent(gi)
+	if written == 0 {
+		return false
+	}
+	return written < lastCol+1
 }
 
 // clipRow returns cells truncated or padded to viewWidth. Used for NoWrap

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -238,7 +238,29 @@ func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int
 			if gi <= writeTop {
 				break
 			}
-			gi--
+			// Walk to the start of the previous chain (mirrors the non-empty
+			// branch below). Without this, gi-- could land in the middle of a
+			// wrapped chain and walkChain would count only its tail row,
+			// leading the next iteration to count the same chain again.
+			prevGI := gi - 1
+			prevCells := s.GetLine(prevGI)
+			if len(prevCells) == 0 {
+				gi = prevGI
+				continue
+			}
+			prevChainStart := prevGI
+			for steps := 0; steps < maxSteps && prevChainStart > writeTop; steps++ {
+				pp := prevChainStart - 1
+				ppCells := s.GetLine(pp)
+				if len(ppCells) == 0 {
+					break
+				}
+				if !ppCells[len(ppCells)-1].Wrapped {
+					break
+				}
+				prevChainStart = pp
+			}
+			gi = prevChainStart
 			continue
 		}
 		end, nowrap := walkChain(s, gi, maxSteps)
@@ -284,11 +306,75 @@ func (v *ViewWindow) RecomputeLiveAnchor(s *Store, cursorGI int64, cursorCol int
 		gi = prevChainStart
 	}
 
-	// Ran out of content (or hit writeTop): anchor at writeTop so Render
-	// starts from the live window's top. For a fresh session (writeTop=0)
+	// First-stage walk hit writeTop without filling the viewport. If the
+	// cursor sits at or below the natural bottom of a height-sized window
+	// rooted at writeTop, pull scrollback (rows < writeTop) to refill the
+	// top so the cursor stays pinned at the viewport bottom (issue #197).
+	//
+	// Guard: if the cursor is well above that bottom, the live region is
+	// not full — we're in a fresh-resize state where the application (a
+	// TUI repainting via SIGWINCH, or a script that reset the cursor) will
+	// fill the live region itself. Pulling scrollback here would duplicate
+	// content the application is about to overwrite (#48).
+	if cursorGI < writeTop+int64(height)-1 {
+		v.mu.Lock()
+		v.viewAnchor = writeTop
+		v.viewAnchorOffset = 0
+		v.mu.Unlock()
+		return
+	}
+
+	// Skip any chain whose tail crosses writeTop — its live-side portion
+	// was already counted in the first stage, and re-counting the
+	// scrollback portion would duplicate cells.
+	gi = writeTop - 1
+	for accumulated < height && gi >= 0 {
+		cells := s.GetLine(gi)
+		if len(cells) == 0 && !s.RowNoWrap(gi) {
+			accumulated++
+			if accumulated >= height {
+				offset := accumulated - height
+				v.mu.Lock()
+				v.viewAnchor = gi
+				v.viewAnchorOffset = offset
+				v.mu.Unlock()
+				return
+			}
+			gi--
+			continue
+		}
+		chainStart := findChainStart(s, gi, maxSteps)
+		end, nowrap := walkChain(s, chainStart, maxSteps)
+		if end >= writeTop {
+			gi = chainStart - 1
+			continue
+		}
+		if reflowOff {
+			nowrap = true
+		}
+		chainRows := chainReflowedRowCount(s, chainStart, end, width, nowrap)
+		accumulated += chainRows
+		if accumulated >= height {
+			offset := accumulated - height
+			v.mu.Lock()
+			v.viewAnchor = chainStart
+			v.viewAnchorOffset = offset
+			v.mu.Unlock()
+			return
+		}
+		gi = chainStart - 1
+	}
+
+	// Ran out of content entirely: anchor at the earliest available row
+	// (0 if we exhausted scrollback, writeTop otherwise) so Render starts
+	// from the top of what's available. For a fresh session (writeTop=0)
 	// this degenerates to the old "anchor at top" behavior.
 	v.mu.Lock()
-	v.viewAnchor = writeTop
+	if gi < 0 {
+		v.viewAnchor = 0
+	} else {
+		v.viewAnchor = writeTop
+	}
 	v.viewAnchorOffset = 0
 	v.mu.Unlock()
 }

--- a/apps/texelterm/parser/sparse/write_window.go
+++ b/apps/texelterm/parser/sparse/write_window.go
@@ -281,23 +281,27 @@ func (w *WriteWindow) EraseLine() {
 }
 
 // EraseToEndOfLine clears cells from col to the end of the current line.
+// Erase uses Store.EraseCell so cleared cells are unmarked as written —
+// reflow's gap detector treats them as positional padding rather than
+// typed content (issue #193 / #197).
 func (w *WriteWindow) EraseToEndOfLine(col int) {
 	w.mu.Lock()
 	gi := w.cursorGlobalIdx
 	width := w.width
 	w.mu.Unlock()
 	for x := col; x < width; x++ {
-		w.store.Set(gi, x, parser.Cell{})
+		w.store.EraseCell(gi, x, parser.Cell{})
 	}
 }
 
 // EraseFromStartOfLine clears cells from column 0 through col (inclusive).
+// See EraseToEndOfLine for the written-mask rationale.
 func (w *WriteWindow) EraseFromStartOfLine(col int) {
 	w.mu.Lock()
 	gi := w.cursorGlobalIdx
 	w.mu.Unlock()
 	for x := 0; x <= col; x++ {
-		w.store.Set(gi, x, parser.Cell{})
+		w.store.EraseCell(gi, x, parser.Cell{})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Distinguishes shell-written cells from positional fillers via a parallel `written []bool` mask in `storeLine` — eliminates the heuristic-based gap detection from prior attempts.
- Single-row chains with a positional gap (`writtenCount < lastWrittenCol+1`) stay as one physical row on shrink; rows whose content is contiguous from col 0 still reflow normally.
- `EraseToEndOfLine` / `EraseFromStartOfLine` route through a new `Store.EraseCell` that clears cells without marking them written — without this, `\e[K` on the cursor row defeats gap detection.

## Why this approach

Prior attempts (cursorGI threading, capture trimming) were heuristic: they scoped the guard to "the cursor's chain" or special-cased shrink direction. The user pushed back: "I prefer this solution than using heuristics, it goes to the root of the problem and removes heuristics which look like a hack and can be hairy."

The written-mask approach IS that root cause: powerline prompts (`\e[500C\e[17D`) and EL erases write into columns that have no typed content, but `Store.Set` previously couldn't tell those positional fillers from real output. Now it can.

## Closes

Closes #193
Closes #197

## Test plan

- [x] `TestIssue193_PowerlinePromptDoesNotWrapOnShrink` passes (with original `\r\r\n` capture restored — no longer needs cursor scoping)
- [x] `TestIssue197_CursorPinnedAtBottomOnWiden` passes
- [x] Full parser test suite passes (`go test ./apps/texelterm/parser/...`)
- [x] Full project test suite passes (`make test`)
- [x] Manual verification in `texelation` binary: powerline prompt no longer wraps on shrink, cursor row no longer wraps blank EL'd cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)