### PR TITLE
Viewport clipping + FetchRange foundation (#199, Plan A)

### DIFF
--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -65,6 +65,14 @@ type MainScreen interface {
 	// Uses chain-walking + NoWrap flags to preserve structured content.
 	RenderReflow() [][]Cell
 
+	// RenderReflowWithRowIdx is the RenderReflow variant that also returns
+	// the per-row globalIdx slice produced by the same walk. rowGI[y] is the
+	// store globalIdx that row y corresponds to (chain-head gi for reflowed
+	// sub-rows), or -1 for blank/pad rows with no underlying store position.
+	// The two slices are lockstep-consistent — callers that need both should
+	// use this method rather than calling RenderReflow and querying separately.
+	RenderReflowWithRowIdx() ([][]Cell, []int64)
+
 	// CursorToView maps the current cursor to its viewport-relative (row, col)
 	// in the reflowed view. Returns ok=false if the cursor's globalIdx is not
 	// inside the currently-rendered chain walk, in which case callers should

--- a/apps/texelterm/parser/sparse/live_anchor_writetop_test.go
+++ b/apps/texelterm/parser/sparse/live_anchor_writetop_test.go
@@ -51,7 +51,7 @@ func TestLiveAnchor_ClampsAtWriteTop(t *testing.T) {
 
 	// Render must not paint any scrollback cells. The scrollback chain is
 	// all a/b/c/d runs; a correctly-clamped render shows only blanks.
-	out := vw.Render(s)
+	out, _ := vw.Render(s)
 	for row, cells := range out {
 		text := cellsToStringSparse(cells)
 		for _, bad := range []string{"aaaa", "bbbb", "cccc", "dddd"} {

--- a/apps/texelterm/parser/sparse/reflow_tail_test.go
+++ b/apps/texelterm/parser/sparse/reflow_tail_test.go
@@ -119,7 +119,7 @@ func TestRender_EmptyContinuationEmitsRow(t *testing.T) {
 
 	vw := NewViewWindow(80, 5)
 	vw.SetViewAnchor(0, 0)
-	out := vw.Render(s)
+	out, _ := vw.Render(s)
 
 	if len(out) < 3 {
 		t.Fatalf("Render too short: %d rows", len(out))
@@ -161,7 +161,8 @@ func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
 	vw := NewViewWindow(40, 3)
 	// Start by anchoring at the tail (line 4) so we're "past" the chain.
 	vw.SetViewAnchor(4, 0)
-	baseline := cellsToStringSparse(vw.Render(s)[0])
+	baselineRows, _ := vw.Render(s)
+	baseline := cellsToStringSparse(baselineRows[0])
 	if !strings.HasPrefix(baseline, "tail") {
 		t.Fatalf("baseline row 0 = %q; expected tail", baseline)
 	}
@@ -179,7 +180,7 @@ func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
 
 	// Top of viewport should show a non-fragmented reflowed row from the
 	// chain. Row 6 of the reflow = cells [240..280] = all 'd' (40 cells).
-	out := vw.Render(s)
+	out, _ := vw.Render(s)
 	row0 := cellsToStringSparse(out[0])
 	if !strings.HasPrefix(row0, strings.Repeat("d", 40)) {
 		t.Errorf("ScrollUp(1) top row = %q; want 40 d's (last reflowed row)", row0)

--- a/apps/texelterm/parser/sparse/store.go
+++ b/apps/texelterm/parser/sparse/store.go
@@ -65,6 +65,21 @@ func (s *Store) Max() int64 {
 	return s.contentEnd
 }
 
+// OldestRetained returns the lowest globalIdx currently resident in the Store.
+// Returns -1 when the Store is empty. O(n) in the number of resident rows; the
+// Store is typically small (resident window is bounded) so this is acceptable.
+func (s *Store) OldestRetained() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	oldest := int64(-1)
+	for k := range s.lines {
+		if oldest == -1 || k < oldest {
+			oldest = k
+		}
+	}
+	return oldest
+}
+
 // Get returns the Cell at (globalIdx, col). Returns a zero-value Cell if the
 // globalIdx has never been written to or if col is outside the line's current
 // length.

--- a/apps/texelterm/parser/sparse/store_test.go
+++ b/apps/texelterm/parser/sparse/store_test.go
@@ -148,6 +148,23 @@ func TestStore_ClearRangeKeepsContentEnd(t *testing.T) {
 	}
 }
 
+func TestStore_OldestRetained(t *testing.T) {
+	s := NewStore(80)
+	if got := s.OldestRetained(); got != -1 {
+		t.Fatalf("empty: got %d want -1", got)
+	}
+	s.Set(5, 0, parser.Cell{})
+	s.Set(10, 0, parser.Cell{})
+	s.Set(3, 0, parser.Cell{})
+	if got := s.OldestRetained(); got != 3 {
+		t.Fatalf("got %d want 3", got)
+	}
+	s.ClearRange(3, 3)
+	if got := s.OldestRetained(); got != 5 {
+		t.Fatalf("after clear: got %d want 5", got)
+	}
+}
+
 func TestStore_ConcurrentReadersWriter(t *testing.T) {
 	s := NewStore(80)
 	const N = 200

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -312,3 +312,9 @@ func (t *Terminal) Grid() [][]parser.Cell {
 // Store returns the underlying sparse store. Intended for read-only
 // scrollback fetch paths; callers must not mutate cells through it.
 func (t *Terminal) Store() *Store { return t.store }
+
+// ViewWindow returns the underlying ViewWindow. Intended for callers that
+// need to query per-row globalIdxs of the last RenderReflow call (see
+// ViewWindow.RowGlobalIdx). Callers must not mutate the ViewWindow's view
+// state through this handle.
+func (t *Terminal) ViewWindow() *ViewWindow { return t.view }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -275,6 +275,17 @@ func (t *Terminal) CursorToView() (viewRow, viewCol int, ok bool) {
 // autoFollow keeps the cursor on the bottom row of the viewport. This is the
 // bridge method; callers switch over from Grid() in a later step.
 func (t *Terminal) RenderReflow() [][]parser.Cell {
+	cells, _ := t.RenderReflowWithRowIdx()
+	return cells
+}
+
+// RenderReflowWithRowIdx is the RenderReflow variant that also returns the
+// per-row globalIdx slice produced by the view walk. The two slices are
+// always lockstep-consistent: rowGI[y] describes the row at out[y] for the
+// exact same walk. Callers that need to map viewport rows back to store
+// positions (e.g., the publisher's per-row clipping, the texelterm app's
+// RowGlobalIdxProvider) should use this variant to avoid re-walking.
+func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
 	cursorGI, cursorCol := t.write.Cursor()
 	t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
 	return t.view.Render(t.store)
@@ -314,7 +325,8 @@ func (t *Terminal) Grid() [][]parser.Cell {
 func (t *Terminal) Store() *Store { return t.store }
 
 // ViewWindow returns the underlying ViewWindow. Intended for callers that
-// need to query per-row globalIdxs of the last RenderReflow call (see
-// ViewWindow.RowGlobalIdx). Callers must not mutate the ViewWindow's view
-// state through this handle.
+// need to drive a reflow walk directly (e.g. the cursor-to-view mapping
+// path). Callers must not mutate the ViewWindow's view state through this
+// handle. Per-row globalIdxs of the current render are available via
+// Terminal.RenderReflowWithRowIdx rather than a stateful query.
 func (t *Terminal) ViewWindow() *ViewWindow { return t.view }

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -308,3 +308,7 @@ func (t *Terminal) Grid() [][]parser.Cell {
 	}
 	return grid
 }
+
+// Store returns the underlying sparse store. Intended for read-only
+// scrollback fetch paths; callers must not mutate cells through it.
+func (t *Terminal) Store() *Store { return t.store }

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -28,6 +28,13 @@ type ViewWindow struct {
 	viewAnchorOffset int
 	globalReflowOff  bool
 	autoJumpOnInput  bool
+
+	// rowGlobalIdx is a cache populated by Render(): rowGlobalIdx[y] is the
+	// store globalIdx that output row y corresponds to, or -1 if the row was
+	// a blank-pad row with no underlying store position. Length tracks the
+	// last-rendered height. Used by RowGlobalIdx(y) so callers see exactly
+	// what Render produced rather than a re-walked (possibly drifted) value.
+	rowGlobalIdx []int64
 }
 
 // NewViewWindow creates a ViewWindow in autoFollow mode. viewBottom starts
@@ -104,6 +111,7 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 	v.mu.Unlock()
 
 	out := make([][]parser.Cell, 0, height)
+	rowGI := make([]int64, 0, height)
 	maxSteps := 4 * height
 	if maxSteps < 4 {
 		maxSteps = 4
@@ -123,20 +131,32 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 				// A skip on an empty first chain is a no-op.
 			}
 			out = append(out, make([]parser.Cell, width))
+			// Blank/pad rows with no real content track as -1 so callers
+			// don't conflate them with a written row at that globalIdx.
+			rowGI = append(rowGI, -1)
 			gi++
 			continue
 		}
 		end, nowrap := walkChain(s, gi, maxSteps)
 
 		var rows [][]parser.Cell
+		var rowsGI []int64
 		if reflowOff || nowrap {
+			// Each physical row is its own globalIdx: gi, gi+1, ..., end.
 			for r := gi; r <= end; r++ {
 				rows = append(rows, clipRow(s.GetLine(r), width))
+				rowsGI = append(rowsGI, r)
 			}
 		} else {
+			// Wrapped chain reflowed to this viewport's width: all reflowed
+			// sub-rows share the chain's head globalIdx. Sub-row resolution
+			// would require tracking cell-range provenance through
+			// reflowChain; the publisher only needs "does this row belong
+			// to a real store position" which the chain head answers.
 			reflowed := reflowChain(s, gi, end, width)
 			for _, row := range reflowed {
 				rows = append(rows, clipRow(row, width))
+				rowsGI = append(rowsGI, gi)
 			}
 		}
 
@@ -144,24 +164,51 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 			first = false
 			if skip < len(rows) {
 				rows = rows[skip:]
+				rowsGI = rowsGI[skip:]
 			} else {
 				rows = nil
+				rowsGI = nil
 			}
 		}
 
-		for _, row := range rows {
+		for i, row := range rows {
 			if len(out) >= height {
 				break
 			}
 			out = append(out, row)
+			rowGI = append(rowGI, rowsGI[i])
 		}
 		gi = end + 1
 	}
 
 	for len(out) < height {
 		out = append(out, make([]parser.Cell, width))
+		rowGI = append(rowGI, -1)
 	}
+
+	// Trim to height in case any loop appended one extra entry.
+	if len(rowGI) > height {
+		rowGI = rowGI[:height]
+	}
+
+	v.mu.Lock()
+	v.rowGlobalIdx = rowGI
+	v.mu.Unlock()
+
 	return out
+}
+
+// RowGlobalIdx returns the store globalIdx that the last Render(s) call
+// placed at viewport row y, or -1 if y is out of [0, height) or the row was
+// a blank/pad row with no underlying store position. Reads the cache
+// populated by Render; returns -1 if Render has never been called.
+func (v *ViewWindow) RowGlobalIdx(y int) int64 {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if y < 0 || y >= len(v.rowGlobalIdx) {
+		return -1
+	}
+	return v.rowGlobalIdx[y]
 }
 
 // RecomputeLiveAnchor repositions viewAnchor/viewAnchorOffset so that the

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -28,13 +28,6 @@ type ViewWindow struct {
 	viewAnchorOffset int
 	globalReflowOff  bool
 	autoJumpOnInput  bool
-
-	// rowGlobalIdx is a cache populated by Render(): rowGlobalIdx[y] is the
-	// store globalIdx that output row y corresponds to, or -1 if the row was
-	// a blank-pad row with no underlying store position. Length tracks the
-	// last-rendered height. Used by RowGlobalIdx(y) so callers see exactly
-	// what Render produced rather than a re-walked (possibly drifted) value.
-	rowGlobalIdx []int64
 }
 
 // NewViewWindow creates a ViewWindow in autoFollow mode. viewBottom starts
@@ -100,8 +93,16 @@ func (v *ViewWindow) SetAutoJumpOnInput(enabled bool) {
 // Render projects the viewport by walking chains from viewAnchor. Each
 // chain is reflowed to viewWidth (unless NoWrap or globalReflowOff is set,
 // in which case rows render 1:1 via clipRow). Returns exactly viewHeight
-// rows, padded with empty cells if content is exhausted.
-func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
+// rows, padded with empty cells if content is exhausted, paired with a
+// parallel per-row globalIdx slice: rowGI[y] is the store globalIdx that
+// row y corresponds to (chain-head gi for reflowed sub-rows), or -1 if
+// the row is a blank-pad row with no underlying store position.
+//
+// Returning the rowGI slice alongside the rendered rows keeps the two in
+// lockstep even under concurrent Render calls — callers receive a
+// self-consistent pair, and no per-instance state has to straddle the
+// walk/publish boundary.
+func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 	v.mu.Lock()
 	width := v.width
 	height := v.height
@@ -191,24 +192,7 @@ func (v *ViewWindow) Render(s *Store) [][]parser.Cell {
 		rowGI = rowGI[:height]
 	}
 
-	v.mu.Lock()
-	v.rowGlobalIdx = rowGI
-	v.mu.Unlock()
-
-	return out
-}
-
-// RowGlobalIdx returns the store globalIdx that the last Render(s) call
-// placed at viewport row y, or -1 if y is out of [0, height) or the row was
-// a blank/pad row with no underlying store position. Reads the cache
-// populated by Render; returns -1 if Render has never been called.
-func (v *ViewWindow) RowGlobalIdx(y int) int64 {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	if y < 0 || y >= len(v.rowGlobalIdx) {
-		return -1
-	}
-	return v.rowGlobalIdx[y]
+	return out, rowGI
 }
 
 // RecomputeLiveAnchor repositions viewAnchor/viewAnchorOffset so that the

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -13,7 +13,7 @@ func TestViewWindow_Render_ReflowsOnNarrow(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out := vw.Render(s)
+	out, _ := vw.Render(s)
 
 	if len(out) != 5 {
 		t.Fatalf("Render should return viewHeight=5 rows, got %d", len(out))
@@ -35,7 +35,7 @@ func TestViewWindow_Render_NoWrapChainStays1to1(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out := vw.Render(s)
+	out, _ := vw.Render(s)
 
 	if !strings.HasPrefix(cellsToStringSparse(out[0]), "01234567890123456789") {
 		t.Errorf("NoWrap row 0 should be clipped 1:1, got %q", cellsToStringSparse(out[0]))

--- a/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
+++ b/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
@@ -1,0 +1,107 @@
+package sparse
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestViewWindow_RowGlobalIdx_MatchesRender asserts that RowGlobalIdx(y)
+// returns the globalIdx of the content on row y of the last Render() call.
+func TestViewWindow_RowGlobalIdx_MatchesRender(t *testing.T) {
+	s := NewStore(80)
+	for gi := int64(0); gi < 50; gi++ {
+		fillRow(s, gi, "row-"+strings.Repeat("x", int(gi%5)), false)
+	}
+
+	vw := NewViewWindow(40, 10)
+	vw.SetViewAnchor(5, 0)
+	out := vw.Render(s)
+	if len(out) != 10 {
+		t.Fatalf("Render returned %d rows, want 10", len(out))
+	}
+
+	// Each row's globalIdx should match the sequential walk from anchor.
+	// With no wrapping (rows fit in width 40), row y maps to gi = anchor + y.
+	for y := 0; y < 10; y++ {
+		got := vw.RowGlobalIdx(y)
+		want := int64(5 + y)
+		if got != want {
+			t.Errorf("RowGlobalIdx(%d) = %d, want %d", y, got, want)
+		}
+	}
+
+	// Out-of-range must be -1.
+	if got := vw.RowGlobalIdx(-1); got != -1 {
+		t.Errorf("RowGlobalIdx(-1) = %d, want -1", got)
+	}
+	if got := vw.RowGlobalIdx(10); got != -1 {
+		t.Errorf("RowGlobalIdx(10) = %d, want -1", got)
+	}
+}
+
+// TestViewWindow_RowGlobalIdx_ReflowedChain — a wrapped chain produces
+// multiple output rows but they all belong to the chain's first globalIdx.
+func TestViewWindow_RowGlobalIdx_ReflowedChain(t *testing.T) {
+	s := NewStore(80)
+	// 80 chars at store width 80, wrapped to next row with 5 chars.
+	text80 := strings.Repeat("0123456789", 8)
+	fillRow(s, 0, text80, true)
+	fillRow(s, 1, "abcde", false)
+	fillRow(s, 2, "final", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	out := vw.Render(s)
+	if len(out) != 5 {
+		t.Fatalf("Render returned %d rows, want 5", len(out))
+	}
+
+	// Reflow to width 40: chain 0..1 reflows to 3 rows (80+5 = 85 chars
+	// across width 40 => rows 0..2 all within chain anchored at gi=0).
+	// Row 3 = gi 2. Row 4 = beyond content (blank).
+	got0 := vw.RowGlobalIdx(0)
+	got1 := vw.RowGlobalIdx(1)
+	got2 := vw.RowGlobalIdx(2)
+	got3 := vw.RowGlobalIdx(3)
+	// The chain [0,1] covers output rows 0..2; all three rows get gi=0.
+	if got0 != 0 || got1 != 0 || got2 != 0 {
+		t.Errorf("reflowed chain rows: got (%d,%d,%d), want (0,0,0)", got0, got1, got2)
+	}
+	if got3 != 2 {
+		t.Errorf("row after chain: got %d, want 2", got3)
+	}
+}
+
+// TestViewWindow_RowGlobalIdx_BlankPadded — when content is exhausted,
+// extra padding rows must report -1.
+func TestViewWindow_RowGlobalIdx_BlankPadded(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 0, "only-one", false)
+
+	vw := NewViewWindow(40, 5)
+	vw.SetViewAnchor(0, 0)
+	vw.Render(s)
+
+	// Row 0 has gi=0. Row 1 is the next gi (1) with empty content — the
+	// walk emits blank rows for empty gis until the height fills.
+	got0 := vw.RowGlobalIdx(0)
+	if got0 != 0 {
+		t.Errorf("row 0: got %d, want 0", got0)
+	}
+	// Rows 1..4 are blank pad rows (no content in the store). They map to
+	// the "past content" region; RowGlobalIdx returns -1 since the walk
+	// synthesised them from blank rows. The exact gi isn't load-bearing;
+	// we only require that RowGlobalIdx produces a slice of the right
+	// length and that blank-filler rows at the bottom do not claim a
+	// globalIdx pointing at real content.
+	for y := 1; y < 5; y++ {
+		got := vw.RowGlobalIdx(y)
+		// The walk emits empty rows for each gi and increments gi — so
+		// row y maps to gi=y (an unwritten slot). The contract is that
+		// the index returned corresponds to that slot. For this test we
+		// only require it does NOT point to the only content row (0).
+		if got == 0 {
+			t.Errorf("row %d returned gi=0 but should not point at the lone content row", y)
+		}
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
+++ b/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 )
 
-// TestViewWindow_RowGlobalIdx_MatchesRender asserts that RowGlobalIdx(y)
-// returns the globalIdx of the content on row y of the last Render() call.
+// TestViewWindow_RowGlobalIdx_MatchesRender asserts that the gi slice
+// returned alongside the rendered rows places each row at the globalIdx
+// the walk emitted for it.
 func TestViewWindow_RowGlobalIdx_MatchesRender(t *testing.T) {
 	s := NewStore(80)
 	for gi := int64(0); gi < 50; gi++ {
@@ -15,27 +16,21 @@ func TestViewWindow_RowGlobalIdx_MatchesRender(t *testing.T) {
 
 	vw := NewViewWindow(40, 10)
 	vw.SetViewAnchor(5, 0)
-	out := vw.Render(s)
+	out, gi := vw.Render(s)
 	if len(out) != 10 {
 		t.Fatalf("Render returned %d rows, want 10", len(out))
+	}
+	if len(gi) != 10 {
+		t.Fatalf("Render returned gi len %d, want 10", len(gi))
 	}
 
 	// Each row's globalIdx should match the sequential walk from anchor.
 	// With no wrapping (rows fit in width 40), row y maps to gi = anchor + y.
 	for y := 0; y < 10; y++ {
-		got := vw.RowGlobalIdx(y)
 		want := int64(5 + y)
-		if got != want {
-			t.Errorf("RowGlobalIdx(%d) = %d, want %d", y, got, want)
+		if gi[y] != want {
+			t.Errorf("gi[%d] = %d, want %d", y, gi[y], want)
 		}
-	}
-
-	// Out-of-range must be -1.
-	if got := vw.RowGlobalIdx(-1); got != -1 {
-		t.Errorf("RowGlobalIdx(-1) = %d, want -1", got)
-	}
-	if got := vw.RowGlobalIdx(10); got != -1 {
-		t.Errorf("RowGlobalIdx(10) = %d, want -1", got)
 	}
 }
 
@@ -51,57 +46,50 @@ func TestViewWindow_RowGlobalIdx_ReflowedChain(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out := vw.Render(s)
+	out, gi := vw.Render(s)
 	if len(out) != 5 {
 		t.Fatalf("Render returned %d rows, want 5", len(out))
+	}
+	if len(gi) != 5 {
+		t.Fatalf("Render returned gi len %d, want 5", len(gi))
 	}
 
 	// Reflow to width 40: chain 0..1 reflows to 3 rows (80+5 = 85 chars
 	// across width 40 => rows 0..2 all within chain anchored at gi=0).
 	// Row 3 = gi 2. Row 4 = beyond content (blank).
-	got0 := vw.RowGlobalIdx(0)
-	got1 := vw.RowGlobalIdx(1)
-	got2 := vw.RowGlobalIdx(2)
-	got3 := vw.RowGlobalIdx(3)
 	// The chain [0,1] covers output rows 0..2; all three rows get gi=0.
-	if got0 != 0 || got1 != 0 || got2 != 0 {
-		t.Errorf("reflowed chain rows: got (%d,%d,%d), want (0,0,0)", got0, got1, got2)
+	if gi[0] != 0 || gi[1] != 0 || gi[2] != 0 {
+		t.Errorf("reflowed chain rows: got (%d,%d,%d), want (0,0,0)", gi[0], gi[1], gi[2])
 	}
-	if got3 != 2 {
-		t.Errorf("row after chain: got %d, want 2", got3)
+	if gi[3] != 2 {
+		t.Errorf("row after chain: got %d, want 2", gi[3])
 	}
 }
 
 // TestViewWindow_RowGlobalIdx_BlankPadded — when content is exhausted,
-// extra padding rows must report -1.
+// the extra rows above the bottom of the viewport must report -1 exactly
+// (per the documented "blank/pad rows → -1" contract), so callers don't
+// conflate a synthesized blank row with a real store position.
 func TestViewWindow_RowGlobalIdx_BlankPadded(t *testing.T) {
 	s := NewStore(80)
 	fillRow(s, 0, "only-one", false)
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	vw.Render(s)
-
-	// Row 0 has gi=0. Row 1 is the next gi (1) with empty content — the
-	// walk emits blank rows for empty gis until the height fills.
-	got0 := vw.RowGlobalIdx(0)
-	if got0 != 0 {
-		t.Errorf("row 0: got %d, want 0", got0)
+	_, gi := vw.Render(s)
+	if len(gi) != 5 {
+		t.Fatalf("Render returned gi len %d, want 5", len(gi))
 	}
-	// Rows 1..4 are blank pad rows (no content in the store). They map to
-	// the "past content" region; RowGlobalIdx returns -1 since the walk
-	// synthesised them from blank rows. The exact gi isn't load-bearing;
-	// we only require that RowGlobalIdx produces a slice of the right
-	// length and that blank-filler rows at the bottom do not claim a
-	// globalIdx pointing at real content.
+
+	// Row 0 has gi=0.
+	if gi[0] != 0 {
+		t.Errorf("row 0: got %d, want 0", gi[0])
+	}
+	// Rows 1..4 are blank pad rows (no content in the store). The
+	// documented contract is "blank/pad rows → -1"; assert that exactly.
 	for y := 1; y < 5; y++ {
-		got := vw.RowGlobalIdx(y)
-		// The walk emits empty rows for each gi and increments gi — so
-		// row y maps to gi=y (an unwritten slot). The contract is that
-		// the index returned corresponds to that slot. For this test we
-		// only require it does NOT point to the only content row (0).
-		if got == 0 {
-			t.Errorf("row %d returned gi=0 but should not point at the lone content row", y)
+		if gi[y] != -1 {
+			t.Errorf("row %d: got gi=%d, want -1 (blank/pad row)", y, gi[y])
 		}
 	}
 }

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -208,6 +208,22 @@ func (v *VTerm) Grid() [][]Cell {
 	return v.mainScreenGrid()
 }
 
+// GridWithRowIdx returns both the currently visible grid and a parallel
+// per-row globalIdx slice. On the main-screen path, rowIdx[y] is the sparse
+// store globalIdx that produced row y of the rendered grid (chain-head gi
+// for reflowed sub-rows, -1 for blank/pad rows). On the alt-screen path,
+// rowIdx is nil — alt-screen rows have no main-screen globalIdx mapping.
+// The grid and rowIdx slices come from a single view walk, so they are
+// lockstep-consistent.
+func (v *VTerm) GridWithRowIdx() ([][]Cell, []int64) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	if v.inAltScreen {
+		return v.altBuffer, nil
+	}
+	return v.mainScreenGridWithRowIdx()
+}
+
 // MainScreenGrid returns the sparse MainScreen's grid, or nil if no MainScreen
 // is configured.
 func (v *VTerm) MainScreenGrid() [][]Cell {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -107,22 +107,22 @@ type VTerm struct {
 // NewVTerm creates and initializes a new virtual terminal.
 func NewVTerm(width, height int, opts ...Option) *VTerm {
 	v := &VTerm{
-		width:                 width,
-		height:                height,
-		currentFG:             DefaultFG,
-		currentBG:             DefaultBG,
-		tabStops:              make(map[int]bool),
-		cursorVisible:         true,
-		autoWrapMode:          true,
-		marginTop:             0,
-		marginBottom:          height - 1,
-		marginLeft:            0,
-		marginRight:           width - 1,
-		leftRightMarginMode:   false,
-		defaultFG:             DefaultFG,
-		defaultBG:             DefaultBG,
-		dirtyLines:            make(map[int]bool),
-		allDirty:              true,
+		width:                  width,
+		height:                 height,
+		currentFG:              DefaultFG,
+		currentBG:              DefaultBG,
+		tabStops:               make(map[int]bool),
+		cursorVisible:          true,
+		autoWrapMode:           true,
+		marginTop:              0,
+		marginBottom:           height - 1,
+		marginLeft:             0,
+		marginRight:            width - 1,
+		leftRightMarginMode:    false,
+		defaultFG:              DefaultFG,
+		defaultBG:              DefaultBG,
+		dirtyLines:             make(map[int]bool),
+		allDirty:               true,
 		PromptStartGlobalLine:  -1,
 		InputStartGlobalLine:   -1,
 		CommandStartGlobalLine: -1,
@@ -1339,7 +1339,6 @@ func (v *VTerm) NotifyLinePersist(lineIdx int64) {
 	}
 }
 
-
 // Resize handles changes to the terminal's dimensions.
 func (v *VTerm) Resize(width, height int) {
 	v.mu.Lock()
@@ -1475,9 +1474,9 @@ func (v *VTerm) PhysicalCursor() (physX, physY int) {
 	physX = v.cursorX % v.width
 	return physX, physY
 }
-func (v *VTerm) DefaultFG() Color    { return v.defaultFG }
-func (v *VTerm) DefaultBG() Color    { return v.defaultBG }
-func (v *VTerm) OriginMode() bool    { return v.originMode }
+func (v *VTerm) DefaultFG() Color { return v.defaultFG }
+func (v *VTerm) DefaultBG() Color { return v.defaultBG }
+func (v *VTerm) OriginMode() bool { return v.originMode }
 
 // InAltScreen returns true if the terminal is currently showing the alternate screen buffer.
 func (v *VTerm) InAltScreen() bool { return v.inAltScreen }
@@ -1512,3 +1511,7 @@ func (v *VTerm) GetAltBufferLine(y int) []Cell {
 func (v *VTerm) ScrollMargins() (int, int) {
 	return v.marginTop, v.marginLeft
 }
+
+// MainScreenImpl returns the underlying MainScreen implementation, or nil
+// if no MainScreen is configured.
+func (v *VTerm) MainScreenImpl() MainScreen { return v.mainScreen }

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -436,10 +436,19 @@ func (v *VTerm) mainScreenEraseLine(mode int) {
 
 // mainScreenGrid returns the current sparse grid.
 func (v *VTerm) mainScreenGrid() [][]Cell {
+	grid, _ := v.mainScreenGridWithRowIdx()
+	return grid
+}
+
+// mainScreenGridWithRowIdx returns both the current sparse grid and the
+// parallel per-row globalIdx slice from the same view walk. Space-padding
+// and search highlighting are applied on the rendered grid just as in
+// mainScreenGrid; the rowIdx slice is passed through unchanged.
+func (v *VTerm) mainScreenGridWithRowIdx() ([][]Cell, []int64) {
 	if v.mainScreen == nil {
-		return nil
+		return nil, nil
 	}
-	grid := v.mainScreen.RenderReflow()
+	grid, rowIdx := v.mainScreen.RenderReflowWithRowIdx()
 	// Sparse Grid() returns Cell{} (Rune=0) for unwritten/erased cells.
 	// Convert to space so callers see consistent blank cells.
 	for _, row := range grid {
@@ -453,7 +462,7 @@ func (v *VTerm) mainScreenGrid() [][]Cell {
 	if v.searchHighlight != "" && len(grid) > 0 {
 		v.applySearchHighlight(grid)
 	}
-	return grid
+	return grid, rowIdx
 }
 
 // mainScreenScroll scrolls the user's view.

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -641,6 +641,57 @@ func (a *TexelTerm) logRenderDebug(grid [][]parser.Cell, cursorX, cursorY int, d
 	}
 }
 
+// RowGlobalIdx implements texel.RowGlobalIdxProvider. Returns a slice of
+// length == len(a.buf) where entry [y] is the sparse-store globalIdx of row
+// y of the last-rendered buffer, or -1 if that row has no main-screen
+// globalIdx (borders, statusbar, alt-screen content, or the buffer has not
+// been built yet). Must be called AFTER Render(); the underlying per-row
+// globalIdx slice is populated as a side-effect of the ViewWindow walk that
+// Render drives.
+func (a *TexelTerm) RowGlobalIdx() []int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.vterm == nil || a.buf == nil {
+		return nil
+	}
+	total := len(a.buf)
+	if total == 0 {
+		return nil
+	}
+	out := make([]int64, total)
+	for i := range out {
+		out[i] = -1
+	}
+	// Alt-screen rows have no main-screen globalIdx mapping.
+	if a.vterm.InAltScreen() {
+		return out
+	}
+	// Main-screen path: walk the sparse.Terminal's ViewWindow for per-row
+	// globalIdxs. Rows 0..termRows-1 are content; the final row is the
+	// statusbar (always -1) and is left at the default.
+	ms := a.vterm.MainScreenImpl()
+	if ms == nil {
+		return out
+	}
+	st, ok := ms.(*sparse.Terminal)
+	if !ok {
+		return out
+	}
+	vw := st.ViewWindow()
+	if vw == nil {
+		return out
+	}
+	// The rendered buffer has termRows content rows plus a 1-row statusbar.
+	termRows := total - 1
+	if termRows < 0 {
+		termRows = 0
+	}
+	for y := 0; y < termRows; y++ {
+		out[y] = vw.RowGlobalIdx(y)
+	}
+	return out
+}
+
 func (a *TexelTerm) Render() [][]texelcore.Cell {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -31,6 +31,7 @@ import (
 	"github.com/framegrace/texelui/widgets"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
 	"github.com/framegrace/texelation/apps/texelterm/shell"
 	"github.com/framegrace/texelation/apps/texelterm/transformer"
 	"github.com/framegrace/texelation/config"
@@ -39,9 +40,6 @@ import (
 	// Import transformers for init() side-effect registration.
 	_ "github.com/framegrace/texelation/apps/texelterm/tablefmt"
 	_ "github.com/framegrace/texelation/apps/texelterm/txfmt"
-
-	// Import sparse for init() side-effect: registers MainScreenFactory.
-	_ "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
 	"github.com/framegrace/texelation/internal/theming"
 	"github.com/framegrace/texelation/texel"
 	"github.com/framegrace/texelui/theme"
@@ -142,12 +140,12 @@ type TexelTerm struct {
 	scrollbar *ScrollBar
 
 	// Status bar with toggle button mode indicators
-	statusBar       *widgets.StatusBar
-	tfmToggle       *widgets.ToggleButton
-	tfmUserPref     bool // user's preferred transformer state (restored when TUI/alt clears)
-	tfmPillVisible  bool // whether the transformer pill button is shown on the decorator
-	searchToggle    *widgets.ToggleButton
-	cfgToggle       *widgets.ToggleButton
+	statusBar      *widgets.StatusBar
+	tfmToggle      *widgets.ToggleButton
+	tfmUserPref    bool // user's preferred transformer state (restored when TUI/alt clears)
+	tfmPillVisible bool // whether the transformer pill button is shown on the decorator
+	searchToggle   *widgets.ToggleButton
+	cfgToggle      *widgets.ToggleButton
 	// Config panel overlay
 	configPanel *ConfigPanel
 
@@ -189,21 +187,21 @@ func New(title, command string) texelcore.App {
 	cfg.SetHelpText("Configuration (F4)")
 
 	term := &TexelTerm{
-		title:        title,
-		command:      command,
-		width:        80,
-		height:       24,
-		stop:         make(chan struct{}),
-		colorPalette: newDefaultPalette(),
-		closeCh:      make(chan struct{}),
-		restartCh:    make(chan struct{}, 1),
-		controlBus:   texelcore.NewControlBus(),
-		statusBar:    sb,
-		tfmToggle:    tfm,
-		tfmUserPref:  initCfg.GetBool("transformers", "enabled", false),
+		title:          title,
+		command:        command,
+		width:          80,
+		height:         24,
+		stop:           make(chan struct{}),
+		colorPalette:   newDefaultPalette(),
+		closeCh:        make(chan struct{}),
+		restartCh:      make(chan struct{}, 1),
+		controlBus:     texelcore.NewControlBus(),
+		statusBar:      sb,
+		tfmToggle:      tfm,
+		tfmUserPref:    initCfg.GetBool("transformers", "enabled", false),
 		tfmPillVisible: initCfg.GetBool("transformers", "show_pill_button", true),
-		searchToggle: srch,
-		cfgToggle:    cfg,
+		searchToggle:   srch,
+		cfgToggle:      cfg,
 	}
 
 	// Wire config toggle to open/close config panel
@@ -320,6 +318,31 @@ func (a *TexelTerm) drawConfirmation(buf [][]texelcore.Cell) {
 
 func (a *TexelTerm) Vterm() *parser.VTerm {
 	return a.vterm
+}
+
+// InAltScreen reports whether the alt-screen buffer is currently active.
+func (a *TexelTerm) InAltScreen() bool {
+	if a.vterm == nil {
+		return false
+	}
+	return a.vterm.InAltScreen()
+}
+
+// SparseStore returns the underlying sparse.Store for the main screen, or nil
+// if no sparse-backed main screen is configured or the type assertion fails.
+func (a *TexelTerm) SparseStore() *sparse.Store {
+	if a.vterm == nil {
+		return nil
+	}
+	ms := a.vterm.MainScreenImpl()
+	if ms == nil {
+		return nil
+	}
+	term, ok := ms.(*sparse.Terminal)
+	if !ok {
+		return nil
+	}
+	return term.Store()
 }
 
 func (a *TexelTerm) mapParserColorToTCell(c parser.Color) tcell.Color {

--- a/apps/texelterm/term.go
+++ b/apps/texelterm/term.go
@@ -157,6 +157,14 @@ type TexelTerm struct {
 
 	// Visual bell flash state
 	bellFlashUntil time.Time
+
+	// lastRowGlobalIdx caches the per-row globalIdx slice produced by the
+	// most recent Render() call. Populated in the main-screen branch from
+	// VTerm.GridWithRowIdx; left nil on the alt-screen path (RowGlobalIdx
+	// synthesises an all-(-1) slice in that case). a.mu serialises reads
+	// and writes, so callers reading via RowGlobalIdx under the same lock
+	// always observe a self-consistent slice paired with the rendered buf.
+	lastRowGlobalIdx []int64
 }
 
 var _ texelcore.CloseRequester = (*TexelTerm)(nil)
@@ -645,9 +653,10 @@ func (a *TexelTerm) logRenderDebug(grid [][]parser.Cell, cursorX, cursorY int, d
 // length == len(a.buf) where entry [y] is the sparse-store globalIdx of row
 // y of the last-rendered buffer, or -1 if that row has no main-screen
 // globalIdx (borders, statusbar, alt-screen content, or the buffer has not
-// been built yet). Must be called AFTER Render(); the underlying per-row
-// globalIdx slice is populated as a side-effect of the ViewWindow walk that
-// Render drives.
+// been built yet). Must be called AFTER Render(); the per-row globalIdx
+// slice is captured during Render from VTerm.GridWithRowIdx and cached on
+// the TexelTerm under a.mu, so callers observe a slice that is lockstep-
+// consistent with a.buf.
 func (a *TexelTerm) RowGlobalIdx() []int64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -666,28 +675,15 @@ func (a *TexelTerm) RowGlobalIdx() []int64 {
 	if a.vterm.InAltScreen() {
 		return out
 	}
-	// Main-screen path: walk the sparse.Terminal's ViewWindow for per-row
-	// globalIdxs. Rows 0..termRows-1 are content; the final row is the
-	// statusbar (always -1) and is left at the default.
-	ms := a.vterm.MainScreenImpl()
-	if ms == nil {
-		return out
-	}
-	st, ok := ms.(*sparse.Terminal)
-	if !ok {
-		return out
-	}
-	vw := st.ViewWindow()
-	if vw == nil {
-		return out
-	}
-	// The rendered buffer has termRows content rows plus a 1-row statusbar.
+	// Main-screen path: copy from the cached slice populated by Render.
+	// The rendered buffer has termRows content rows plus a 1-row statusbar;
+	// the statusbar row stays at the default -1.
 	termRows := total - 1
 	if termRows < 0 {
 		termRows = 0
 	}
-	for y := 0; y < termRows; y++ {
-		out[y] = vw.RowGlobalIdx(y)
+	for y := 0; y < termRows && y < len(a.lastRowGlobalIdx); y++ {
+		out[y] = a.lastRowGlobalIdx[y]
 	}
 	return out
 }
@@ -700,11 +696,16 @@ func (a *TexelTerm) Render() [][]texelcore.Cell {
 		return nil
 	}
 
-	vtermGrid := a.vterm.Grid()
+	vtermGrid, vtermRowIdx := a.vterm.GridWithRowIdx()
 	termRows := len(vtermGrid)
 	if termRows == 0 {
+		a.lastRowGlobalIdx = nil
 		return nil
 	}
+	// Stash the per-row globalIdx slice for later RowGlobalIdx() queries.
+	// vtermRowIdx is nil on the alt-screen path; RowGlobalIdx handles that
+	// by synthesising an all-(-1) slice when needed.
+	a.lastRowGlobalIdx = vtermRowIdx
 	vtermCols := len(vtermGrid[0])
 
 	totalCols := vtermCols

--- a/apps/texelterm/term_test.go
+++ b/apps/texelterm/term_test.go
@@ -22,6 +22,7 @@ import (
 	texelcore "github.com/framegrace/texelui/core"
 
 	"github.com/framegrace/texelation/apps/texelterm"
+	"github.com/framegrace/texelation/texel"
 )
 
 func TestTexelTermRunRendersOutput(t *testing.T) {
@@ -329,6 +330,120 @@ func TestRenderCursorPositionAfterHorizontalResize(t *testing.T) {
 		t.Errorf("cursor row %d doesn't contain prompt: %q", cursorRowAfter, promptRow)
 		for y := 0; y < 5 && y < len(buf); y++ {
 			t.Logf("  row %d: %q", y, rowToString(buf[y]))
+		}
+	}
+
+	app.Stop()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("texelterm did not exit after stop")
+	}
+}
+
+// TestTexelTerm_RowGlobalIdxProvider_MainScreen verifies that a TexelTerm on
+// the main screen surfaces per-row globalIdx entries aligned with Render().
+// The content rows carry non-negative globalIdxs, and the statusbar row at
+// the bottom of the rendered buffer is -1.
+func TestTexelTerm_RowGlobalIdxProvider_MainScreen(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	script := writeScript(t, "#!/bin/sh\nprintf 'hello texelterm\\n'\nsleep 5\n")
+
+	app := texelterm.New("texelterm", script)
+	app.Resize(40, 10)
+	app.SetRefreshNotifier(make(chan bool, 4))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run()
+	}()
+
+	// Wait for the shell to print and the terminal to render at least one frame.
+	time.Sleep(500 * time.Millisecond)
+
+	buf := app.Render()
+	if len(buf) == 0 {
+		app.Stop()
+		<-errCh
+		t.Fatal("expected render buffer, got none")
+	}
+
+	provider, ok := app.(texel.RowGlobalIdxProvider)
+	if !ok {
+		app.Stop()
+		<-errCh
+		t.Fatal("TexelTerm does not implement texel.RowGlobalIdxProvider")
+	}
+	idx := provider.RowGlobalIdx()
+	if len(idx) != len(buf) {
+		app.Stop()
+		<-errCh
+		t.Fatalf("RowGlobalIdx length %d != Render length %d", len(idx), len(buf))
+	}
+
+	// The first content row must carry a valid main-screen globalIdx (>= 0).
+	if idx[0] < 0 {
+		t.Errorf("row 0 globalIdx = %d, want >= 0 for main-screen content", idx[0])
+	}
+	// The last row (statusbar) must be -1.
+	last := len(idx) - 1
+	if idx[last] != -1 {
+		t.Errorf("row %d (statusbar) globalIdx = %d, want -1", last, idx[last])
+	}
+
+	app.Stop()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("texelterm did not exit after stop")
+	}
+}
+
+// TestTexelTerm_RowGlobalIdxProvider_AltScreen verifies that when the
+// terminal is switched to the alt screen, every row reports -1 — alt-screen
+// content has no main-screen globalIdx mapping.
+func TestTexelTerm_RowGlobalIdxProvider_AltScreen(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Enter alt screen via DECSET ?1049h, print something, and sleep so
+	// we can sample the buffer while the app is still in alt-screen mode.
+	script := writeScript(t, "#!/bin/sh\nprintf '\\033[?1049h'\nprintf 'alt-screen content'\nsleep 5\n")
+
+	app := texelterm.New("texelterm", script)
+	app.Resize(40, 10)
+	app.SetRefreshNotifier(make(chan bool, 4))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- app.Run()
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	buf := app.Render()
+	if len(buf) == 0 {
+		app.Stop()
+		<-errCh
+		t.Fatal("expected render buffer, got none")
+	}
+
+	provider, ok := app.(texel.RowGlobalIdxProvider)
+	if !ok {
+		app.Stop()
+		<-errCh
+		t.Fatal("TexelTerm does not implement texel.RowGlobalIdxProvider")
+	}
+	idx := provider.RowGlobalIdx()
+	if len(idx) != len(buf) {
+		app.Stop()
+		<-errCh
+		t.Fatalf("RowGlobalIdx length %d != Render length %d", len(idx), len(buf))
+	}
+
+	for y, gi := range idx {
+		if gi != -1 {
+			t.Errorf("alt-screen row %d globalIdx = %d, want -1", y, gi)
 		}
 	}
 

--- a/client/buffercache.go
+++ b/client/buffercache.go
@@ -305,6 +305,20 @@ func (c *BufferCache) PaneByID(id [16]byte) *PaneState {
 	return c.panes[id]
 }
 
+// MarkPaneDirty forces a full re-render of the pane on the next frame.
+// Use when pane-adjacent state changed (e.g. PaneCache got new rows from a
+// FetchRange response) but no BufferDelta arrived to set Dirty itself.
+func (c *BufferCache) MarkPaneDirty(id [16]byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	pane := c.panes[id]
+	if pane == nil {
+		return
+	}
+	pane.Dirty = true
+	pane.DirtyRows = nil // full re-render
+}
+
 // PaneAt returns the topmost pane containing the provided workspace coordinates.
 func (c *BufferCache) PaneAt(x, y int) *PaneState {
 	c.mu.RLock()

--- a/client/buffercache.go
+++ b/client/buffercache.go
@@ -316,7 +316,7 @@ func (c *BufferCache) MarkPaneDirty(id [16]byte) {
 		return
 	}
 	pane.Dirty = true
-	pane.DirtyRows = nil // full re-render
+	pane.DirtyRows = nil
 }
 
 // PaneAt returns the topmost pane containing the provided workspace coordinates.

--- a/client/pane_cache.go
+++ b/client/pane_cache.go
@@ -1,0 +1,186 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: client/pane_cache.go
+// Summary: Sparse per-pane cell cache keyed by globalIdx for viewport-only rendering.
+// Usage: Receives clipped BufferDelta and FetchRangeResponse from the server;
+//
+//	renderer reads rows by globalIdx instead of screen-row index.
+//
+// Notes: Main-screen rows are keyed by globalIdx; alt-screen rows are a flat
+//
+//	screen-sized 2D buffer indexed by screen row.
+
+package client
+
+import (
+	"sync"
+
+	"github.com/framegrace/texelation/protocol"
+	"github.com/gdamore/tcell/v2"
+)
+
+// PaneCache is the client's local copy of a pane's displayable cells.
+// Main-screen rows are keyed by globalIdx; alt-screen rows are a flat
+// screen-sized 2D buffer.
+type PaneCache struct {
+	mu        sync.RWMutex
+	altScreen bool
+	main      map[int64][]Cell
+	alt       [][]Cell
+	revision  uint32
+}
+
+// NewPaneCache constructs an empty PaneCache.
+func NewPaneCache() *PaneCache {
+	return &PaneCache{main: make(map[int64][]Cell)}
+}
+
+// IsAltScreen reports whether the pane is currently in alt-screen mode.
+func (c *PaneCache) IsAltScreen() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.altScreen
+}
+
+// ApplyDelta merges a BufferDelta into the cache.
+func (c *PaneCache) ApplyDelta(d protocol.BufferDelta) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	alt := d.Flags&protocol.BufferDeltaAltScreen != 0
+	if alt != c.altScreen {
+		// Mode changed — drop the other side's state.
+		c.altScreen = alt
+		if alt {
+			c.main = make(map[int64][]Cell)
+		} else {
+			c.alt = nil
+		}
+	}
+	if d.Revision > c.revision {
+		c.revision = d.Revision
+	}
+	// NOTE: Styles are per-delta. We decode spans into concrete cells
+	// eagerly so later reads don't need the style table.
+	styles := d.Styles
+	for _, row := range d.Rows {
+		cells := decodeSpans(row.Spans, styles)
+		if alt {
+			c.putAlt(int(row.Row), cells)
+		} else {
+			gid := d.RowBase + int64(row.Row)
+			c.main[gid] = cells
+		}
+	}
+}
+
+// ApplyFetchRange merges rows fetched on-demand.
+func (c *PaneCache) ApplyFetchRange(r protocol.FetchRangeResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if r.Flags&protocol.FetchRangeAltScreenActive != 0 {
+		// Server says alt-screen is active — nothing to cache.
+		return
+	}
+	// Coherence rule: drop stale responses.
+	if r.Revision < c.revision {
+		return
+	}
+	if r.Revision > c.revision {
+		c.revision = r.Revision
+	}
+	styles := r.Styles
+	for _, row := range r.Rows {
+		cells := decodeSpans(row.Spans, styles)
+		c.main[row.GlobalIdx] = cells
+	}
+}
+
+// RowAt returns the main-screen row for globalIdx.
+func (c *PaneCache) RowAt(globalIdx int64) ([]Cell, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	row, ok := c.main[globalIdx]
+	return row, ok
+}
+
+// AltRowAt returns the alt-screen row for screenRow.
+func (c *PaneCache) AltRowAt(screenRow int) ([]Cell, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if screenRow < 0 || screenRow >= len(c.alt) {
+		return nil, false
+	}
+	return c.alt[screenRow], true
+}
+
+// Evict drops main-screen rows outside [lo − overscan×1.5, hi + overscan×1.5].
+// Called after each viewport change. Small hysteresis prevents thrash on
+// micro-scrolls.
+func (c *PaneCache) Evict(lo, hi, overscan int64) {
+	band := int64(float64(overscan) * 1.5)
+	lowerBound := lo - band
+	upperBound := hi + band
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.main {
+		if k < lowerBound || k > upperBound {
+			delete(c.main, k)
+		}
+	}
+}
+
+// MissingRows returns the globalIdxs in [lo, hi] not currently in cache.
+// Caller uses this to issue a MsgFetchRange. Returned slice is sorted ascending.
+func (c *PaneCache) MissingRows(lo, hi int64) []int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	var miss []int64
+	for gid := lo; gid <= hi; gid++ {
+		if _, ok := c.main[gid]; !ok {
+			miss = append(miss, gid)
+		}
+	}
+	return miss
+}
+
+func (c *PaneCache) putAlt(row int, cells []Cell) {
+	for row >= len(c.alt) {
+		c.alt = append(c.alt, nil)
+	}
+	c.alt[row] = cells
+}
+
+// decodeSpans expands a slice of CellSpan into a concrete []Cell row.
+// The returned slice length covers all columns written by the spans.
+func decodeSpans(spans []protocol.CellSpan, styles []protocol.StyleEntry) []Cell {
+	built := buildStyles(styles)
+	var row []Cell
+	for _, span := range spans {
+		start := int(span.StartCol)
+		textRunes := []rune(span.Text)
+		needed := start + len(textRunes)
+		row = ensureRowLength(row, needed)
+		style := buildStyleAt(built, int(span.StyleIndex))
+		var dynFG, dynBG protocol.DynColorDesc
+		if int(span.StyleIndex) < len(styles) {
+			entry := styles[span.StyleIndex]
+			if entry.AttrFlags&protocol.AttrHasDynamic != 0 {
+				dynFG = entry.DynFG
+				dynBG = entry.DynBG
+			}
+		}
+		for i, r := range textRunes {
+			row[start+i] = Cell{Ch: r, Style: style, DynFG: dynFG, DynBG: dynBG}
+		}
+	}
+	return row
+}
+
+// buildStyleAt returns the tcell.Style at index i, or StyleDefault when out of range.
+func buildStyleAt(styles []tcell.Style, i int) tcell.Style {
+	if i < 0 || i >= len(styles) {
+		return tcell.StyleDefault
+	}
+	return styles[i]
+}

--- a/client/pane_cache.go
+++ b/client/pane_cache.go
@@ -97,6 +97,7 @@ func (c *PaneCache) ApplyFetchRange(r protocol.FetchRangeResponse) {
 }
 
 // RowAt returns the main-screen row for globalIdx.
+// The caller must not modify or retain the returned slice beyond the current frame.
 func (c *PaneCache) RowAt(globalIdx int64) ([]Cell, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -105,6 +106,7 @@ func (c *PaneCache) RowAt(globalIdx int64) ([]Cell, bool) {
 }
 
 // AltRowAt returns the alt-screen row for screenRow.
+// The caller must not modify or retain the returned slice beyond the current frame.
 func (c *PaneCache) AltRowAt(screenRow int) ([]Cell, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -118,7 +120,10 @@ func (c *PaneCache) AltRowAt(screenRow int) ([]Cell, bool) {
 // Called after each viewport change. Small hysteresis prevents thrash on
 // micro-scrolls.
 func (c *PaneCache) Evict(lo, hi, overscan int64) {
-	band := int64(float64(overscan) * 1.5)
+	if overscan < 0 {
+		overscan = 0
+	}
+	band := overscan + overscan/2
 	lowerBound := lo - band
 	upperBound := hi + band
 	c.mu.Lock()

--- a/client/pane_cache_test.go
+++ b/client/pane_cache_test.go
@@ -56,7 +56,7 @@ func TestPaneCache_EvictsOutsideWindow(t *testing.T) {
 		},
 		Styles: []protocol.StyleEntry{{AttrFlags: 0}},
 	})
-	// Viewport is [1,2] + 1× overscan of 2 rows → [−1, 4]; hysteresis 1.5×.
+	// Viewport is [1,2] + band of 3 (overscan=2 → 2+2/2=3) → [−2, 5]; hysteresis 1.5×.
 	pc.Evict(1, 2, 2)
 	if _, ok := pc.RowAt(0); !ok {
 		t.Fatalf("row 0 inside hysteresis band, should be retained")

--- a/client/pane_cache_test.go
+++ b/client/pane_cache_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package client
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestPaneCache_ApplyDeltaMainScreen(t *testing.T) {
+	pc := NewPaneCache()
+	pc.ApplyDelta(protocol.BufferDelta{
+		RowBase: 1_000,
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "hello", StyleIndex: 0}}},
+			{Row: 2, Spans: []protocol.CellSpan{{StartCol: 0, Text: "world", StyleIndex: 0}}},
+		},
+		Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+	})
+	if row, ok := pc.RowAt(1_000); !ok || !rowStartsWith(row, "hello") {
+		t.Fatalf("globalIdx 1000 missing or wrong: ok=%v row=%v", ok, row)
+	}
+	if _, ok := pc.RowAt(1_001); ok {
+		t.Fatalf("globalIdx 1001 should be absent (no delta row)")
+	}
+	if row, ok := pc.RowAt(1_002); !ok || !rowStartsWith(row, "world") {
+		t.Fatalf("globalIdx 1002 missing or wrong")
+	}
+}
+
+func TestPaneCache_ApplyDeltaAltScreen(t *testing.T) {
+	pc := NewPaneCache()
+	pc.ApplyDelta(protocol.BufferDelta{
+		Flags:  protocol.BufferDeltaAltScreen,
+		Rows:   []protocol.RowDelta{{Row: 3, Spans: []protocol.CellSpan{{StartCol: 0, Text: "vim", StyleIndex: 0}}}},
+		Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+	})
+	if !pc.IsAltScreen() {
+		t.Fatalf("expected alt-screen mode")
+	}
+	if row, ok := pc.AltRowAt(3); !ok || !rowStartsWith(row, "vim") {
+		t.Fatalf("alt row 3 missing")
+	}
+}
+
+func TestPaneCache_EvictsOutsideWindow(t *testing.T) {
+	pc := NewPaneCache()
+	pc.ApplyDelta(protocol.BufferDelta{
+		RowBase: 0,
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "a", StyleIndex: 0}}},
+			{Row: 1, Spans: []protocol.CellSpan{{StartCol: 0, Text: "b", StyleIndex: 0}}},
+			{Row: 2, Spans: []protocol.CellSpan{{StartCol: 0, Text: "c", StyleIndex: 0}}},
+		},
+		Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+	})
+	// Viewport is [1,2] + 1× overscan of 2 rows → [−1, 4]; hysteresis 1.5×.
+	pc.Evict(1, 2, 2)
+	if _, ok := pc.RowAt(0); !ok {
+		t.Fatalf("row 0 inside hysteresis band, should be retained")
+	}
+	// Now slam the viewport far away — eviction should clear row 0.
+	pc.Evict(1_000, 1_002, 2)
+	if _, ok := pc.RowAt(0); ok {
+		t.Fatalf("row 0 should be evicted after viewport jump")
+	}
+}
+
+func rowStartsWith(row []Cell, s string) bool {
+	if len(row) < len(s) {
+		return false
+	}
+	var buf []rune
+	for _, c := range row {
+		buf = append(buf, c.Ch)
+	}
+	return string(buf[:len(s)]) == s
+}

--- a/docs/superpowers/plans/2026-04-21-issue-199-plan-a-viewport-clipping-fetchrange.md
+++ b/docs/superpowers/plans/2026-04-21-issue-199-plan-a-viewport-clipping-fetchrange.md
@@ -1,0 +1,1976 @@
+# Issue #199 — Plan A: Viewport Clipping + FetchRange Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the viewport-clipping data path end-to-end. After this plan, the server emits only the client's visible window (plus 1× overscan) in `BufferDelta`, and clients can fetch arbitrary scrollback ranges on demand via `MsgFetchRange`. Resume still snaps to live edge, selection is still client-only — those ship in Plans B / C.
+
+**Architecture:** Extend `BufferDelta` with `RowBase int64` and a `Flags.AltScreen` bit. Add `MsgViewportUpdate` (client → server per-pane viewport state), `MsgFetchRange` + `MsgFetchRangeResponse` (on-demand scrollback). Server tracks `map[PaneID]ClientViewport` per `Session`. Publisher clips rows at emit time. Client replaces `BufferCache` with a per-pane sparse cache keyed by `globalIdx`, populated by deltas and fetch responses, rendered against the current `ViewWindow`. Alt-screen keeps current flat-buffer semantics, opts out of clipping and FetchRange via the new flag.
+
+**Tech Stack:** Go 1.24.3, existing binary protocol (`protocol/`), `sparse.Store` + `sparse.ViewWindow`, `tcell`-based client renderer, `DesktopPublisher` + `Session` fan-out.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md` — this plan implements spec sequencing steps **1–4**. Steps 5–8 land in follow-up plans B/C/D/E.
+
+**Branch:** `design/issue-199-viewport-only-rendering` — do **not** merge to main until Plan A lands green. Per project CLAUDE.md: never commit directly to main.
+
+---
+
+## File Structure
+
+### New files
+
+- `protocol/viewport.go` — `ViewportUpdate` encode/decode.
+- `protocol/viewport_test.go` — round-trip tests.
+- `protocol/fetch_range.go` — `FetchRange`, `FetchRangeResponse`, `LogicalRow` wire format.
+- `protocol/fetch_range_test.go` — round-trip tests.
+- `internal/runtime/server/client_viewport.go` — per-pane `ClientViewport` struct, `Session`-scoped map, helpers.
+- `internal/runtime/server/client_viewport_test.go` — clipping unit tests.
+- `internal/runtime/server/fetch_range_handler.go` — handles `MsgFetchRange`, produces `MsgFetchRangeResponse`.
+- `internal/runtime/server/fetch_range_handler_test.go`.
+- `internal/runtime/client/pane_cache.go` — per-pane sparse cache keyed by globalIdx; replaces `BufferCache` incrementally.
+- `internal/runtime/client/pane_cache_test.go`.
+
+### Modified files
+
+- `protocol/protocol.go` — new `MessageType` constants: `MsgViewportUpdate`, `MsgFetchRange`, `MsgFetchRangeResponse`. Bump protocol version.
+- `protocol/buffer_delta.go` — add `RowBase int64` field; add `BufferDeltaAltScreen` flag constant; extend encode/decode with backward-incompatible version guard.
+- `protocol/buffer_delta_test.go` — expand round-trip coverage.
+- `texel/snapshot.go` — add `RowGlobalIdx []int64` to `PaneSnapshot`; one entry per row of `Buffer`, value is the `globalIdx` of that row for main-screen panes, `-1` for alt-screen rows.
+- `apps/texelterm/term.go` (and any other App with `Snapshot()` on a sparse-backed pane) — populate `RowGlobalIdx` from `ViewWindow`.
+- `texel/desktop.go` / `texel/desktop_engine_core.go` — plumb `RowGlobalIdx` through `SnapshotBuffers`.
+- `internal/runtime/server/desktop_publisher.go` — clip per-client at emit time; track per-pane `Revision`; populate `RowBase`; set `Flags.AltScreen` for alt-screen panes.
+- `internal/runtime/server/desktop_publisher_test.go` — rewrite full-pane assertions as viewport-clipped.
+- `internal/runtime/server/session.go` — store `viewports map[PaneID]ClientViewport`; extend handshake hook to accept `ViewportUpdate`.
+- `internal/runtime/server/connection_handler.go` — dispatch `MsgViewportUpdate` and `MsgFetchRange`.
+- `internal/runtime/client/renderer.go` — replace `pane.RowCells` / `RowCellsDirect` dispatch with `PaneCache.RowAt(globalIdx)`.
+- `internal/runtime/client/client_loop.go` (or equivalent) — on `MsgBufferDelta` receipt, index rows by `RowBase + offset`; handle `MsgFetchRangeResponse`.
+- `internal/runtime/client/input.go` (or wherever scroll/resize reach the wire) — emit `MsgViewportUpdate` on viewport change, coalesced per animation frame; issue `MsgFetchRange` for cache misses inside the resident window.
+- `apps/texelterm/parser/sparse/store.go` — add `OldestRetained() int64` (needed by Plan B but cheap to land here; used by clipping overscan edge).
+
+---
+
+## Task 1 — `BufferDelta` wire format: `RowBase` + `Flags.AltScreen`
+
+No behavior change — server still sends `RowBase = 0` and `Flags.AltScreen = 0` by default. Purpose: get the wire-format extension in first so everything downstream can rely on it.
+
+**Files:**
+- Modify: `protocol/buffer_delta.go`
+- Modify: `protocol/buffer_delta_test.go`
+
+- [ ] **Step 1: Write the failing round-trip test for `RowBase`**
+
+Add to `protocol/buffer_delta_test.go`:
+
+```go
+func TestBufferDelta_RowBaseRoundTrip(t *testing.T) {
+    in := BufferDelta{
+        PaneID:   [16]byte{1, 2, 3},
+        Revision: 42,
+        Flags:    BufferDeltaNone,
+        RowBase:  1_234_567,
+        Rows: []RowDelta{
+            {Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "hello", StyleIndex: 0}}},
+        },
+        Styles: []StyleEntry{{AttrFlags: 0}},
+    }
+    raw, err := EncodeBufferDelta(in)
+    if err != nil {
+        t.Fatalf("encode: %v", err)
+    }
+    out, err := DecodeBufferDelta(raw)
+    if err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    if out.RowBase != in.RowBase {
+        t.Fatalf("RowBase: got %d want %d", out.RowBase, in.RowBase)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./protocol/ -run TestBufferDelta_RowBaseRoundTrip -v`
+Expected: FAIL — either "unknown field RowBase" compile error, or `RowBase` decoded as 0.
+
+- [ ] **Step 3: Add `RowBase` field to the struct**
+
+In `protocol/buffer_delta.go`:
+
+```go
+type BufferDelta struct {
+    PaneID   [16]byte
+    Revision uint32
+    Flags    BufferDeltaFlags
+    RowBase  int64
+    Styles   []StyleEntry
+    Rows     []RowDelta
+}
+```
+
+- [ ] **Step 4: Extend `EncodeBufferDelta` to write `RowBase` after `Flags`**
+
+Insert after `buf.WriteByte(byte(delta.Flags))`:
+
+```go
+if err := binary.Write(buf, binary.LittleEndian, delta.RowBase); err != nil {
+    return nil, err
+}
+```
+
+- [ ] **Step 5: Extend `DecodeBufferDelta` to read `RowBase`**
+
+Update the header-length guard from 21 to 29 bytes and insert after the `Flags` read:
+
+```go
+if len(b) < 29 { // paneID(16)+revision(4)+flags(1)+rowBase(8)
+    return delta, ErrPayloadShort
+}
+copy(delta.PaneID[:], b[:16])
+delta.Revision = binary.LittleEndian.Uint32(b[16:20])
+delta.Flags = BufferDeltaFlags(b[20])
+delta.RowBase = int64(binary.LittleEndian.Uint64(b[21:29]))
+b = b[29:]
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `go test ./protocol/ -run TestBufferDelta_RowBaseRoundTrip -v`
+Expected: PASS.
+
+- [ ] **Step 7: Write the failing `Flags.AltScreen` round-trip test**
+
+Add:
+
+```go
+func TestBufferDelta_AltScreenFlagRoundTrip(t *testing.T) {
+    in := BufferDelta{
+        PaneID: [16]byte{9},
+        Flags:  BufferDeltaAltScreen,
+        Rows:   []RowDelta{{Row: 3, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+        Styles: []StyleEntry{{AttrFlags: 0}},
+    }
+    raw, err := EncodeBufferDelta(in)
+    if err != nil {
+        t.Fatalf("encode: %v", err)
+    }
+    out, err := DecodeBufferDelta(raw)
+    if err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    if out.Flags&BufferDeltaAltScreen == 0 {
+        t.Fatalf("AltScreen flag lost")
+    }
+}
+```
+
+- [ ] **Step 8: Add the `BufferDeltaAltScreen` constant**
+
+In `protocol/buffer_delta.go`:
+
+```go
+const (
+    BufferDeltaNone      BufferDeltaFlags = 0
+    BufferDeltaAltScreen BufferDeltaFlags = 1 << 0
+)
+```
+
+- [ ] **Step 9: Run the test to verify it passes**
+
+Run: `go test ./protocol/ -run TestBufferDelta_AltScreenFlagRoundTrip -v`
+Expected: PASS.
+
+- [ ] **Step 10: Run the full protocol test suite**
+
+Run: `go test ./protocol/...`
+Expected: all pre-existing tests still pass.
+
+- [ ] **Step 11: Bump protocol version**
+
+In `protocol/protocol.go`:
+
+```go
+// Update whatever constant holds the protocol version (locate via grep). Bump by one.
+```
+
+Run: `go test ./protocol/...` — confirm still green.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add protocol/buffer_delta.go protocol/buffer_delta_test.go protocol/protocol.go
+git commit -m "protocol: extend BufferDelta with RowBase and AltScreen flag (#199)"
+```
+
+---
+
+## Task 2 — `MsgViewportUpdate` wire message
+
+Introduces the client → server message carrying per-pane viewport state. Server decodes and stores; no clipping yet.
+
+**Files:**
+- Create: `protocol/viewport.go`
+- Create: `protocol/viewport_test.go`
+- Modify: `protocol/protocol.go` (new `MsgViewportUpdate` constant)
+- Create: `internal/runtime/server/client_viewport.go`
+- Create: `internal/runtime/server/client_viewport_test.go`
+- Modify: `internal/runtime/server/session.go`
+- Modify: `internal/runtime/server/connection_handler.go`
+
+### Task 2a — Wire format
+
+- [ ] **Step 1: Add the `MsgViewportUpdate` type constant**
+
+In `protocol/protocol.go`, extend the `MessageType` block (placement: after the last existing client→server message; renumbering other constants is **not** safe, so append at the end):
+
+```go
+MsgViewportUpdate MessageType = <next unused value>
+```
+
+Confirm by running: `go test ./protocol/...`.
+
+- [ ] **Step 2: Write the failing round-trip test**
+
+Create `protocol/viewport_test.go`:
+
+```go
+package protocol
+
+import "testing"
+
+func TestViewportUpdate_RoundTrip(t *testing.T) {
+    in := ViewportUpdate{
+        PaneID:         [16]byte{0xDE, 0xAD, 0xBE, 0xEF},
+        AltScreen:      false,
+        ViewTopIdx:     1_000,
+        ViewBottomIdx:  1_023,
+        WrapSegmentIdx: 2,
+        Rows:           24,
+        Cols:           80,
+        AutoFollow:     true,
+    }
+    raw, err := EncodeViewportUpdate(in)
+    if err != nil {
+        t.Fatalf("encode: %v", err)
+    }
+    out, err := DecodeViewportUpdate(raw)
+    if err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    if out != in {
+        t.Fatalf("round-trip mismatch:\n got  %#v\n want %#v", out, in)
+    }
+}
+```
+
+- [ ] **Step 3: Run to confirm failure**
+
+Run: `go test ./protocol/ -run TestViewportUpdate_RoundTrip -v`
+Expected: FAIL — `ViewportUpdate` / encoder / decoder undefined.
+
+- [ ] **Step 4: Implement `ViewportUpdate` encode/decode**
+
+Create `protocol/viewport.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+    "bytes"
+    "encoding/binary"
+)
+
+// ViewportUpdate is sent by the client whenever its per-pane viewport changes
+// (scroll, resize, alt-screen enter/exit). The server uses it to clip
+// subsequent BufferDeltas.
+type ViewportUpdate struct {
+    PaneID         [16]byte
+    AltScreen      bool
+    ViewTopIdx     int64
+    ViewBottomIdx  int64
+    WrapSegmentIdx uint16
+    Rows           uint16
+    Cols           uint16
+    AutoFollow     bool
+}
+
+func EncodeViewportUpdate(v ViewportUpdate) ([]byte, error) {
+    buf := bytes.NewBuffer(make([]byte, 0, 45))
+    buf.Write(v.PaneID[:])
+    var bools uint8
+    if v.AltScreen {
+        bools |= 1 << 0
+    }
+    if v.AutoFollow {
+        bools |= 1 << 1
+    }
+    buf.WriteByte(bools)
+    if err := binary.Write(buf, binary.LittleEndian, v.ViewTopIdx); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, v.ViewBottomIdx); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, v.WrapSegmentIdx); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, v.Rows); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, v.Cols); err != nil {
+        return nil, err
+    }
+    return buf.Bytes(), nil
+}
+
+func DecodeViewportUpdate(b []byte) (ViewportUpdate, error) {
+    var v ViewportUpdate
+    // 16 + 1 + 8 + 8 + 2 + 2 + 2 = 39
+    if len(b) < 39 {
+        return v, ErrPayloadShort
+    }
+    copy(v.PaneID[:], b[:16])
+    bools := b[16]
+    v.AltScreen = bools&(1<<0) != 0
+    v.AutoFollow = bools&(1<<1) != 0
+    v.ViewTopIdx = int64(binary.LittleEndian.Uint64(b[17:25]))
+    v.ViewBottomIdx = int64(binary.LittleEndian.Uint64(b[25:33]))
+    v.WrapSegmentIdx = binary.LittleEndian.Uint16(b[33:35])
+    v.Rows = binary.LittleEndian.Uint16(b[35:37])
+    v.Cols = binary.LittleEndian.Uint16(b[37:39])
+    return v, nil
+}
+```
+
+- [ ] **Step 5: Run the round-trip test**
+
+Run: `go test ./protocol/ -run TestViewportUpdate -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add protocol/viewport.go protocol/viewport_test.go protocol/protocol.go
+git commit -m "protocol: add MsgViewportUpdate wire message (#199)"
+```
+
+### Task 2b — Server-side per-pane `ClientViewport`
+
+- [ ] **Step 1: Write the failing unit test for `ClientViewport.Apply`**
+
+Create `internal/runtime/server/client_viewport_test.go`:
+
+```go
+package server
+
+import (
+    "testing"
+
+    "github.com/framegrace/texelation/protocol"
+)
+
+func TestClientViewports_ApplyUpdate(t *testing.T) {
+    vs := NewClientViewports()
+    pane := [16]byte{1, 2, 3}
+    vs.Apply(protocol.ViewportUpdate{
+        PaneID:        pane,
+        ViewTopIdx:    100,
+        ViewBottomIdx: 123,
+        Rows:          24,
+        Cols:          80,
+        AutoFollow:    false,
+    })
+    got, ok := vs.Get(pane)
+    if !ok {
+        t.Fatal("viewport missing after Apply")
+    }
+    if got.ViewTopIdx != 100 || got.ViewBottomIdx != 123 || got.Rows != 24 {
+        t.Fatalf("unexpected state: %#v", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to confirm failure**
+
+Run: `go test ./internal/runtime/server/ -run TestClientViewports -v`
+Expected: FAIL — package does not define `NewClientViewports`.
+
+- [ ] **Step 3: Implement `ClientViewports`**
+
+Create `internal/runtime/server/client_viewport.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+    "sync"
+
+    "github.com/framegrace/texelation/protocol"
+)
+
+// ClientViewport is the server's view of a single pane's state inside a client
+// session. Publisher uses it to clip BufferDelta rows at emit time.
+type ClientViewport struct {
+    AltScreen     bool
+    ViewTopIdx    int64
+    ViewBottomIdx int64
+    Rows          uint16
+    Cols          uint16
+    AutoFollow    bool
+}
+
+// ClientViewports is the per-Session map of pane → viewport.
+type ClientViewports struct {
+    mu       sync.RWMutex
+    byPaneID map[[16]byte]ClientViewport
+}
+
+func NewClientViewports() *ClientViewports {
+    return &ClientViewports{byPaneID: make(map[[16]byte]ClientViewport)}
+}
+
+func (c *ClientViewports) Apply(u protocol.ViewportUpdate) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    c.byPaneID[u.PaneID] = ClientViewport{
+        AltScreen:     u.AltScreen,
+        ViewTopIdx:    u.ViewTopIdx,
+        ViewBottomIdx: u.ViewBottomIdx,
+        Rows:          u.Rows,
+        Cols:          u.Cols,
+        AutoFollow:    u.AutoFollow,
+    }
+}
+
+func (c *ClientViewports) Get(paneID [16]byte) (ClientViewport, bool) {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    v, ok := c.byPaneID[paneID]
+    return v, ok
+}
+
+// Snapshot returns a shallow copy of all viewports. Intended for publisher
+// fan-out; callers must treat the result as read-only.
+func (c *ClientViewports) Snapshot() map[[16]byte]ClientViewport {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    out := make(map[[16]byte]ClientViewport, len(c.byPaneID))
+    for k, v := range c.byPaneID {
+        out[k] = v
+    }
+    return out
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/runtime/server/ -run TestClientViewports -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `ClientViewports` into `Session`**
+
+In `internal/runtime/server/session.go`, add a field on `Session`:
+
+```go
+viewports *ClientViewports
+```
+
+Initialize it in the session constructor (search for `&Session{` allocations; there should be one central one — typically in `newSession` / `attachSession`):
+
+```go
+viewports: NewClientViewports(),
+```
+
+Expose a helper:
+
+```go
+func (s *Session) ApplyViewportUpdate(u protocol.ViewportUpdate) {
+    s.viewports.Apply(u)
+}
+```
+
+- [ ] **Step 6: Dispatch `MsgViewportUpdate` in the connection handler**
+
+In `internal/runtime/server/connection_handler.go`, add a case to the existing message-type switch:
+
+```go
+case protocol.MsgViewportUpdate:
+    u, err := protocol.DecodeViewportUpdate(payload)
+    if err != nil {
+        return fmt.Errorf("decode viewport update: %w", err)
+    }
+    session.ApplyViewportUpdate(u)
+```
+
+- [ ] **Step 7: Write an end-to-end test**
+
+Add to `internal/runtime/server/client_viewport_test.go`:
+
+```go
+func TestSession_ApplyViewportUpdate(t *testing.T) {
+    s := newTestSession(t)
+    pane := [16]byte{7}
+    s.ApplyViewportUpdate(protocol.ViewportUpdate{
+        PaneID:        pane,
+        ViewTopIdx:    500,
+        ViewBottomIdx: 523,
+        Rows:          24,
+        Cols:          80,
+    })
+    got, ok := s.viewports.Get(pane)
+    if !ok || got.ViewTopIdx != 500 {
+        t.Fatalf("unexpected: %#v ok=%v", got, ok)
+    }
+}
+```
+
+`newTestSession` helper: if none exists, add one at the top of the test file that constructs a bare `Session{viewports: NewClientViewports()}`. Keep the helper minimal — don't wire connections.
+
+- [ ] **Step 8: Run the test**
+
+Run: `go test ./internal/runtime/server/ -run TestSession_ApplyViewportUpdate -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/runtime/server/client_viewport.go internal/runtime/server/client_viewport_test.go internal/runtime/server/session.go internal/runtime/server/connection_handler.go
+git commit -m "server: track per-pane ClientViewport state in Session (#199)"
+```
+
+---
+
+## Task 3 — `MsgFetchRange` and `MsgFetchRangeResponse`
+
+Lets the client pull arbitrary scrollback. Ships before the publisher starts clipping so that by the time clipping is live, clients have a way to recover rows outside the resident window.
+
+**Files:**
+- Create: `protocol/fetch_range.go`
+- Create: `protocol/fetch_range_test.go`
+- Modify: `protocol/protocol.go`
+- Create: `internal/runtime/server/fetch_range_handler.go`
+- Create: `internal/runtime/server/fetch_range_handler_test.go`
+- Modify: `internal/runtime/server/connection_handler.go`
+- Modify: `apps/texelterm/parser/sparse/store.go` (add `OldestRetained()`)
+
+### Task 3a — Add `OldestRetained()` to `sparse.Store`
+
+Publisher needs to know the bottom of the in-memory window so it can respond with `BelowRetention` when appropriate.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/texelterm/parser/sparse/store_test.go` (create if missing):
+
+```go
+package sparse
+
+import (
+    "testing"
+
+    "github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestStore_OldestRetained(t *testing.T) {
+    s := NewStore(80)
+    if got := s.OldestRetained(); got != -1 {
+        t.Fatalf("empty: got %d want -1", got)
+    }
+    s.Set(5, 0, parser.Cell{})
+    s.Set(10, 0, parser.Cell{})
+    s.Set(3, 0, parser.Cell{})
+    if got := s.OldestRetained(); got != 3 {
+        t.Fatalf("got %d want 3", got)
+    }
+    s.ClearRange(3, 3)
+    if got := s.OldestRetained(); got != 5 {
+        t.Fatalf("after clear: got %d want 5", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./apps/texelterm/parser/sparse/ -run TestStore_OldestRetained -v`
+Expected: FAIL — method undefined.
+
+- [ ] **Step 3: Implement `OldestRetained`**
+
+In `apps/texelterm/parser/sparse/store.go`:
+
+```go
+// OldestRetained returns the lowest globalIdx currently resident in the Store.
+// Returns -1 when the Store is empty. O(n) in the number of resident rows; the
+// Store is typically small (resident window is bounded) so this is acceptable.
+func (s *Store) OldestRetained() int64 {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+    oldest := int64(-1)
+    for k := range s.lines {
+        if oldest == -1 || k < oldest {
+            oldest = k
+        }
+    }
+    return oldest
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `go test ./apps/texelterm/parser/sparse/ -run TestStore_OldestRetained -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/store.go apps/texelterm/parser/sparse/store_test.go
+git commit -m "sparse: add OldestRetained() to Store (#199)"
+```
+
+### Task 3b — Wire format
+
+- [ ] **Step 1: Add the new MessageType constants**
+
+In `protocol/protocol.go`, append:
+
+```go
+MsgFetchRange         MessageType = <next unused>
+MsgFetchRangeResponse MessageType = <next unused>
+```
+
+- [ ] **Step 2: Write the failing round-trip test**
+
+Create `protocol/fetch_range_test.go`:
+
+```go
+package protocol
+
+import (
+    "reflect"
+    "testing"
+)
+
+func TestFetchRange_RoundTrip(t *testing.T) {
+    in := FetchRange{
+        RequestID:    7,
+        PaneID:       [16]byte{0xAA},
+        LoIdx:        1_000,
+        HiIdx:        1_050,
+        AsOfRevision: 42,
+    }
+    raw, err := EncodeFetchRange(in)
+    if err != nil {
+        t.Fatalf("encode: %v", err)
+    }
+    out, err := DecodeFetchRange(raw)
+    if err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    if out != in {
+        t.Fatalf("mismatch: %#v vs %#v", out, in)
+    }
+}
+
+func TestFetchRangeResponse_RoundTrip(t *testing.T) {
+    in := FetchRangeResponse{
+        RequestID: 7,
+        PaneID:    [16]byte{0xAA},
+        Revision:  99,
+        Flags:     FetchRangeNone,
+        Rows: []LogicalRow{
+            {GlobalIdx: 1_000, Wrapped: false, NoWrap: false, Spans: []CellSpan{{StartCol: 0, Text: "hi", StyleIndex: 0}}},
+            {GlobalIdx: 1_001, Wrapped: true, Spans: []CellSpan{{StartCol: 0, Text: "continuation", StyleIndex: 0}}},
+        },
+        Styles: []StyleEntry{{AttrFlags: 0}},
+    }
+    raw, err := EncodeFetchRangeResponse(in)
+    if err != nil {
+        t.Fatalf("encode: %v", err)
+    }
+    out, err := DecodeFetchRangeResponse(raw)
+    if err != nil {
+        t.Fatalf("decode: %v", err)
+    }
+    if !reflect.DeepEqual(out, in) {
+        t.Fatalf("mismatch:\n got %#v\n want %#v", out, in)
+    }
+}
+```
+
+- [ ] **Step 3: Run to confirm failure**
+
+Run: `go test ./protocol/ -run TestFetchRange -v`
+Expected: FAIL — undefined types.
+
+- [ ] **Step 4: Implement encode/decode**
+
+Create `protocol/fetch_range.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+    "bytes"
+    "encoding/binary"
+)
+
+// FetchRangeFlags is a bitmask set on FetchRangeResponse.
+type FetchRangeFlags uint8
+
+const (
+    FetchRangeNone           FetchRangeFlags = 0
+    FetchRangeAltScreenActive FetchRangeFlags = 1 << 0
+    FetchRangeBelowRetention  FetchRangeFlags = 1 << 1
+    FetchRangeEmpty           FetchRangeFlags = 1 << 2
+)
+
+// FetchRange is a client → server request for a slice of scrollback.
+// LoIdx is inclusive; HiIdx is exclusive. AsOfRevision is informational
+// (server stamps the response with its own Revision at read time).
+type FetchRange struct {
+    RequestID    uint32
+    PaneID       [16]byte
+    LoIdx        int64
+    HiIdx        int64
+    AsOfRevision uint32
+}
+
+// LogicalRow is one row in a FetchRangeResponse. Spans use the same shared
+// Styles table as BufferDelta rows.
+type LogicalRow struct {
+    GlobalIdx int64
+    Wrapped   bool
+    NoWrap    bool
+    Spans     []CellSpan
+}
+
+// FetchRangeResponse is the server → client reply.
+type FetchRangeResponse struct {
+    RequestID uint32
+    PaneID    [16]byte
+    Revision  uint32
+    Flags     FetchRangeFlags
+    Styles    []StyleEntry
+    Rows      []LogicalRow
+}
+
+func EncodeFetchRange(f FetchRange) ([]byte, error) {
+    buf := bytes.NewBuffer(make([]byte, 0, 36))
+    if err := binary.Write(buf, binary.LittleEndian, f.RequestID); err != nil {
+        return nil, err
+    }
+    buf.Write(f.PaneID[:])
+    if err := binary.Write(buf, binary.LittleEndian, f.LoIdx); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, f.HiIdx); err != nil {
+        return nil, err
+    }
+    if err := binary.Write(buf, binary.LittleEndian, f.AsOfRevision); err != nil {
+        return nil, err
+    }
+    return buf.Bytes(), nil
+}
+
+func DecodeFetchRange(b []byte) (FetchRange, error) {
+    var f FetchRange
+    // 4 + 16 + 8 + 8 + 4 = 40
+    if len(b) < 40 {
+        return f, ErrPayloadShort
+    }
+    f.RequestID = binary.LittleEndian.Uint32(b[:4])
+    copy(f.PaneID[:], b[4:20])
+    f.LoIdx = int64(binary.LittleEndian.Uint64(b[20:28]))
+    f.HiIdx = int64(binary.LittleEndian.Uint64(b[28:36]))
+    f.AsOfRevision = binary.LittleEndian.Uint32(b[36:40])
+    return f, nil
+}
+
+func EncodeFetchRangeResponse(r FetchRangeResponse) ([]byte, error) {
+    buf := bytes.NewBuffer(make([]byte, 0, 64))
+    if err := binary.Write(buf, binary.LittleEndian, r.RequestID); err != nil {
+        return nil, err
+    }
+    buf.Write(r.PaneID[:])
+    if err := binary.Write(buf, binary.LittleEndian, r.Revision); err != nil {
+        return nil, err
+    }
+    buf.WriteByte(byte(r.Flags))
+
+    if len(r.Styles) > 0xFFFF || len(r.Rows) > 0xFFFF {
+        return nil, ErrBufferTooLarge
+    }
+    if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Styles))); err != nil {
+        return nil, err
+    }
+    // Reuse the same inline style-entry encoding as BufferDelta — factor out
+    // if the duplication grows. For now it's two sites.
+    for _, s := range r.Styles {
+        if err := binary.Write(buf, binary.LittleEndian, s.AttrFlags); err != nil {
+            return nil, err
+        }
+        buf.WriteByte(byte(s.FgModel))
+        binary.Write(buf, binary.LittleEndian, s.FgValue)
+        buf.WriteByte(byte(s.BgModel))
+        binary.Write(buf, binary.LittleEndian, s.BgValue)
+        // Dynamic colors are not supported in FetchRange rows for v1.
+        if s.AttrFlags&AttrHasDynamic != 0 {
+            return nil, ErrBufferTooLarge
+        }
+    }
+
+    if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Rows))); err != nil {
+        return nil, err
+    }
+    for _, row := range r.Rows {
+        if err := binary.Write(buf, binary.LittleEndian, row.GlobalIdx); err != nil {
+            return nil, err
+        }
+        var flags uint8
+        if row.Wrapped {
+            flags |= 1 << 0
+        }
+        if row.NoWrap {
+            flags |= 1 << 1
+        }
+        buf.WriteByte(flags)
+        if len(row.Spans) > 0xFFFF {
+            return nil, ErrBufferTooLarge
+        }
+        if err := binary.Write(buf, binary.LittleEndian, uint16(len(row.Spans))); err != nil {
+            return nil, err
+        }
+        for _, span := range row.Spans {
+            textBytes := []byte(span.Text)
+            if len(textBytes) > 0xFFFF {
+                return nil, ErrInvalidSpan
+            }
+            binary.Write(buf, binary.LittleEndian, span.StartCol)
+            binary.Write(buf, binary.LittleEndian, uint16(len(textBytes)))
+            binary.Write(buf, binary.LittleEndian, span.StyleIndex)
+            buf.Write(textBytes)
+        }
+    }
+    return buf.Bytes(), nil
+}
+
+func DecodeFetchRangeResponse(b []byte) (FetchRangeResponse, error) {
+    var r FetchRangeResponse
+    // 4 + 16 + 4 + 1 = 25
+    if len(b) < 25 {
+        return r, ErrPayloadShort
+    }
+    r.RequestID = binary.LittleEndian.Uint32(b[:4])
+    copy(r.PaneID[:], b[4:20])
+    r.Revision = binary.LittleEndian.Uint32(b[20:24])
+    r.Flags = FetchRangeFlags(b[24])
+    b = b[25:]
+
+    if len(b) < 2 {
+        return r, ErrPayloadShort
+    }
+    styleCount := binary.LittleEndian.Uint16(b[:2])
+    b = b[2:]
+    r.Styles = make([]StyleEntry, styleCount)
+    for i := 0; i < int(styleCount); i++ {
+        if len(b) < 12 {
+            return r, ErrPayloadShort
+        }
+        r.Styles[i].AttrFlags = binary.LittleEndian.Uint16(b[:2])
+        r.Styles[i].FgModel = ColorModel(b[2])
+        r.Styles[i].FgValue = binary.LittleEndian.Uint32(b[3:7])
+        r.Styles[i].BgModel = ColorModel(b[7])
+        r.Styles[i].BgValue = binary.LittleEndian.Uint32(b[8:12])
+        b = b[12:]
+        if r.Styles[i].AttrFlags&AttrHasDynamic != 0 {
+            return r, ErrPayloadShort // unsupported in v1
+        }
+    }
+
+    if len(b) < 2 {
+        return r, ErrPayloadShort
+    }
+    rowCount := binary.LittleEndian.Uint16(b[:2])
+    b = b[2:]
+    r.Rows = make([]LogicalRow, rowCount)
+    for i := 0; i < int(rowCount); i++ {
+        if len(b) < 11 { // globalIdx(8)+flags(1)+spanCount(2)
+            return r, ErrPayloadShort
+        }
+        r.Rows[i].GlobalIdx = int64(binary.LittleEndian.Uint64(b[:8]))
+        rowFlags := b[8]
+        r.Rows[i].Wrapped = rowFlags&(1<<0) != 0
+        r.Rows[i].NoWrap = rowFlags&(1<<1) != 0
+        spanCount := binary.LittleEndian.Uint16(b[9:11])
+        b = b[11:]
+        spans := make([]CellSpan, spanCount)
+        for s := 0; s < int(spanCount); s++ {
+            if len(b) < 6 {
+                return r, ErrPayloadShort
+            }
+            startCol := binary.LittleEndian.Uint16(b[:2])
+            textLen := binary.LittleEndian.Uint16(b[2:4])
+            styleIndex := binary.LittleEndian.Uint16(b[4:6])
+            b = b[6:]
+            if len(b) < int(textLen) {
+                return r, ErrPayloadShort
+            }
+            spans[s] = CellSpan{StartCol: startCol, Text: string(b[:textLen]), StyleIndex: styleIndex}
+            b = b[textLen:]
+        }
+        r.Rows[i].Spans = spans
+    }
+    return r, nil
+}
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `go test ./protocol/ -run TestFetchRange -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add protocol/fetch_range.go protocol/fetch_range_test.go protocol/protocol.go
+git commit -m "protocol: add MsgFetchRange and MsgFetchRangeResponse (#199)"
+```
+
+### Task 3c — Server handler
+
+- [ ] **Step 1: Write the failing handler test**
+
+Create `internal/runtime/server/fetch_range_handler_test.go`:
+
+```go
+package server
+
+import (
+    "testing"
+
+    "github.com/framegrace/texelation/apps/texelterm/parser"
+    "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+    "github.com/framegrace/texelation/protocol"
+)
+
+func TestFetchRangeHandler_Basic(t *testing.T) {
+    st := sparse.NewStore(80)
+    st.Set(100, 0, parser.Cell{Char: 'a'})
+    st.Set(101, 0, parser.Cell{Char: 'b'})
+
+    resp, err := ServeFetchRange(st, protocol.FetchRange{
+        LoIdx: 100,
+        HiIdx: 102,
+    }, 42) // revision
+    if err != nil {
+        t.Fatalf("serve: %v", err)
+    }
+    if resp.Revision != 42 {
+        t.Fatalf("revision: got %d want 42", resp.Revision)
+    }
+    if len(resp.Rows) != 2 {
+        t.Fatalf("rows: got %d want 2", len(resp.Rows))
+    }
+    if resp.Rows[0].GlobalIdx != 100 {
+        t.Fatalf("row[0].GlobalIdx: got %d want 100", resp.Rows[0].GlobalIdx)
+    }
+}
+
+func TestFetchRangeHandler_BelowRetention(t *testing.T) {
+    st := sparse.NewStore(80)
+    st.Set(500, 0, parser.Cell{Char: 'a'})
+    resp, err := ServeFetchRange(st, protocol.FetchRange{
+        LoIdx: 0,
+        HiIdx: 10,
+    }, 1)
+    if err != nil {
+        t.Fatalf("serve: %v", err)
+    }
+    if resp.Flags&protocol.FetchRangeBelowRetention == 0 {
+        t.Fatalf("expected BelowRetention flag")
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/runtime/server/ -run TestFetchRangeHandler -v`
+Expected: FAIL — `ServeFetchRange` undefined.
+
+- [ ] **Step 3: Implement `ServeFetchRange`**
+
+Create `internal/runtime/server/fetch_range_handler.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+    "github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+    "github.com/framegrace/texelation/protocol"
+)
+
+// ServeFetchRange reads rows [lo, hi) from the sparse store and returns a
+// FetchRangeResponse stamped with the provided revision. Cold pages are
+// expected to have been faulted in by the Store's own persistence bridge
+// before this call; ServeFetchRange does not drive page loads itself.
+//
+// If any row in the range has globalIdx below Store.OldestRetained(), the
+// response flags include FetchRangeBelowRetention. Callers that need
+// cross-restart resume should fault cold pages before calling.
+func ServeFetchRange(st *sparse.Store, req protocol.FetchRange, revision uint32) (protocol.FetchRangeResponse, error) {
+    resp := protocol.FetchRangeResponse{
+        RequestID: req.RequestID,
+        PaneID:    req.PaneID,
+        Revision:  revision,
+    }
+    if req.LoIdx >= req.HiIdx {
+        resp.Flags |= protocol.FetchRangeEmpty
+        return resp, nil
+    }
+    oldest := st.OldestRetained()
+    if oldest == -1 || req.LoIdx < oldest {
+        resp.Flags |= protocol.FetchRangeBelowRetention
+    }
+    // Style dedup table scoped to this response.
+    styleTable := newStyleTable()
+    for idx := req.LoIdx; idx < req.HiIdx; idx++ {
+        cells := st.GetLine(idx)
+        if cells == nil {
+            continue
+        }
+        row := protocol.LogicalRow{
+            GlobalIdx: idx,
+            NoWrap:    st.RowNoWrap(idx),
+        }
+        row.Spans = encodeCellsToSpans(cells, styleTable)
+        // Wrapped flag: rows other than the last in a wrap chain have Wrapped=true.
+        // Source of truth lives on the cells themselves (parser.Cell.Wrapped).
+        // Use the last cell of this row — if it wrapped, the next row is a continuation.
+        if n := len(cells); n > 0 && cells[n-1].Wrapped {
+            row.Wrapped = true
+        }
+        resp.Rows = append(resp.Rows, row)
+    }
+    resp.Styles = styleTable.entries()
+    if len(resp.Rows) == 0 && resp.Flags&protocol.FetchRangeBelowRetention == 0 {
+        resp.Flags |= protocol.FetchRangeEmpty
+    }
+    return resp, nil
+}
+```
+
+`newStyleTable` / `encodeCellsToSpans` likely already exist inside `desktop_publisher.go` for `BufferDelta` encoding. If they are not exported, either promote them to package-level helpers in a new file `internal/runtime/server/encoding.go` or duplicate the small helpers here. **Prefer promotion**: the publisher and the fetch handler should share one encoder.
+
+- [ ] **Step 4: Promote shared cell-encoding helpers**
+
+Locate the style dedup + span encoder in `internal/runtime/server/desktop_publisher.go` (search for `Styles` build-up). Extract to `internal/runtime/server/encoding.go` with signatures:
+
+```go
+type styleTable struct { /* existing fields */ }
+func newStyleTable() *styleTable
+func (t *styleTable) indexOf(cell parser.Cell) uint16
+func (t *styleTable) entries() []protocol.StyleEntry
+func encodeCellsToSpans(cells []parser.Cell, t *styleTable) []protocol.CellSpan
+```
+
+Keep behavior identical — this is refactor, not rewrite. Update `bufferToDelta` to use the helpers.
+
+Run the existing publisher tests to confirm no regression:
+
+```
+go test ./internal/runtime/server/ -run TestDesktopPublisher -v
+```
+
+- [ ] **Step 5: Run the handler tests**
+
+Run: `go test ./internal/runtime/server/ -run TestFetchRangeHandler -v`
+Expected: PASS.
+
+- [ ] **Step 6: Dispatch `MsgFetchRange` in the connection handler**
+
+In `internal/runtime/server/connection_handler.go`:
+
+```go
+case protocol.MsgFetchRange:
+    req, err := protocol.DecodeFetchRange(payload)
+    if err != nil {
+        return fmt.Errorf("decode fetch range: %w", err)
+    }
+    resp, err := session.ServeFetchRange(req)
+    if err != nil {
+        return fmt.Errorf("serve fetch range: %w", err)
+    }
+    raw, err := protocol.EncodeFetchRangeResponse(resp)
+    if err != nil {
+        return fmt.Errorf("encode fetch range response: %w", err)
+    }
+    return session.Send(protocol.MsgFetchRangeResponse, raw)
+```
+
+`session.ServeFetchRange` is a thin wrapper around `ServeFetchRange`:
+
+```go
+func (s *Session) ServeFetchRange(req protocol.FetchRange) (protocol.FetchRangeResponse, error) {
+    pane := s.desktop.PaneByID(req.PaneID)
+    if pane == nil {
+        return protocol.FetchRangeResponse{RequestID: req.RequestID, PaneID: req.PaneID, Flags: protocol.FetchRangeEmpty}, nil
+    }
+    if pane.IsAltScreenActive() {
+        return protocol.FetchRangeResponse{RequestID: req.RequestID, PaneID: req.PaneID, Flags: protocol.FetchRangeAltScreenActive}, nil
+    }
+    st := pane.SparseStore()      // helper to be added on the pane/app
+    rev := s.publisher.RevisionFor(req.PaneID)
+    return ServeFetchRange(st, req, rev)
+}
+```
+
+If `PaneByID` / `IsAltScreenActive` / `SparseStore` are not yet exposed, add minimal accessors — they already exist somewhere inside `texel.Desktop` and `texelterm.App`. Grep for `altBuffer` and `PaneByID`; add thin public shims if they are internal.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/runtime/server/fetch_range_handler.go internal/runtime/server/fetch_range_handler_test.go internal/runtime/server/encoding.go internal/runtime/server/desktop_publisher.go internal/runtime/server/connection_handler.go internal/runtime/server/session.go
+git commit -m "server: serve MsgFetchRange from sparse store (#199)"
+```
+
+---
+
+## Task 4 — Flip the publisher to clip on emit, land the client sparse cache
+
+This is the **behavior-change** task. Everything before this has been plumbing.
+
+### Task 4a — Extend `PaneSnapshot` with `RowGlobalIdx`
+
+So the publisher knows which globalIdx each row in the snapshot buffer corresponds to.
+
+**Files:**
+- Modify: `texel/snapshot.go`
+- Modify: `apps/texelterm/term.go` (and any other App producing snapshots with sparse backing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/texelterm/term_test.go`:
+
+```go
+func TestTexelTerm_SnapshotCarriesGlobalIdx(t *testing.T) {
+    a := newTestTerm(t, 80, 24)
+    a.Feed([]byte("hello\r\n"))
+    snap := a.Snapshot()
+    if len(snap.RowGlobalIdx) != len(snap.Buffer) {
+        t.Fatalf("RowGlobalIdx len=%d Buffer len=%d", len(snap.RowGlobalIdx), len(snap.Buffer))
+    }
+    // After "hello\r\n" the first visible row carries a main-screen globalIdx >= 0.
+    if snap.RowGlobalIdx[0] < 0 {
+        t.Fatalf("row 0 should have main-screen idx, got %d", snap.RowGlobalIdx[0])
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./apps/texelterm/ -run TestTexelTerm_SnapshotCarriesGlobalIdx -v`
+Expected: FAIL — field missing.
+
+- [ ] **Step 3: Add the field to `PaneSnapshot`**
+
+In `texel/snapshot.go`:
+
+```go
+type PaneSnapshot struct {
+    ID           [16]byte
+    Title        string
+    Buffer       [][]Cell
+    RowGlobalIdx []int64  // len == len(Buffer); -1 for alt-screen rows
+    Rect         Rectangle
+    AppType      string
+    AppConfig    map[string]interface{}
+}
+```
+
+- [ ] **Step 4: Populate it in texelterm**
+
+In `apps/texelterm/term.go`, in whatever `Snapshot()` / `Render()` path constructs the `PaneSnapshot.Buffer`, fill `RowGlobalIdx` alongside. For main-screen panes the source is `ViewWindow.RowGlobalIdx(y)`; for alt-screen, `-1`. If no such helper exists on `ViewWindow`, add:
+
+```go
+// In apps/texelterm/parser/sparse/view_window.go:
+//
+// RowGlobalIdx returns the globalIdx of the row currently at viewport y,
+// or -1 if y is outside the viewport or the row has no globalIdx yet.
+func (vw *ViewWindow) RowGlobalIdx(y int) int64 { /* ... */ }
+```
+
+Implement it from the existing reflow state (the walk that resolves wrap segments already knows the globalIdx of each rendered row — expose that).
+
+- [ ] **Step 5: Run the test**
+
+Run: `go test ./apps/texelterm/ -run TestTexelTerm_SnapshotCarriesGlobalIdx -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full texelterm suite**
+
+Run: `go test ./apps/texelterm/...`
+Expected: no regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add texel/snapshot.go apps/texelterm/term.go apps/texelterm/term_test.go apps/texelterm/parser/sparse/view_window.go
+git commit -m "texel: carry per-row globalIdx in PaneSnapshot (#199)"
+```
+
+### Task 4b — Publisher: per-client clip + `RowBase` + `Flags.AltScreen`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/runtime/server/desktop_publisher_test.go`:
+
+```go
+func TestPublisher_ClipsToViewport(t *testing.T) {
+    pub, session, paneID := newTestPublisherWithPane(t)
+    session.ApplyViewportUpdate(protocol.ViewportUpdate{
+        PaneID:        paneID,
+        ViewTopIdx:    100,
+        ViewBottomIdx: 123,
+        Rows:          24,
+        Cols:          80,
+        AutoFollow:    false,
+    })
+    // Pane has 200 rows of content; feed a snapshot with globalIdx 0..199.
+    snap := makeTestPaneSnapshot(paneID, 200)
+    pub.Publish([]texel.PaneSnapshot{snap})
+
+    delta := session.LastDelta(paneID)
+    // Expect rows only in [76, 147] (viewport [100,123] + 1× overscan = ±24).
+    for _, row := range delta.Rows {
+        globalIdx := delta.RowBase + int64(row.Row)
+        if globalIdx < 76 || globalIdx > 147 {
+            t.Fatalf("row %d (idx %d) outside resident window", row.Row, globalIdx)
+        }
+    }
+    if delta.Flags&protocol.BufferDeltaAltScreen != 0 {
+        t.Fatalf("main-screen pane should not set AltScreen flag")
+    }
+}
+
+func TestPublisher_AltScreenSetsFlag(t *testing.T) {
+    pub, session, paneID := newTestPublisherWithAltScreenPane(t)
+    snap := makeAltScreenPaneSnapshot(paneID, 24, 80)
+    pub.Publish([]texel.PaneSnapshot{snap})
+    delta := session.LastDelta(paneID)
+    if delta.Flags&protocol.BufferDeltaAltScreen == 0 {
+        t.Fatalf("alt-screen pane should set AltScreen flag")
+    }
+    if delta.RowBase != 0 {
+        t.Fatalf("alt-screen pane should have RowBase=0, got %d", delta.RowBase)
+    }
+}
+```
+
+Helpers `newTestPublisherWithPane`, `makeTestPaneSnapshot`, `LastDelta`: write in the same test file. Keep them minimal; reuse existing patterns from `desktop_publisher_test.go`.
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/runtime/server/ -run TestPublisher_Clips -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement clip-on-emit**
+
+In `internal/runtime/server/desktop_publisher.go`, change `bufferToDelta(snap, prev, rev)` to accept the client viewport and clip rows:
+
+```go
+func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, rev uint32, vp ClientViewport, altScreen bool) protocol.BufferDelta {
+    delta := protocol.BufferDelta{
+        PaneID:   snap.ID,
+        Revision: rev,
+    }
+    if altScreen {
+        delta.Flags |= protocol.BufferDeltaAltScreen
+        // Alt-screen: no clipping, no RowBase. Existing encoding per-row.
+        for y := range snap.Buffer {
+            if !rowsEqual(snap.Buffer[y], rowAt(prev, y)) {
+                delta.Rows = append(delta.Rows, encodeRow(snap.Buffer[y], y))
+            }
+        }
+        return delta
+    }
+    // Main screen: clip to viewport ± 1× overscan, set RowBase.
+    overscan := int64(vp.Rows)
+    liveTop := int64(0)
+    if len(snap.RowGlobalIdx) > 0 {
+        liveTop = snap.RowGlobalIdx[0]
+    }
+    var lo, hi int64
+    if vp.AutoFollow {
+        lo = liveTop - overscan
+        hi = liveTop + int64(vp.Rows) + overscan
+    } else {
+        lo = vp.ViewTopIdx - overscan
+        hi = vp.ViewBottomIdx + overscan
+    }
+    // RowBase = lo (first potentially-emitted globalIdx).
+    delta.RowBase = lo
+    styleTable := newStyleTable()
+    for y, rowCells := range snap.Buffer {
+        gid := snap.RowGlobalIdx[y]
+        if gid < lo || gid > hi {
+            continue
+        }
+        if rowsEqual(rowCells, rowAt(prev, y)) {
+            continue
+        }
+        offset := uint16(gid - lo)
+        delta.Rows = append(delta.Rows, protocol.RowDelta{
+            Row:   offset,
+            Spans: encodeCellsToSpans(rowCells, styleTable),
+        })
+    }
+    delta.Styles = styleTable.entries()
+    return delta
+}
+```
+
+Update the single call site in the publisher's `Publish` path to pass `ClientViewport` (pulled from `session.viewports.Get(paneID)`; default zero-value means "send nothing until client tells us its viewport"). For the zero-value case, skip emit entirely — the client will send its first `ViewportUpdate` shortly after handshake.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/runtime/server/ -run TestPublisher -v`
+Expected: PASS.
+
+- [ ] **Step 5: Rewrite pre-existing full-pane publisher assertions**
+
+Hunt with grep:
+
+```
+grep -nR "Buffer\[" internal/runtime/server/*_test.go
+grep -nR "RowDelta" internal/runtime/server/*_test.go
+```
+
+For each test that asserts against the full-pane buffer, rewrite to assert against the clipped window. Expected test touch count: ~6–10.
+
+Run: `go test ./internal/runtime/server/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/server/desktop_publisher.go internal/runtime/server/desktop_publisher_test.go
+git commit -m "server: clip BufferDelta rows to per-client viewport (#199)"
+```
+
+### Task 4c — Client: per-pane sparse cache
+
+Replace the row-index `BufferCache` lookups with a globalIdx-keyed cache.
+
+**Files:**
+- Create: `internal/runtime/client/pane_cache.go`
+- Create: `internal/runtime/client/pane_cache_test.go`
+- Modify: `internal/runtime/client/renderer.go`
+- Modify: `internal/runtime/client/client_loop.go` (or whichever file dispatches `MsgBufferDelta`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/runtime/client/pane_cache_test.go`:
+
+```go
+package client
+
+import (
+    "testing"
+
+    "github.com/framegrace/texelation/protocol"
+)
+
+func TestPaneCache_ApplyDeltaMainScreen(t *testing.T) {
+    pc := NewPaneCache()
+    pc.ApplyDelta(protocol.BufferDelta{
+        RowBase: 1_000,
+        Rows: []protocol.RowDelta{
+            {Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "hello", StyleIndex: 0}}},
+            {Row: 2, Spans: []protocol.CellSpan{{StartCol: 0, Text: "world", StyleIndex: 0}}},
+        },
+        Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+    })
+    if row, ok := pc.RowAt(1_000); !ok || !rowStartsWith(row, "hello") {
+        t.Fatalf("globalIdx 1000 missing or wrong: ok=%v row=%v", ok, row)
+    }
+    if _, ok := pc.RowAt(1_001); ok {
+        t.Fatalf("globalIdx 1001 should be absent (no delta row)")
+    }
+    if row, ok := pc.RowAt(1_002); !ok || !rowStartsWith(row, "world") {
+        t.Fatalf("globalIdx 1002 missing or wrong")
+    }
+}
+
+func TestPaneCache_ApplyDeltaAltScreen(t *testing.T) {
+    pc := NewPaneCache()
+    pc.ApplyDelta(protocol.BufferDelta{
+        Flags: protocol.BufferDeltaAltScreen,
+        Rows:  []protocol.RowDelta{{Row: 3, Spans: []protocol.CellSpan{{StartCol: 0, Text: "vim", StyleIndex: 0}}}},
+        Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+    })
+    if !pc.IsAltScreen() {
+        t.Fatalf("expected alt-screen mode")
+    }
+    if row, ok := pc.AltRowAt(3); !ok || !rowStartsWith(row, "vim") {
+        t.Fatalf("alt row 3 missing")
+    }
+}
+
+func TestPaneCache_EvictsOutsideWindow(t *testing.T) {
+    pc := NewPaneCache()
+    pc.ApplyDelta(protocol.BufferDelta{
+        RowBase: 0,
+        Rows: []protocol.RowDelta{
+            {Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "a", StyleIndex: 0}}},
+            {Row: 1, Spans: []protocol.CellSpan{{StartCol: 0, Text: "b", StyleIndex: 0}}},
+            {Row: 2, Spans: []protocol.CellSpan{{StartCol: 0, Text: "c", StyleIndex: 0}}},
+        },
+        Styles: []protocol.StyleEntry{{AttrFlags: 0}},
+    })
+    // Viewport is [1,2] + 1× overscan of 2 rows → [−1, 4]; hysteresis 1.5×.
+    pc.Evict(1, 2, 2)
+    if _, ok := pc.RowAt(0); !ok {
+        t.Fatalf("row 0 inside hysteresis band, should be retained")
+    }
+    // Now slam the viewport far away — eviction should clear row 0.
+    pc.Evict(1_000, 1_002, 2)
+    if _, ok := pc.RowAt(0); ok {
+        t.Fatalf("row 0 should be evicted after viewport jump")
+    }
+}
+
+func rowStartsWith(row []Cell, s string) bool {
+    var buf []rune
+    for _, c := range row {
+        buf = append(buf, rune(c.Char))
+    }
+    return string(buf[:len(s)]) == s
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/runtime/client/ -run TestPaneCache -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `PaneCache`**
+
+Create `internal/runtime/client/pane_cache.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package client
+
+import (
+    "sync"
+
+    "github.com/framegrace/texelation/protocol"
+)
+
+// PaneCache is the client's local copy of a pane's displayable cells.
+// Main-screen rows are keyed by globalIdx; alt-screen rows are a flat
+// screen-sized 2D buffer.
+type PaneCache struct {
+    mu        sync.RWMutex
+    altScreen bool
+    main      map[int64][]Cell
+    alt       [][]Cell
+    revision  uint32
+    styles    []protocol.StyleEntry
+}
+
+func NewPaneCache() *PaneCache {
+    return &PaneCache{main: make(map[int64][]Cell)}
+}
+
+func (c *PaneCache) IsAltScreen() bool {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    return c.altScreen
+}
+
+// ApplyDelta merges a BufferDelta into the cache.
+func (c *PaneCache) ApplyDelta(d protocol.BufferDelta) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    alt := d.Flags&protocol.BufferDeltaAltScreen != 0
+    if alt != c.altScreen {
+        // Mode changed — drop the other side's state.
+        c.altScreen = alt
+        if alt {
+            c.main = make(map[int64][]Cell)
+        } else {
+            c.alt = nil
+        }
+    }
+    if d.Revision > c.revision {
+        c.revision = d.Revision
+    }
+    // NOTE: Styles are per-delta. We decode spans into concrete cells
+    // eagerly so later reads don't need the style table.
+    styles := d.Styles
+    for _, row := range d.Rows {
+        cells := decodeSpans(row.Spans, styles)
+        if alt {
+            c.putAlt(int(row.Row), cells)
+        } else {
+            gid := d.RowBase + int64(row.Row)
+            c.main[gid] = cells
+        }
+    }
+}
+
+// ApplyFetchRange merges rows fetched on-demand.
+func (c *PaneCache) ApplyFetchRange(r protocol.FetchRangeResponse) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    if r.Flags&protocol.FetchRangeAltScreenActive != 0 {
+        // Server says alt-screen is active — nothing to cache.
+        return
+    }
+    // Coherence rule: drop stale responses.
+    if r.Revision < c.revision {
+        return
+    }
+    if r.Revision > c.revision {
+        c.revision = r.Revision
+    }
+    styles := r.Styles
+    for _, row := range r.Rows {
+        cells := decodeSpans(row.Spans, styles)
+        c.main[row.GlobalIdx] = cells
+    }
+}
+
+// RowAt returns the main-screen row for globalIdx.
+func (c *PaneCache) RowAt(globalIdx int64) ([]Cell, bool) {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    row, ok := c.main[globalIdx]
+    return row, ok
+}
+
+// AltRowAt returns the alt-screen row for screenRow.
+func (c *PaneCache) AltRowAt(screenRow int) ([]Cell, bool) {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    if screenRow < 0 || screenRow >= len(c.alt) {
+        return nil, false
+    }
+    return c.alt[screenRow], true
+}
+
+// Evict drops main-screen rows outside [lo − overscan×1.5, hi + overscan×1.5].
+// Called after each viewport change. Small hysteresis prevents thrash on
+// micro-scrolls.
+func (c *PaneCache) Evict(lo, hi, overscan int64) {
+    band := int64(float64(overscan) * 1.5)
+    lowerBound := lo - band
+    upperBound := hi + band
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    for k := range c.main {
+        if k < lowerBound || k > upperBound {
+            delete(c.main, k)
+        }
+    }
+}
+
+// MissingRows returns the globalIdxs in [lo, hi] not currently in cache.
+// Caller uses this to issue a MsgFetchRange. Returned slice is sorted ascending.
+func (c *PaneCache) MissingRows(lo, hi int64) []int64 {
+    c.mu.RLock()
+    defer c.mu.RUnlock()
+    var miss []int64
+    for gid := lo; gid <= hi; gid++ {
+        if _, ok := c.main[gid]; !ok {
+            miss = append(miss, gid)
+        }
+    }
+    return miss
+}
+
+func (c *PaneCache) putAlt(row int, cells []Cell) {
+    for row >= len(c.alt) {
+        c.alt = append(c.alt, nil)
+    }
+    c.alt[row] = cells
+}
+```
+
+`decodeSpans` likely already exists in the client package (symmetric to server-side `encodeCellsToSpans`). Grep for it; reuse if present, add if missing.
+
+- [ ] **Step 4: Run the PaneCache tests**
+
+Run: `go test ./internal/runtime/client/ -run TestPaneCache -v`
+Expected: PASS.
+
+- [ ] **Step 5: Replace `BufferCache` lookups in the renderer**
+
+In `internal/runtime/client/renderer.go`, replace:
+
+```go
+cells := pane.RowCells(rowIdx)
+```
+
+…with:
+
+```go
+gid := pane.RowGlobalIdx(rowIdx)  // translates screen row → globalIdx via local ViewWindow
+if gid >= 0 {
+    cells, ok := paneCache.RowAt(gid)
+    if !ok {
+        cells = emptyCells(paneWidth) // missed-deadline path; see Task 4d for indicator
+    }
+    // ... existing draw code using `cells` ...
+} else {
+    // alt-screen row
+    cells, _ := paneCache.AltRowAt(rowIdx)
+    // ... draw ...
+}
+```
+
+Compile:
+
+```
+go build ./...
+```
+
+Fix any lingering `BufferCache` references — it's being retired.
+
+- [ ] **Step 6: Wire `MsgBufferDelta` and `MsgFetchRangeResponse` in the client loop**
+
+Locate the message dispatch in `internal/runtime/client/client_loop.go` (or equivalent). On receiving `MsgBufferDelta`:
+
+```go
+case protocol.MsgBufferDelta:
+    d, err := protocol.DecodeBufferDelta(payload)
+    if err != nil {
+        return err
+    }
+    pc := client.PaneCacheFor(d.PaneID)
+    pc.ApplyDelta(d)
+```
+
+On receiving `MsgFetchRangeResponse`:
+
+```go
+case protocol.MsgFetchRangeResponse:
+    r, err := protocol.DecodeFetchRangeResponse(payload)
+    if err != nil {
+        return err
+    }
+    pc := client.PaneCacheFor(r.PaneID)
+    pc.ApplyFetchRange(r)
+    client.NotifyFetchResolved(r.PaneID, r.RequestID)
+```
+
+`NotifyFetchResolved` wakes any waiter tracking "fetch pending" state — used by the statusbar in Plan E but already wired here as a no-op hook.
+
+- [ ] **Step 7: Run the full client test suite**
+
+Run: `go test ./internal/runtime/client/...`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/runtime/client/pane_cache.go internal/runtime/client/pane_cache_test.go internal/runtime/client/renderer.go internal/runtime/client/client_loop.go
+git commit -m "client: sparse per-pane cache keyed by globalIdx (#199)"
+```
+
+### Task 4d — Client: emit `MsgViewportUpdate` + `MsgFetchRange`
+
+Plumb scroll / resize / alt-screen-flag into the wire.
+
+**Files:**
+- Modify: `internal/runtime/client/input.go` (or wherever scroll lives) — add `MsgViewportUpdate` emit
+- Modify: client render loop — issue `MsgFetchRange` for cache misses
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/runtime/client/client_loop_test.go`:
+
+```go
+func TestClient_EmitsViewportUpdateOnScroll(t *testing.T) {
+    c, tx := newTestClient(t)
+    paneID := [16]byte{1}
+    c.OnScroll(paneID, /*newTop*/ 100, /*newBottom*/ 123, /*autoFollow*/ false)
+    // Expect one MsgViewportUpdate on the wire.
+    msg := tx.WaitFor(protocol.MsgViewportUpdate)
+    u, _ := protocol.DecodeViewportUpdate(msg.Payload)
+    if u.ViewTopIdx != 100 || u.ViewBottomIdx != 123 || u.AutoFollow {
+        t.Fatalf("unexpected: %#v", u)
+    }
+}
+
+func TestClient_CoalescesViewportUpdatesWithinFrame(t *testing.T) {
+    c, tx := newTestClient(t)
+    paneID := [16]byte{1}
+    c.OnScroll(paneID, 100, 123, false)
+    c.OnScroll(paneID, 110, 133, false)
+    c.OnScroll(paneID, 120, 143, false)
+    c.FlushFrame()
+    msgs := tx.AllFor(protocol.MsgViewportUpdate)
+    if len(msgs) != 1 {
+        t.Fatalf("expected exactly 1 update per frame, got %d", len(msgs))
+    }
+}
+
+func TestClient_IssuesFetchForMissingVisibleRows(t *testing.T) {
+    c, tx := newTestClient(t)
+    paneID := [16]byte{1}
+    c.OnScroll(paneID, 1_000, 1_023, false) // no rows cached in this range
+    c.FlushFrame()
+    msg := tx.WaitFor(protocol.MsgFetchRange)
+    r, _ := protocol.DecodeFetchRange(msg.Payload)
+    if r.LoIdx > 1_000 || r.HiIdx < 1_024 {
+        t.Fatalf("fetch range should cover [1000, 1024), got [%d,%d)", r.LoIdx, r.HiIdx)
+    }
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test ./internal/runtime/client/ -run "TestClient_Emits|TestClient_Coalesces|TestClient_IssuesFetch" -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `OnScroll` + per-frame coalescing**
+
+Add a per-pane pending-update struct on the client's top-level struct:
+
+```go
+type pendingViewport struct {
+    update   protocol.ViewportUpdate
+    dirty    bool
+}
+```
+
+`OnScroll(paneID, top, bottom, autoFollow)` stores into `pendingViewport[paneID]` with `dirty=true`.
+
+`FlushFrame()` (called at the top of each render tick):
+
+```go
+for pid, pv := range c.pendingViewport {
+    if !pv.dirty { continue }
+    c.sendViewportUpdate(pv.update)
+    pv.dirty = false
+    c.pendingViewport[pid] = pv
+    // Also check the cache for missing rows in the new viewport + 1× overscan.
+    pc := c.PaneCacheFor(pid)
+    lo := pv.update.ViewTopIdx - int64(pv.update.Rows)
+    hi := pv.update.ViewBottomIdx + int64(pv.update.Rows)
+    miss := pc.MissingRows(lo, hi)
+    if len(miss) > 0 {
+        c.requestFetch(pid, miss[0], miss[len(miss)-1]+1)
+    }
+    pc.Evict(pv.update.ViewTopIdx, pv.update.ViewBottomIdx, int64(pv.update.Rows))
+}
+```
+
+`requestFetch` enforces at-most-one-in-flight-per-pane:
+
+```go
+func (c *Client) requestFetch(paneID [16]byte, lo, hi int64) {
+    if c.inflightFetch[paneID] {
+        c.pendingFetch[paneID] = [2]int64{lo, hi}
+        return
+    }
+    c.inflightFetch[paneID] = true
+    req := protocol.FetchRange{
+        RequestID: c.nextFetchID(),
+        PaneID:    paneID,
+        LoIdx:     lo,
+        HiIdx:     hi,
+    }
+    raw, _ := protocol.EncodeFetchRange(req)
+    c.send(protocol.MsgFetchRange, raw)
+}
+```
+
+On `FetchRangeResponse` dispatch (Task 4c step 6), clear `inflightFetch[paneID]`; if `pendingFetch[paneID]` is set, emit it now.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/runtime/client/ -run "TestClient_Emits|TestClient_Coalesces|TestClient_IssuesFetch" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Smoke-test the whole thing**
+
+Build and run:
+
+```bash
+make build
+./bin/texel-server &
+./bin/texel-client  # in another terminal
+```
+
+- Open a long scrollback (Claude or `yes | head -n 5000 | cat`).
+- Scroll up far; verify the visible rows populate within a frame or two.
+- Run `vim` in a pane, exit; verify the main-screen scroll position is preserved.
+- Resize a pane; verify no visible tearing.
+
+If anything looks wrong, fall back to smaller debugging chunks with the `testutil` reference-terminal framework on texelterm snapshots.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/client/input.go internal/runtime/client/client_loop.go internal/runtime/client/client_loop_test.go
+git commit -m "client: emit ViewportUpdate + FetchRange on scroll/resize (#199)"
+```
+
+### Task 4e — Integration tests
+
+Using the existing memconn harness (`internal/runtime/server/testutil/memconn.go`), land end-to-end tests that exercise the clipping + FetchRange loop.
+
+**Files:**
+- Create: `internal/runtime/server/viewport_integration_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build integration
+// +build integration
+
+package server
+
+import (
+    "testing"
+    "time"
+
+    "github.com/framegrace/texelation/internal/runtime/server/testutil"
+    "github.com/framegrace/texelation/protocol"
+)
+
+func TestIntegration_ClipsAndFetches(t *testing.T) {
+    srv, cli := testutil.NewMemConnPair(t)
+    defer srv.Close()
+    defer cli.Close()
+
+    paneID := srv.SpawnTexelTerm(t)
+    srv.FeedPane(paneID, longOutput(5000)) // >> 24 visible rows
+
+    cli.ApplyViewport(paneID, 4900, 4923, /*autoFollow*/ true)
+    cli.AwaitRow(paneID, 4900, 2*time.Second)
+
+    // Scroll back 1000 rows.
+    cli.ApplyViewport(paneID, 3900, 3923, /*autoFollow*/ false)
+    cli.AwaitRow(paneID, 3900, 2*time.Second)
+}
+
+func TestIntegration_AltScreenOptsOut(t *testing.T) {
+    srv, cli := testutil.NewMemConnPair(t)
+    defer srv.Close()
+    defer cli.Close()
+
+    paneID := srv.SpawnTexelTerm(t)
+    srv.FeedPane(paneID, []byte("\x1b[?1049h")) // enter alt-screen
+    srv.FeedPane(paneID, []byte("hello alt"))
+
+    cli.AwaitAltRow(paneID, 0, "hello alt", time.Second)
+
+    // FetchRange while alt-screen is active must return AltScreenActive.
+    resp := cli.FetchRangeSync(paneID, 0, 100)
+    if resp.Flags&protocol.FetchRangeAltScreenActive == 0 {
+        t.Fatal("expected AltScreenActive")
+    }
+}
+```
+
+Helpers `SpawnTexelTerm`, `FeedPane`, `ApplyViewport`, `AwaitRow`, `AwaitAltRow`, `FetchRangeSync`: add to `testutil/memconn.go`. Pattern-match against existing helpers in that file; do not invent new patterns.
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `go test -tags=integration ./internal/runtime/server/ -run TestIntegration_Clips -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Iterate until green**
+
+Stabilize the memconn helpers and handler plumbing until both tests pass.
+
+- [ ] **Step 4: Run the full test suite one more time**
+
+```
+make test
+go test -tags=integration ./...
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/viewport_integration_test.go internal/runtime/server/testutil/memconn.go
+git commit -m "tests: integration coverage for viewport clipping + FetchRange (#199)"
+```
+
+---
+
+## Task 5 — Push the branch and open the Plan A PR
+
+- [ ] **Step 1: Final self-review**
+
+- `git diff main...HEAD` — eyeball the whole thing.
+- `make test` and `go test -tags=integration ./...` — green.
+- `make fmt && make lint` — clean.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin design/issue-199-viewport-only-rendering
+gh pr create --title "Viewport clipping + FetchRange foundation (#199, Plan A)" --body "$(cat <<'EOF'
+## Summary
+- Adds RowBase + AltScreen flag to BufferDelta; every delta is now viewport-clipped to per-client window + 1× overscan.
+- New MsgViewportUpdate (client → server) and MsgFetchRange / MsgFetchRangeResponse (on-demand scrollback).
+- Client-side sparse PaneCache keyed by globalIdx replaces row-index BufferCache lookups.
+- Protocol version bumped in lockstep; old clients reconnect against the supervisor.
+
+Plan: docs/superpowers/plans/2026-04-21-issue-199-plan-a-viewport-clipping-fetchrange.md
+Spec: docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md
+
+## Test plan
+- [x] Unit: `go test ./...`
+- [x] Integration: `go test -tags=integration ./...`
+- [x] Smoke: scroll far back on a 5k-row pane; alt-screen enter/exit preserves scroll position.
+- [ ] Manual: `texelation` with live Claude session, verify no regression on resize.
+
+Follow-up plans (not this PR):
+- Plan B: viewport-aware resume (precise wrap-segment anchor).
+- Plan C: server-side selection/copy (`ResolveBoundary`, `CaptureSelection`).
+- Plan D: cross-restart persistence of PaneViewportState.
+- Plan E: statusbar "fetch pending" indicator.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before calling Plan A done)
+
+1. **Spec coverage (steps 1–4 only):**
+   - Step 1 (BufferDelta wire format) — Task 1.
+   - Step 2 (MsgViewportUpdate + server tracks) — Task 2.
+   - Step 3 (FetchRange) — Task 3.
+   - Step 4 (clip-on-emit + client cache) — Task 4.
+   Steps 5–8 are deferred to Plans B/C/D/E.
+
+2. **No placeholders** — all encode/decode functions have full bodies; all tests have real assertions.
+
+3. **Type consistency** — `ClientViewport`, `PaneCache`, `ViewportUpdate`, `FetchRange`, `FetchRangeResponse`, `LogicalRow` names match across every task.
+
+4. **Backwards compatibility** — none expected; protocol version bump + supervisor restart. Called out in task 1 step 11.
+
+5. **TDD discipline** — every implementation step is preceded by a failing test. Every task ends with a commit.

--- a/docs/superpowers/plans/2026-04-21-issue-199-plans-index.md
+++ b/docs/superpowers/plans/2026-04-21-issue-199-plans-index.md
@@ -1,0 +1,26 @@
+# Issue #199 — Plans Index
+
+Issue #199 (viewport-only client rendering) is split into five sequential PRs after pre-design audit and brainstorming. Spec: `docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md`.
+
+Each plan is independently mergeable and must ship on its own PR off `main`. Order matters — later plans depend on the wire formats introduced earlier.
+
+| Plan | Scope | Spec steps | Status | File |
+|------|-------|------------|--------|------|
+| **A** | Viewport clipping + FetchRange foundation. New `BufferDelta.RowBase`, `Flags.AltScreen`, `MsgViewportUpdate`, `MsgFetchRange`/`Response`. Client sparse PaneCache. Publisher clips per-client. | 1–4 | **Written, ready for execution** | `2026-04-21-issue-199-plan-a-viewport-clipping-fetchrange.md` |
+| **B** | Viewport-aware resume. Extend `MsgResumeRequest` with `[]PaneViewportState`. Server honors anchor + wrap-segment + autoFollow on first paint. Missing-anchor → snap-to-oldest, autoFollow=false. | 5 | Stub | `2026-04-22-issue-199-plan-b-viewport-aware-resume.md` |
+| **C** | Server-side selection/copy. `MsgResolveBoundary`, `MsgCaptureSelection`, `MsgCaptureResult`. Client selection state migrates to `(globalIdx, col)` / `(screenRow, col)` with coord-space discriminator. Copy returns `{entryID, plain, ansi}`. | 6 | Stub | `2026-04-23-issue-199-plan-c-server-side-selection.md` |
+| **D** | Cross-restart persistence of `PaneViewportState` alongside scrollback WAL/PageStore. Best-effort first-paint resume across server restarts. | 7 | Stub | `2026-04-24-issue-199-plan-d-viewport-persistence.md` |
+| **E** | Statusbar "scrollback fetch pending" indicator. Statusbar app subscribes to server `EventDispatcher`; renders unobtrusive spinner/text while inflight fetches for visible rows exist. | 8 | Stub | `2026-04-25-issue-199-plan-e-statusbar-fetch-indicator.md` |
+
+## Rules across the plans
+
+- All plans stay on branch `design/issue-199-viewport-only-rendering` until merged. Per project CLAUDE.md: never commit directly to `main`.
+- Each plan produces its own PR; A must land before B; B and C can land in either order but both must land before D uses resume semantics.
+- After Plan A's protocol version bump, older clients cannot connect without a new version bump only if the wire format changes again. Plans B–E must treat the Plan A protocol version as the floor.
+- Test rewrite budget (from spec): ~15–20 tests touched. Plan A absorbs most of it (steps 4b/4c). Later plans should be lighter.
+
+## Post-ship follow-ups (separate tracking, not in any of the above)
+
+- Investigate whether cross-scrollback selection worked in a previous build but regressed (user belief). Plan C supersedes the current selection path regardless, so this is archaeology, not blocking.
+- Hysteresis / deadline tuning on the PaneCache based on profiling.
+- Predictive prefetch thread — explicitly deferred unless measurement shows need.

--- a/docs/superpowers/plans/2026-04-22-issue-199-plan-b-viewport-aware-resume.md
+++ b/docs/superpowers/plans/2026-04-22-issue-199-plan-b-viewport-aware-resume.md
@@ -1,0 +1,44 @@
+# Issue #199 — Plan B: Viewport-Aware Resume (STUB)
+
+**Status:** Stub — write the full TDD plan after Plan A lands.
+**Depends on:** Plan A merged.
+**Spec reference:** Sub-problem 2 + spec sequencing step 5.
+
+## Goal
+
+On reconnect, land the client at the exact scrolled-back position they left — not the live edge. Applies to disconnect/reconnect within the same server process; cross-restart is Plan D.
+
+## Scope
+
+- Extend `protocol.ResumeRequest` with `PaneViewports []PaneViewportState`.
+- Define `PaneViewportState{PaneID, AltScreen, ViewBottomIdx, WrapSegmentIdx, AutoFollow, ViewportRows, ViewportCols}`.
+- Server first-paint logic per pane:
+  1. AltScreen → send `altBuffer`, skip scroll resolution.
+  2. AutoFollow → clamp to `Store.Max()`.
+  3. Otherwise honor `ViewBottomIdx` exactly; compute ViewTop by walking `Wrapped` chains; place `WrapSegmentIdx` at bottom physical row.
+- Missing-anchor policy: `ViewBottomIdx < Store.OldestRetained()` → snap to oldest, force `AutoFollow=false`.
+- Client: persist last-known viewport per pane on disconnect; send in `ResumeRequest`.
+
+## Out of scope
+
+- Cross-restart persistence — Plan D.
+- First-paint snapshot size optimizations beyond Plan A's overscan.
+
+## Files touched (estimated)
+
+- `protocol/messages.go` — extend `ResumeRequest`.
+- `protocol/resume_test.go` — round-trip.
+- `internal/runtime/server/session.go` — honor viewports on `ResumeAccept`.
+- `internal/runtime/server/desktop_publisher.go` — first-paint path uses supplied viewport.
+- `apps/texelterm/parser/sparse/view_window.go` — `WalkUpwardFromBottom(viewBottom, wrapSeg, rows, cols)` helper.
+- `internal/runtime/client/client_loop.go` — build ResumeRequest from local ViewWindow state on disconnect.
+- Integration tests.
+
+## Test checklist
+
+- Round-trip `ResumeRequest` with empty / populated `PaneViewports`.
+- First-paint: `AutoFollow=true` clamps to live edge.
+- First-paint: `AutoFollow=false` with valid anchor lands exactly.
+- Missing anchor: snap to oldest + force `AutoFollow=false`.
+- AltScreen: scroll fields ignored; altBuffer sent.
+- Wrap-segment precision: row that wraps into multiple segments → correct segment is bottom.

--- a/docs/superpowers/plans/2026-04-23-issue-199-plan-c-server-side-selection.md
+++ b/docs/superpowers/plans/2026-04-23-issue-199-plan-c-server-side-selection.md
@@ -1,0 +1,51 @@
+# Issue #199 — Plan C: Server-Side Selection / Copy (STUB)
+
+**Status:** Stub — write the full TDD plan after Plan A lands.
+**Depends on:** Plan A merged (needs globalIdx-based addressing).
+**Can ship independently of Plan B.**
+**Spec reference:** Sub-problem 1 + spec sequencing step 6.
+
+## Goal
+
+Selection works across the entire scrollback — including cold pages and rows never cached on the client. Mosh-style silent wrong-byte grabs become structurally impossible.
+
+## Scope
+
+- Client owns live selection state `{anchor, head, mode}` in the current pane's coordinate space.
+  - Main screen: `(globalIdx, col)`.
+  - Alt screen: `(screenRow, col)`.
+- New server RPCs:
+  - `MsgResolveBoundary { paneID, pos, direction, mode } → MsgResolveBoundaryResponse { resolved | unsupported }`.
+  - `MsgCaptureSelection { paneID, coordSpace, anchor, head, mode, formats } → MsgCaptureResult { entryID, formats }`.
+- Modes: `word`, `line`, `paragraph`, `logical-line`, `prompt`, `prompt-output`.
+  - Prompt modes use OSC 133 anchors; alt-screen returns `unsupported`, client greys out binding.
+- `CaptureSelection` walks the range (faulting cold pages), soft-joins wrapped rows, CRLF on hard breaks, trims trailing blanks.
+- Formats supported day one: `plain`, `ansi`.
+- Copy stack: server-scoped in-memory `[]CopyEntry{entryID, timestamp, meta}` seeded by `CaptureSelection`. Protocol surface area for stack operations (`ListStack`, `GetStackEntry`, `TransformStackEntry`, `DeleteStackEntry`) deferred — scaffolded via stable `entryID`.
+- Mid-drag alt-screen transition cancels selection.
+
+## Out of scope
+
+- Copy stack UI / transforms (modal colorize-reformat card) — separate follow-up.
+- Multi-entry clipboard integration — separate follow-up.
+
+## Files touched (estimated)
+
+- `protocol/messages.go` + new test files for the three messages.
+- `internal/runtime/server/selection_handler.go` + tests — resolves modes, walks ranges, faults pages via `PageStore`.
+- `internal/runtime/server/copy_stack.go` + tests — in-memory entries.
+- `apps/texelterm/parser/sparse/store.go` — accessor for OSC 133 anchor map (if not already exposed).
+- `internal/runtime/client/selection.go` — migrate from screen-row to `(globalIdx, col)` / `(screenRow, col)`.
+- `internal/runtime/client/input.go` — mouse/keyboard → `ResolveBoundary` + `CaptureSelection` wiring.
+- Integration tests: cross-scrollback select + copy returning correct bytes.
+
+## Test checklist
+
+- `ResolveBoundary` word/line/paragraph from sparse store.
+- `ResolveBoundary` prompt/prompt-output against OSC 133 anchors.
+- `ResolveBoundary` returns `unsupported` on alt-screen for prompt modes.
+- `CaptureSelection` walks wrapped rows with soft-join, hard break CRLF, trailing-blank trim.
+- `CaptureSelection` loads cold pages when selection straddles on-disk data.
+- `CaptureSelection` returns both `plain` and `ansi` formats.
+- Mid-drag alt-screen transition cancels selection on the client.
+- `entryID` is stable and addressable (list before-after capture).

--- a/docs/superpowers/plans/2026-04-24-issue-199-plan-d-viewport-persistence.md
+++ b/docs/superpowers/plans/2026-04-24-issue-199-plan-d-viewport-persistence.md
@@ -1,0 +1,38 @@
+# Issue #199 — Plan D: Cross-Restart Viewport Persistence (STUB)
+
+**Status:** Stub — write the full TDD plan after Plan B lands.
+**Depends on:** Plan A merged, Plan B merged.
+**Spec reference:** Sub-problem 2 (cross-restart clause) + spec sequencing step 7.
+
+## Goal
+
+Best-effort resume of `PaneViewportState` across server restarts. On server restart, the next `ResumeRequest` for that session matches persisted viewport state; if found and `ViewBottomIdx` is still in the store, restore exactly. Else fall back to Plan B's missing-anchor policy.
+
+## Scope
+
+- Extend existing scrollback WAL / `PageStore` persistence to also carry per-pane `PaneViewportState` alongside cells.
+- On `SnapshotStore` save cycles, include latest per-pane viewport.
+- On `SnapshotStore` load at startup, reconstruct the viewport map keyed by `(SessionID, PaneID)`.
+- On `ResumeRequest`, server layers persisted state onto whatever the client supplied — client-supplied wins when both are present (user has a newer intent than the snapshot).
+
+## Out of scope
+
+- Changing the on-disk scrollback format beyond adding viewport state.
+- Cross-session viewport sharing (viewport is session-scoped).
+
+## Open decision
+
+Spec open question: per-session (simpler) vs per-client-identity (survives multiple clients on the same session). Decide during plan write-up. Default: per-session.
+
+## Files touched (estimated)
+
+- `internal/runtime/server/snapshot_store.go` — add viewport payload.
+- `internal/runtime/server/snapshot_store_test.go`.
+- `apps/texelterm/parser/page_store.go` — possibly; may not need if snapshot store is enough.
+- Server startup wiring — load viewport map before accepting connections.
+
+## Test checklist
+
+- Save → shut down → restart → `ResumeRequest` without viewports lands at persisted position.
+- Save → shut down → restart → `ResumeRequest` with viewports: client wins.
+- Save → shut down → evict enough scrollback → restart → missing-anchor fallback fires.

--- a/docs/superpowers/plans/2026-04-25-issue-199-plan-e-statusbar-fetch-indicator.md
+++ b/docs/superpowers/plans/2026-04-25-issue-199-plan-e-statusbar-fetch-indicator.md
@@ -1,0 +1,36 @@
+# Issue #199 — Plan E: Statusbar Fetch-Pending Indicator (STUB)
+
+**Status:** Stub — write the full TDD plan after Plan A lands.
+**Depends on:** Plan A merged.
+**Can ship independently of B/C/D.**
+**Spec reference:** "Missed-deadline handling" in sub-problem 4 + spec sequencing step 8.
+
+## Goal
+
+When a visible row's `globalIdx` is not yet in the PaneCache and no fetch has resolved within ~50ms, the bottom statusbar surfaces a "scrollback fetch pending" indicator. User gets feedback during fast scroll-jumps without inline placeholder text in the content area.
+
+Parallel user goal: make the statusbar a more-used surface. Currently under-utilized.
+
+## Scope
+
+- Server-side: `DesktopPublisher` emits a scalar "pending count" per pane on the existing `EventDispatcher`. Incremented when a fetch stays unresolved past 50ms; decremented on resolution.
+- `apps/statusbar` subscribes to the event stream, aggregates across panes, renders an unobtrusive spinner + count.
+- No new protocol wire surface — statusbar reads directly from the in-process `EventDispatcher`.
+
+## Out of scope
+
+- Reworking the statusbar's layout or theme system beyond adding one cell group.
+- Inline "loading…" text in the content area — explicitly not wanted.
+
+## Files touched (estimated)
+
+- `internal/runtime/server/desktop_publisher.go` — pending-fetch tracker keyed by `(paneID, requestID)` with 50ms timer.
+- `apps/statusbar/statusbar.go` — subscription + render.
+- Theme JSON — new color slot if desired.
+
+## Test checklist
+
+- Pending event fires when fetch exceeds 50ms; clears on response.
+- Statusbar renders indicator only while `pendingCount > 0`.
+- Aggregate count across multiple panes is correct.
+- AltScreen pane never contributes to the count (it opts out of fetches).

--- a/docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md
@@ -246,7 +246,6 @@ MsgCaptureResult { ... }
 type BufferDelta struct {
     PaneID    [16]byte
     Revision  uint32        // existing (per-pane)
-    Sequence  uint64        // NEW (session-global monotonic)
     Flags     BufferDeltaFlags // NEW bit: AltScreen
     RowBase   int64         // NEW: main-screen globalIdx of row offset 0;
                             // zero and ignored when Flags.AltScreen=1
@@ -255,6 +254,8 @@ type BufferDelta struct {
                             // or a screen-row index (alt)
 }
 ```
+
+**Note on monotonic sequencing.** The protocol frame header already carries a session-global monotonic `Sequence uint64` (`protocol.Header.Sequence`, filled by `Session.EnqueueDiff`). That field already satisfies the audit's "all BufferDelta carry monotonic seq" requirement — we do not add a second sequence to the payload. Per-pane `Revision` lives on the payload and drives FetchRange coherence separately (see below).
 
 ```go
 type ResumeRequest struct {
@@ -270,8 +271,8 @@ type ResumeRequest struct {
 
 Two separate counters, each doing one job:
 
-- `Sequence uint64` (session-global, on every `BufferDelta`): drives wire ordering and resume's `LastSequence`. Monotonically increasing across the session. Existing internal counter promoted to the wire.
-- `Revision uint32` (per-pane, existing on `BufferDelta`): drives `FetchRange` coherence — see below.
+- `Header.Sequence uint64` (session-global, on every frame — already shipped): drives wire ordering and resume's `LastSequence`. Monotonically increasing across the session via `Session.nextSequence`.
+- `BufferDelta.Revision uint32` (per-pane, already on the delta payload): drives `FetchRange` coherence — see below.
 
 **FetchRange coherence rule.**
 
@@ -421,7 +422,7 @@ These are design-settled but need a concrete call during the plan:
 
 Implementation order (refined by `writing-plans`):
 
-1. Extend `BufferDelta` wire format (`Sequence`, `RowBase`, `Flags.AltScreen`); no behavior change yet — `RowBase = 0`, `Sequence` now on wire.
+1. Extend `BufferDelta` wire format (`RowBase`, `Flags.AltScreen`); no behavior change yet — `RowBase = 0`, alt-screen flag unset. Frame-header `Sequence` is already monotonic and needs no change.
 2. Add `MsgViewportUpdate`; server tracks per-client viewport but does not yet clip.
 3. Add `MsgFetchRange` / `MsgFetchRangeResponse`; server can serve ranges.
 4. Flip publisher to clip-on-emit; client sparse per-pane cache lands; eviction behavior tested.

--- a/docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md
@@ -1,0 +1,433 @@
+# Viewport-Only Client Rendering (Issue #199)
+
+**Status**: Design
+**Date**: 2026-04-20
+**Issue**: [#199](https://github.com/framegrace/texelation/issues/199)
+**Relates to**:
+- `docs/superpowers/specs/2026-04-11-sparse-viewport-write-window-split-design.md`
+- `docs/superpowers/specs/2026-04-16-sparse-resize-reflow-design.md`
+- `docs/CLIENT_SERVER_ARCHITECTURE.md`
+
+## Background
+
+Today the server renders and broadcasts the full pane buffer for every pane, regardless of what the client is actually looking at. For terminals running long Claude / AI-agent sessions this produces a pathological pattern: the TUI's visible prompt may sit 1,000+ rows deep in scrollback, but the server still paints and ships the entire pane on every resize, draw, or reconnect. Scrolled-back browsing and aggressive repaints both pay for content nobody is rendering.
+
+Issue #199 asks the server to render only the client's visible viewport (plus small overscan), while preserving everything that works today: selection, copy, search, scrollback persistence, resume, and multi-pane/multi-client fan-out.
+
+A pre-design risk audit (2026-04-19, five parallel agents) identified three sub-problems that must be resolved in specific order before the protocol can be designed without traps:
+
+1. Selection / copy across uncached scrollback.
+2. Reconnect to a scrolled-back state.
+3. Alt-screen semantics.
+
+The protocol shape (`FetchRange`, clipped `BufferDelta`, sequencing) falls out naturally once those three are settled. This spec captures the decisions from the brainstorming session that followed.
+
+## Goals
+
+- Server-rendered data per pane is clipped to the client's visible viewport plus symmetric overscan.
+- Clients can request arbitrary scrollback ranges on demand (`FetchRange`), shipping in the same PR as clipping — no half-state where a scrolled-back client is stuck with no data.
+- Selection and copy work across the entire scrollback, including rows that are cold (on disk) or simply never cached on the client.
+- Reconnect lands the user back at the exact scrolled-back position they left, across client disconnect *and* best-effort across server restart.
+- Alt-screen remains ephemeral, viewport-sized, and cleanly opts out of the globalIdx machinery.
+- Existing UX is preserved. Nothing that works today should regress.
+
+## Non-goals
+
+- Copy-stack UI, multi-entry clipboard operations, or post-copy transforms (colorize / reformat to modal card). Scaffolded via stable `entryID` in the copy-commit path; not shipped in this PR.
+- Predictive prefetch of scrollback beyond the fixed 1× overscan window. User explicitly declined pre-optimization; revisit only if measurement shows need.
+- Alt-screen reflow (already out of scope per sparse design).
+- Reworking the statusbar app beyond adding a "scrollback fetch pending" indicator subscription.
+- Investigating why current selection UX appears to be viewport-only rather than cross-scrollback (user suspects regression). Tracked separately; not this PR.
+
+## Non-negotiables (from audit)
+
+- `FetchRange` ships in the same PR as viewport clipping.
+- Selection/copy is resolved server-side; client is a highlight renderer and event source.
+- Resume carries viewport state (anchor + wrap-offset + autoFollow) per pane.
+- Every `BufferDelta` on the wire carries a monotonic sequence number.
+- Alt-screen explicitly opts out of `FetchRange`.
+- Tests rewrite budget: existing viewport assertions that inspect full-pane buffers must be rewritten against viewport-clipped buffers; estimate is included in the plan.
+
+## The Approach
+
+### Architecture at a glance
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Client                                                          │
+│                                                                 │
+│   Input ── MsgViewportUpdate ─┐        ┌─── MsgBufferDelta ──┐  │
+│                               │        │   (Sequence,         │  │
+│   ViewWindow (scroll state)   │        │    RowBase,          │  │
+│   │                           │        │    Flags.AltScreen)  │  │
+│   ▼                           │        │                      │  │
+│   Per-pane sparse cache  ◄────┼────────┴──────────────────────┘  │
+│   keyed by globalIdx          │                                 │
+│                               │  ┌───► MsgFetchRangeResponse    │
+│   MsgFetchRange  ◄────────────┼──┤     (revision stamp)         │
+│                               │                                 │
+│   MsgResolveBoundary  ◄───────┼─► resolved (idx,col)             │
+│   MsgCaptureSelection ◄───────┼─► {entryID, plain, ansi}        │
+│                               │                                 │
+└───────────────────────────────┼─────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Server                                                          │
+│                                                                 │
+│   Per-session ClientViewport{paneID -> {viewTop, viewBottom,    │
+│                                         overscan, altScreen,    │
+│                                         autoFollow}}            │
+│                                                                 │
+│   Publisher clips per-client on emit                             │
+│   Statusbar subscribes to "fetch pending" signal                │
+│                                                                 │
+│   sparse.Store / WriteWindow / ViewWindow (unchanged)            │
+│   alt buffer (VTerm altBuffer, unchanged)                        │
+│                                                                 │
+│   Persistence: PageStore + WAL + NEW PaneViewportState          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Sub-problem 1 — Selection / copy across uncached scrollback
+
+**Decision.** Selection is a server-resolved concept. The client owns live selection *state* (so mouse drag and highlight rendering stay zero-RPC); the server owns the resolution of that state into text. This keeps the hot path local and makes mosh-style silent wrong-byte grabs structurally impossible — the client never reads bytes past what the server has shipped it.
+
+**Coordinate space.**
+- Main screen: `(globalIdx, col)`. Stable across scrollback growth because the sparse store is append-only by `globalIdx`.
+- Alt screen: `(screenRow, col)`. Separate, ephemeral.
+
+**Live selection (client-side).** The client's `selectionState` holds `{anchor, head, mode}` in the current pane's coordinate space. Mouse drag, keyboard extend, autoscroll-at-edge, and highlight rendering are all local. Screen-row ↔ `globalIdx` translation is done via `ViewWindow` (already tracks which `globalIdx` maps to each visible row).
+
+**Mode resolution (server RPC).** Some selection modes require server-only knowledge. The client sends a `MsgResolveBoundary` to get a boundary position:
+
+```
+MsgResolveBoundary { paneID, pos: (globalIdx, col) | (screenRow, col),
+                     direction: up | down, mode }
+ →
+MsgResolveBoundaryResponse { resolved: (globalIdx, col) | (screenRow, col)
+                           | unsupported }
+```
+
+Modes: `word`, `line`, `paragraph`, `prompt`, `prompt-output`, `logical-line`.
+
+- `word` / `line` / `paragraph` / `logical-line`: resolvable from the sparse store (main) or `altBuffer` (alt).
+- `prompt` / `prompt-output`: uses OSC 133 anchors already tracked by the server. Main-screen only; on alt-screen, server returns `unsupported` and the client disables the binding.
+
+Double-click / triple-click are two `ResolveBoundary` calls (one each direction) paired with `CaptureSelection` below.
+
+**Commit / copy (server RPC).** On mouse-up or explicit copy command, the client sends:
+
+```
+MsgCaptureSelection {
+    paneID,
+    coordSpace: main | alt,
+    anchor, head, mode,
+    formats: [plain, ansi],        // 'b' supported from day one
+}
+ →
+MsgCaptureResult {
+    entryID,                         // stable server-side ID
+    formats: { plain: string, ansi?: string },
+}
+```
+
+Server walks the range (loading cold pages from `PageStore` synchronously if needed), respects `Wrapped` flags (soft-join within a wrapped logical line; CRLF on hard breaks), trims trailing blanks per row, and returns the requested formats. The server pushes `entryID` onto a session-scoped in-memory copy stack. System clipboard sync reuses the existing `MsgClipboardSet`.
+
+**Copy-stack scaffold (out of scope to ship, in scope to design for).** The returned `entryID` is stable and addressable. Follow-up messages (`MsgListStack`, `MsgGetStackEntry`, `MsgTransformStackEntry`, `MsgDeleteStackEntry`) layer on without protocol churn. Transforms that produce a modal card reuse the existing `texel/cards/` pipeline.
+
+**Scrollback regression investigation.** Current code routes selection strictly through the visible pane's `BufferCache`, meaning cross-scrollback selection is not available today. User believes this is a regression and plans to track it separately. Not a prerequisite for this PR.
+
+### Sub-problem 2 — Reconnect to a scrolled-back state
+
+**Decision.** Resume carries per-pane viewport state and the server honors it on first paint — no snap to live edge. Anchor is precise enough to land on the exact wrap-segment the user was viewing, and the state is persisted alongside the scrollback so it survives server restarts on a best-effort basis.
+
+**Per-pane resume payload (new).**
+
+```go
+type PaneViewportState struct {
+    PaneID          [16]byte
+    AltScreen       bool     // if true, scroll fields are ignored
+    ViewBottomIdx   int64    // globalIdx of the bottom-most logical line shown
+    WrapSegmentIdx  uint16   // which wrap-segment of ViewBottomIdx was at the bottom row
+    AutoFollow      bool
+    ViewportRows    uint16
+    ViewportCols    uint16
+}
+```
+
+`MsgResumeRequest` is extended with `[]PaneViewportState`. The client builds this from its `ViewWindow` state on disconnect and from its per-pane selection of segment at render time.
+
+**Server-side first-paint logic.**
+
+For each pane in the request:
+1. If `AltScreen=true`: send current `altBuffer` content; skip scroll resolution.
+2. Else if `AutoFollow=true`: clamp `ViewBottomIdx` to `sparse.Store.Max()` at current server-side geometry.
+3. Else: honor `ViewBottomIdx` exactly. Compute `ViewTopIdx` by walking backwards from `ViewBottomIdx` for `ViewportRows` screen rows at the current pane width, respecting `Wrapped` flags. Place `WrapSegmentIdx` at the bottommost physical row.
+4. Send a viewport-clipped `TreeSnapshot` containing rows `[ViewTopIdx, ViewBottomIdx]` per pane, plus symmetric 1× overscan.
+
+**Missing-anchor policy.** If `ViewBottomIdx < sparse.Store.OldestRetained()` (scrollback evicted while client was offline), server snaps `ViewBottomIdx` to the oldest retained row and forces `AutoFollow=false`. Preserves the user's intent of being scrolled back, and is indistinguishable from the UX of scrolling up and hitting the top of available history.
+
+**Best-effort cross-restart resume.** Server persists `PaneViewportState` alongside the scrollback WAL / PageStore. On server restart, the next `MsgResumeRequest` for that session is matched against persisted viewport state; if found and `ViewBottomIdx` is still in the store, restore exactly. Otherwise fall back to missing-anchor policy above.
+
+**Fresh connect (no SessionID).** No prior viewport state; server sends live-edge viewport with `AutoFollow=true`. Equivalent to current behavior minus the full-pane buffer.
+
+`LastSequence` (existing) continues to drive delta replay and is orthogonal to `PaneViewportState`.
+
+### Sub-problem 3 — Alt-screen semantics
+
+**Decision.** Alt-screen stays a separate, flat, viewport-sized 2D buffer, outside the sparse store. It opts out of the globalIdx machinery wholesale. Entry/exit transitions preserve the main-screen `ViewWindow` state, matching current behavior.
+
+**Clipping.** No-op. Alt-screen *is* the viewport. Server sends the full alt buffer on every delta. Row indices in the delta are screen-local (the existing `RowDelta.Row uint16` suffices unchanged).
+
+**FetchRange.** Opt-out. Server responds with `flags = AltScreenActive` and empty payload. Client should not send `MsgFetchRange` while `altScreen=true` for that pane; if it does (race), the response above is expected — not an error.
+
+**Delta flag.** `BufferDeltaFlags.AltScreen` bit. Set to 1 → row indices target `altBuffer`. Set to 0 → row indices are offsets from `RowBase` in the sparse store (main screen).
+
+**Entry (DECSET 1049 / 47 / 1047).** Server switches the pane's publisher mode. Subsequent deltas carry `Flags.AltScreen=1`. Client's main-screen `ViewWindow` state is not touched; resume state preserves it.
+
+**Exit.** Subsequent deltas carry `Flags.AltScreen=0`. Main-screen `ViewWindow` state resumes exactly where it was. Matches existing texelterm behavior — if the user was scrolled back before running `vim`, they are still scrolled back when `vim` exits.
+
+**Selection on alt-screen.** Client-side, screen-local. `MsgCaptureSelection.coordSpace` discriminator routes to the alt-screen reader path on the server:
+
+```
+coordSpace=main → anchor/head are (globalIdx, col), server reads sparse store
+coordSpace=alt  → anchor/head are (screenRow, col), server reads altBuffer
+```
+
+**Mid-drag alt-screen transition.** Client cancels any in-flight selection on entry or exit. The coordinate space changes out from under the user; any preservation attempt is wrong-byte territory. Matches universal terminal behavior.
+
+**Mode resolution on alt-screen.** `word` / `line` / `paragraph` supported against `altBuffer`. `prompt` / `prompt-output` / `logical-line` return `unsupported`; client greys out the corresponding binding while in alt-screen.
+
+### Sub-problem 4 — Protocol API
+
+**New messages.**
+
+Client → Server:
+```
+MsgViewportUpdate {
+    paneID,
+    altScreen       bool,
+    viewTopIdx      int64,    // ignored if altScreen
+    viewBottomIdx   int64,    // ignored if altScreen or autoFollow
+    wrapSegmentIdx  uint16,
+    rows, cols      uint16,
+    autoFollow      bool,
+}
+
+MsgFetchRange {
+    requestID     uint32,
+    paneID        [16]byte,
+    loIdx         int64,
+    hiIdx         int64,      // exclusive
+    asOfRevision  uint32,
+}
+
+MsgResolveBoundary { ... } // as in Sub-problem 1
+MsgCaptureSelection { ... } // as in Sub-problem 1
+```
+
+Server → Client:
+```
+MsgFetchRangeResponse {
+    requestID   uint32,
+    paneID      [16]byte,
+    revision    uint32,
+    rows        []LogicalRow,   // one per globalIdx in [loIdx, hiIdx)
+    flags       uint8,          // {AltScreenActive, BelowRetention, Empty}
+}
+
+MsgCaptureResult { ... }
+```
+
+**Extended messages.**
+
+```go
+type BufferDelta struct {
+    PaneID    [16]byte
+    Revision  uint32        // existing (per-pane)
+    Sequence  uint64        // NEW (session-global monotonic)
+    Flags     BufferDeltaFlags // NEW bit: AltScreen
+    RowBase   int64         // NEW: main-screen globalIdx of row offset 0;
+                            // zero and ignored when Flags.AltScreen=1
+    Styles    []StyleEntry
+    Rows      []RowDelta    // Row uint16 is now an offset from RowBase (main)
+                            // or a screen-row index (alt)
+}
+```
+
+```go
+type ResumeRequest struct {
+    SessionID     SessionID
+    LastSequence  uint64          // existing
+    PaneViewports []PaneViewportState  // NEW
+}
+```
+
+`TreeSnapshot` is unchanged in structure; its per-pane row payload is now the viewport-clipped slice rather than the full pane.
+
+**Sequencing model.**
+
+Two separate counters, each doing one job:
+
+- `Sequence uint64` (session-global, on every `BufferDelta`): drives wire ordering and resume's `LastSequence`. Monotonically increasing across the session. Existing internal counter promoted to the wire.
+- `Revision uint32` (per-pane, existing on `BufferDelta`): drives `FetchRange` coherence — see below.
+
+**FetchRange coherence rule.**
+
+Invariant: by the time the client applies a `FetchRangeResponse` for revision R, it has already applied every `BufferDelta` with `Revision ≤ R` that it was going to apply. Achieved via:
+
+1. Connection is FIFO. Server emits pending deltas for the pane before the fetch response.
+2. Response stamps `revision = pane.Revision at read time`.
+3. Client discard rule on receive: `if response.revision < pane.localRevision: discard; else: apply rows, set pane.localRevision = max(pane.localRevision, response.revision)`.
+
+This handles the out-of-order case where an in-flight delta at `R+1` arrives after a fetch response at `R`. No cross-pane coordination required.
+
+**Per-client viewport tracking (server).**
+
+Each `Session` maintains:
+```go
+map[PaneID] ClientViewport {
+    ViewTopIdx, ViewBottomIdx int64
+    AltScreen, AutoFollow     bool
+    ViewportRows, ViewportCols uint16
+}
+```
+
+Overscan is derived from `ViewportRows` (1× top, 1× bottom) rather than stored; see "Overscan" below.
+
+Publisher emit path, per pane update at `globalIdx X`:
+```
+for each client session with this pane subscribed:
+    vp := session.viewports[paneID]
+    if vp.AltScreen:
+        emit full alt delta with Flags.AltScreen=1
+        continue
+    overscan := int64(vp.ViewportRows)
+    liveTop := Store.Max() - int64(vp.ViewportRows)
+    live    := Store.Max()
+    lo := (if vp.AutoFollow then liveTop else vp.ViewTopIdx) - overscan
+    hi := (if vp.AutoFollow then live    else vp.ViewBottomIdx) + overscan
+    if X ∈ [lo, hi]:
+        emit delta row with RowBase set for this client
+    else:
+        drop
+```
+
+Fan-out shape is unchanged — deltas are already per-session. This just clips what each session sees.
+
+**Overscan.**
+
+Fixed **1× viewport top and bottom**. With a 24-row viewport, the resident range is 72 rows (24 visible + 24 above + 24 below). Configurable via theme only when measurement shows need.
+
+**FetchRange flow control.**
+
+- Client coalesces viewport changes within one animation frame into a single `MsgViewportUpdate`.
+- Client maintains **at most one in-flight `MsgFetchRange` per pane**. If a new request supersedes an outstanding one, client waits for the response and immediately sends the latest-needed range.
+- Server-side: no explicit debounce. Requests are cheap reads against the sparse store (synchronous cold-page load if needed).
+
+**Missed-deadline handling.**
+
+When a visible row's `globalIdx` is not yet in the client cache and no fetch has resolved within ~50ms of the viewport update:
+
+- Row renders as plain empty cells (normal bg, no inline marker).
+- Statusbar app (`apps/statusbar`) subscribes to a "scrollback fetch pending" signal from the pane publisher and surfaces the loading indicator at the bottom of the screen.
+- Signal clears when all outstanding fetches for visible rows resolve.
+
+No inline "loading" text — keeps the visible content area calm during scroll-jumps. Uses a surface that is currently under-utilized.
+
+**Client-side cache.**
+
+`BufferCache` is replaced with a per-pane sparse structure:
+
+```go
+type PaneCache struct {
+    altScreen bool
+    main      map[int64]LogicalRow   // keyed by globalIdx
+    alt       [][]Cell                // screen-sized 2D (unchanged semantics)
+    revision  uint32
+}
+```
+
+- Entries populated by deltas (`RowBase + offset` → globalIdx) and `FetchRangeResponse` rows.
+- Trailing-edge eviction outside `[viewTop - overscan, viewBottom + overscan]`, with a small hysteresis band to prevent thrash during micro-scrolls.
+- Render path asks the cache for the globalIdx of each visible row; missing rows render empty (see missed-deadline above).
+
+**AutoFollow data path.**
+
+- `AutoFollow=true`: client does not send a `ViewportUpdate` on every new live-edge row. Server derives `viewBottom = Store.Max()` dynamically for clipping. Client's `ViewWindow` continues tailing normally.
+- `AutoFollow=false`: client's `ViewportUpdate` carries explicit `ViewBottomIdx`. Server uses it literally until the next update.
+- Transitions (user scrolls away → `AutoFollow=false`; user hits bottom → `AutoFollow=true`) each produce exactly one `MsgViewportUpdate`.
+
+**Delta queue retention while offline.**
+
+Unattached-session delta queues shrink naturally under clipping: at most `overscan_total` rows worth of deltas matter for any given client viewport. On reconnect, we rely on the viewport-clipped `TreeSnapshot` plus `FetchRange` rather than replaying a long backlog of deltas.
+
+### Statusbar integration
+
+`apps/statusbar` gains a subscription to a server-side "scrollback fetch pending" event. Event is emitted when the pane publisher notes a client is waiting on rows for >50ms; cleared when all outstanding visible-row fetches resolve. Statusbar renders an unobtrusive indicator (spinner or text) while pending. No additional protocol on the wire — statusbar reads from the server-internal `EventDispatcher`.
+
+### Selection-state regression (out of scope)
+
+User observed that cross-scrollback selection, which they remember working previously, does not work in the current build. The exploration confirms selection sources strictly from the visible pane's `BufferCache`. Tracked as a separate investigation; this spec does not block on root-causing it, because the new design supersedes the client-side path entirely (selection coords migrate to `(globalIdx, col)` resolved server-side).
+
+## Testing
+
+### Unit tests
+
+- `sparse.ViewWindow` → produce `PaneViewportState` round-trip.
+- Server viewport clipper: emits rows only inside window + overscan, drops outside.
+- `BufferDelta` encode/decode with `Sequence` + `RowBase` + `Flags.AltScreen`.
+- `FetchRange` coherence: stale response is discarded; in-order response applies.
+- Missing-anchor resume policy: snap-to-oldest + autoFollow=false.
+- Alt-screen entry/exit preserves main-screen `ViewWindow`.
+- Mid-drag alt-screen transition cancels selection.
+- Mode resolution `ResolveBoundary`: word / line / paragraph / prompt against sparse store; prompt modes return `unsupported` in alt-screen.
+- `CaptureSelection`: soft-join wrapped rows, CRLF on hard break, trailing-blank trim; cold-page selection loads correctly.
+
+### Integration tests
+
+- Viewport-aware resume: disconnect scrolled back → reconnect at same visual position.
+- Cross-restart best-effort resume: server restart with persisted `PaneViewportState`; client lands at saved position.
+- FetchRange flow: fast scroll past overscan → row arrives before 50ms deadline in happy path.
+- AutoFollow transitions: live-edge follow → user scrolls back → autoFollow off → user hits bottom → autoFollow on.
+- Alt-screen opt-out: `MsgFetchRange` returns `AltScreenActive` while `vim` is running; main-screen scroll state survives.
+
+### Tests to rewrite (budget)
+
+Existing tests that assert over the full-pane buffer:
+- `internal/runtime/server/desktop_publisher_test.go` — rewrite to expect clipped deltas under a configured viewport.
+- `internal/runtime/server/session_test.go` — resume tests assume full-pane snapshots; rewrite against viewport-clipped snapshots.
+- `internal/runtime/client/*_test.go` — any `BufferCache` assertion against row-index addressing.
+
+Rough estimate: ~15–20 tests touched across server and client runtime packages. Must be confirmed during implementation planning.
+
+## Migration and rollout
+
+- Protocol version bumps by one. Both sides are updated in lockstep in this PR — clipping has no meaningful fallback mode, so there is no mixed-version compatibility window.
+- Old persisted scrollback loads normally; it simply lacks `PaneViewportState`, which is fine (treated as a fresh-connect resume for that pane).
+- The `texelation` supervisor restarts the server daemon on version mismatch, so mixed versions do not co-exist in the wild for long.
+
+## Open questions for implementation
+
+These are design-settled but need a concrete call during the plan:
+
+- Exact wire encoding for `LogicalRow` in `FetchRangeResponse` (reuse `RowDelta` run-length style, or a distinct row format).
+- Hysteresis constant for cache eviction (start with overscan × 1.5).
+- Missed-deadline threshold (50ms is a starting guess; tune on first profiling).
+- Whether `PaneViewportState` is persisted per-session (simpler) or per-client-identity (survives multiple clients on the same session).
+
+## Sequencing within the PR
+
+Implementation order (refined by `writing-plans`):
+
+1. Extend `BufferDelta` wire format (`Sequence`, `RowBase`, `Flags.AltScreen`); no behavior change yet — `RowBase = 0`, `Sequence` now on wire.
+2. Add `MsgViewportUpdate`; server tracks per-client viewport but does not yet clip.
+3. Add `MsgFetchRange` / `MsgFetchRangeResponse`; server can serve ranges.
+4. Flip publisher to clip-on-emit; client sparse per-pane cache lands; eviction behavior tested.
+5. Extend `MsgResumeRequest` with `PaneViewportState`; server honors on first paint.
+6. Add `MsgResolveBoundary`, `MsgCaptureSelection`, `MsgCaptureResult`; migrate client selection to globalIdx coords.
+7. Persist `PaneViewportState` alongside scrollback for cross-restart resume.
+8. Statusbar "scrollback fetch pending" integration.
+
+Each step has an individually-mergeable boundary for local testing, though the public-facing behavior change lands at step 4.

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -66,6 +66,7 @@ func Run(opts Options) error {
 
 	state := &clientState{
 		cache:                   client.NewBufferCache(),
+		viewports:               newViewportTrackers(),
 		themeValues:             make(map[string]map[string]interface{}),
 		defaultStyle:            tcell.StyleDefault,
 		defaultFg:               tcell.ColorDefault,
@@ -75,6 +76,11 @@ func Run(opts Options) error {
 		selectionBg:             tcell.NewRGBColor(232, 217, 255),
 		showRestartNotification: opts.ShowRestartNotification,
 	}
+
+	// Wire connection context for FlushFrame (set once, never mutated).
+	state.conn = conn
+	state.writeMu = &writeMu
+	state.sessionID = accept.SessionID
 
 	// Load keybindings from config file or use platform defaults.
 	state.keybindings = loadKeybindings()

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -51,6 +51,12 @@ type clientState struct {
 	cache        *client.BufferCache
 	paneCaches   map[[16]byte]*client.PaneCache
 	paneCachesMu sync.RWMutex
+	viewports    *viewportTrackers
+
+	// Wire for FlushFrame — set once after connect, never mutated thereafter.
+	conn      net.Conn
+	writeMu   *sync.Mutex
+	sessionID [16]byte
 
 	clipboardMu          sync.Mutex
 	clipboard            protocol.ClipboardData

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -25,8 +25,33 @@ import (
 	"github.com/framegrace/texelation/protocol"
 )
 
+// paneCacheFor returns the PaneCache for id, creating it on first access.
+func (s *clientState) paneCacheFor(id [16]byte) *client.PaneCache {
+	s.paneCachesMu.Lock()
+	defer s.paneCachesMu.Unlock()
+	if s.paneCaches == nil {
+		s.paneCaches = make(map[[16]byte]*client.PaneCache)
+	}
+	pc, ok := s.paneCaches[id]
+	if !ok {
+		pc = client.NewPaneCache()
+		s.paneCaches[id] = pc
+	}
+	return pc
+}
+
+// dropPaneCache removes the PaneCache for id, if present.
+func (s *clientState) dropPaneCache(id [16]byte) {
+	s.paneCachesMu.Lock()
+	defer s.paneCachesMu.Unlock()
+	delete(s.paneCaches, id)
+}
+
 type clientState struct {
-	cache                *client.BufferCache
+	cache        *client.BufferCache
+	paneCaches   map[[16]byte]*client.PaneCache
+	paneCachesMu sync.RWMutex
+
 	clipboardMu          sync.Mutex
 	clipboard            protocol.ClipboardData
 	hasClipboard         bool
@@ -100,7 +125,6 @@ func (s *clientState) triggerRender() {
 		}
 	}
 }
-
 
 func (s *clientState) setThemeValue(section, key string, value interface{}) {
 	if s.themeValues == nil {

--- a/internal/runtime/client/pane_cache_dispatch_test.go
+++ b/internal/runtime/client/pane_cache_dispatch_test.go
@@ -1,0 +1,199 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/pane_cache_dispatch_test.go
+// Summary: Tests for PaneCache dispatch in the protocol handler.
+
+package clientruntime
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/framegrace/texelation/client"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// makeTestState builds a minimal clientState suitable for handler tests.
+func makeTestState() *clientState {
+	return &clientState{
+		cache:       client.NewBufferCache(),
+		paneCaches:  make(map[[16]byte]*client.PaneCache),
+		themeValues: make(map[string]map[string]interface{}),
+	}
+}
+
+func TestClientState_PaneCacheFor_CreatesOnDemand(t *testing.T) {
+	state := makeTestState()
+	var id [16]byte
+	id[0] = 1
+
+	pc := state.paneCacheFor(id)
+	if pc == nil {
+		t.Fatal("paneCacheFor returned nil")
+	}
+
+	// Second call must return the same instance.
+	pc2 := state.paneCacheFor(id)
+	if pc != pc2 {
+		t.Error("paneCacheFor returned different instance on second call")
+	}
+}
+
+func TestClientState_DropPaneCache(t *testing.T) {
+	state := makeTestState()
+	var id [16]byte
+	id[0] = 7
+
+	_ = state.paneCacheFor(id)
+	state.dropPaneCache(id)
+
+	state.paneCachesMu.RLock()
+	_, exists := state.paneCaches[id]
+	state.paneCachesMu.RUnlock()
+	if exists {
+		t.Error("dropPaneCache did not remove the entry")
+	}
+}
+
+func TestClientState_BufferDeltaAppliesToPaneCache(t *testing.T) {
+	state := makeTestState()
+
+	var paneID [16]byte
+	paneID[0] = 42
+
+	// Synthesise a BufferDelta with RowBase=500 and one row of text.
+	delta := protocol.BufferDelta{
+		PaneID:  paneID,
+		RowBase: 500,
+		Styles: []protocol.StyleEntry{
+			{AttrFlags: 0},
+		},
+		Rows: []protocol.RowDelta{
+			{
+				Row: 0,
+				Spans: []protocol.CellSpan{
+					{StartCol: 0, Text: "hello", StyleIndex: 0},
+				},
+			},
+		},
+	}
+
+	payload, err := protocol.EncodeBufferDelta(delta)
+	if err != nil {
+		t.Fatalf("encode delta: %v", err)
+	}
+
+	hdr := protocol.Header{Type: protocol.MsgBufferDelta}
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+
+	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+
+	pc := state.paneCacheFor(paneID)
+	row, ok := pc.RowAt(500)
+	if !ok {
+		t.Fatal("PaneCache.RowAt(500) returned false; delta was not applied")
+	}
+	if len(row) < 5 {
+		t.Fatalf("row has %d cells, want >= 5", len(row))
+	}
+	want := "hello"
+	for i, r := range []rune(want) {
+		if row[i].Ch != r {
+			t.Errorf("row[%d].Ch = %q, want %q", i, row[i].Ch, r)
+		}
+	}
+}
+
+func TestClientState_FetchRangeResponseAppliesToPaneCache(t *testing.T) {
+	state := makeTestState()
+
+	var paneID [16]byte
+	paneID[0] = 99
+
+	resp := protocol.FetchRangeResponse{
+		RequestID: 1,
+		PaneID:    paneID,
+		Revision:  1,
+		Flags:     protocol.FetchRangeNone,
+		Styles: []protocol.StyleEntry{
+			{AttrFlags: 0},
+		},
+		Rows: []protocol.LogicalRow{
+			{
+				GlobalIdx: 1000,
+				Spans: []protocol.CellSpan{
+					{StartCol: 0, Text: "world", StyleIndex: 0},
+				},
+			},
+		},
+	}
+
+	payload, err := protocol.EncodeFetchRangeResponse(resp)
+	if err != nil {
+		t.Fatalf("encode fetch range response: %v", err)
+	}
+
+	hdr := protocol.Header{Type: protocol.MsgFetchRangeResponse}
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+
+	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+
+	pc := state.paneCacheFor(paneID)
+	row, ok := pc.RowAt(1000)
+	if !ok {
+		t.Fatal("PaneCache.RowAt(1000) returned false; FetchRangeResponse was not applied")
+	}
+	if len(row) < 5 {
+		t.Fatalf("row has %d cells, want >= 5", len(row))
+	}
+	want := "world"
+	for i, r := range []rune(want) {
+		if row[i].Ch != r {
+			t.Errorf("row[%d].Ch = %q, want %q", i, row[i].Ch, r)
+		}
+	}
+}
+
+func TestClientState_SnapshotPrunesPaneCache(t *testing.T) {
+	state := makeTestState()
+
+	var id1, id2 [16]byte
+	id1[0] = 1
+	id2[0] = 2
+
+	// Prime both caches.
+	_ = state.paneCacheFor(id1)
+	_ = state.paneCacheFor(id2)
+
+	// Snapshot that contains only id1.
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{PaneID: id1},
+		},
+	}
+	payload, err := protocol.EncodeTreeSnapshot(snap)
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+
+	hdr := protocol.Header{Type: protocol.MsgTreeSnapshot}
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+
+	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+
+	state.paneCachesMu.RLock()
+	_, has1 := state.paneCaches[id1]
+	_, has2 := state.paneCaches[id2]
+	state.paneCachesMu.RUnlock()
+
+	if !has1 {
+		t.Error("id1 should still be in paneCaches after snapshot")
+	}
+	if has2 {
+		t.Error("id2 should have been pruned from paneCaches after snapshot")
+	}
+}

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -53,6 +53,18 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		if state.effects != nil {
 			state.effects.ResetPaneStates(cache.SortedPanes())
 		}
+		// Prune pane caches that are no longer in the snapshot.
+		livePanes := make(map[[16]byte]struct{}, len(snap.Panes))
+		for _, p := range snap.Panes {
+			livePanes[p.PaneID] = struct{}{}
+		}
+		state.paneCachesMu.Lock()
+		for id := range state.paneCaches {
+			if _, live := livePanes[id]; !live {
+				delete(state.paneCaches, id)
+			}
+		}
+		state.paneCachesMu.Unlock()
 		return true
 	case protocol.MsgBufferDelta:
 		delta, err := protocol.DecodeBufferDelta(payload)
@@ -61,10 +73,21 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 			return false
 		}
 		cache.ApplyDelta(delta)
+		state.paneCacheFor(delta.PaneID).ApplyDelta(delta)
 		scheduleAck(pendingAck, ackSignal, hdr.Sequence)
 		if lastSequence != nil && hdr.Sequence > *lastSequence {
 			*lastSequence = hdr.Sequence
 		}
+		return true
+	case protocol.MsgFetchRangeResponse:
+		resp, err := protocol.DecodeFetchRangeResponse(payload)
+		if err != nil {
+			log.Printf("decode fetch range response failed: %v", err)
+			return false
+		}
+		// FetchRangeResponse is a targeted reply, not a broadcast delta.
+		// It does not participate in the seq/ack stream.
+		state.paneCacheFor(resp.PaneID).ApplyFetchRange(resp)
 		return true
 	case protocol.MsgPing:
 		pong, _ := protocol.EncodePong(protocol.Pong{Timestamp: time.Now().UnixNano()})

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -105,9 +105,10 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		if state.viewports != nil {
 			if lo, hi, send := state.onFetchRangeResponse(resp.PaneID); send {
 				if !sendFetchRange(state, conn, writeMu, sessionID, resp.PaneID, lo, hi) {
-					// Roll back the reservation onFetchRangeResponse
-					// installed when it drained the pending slot.
-					state.releaseInflight(resp.PaneID)
+					// Write failed after we drained pendingFetch — restore
+					// the window so flushFrame retries instead of silently
+					// losing the request.
+					state.restorePendingFetch(resp.PaneID, lo, hi)
 				}
 			}
 		}

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -65,6 +65,10 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 			}
 		}
 		state.paneCachesMu.Unlock()
+		// Initialise per-pane viewport trackers from snapshot geometry.
+		if state.viewports != nil {
+			state.onTreeSnapshot(snap)
+		}
 		return true
 	case protocol.MsgBufferDelta:
 		delta, err := protocol.DecodeBufferDelta(payload)
@@ -74,6 +78,10 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		}
 		cache.ApplyDelta(delta)
 		state.paneCacheFor(delta.PaneID).ApplyDelta(delta)
+		// Update viewport tracker: alt-screen transitions + AutoFollow advance.
+		if state.viewports != nil {
+			state.onBufferDelta(delta)
+		}
 		scheduleAck(pendingAck, ackSignal, hdr.Sequence)
 		if lastSequence != nil && hdr.Sequence > *lastSequence {
 			*lastSequence = hdr.Sequence
@@ -88,6 +96,12 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		// FetchRangeResponse is a targeted reply, not a broadcast delta.
 		// It does not participate in the seq/ack stream.
 		state.paneCacheFor(resp.PaneID).ApplyFetchRange(resp)
+		// Clear inflight flag and emit pending fetch if one was stashed.
+		if state.viewports != nil {
+			if lo, hi, send := state.onFetchRangeResponse(resp.PaneID); send {
+				sendFetchRange(state, conn, writeMu, sessionID, resp.PaneID, lo, hi)
+			}
+		}
 		return true
 	case protocol.MsgPing:
 		pong, _ := protocol.EncodePong(protocol.Pong{Timestamp: time.Now().UnixNano()})

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -96,10 +96,19 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		// FetchRangeResponse is a targeted reply, not a broadcast delta.
 		// It does not participate in the seq/ack stream.
 		state.paneCacheFor(resp.PaneID).ApplyFetchRange(resp)
+		// Mark the BufferCache pane dirty — incrementalComposite skips panes
+		// with Dirty=false, so without this the newly-fetched rows would sit
+		// in PaneCache unrendered until unrelated content marked the pane
+		// dirty.
+		state.cache.MarkPaneDirty(resp.PaneID)
 		// Clear inflight flag and emit pending fetch if one was stashed.
 		if state.viewports != nil {
 			if lo, hi, send := state.onFetchRangeResponse(resp.PaneID); send {
-				sendFetchRange(state, conn, writeMu, sessionID, resp.PaneID, lo, hi)
+				if !sendFetchRange(state, conn, writeMu, sessionID, resp.PaneID, lo, hi) {
+					// Roll back the reservation onFetchRangeResponse
+					// installed when it drained the pending slot.
+					state.releaseInflight(resp.PaneID)
+				}
 			}
 		}
 		return true

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -154,6 +154,40 @@ func diffAndShow(screen tcell.Screen, current, previous [][]client.Cell, default
 	screen.Show()
 }
 
+// rowSourceForPane resolves the cell source for rowIdx of a pane.
+// Preference order:
+//  1. If a viewport is registered and pane is alt-screen → PaneCache.AltRowAt.
+//  2. If a viewport is registered and pane is main-screen → PaneCache.RowAt(viewTopIdx+rowIdx).
+//  3. Fallback → pane.RowCellsDirect (BufferCache path, used during bootstrap
+//     or when PaneCache has no entry for this globalIdx yet).
+//
+// The returned slice must not be retained across frame boundaries.
+func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []client.Cell {
+	if state.viewports == nil {
+		return pane.RowCellsDirect(rowIdx)
+	}
+	vc, ok := state.paneViewportFor(pane.ID)
+	if !ok {
+		return pane.RowCellsDirect(rowIdx)
+	}
+	pc := state.paneCacheFor(pane.ID)
+	if vc.AltScreen {
+		row, found := pc.AltRowAt(rowIdx)
+		if !found {
+			return pane.RowCellsDirect(rowIdx)
+		}
+		return row
+	}
+	gid := vc.ViewTopIdx + int64(rowIdx)
+	row, found := pc.RowAt(gid)
+	if !found {
+		// Row not yet in cache (fetch is en route). Render blank rather than
+		// showing stale BufferCache content at a mismatched globalIdx.
+		return nil
+	}
+	return row
+}
+
 // incrementalComposite updates only dirty panes/rows into state.prevBuffer.
 // Returns true if any cell has dynamic colors that need continuous rendering.
 func incrementalComposite(state *clientState, screenW, screenH int) bool {
@@ -180,15 +214,15 @@ func incrementalComposite(state *clientState, screenW, screenH int) bool {
 			continue
 		}
 
-		// Build a local pane buffer from RowCells so pane effects are applied
-		// to clean source content. Copying from prevBuffer is intentionally
-		// avoided: prevBuffer already has effects applied from the previous
-		// render, so copying and re-applying would accumulate tint each frame.
+		// Build a local pane buffer from the preferred row source.
+		// PaneCache is preferred when a viewport is registered; falls back to
+		// BufferCache (pane.RowCellsDirect) during bootstrap or for alt-screen
+		// when PaneCache has no entry yet.
 		paneBuffer := ensurePaneBuffer(state, w, h)
 		defaultCell := client.Cell{Ch: ' ', Style: state.defaultStyle}
 		for rowIdx := 0; rowIdx < h; rowIdx++ {
 			row := paneBuffer[rowIdx]
-			source := pane.RowCellsDirect(rowIdx)
+			source := rowSourceForPane(state, pane, rowIdx)
 			for col := 0; col < w; col++ {
 				if col < len(source) {
 					cell := source[col]
@@ -262,6 +296,13 @@ func incrementalComposite(state *clientState, screenW, screenH int) bool {
 
 // render dispatches between incremental and full rendering paths.
 func render(state *clientState, screen tcell.Screen) {
+	// Flush viewport updates and issue fetch requests before drawing.
+	// This puts MsgViewportUpdate on the wire before the frame is rendered,
+	// so the server's next emission window is already correct.
+	if state.viewports != nil {
+		FlushFrame(state, state.conn, state.writeMu, state.sessionID)
+	}
+
 	width, height := screen.Size()
 
 	resized := ensureBuffers(state, width, height)
@@ -428,7 +469,7 @@ func compositeInto(workspaceBuffer [][]client.Cell, panes []*client.PaneState, s
 		defaultCell := client.Cell{Ch: ' ', Style: state.defaultStyle}
 		for rowIdx := 0; rowIdx < h; rowIdx++ {
 			row := paneBuffer[rowIdx]
-			source := pane.RowCellsDirect(rowIdx)
+			source := rowSourceForPane(state, pane, rowIdx)
 			for col := 0; col < w; col++ {
 				if col < len(source) {
 					cell := source[col]

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -300,7 +300,7 @@ func render(state *clientState, screen tcell.Screen) {
 	// This puts MsgViewportUpdate on the wire before the frame is rendered,
 	// so the server's next emission window is already correct.
 	if state.viewports != nil {
-		FlushFrame(state, state.conn, state.writeMu, state.sessionID)
+		flushFrame(state, state.conn, state.writeMu, state.sessionID)
 	}
 
 	width, height := screen.Size()

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // File: internal/runtime/client/viewport_tracker.go
-// Summary: Per-pane client-side viewport tracker and FlushFrame emission.
+// Summary: Per-pane client-side viewport tracker and flushFrame emission.
 // Usage: Tracks each pane's current viewport (AltScreen, ViewTopIdx,
 //
 //	ViewBottomIdx, Rows, Cols, AutoFollow) and emits MsgViewportUpdate /
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/framegrace/texelation/client"
 	"github.com/framegrace/texelation/protocol"
 )
 
@@ -149,6 +150,7 @@ func (s *clientState) onTreeSnapshot(snap protocol.TreeSnapshot) {
 			vp.Rows = rows
 			vp.Cols = cols
 			vp.AutoFollow = true
+			vp.knownBottomGid = -1
 			vp.dirty = true
 		} else if vp.Rows != rows || vp.Cols != cols {
 			// Geometry changed — update dims and mark dirty.
@@ -247,13 +249,16 @@ func (s *clientState) paneViewportFor(id [16]byte) (paneViewportCopy, bool) {
 	}, true
 }
 
-// FlushFrame is called at the top of each render iteration. It:
+// flushFrame is called at the top of each render iteration. It:
 //  1. Snapshots dirty viewport trackers.
-//  2. Sends a MsgViewportUpdate for each dirty pane.
-//  3. Checks for missing rows in the overscan window via PaneCache.MissingRows.
-//  4. Issues MsgFetchRange when missing rows exist and no fetch is inflight.
-//  5. Evicts rows outside the hysteresis band from PaneCache.
-func FlushFrame(
+//  2. Pre-fetches PaneCaches for qualifying entries BEFORE taking any per-pane
+//     viewport lock (honours the documented locking order: paneCachesMu must
+//     never be acquired while holding a per-pane vp.mu).
+//  3. Sends a MsgViewportUpdate for each dirty pane.
+//  4. Checks for missing rows in the overscan window via PaneCache.MissingRows.
+//  5. Issues MsgFetchRange when missing rows exist and no fetch is inflight.
+//  6. Evicts rows outside the hysteresis band from PaneCache.
+func flushFrame(
 	state *clientState,
 	conn net.Conn,
 	writeMu *sync.Mutex,
@@ -263,6 +268,24 @@ func FlushFrame(
 		return
 	}
 	entries, rawPanes := state.viewports.snapshot()
+
+	// Pass 1: pre-fetch PaneCaches for every non-alt-screen entry with
+	// non-zero dimensions. This ensures paneCachesMu is fully released before
+	// we acquire any per-pane vp.mu below, matching the documented locking
+	// order.
+	caches := make(map[[16]byte]*client.PaneCache, len(entries))
+	for _, e := range entries {
+		if e.vp.Rows == 0 || e.vp.Cols == 0 {
+			continue
+		}
+		if e.vp.AltScreen {
+			continue
+		}
+		caches[e.id] = state.paneCacheFor(e.id)
+	}
+
+	// Pass 2: emit viewport updates and handle fetch/evict using the
+	// pre-fetched caches. Per-pane vp.mu is only ever taken here.
 	for _, e := range entries {
 		id := e.id
 		vc := e.vp
@@ -310,8 +333,9 @@ func FlushFrame(
 		}
 		hi := vc.ViewBottomIdx + overscan
 
-		// Get PaneCache for missing-row query (acquire paneCachesMu before viewportMu).
-		pc := state.paneCacheFor(id)
+		// Use the pre-fetched PaneCache; paneCachesMu has already been
+		// released before we touch vp.mu below.
+		pc := caches[id]
 		miss := pc.MissingRows(lo, hi)
 
 		if len(miss) > 0 {

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -1,0 +1,367 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/viewport_tracker.go
+// Summary: Per-pane client-side viewport tracker and FlushFrame emission.
+// Usage: Tracks each pane's current viewport (AltScreen, ViewTopIdx,
+//
+//	ViewBottomIdx, Rows, Cols, AutoFollow) and emits MsgViewportUpdate /
+//	MsgFetchRange to the server once per render frame.
+//
+// Locking order: always acquire paneCachesMu (if needed) BEFORE any per-pane
+//
+//	viewportMu. Never hold any mutex across writeMessage calls — copy out
+//	state first, then send.
+package clientruntime
+
+import (
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// paneViewport is the per-pane viewport state tracked on the client.
+type paneViewport struct {
+	mu sync.Mutex
+
+	AltScreen     bool
+	ViewTopIdx    int64
+	ViewBottomIdx int64
+	Rows          uint16
+	Cols          uint16
+	AutoFollow    bool
+
+	// bookkeeping
+	dirty          bool
+	inflightFetch  bool
+	pendingFetch   *[2]int64 // nil when none; non-nil = {lo, hi}
+	knownBottomGid int64     // highest gid ever seen for this pane
+}
+
+// viewportTrackers holds all per-pane trackers plus a counter for FetchRange
+// RequestIDs.
+type viewportTrackers struct {
+	mu      sync.RWMutex
+	panes   map[[16]byte]*paneViewport
+	fetchID atomic.Uint32
+}
+
+func newViewportTrackers() *viewportTrackers {
+	return &viewportTrackers{
+		panes: make(map[[16]byte]*paneViewport),
+	}
+}
+
+// get returns the tracker for id, creating it on first access.
+func (t *viewportTrackers) get(id [16]byte) *paneViewport {
+	t.mu.RLock()
+	vp, ok := t.panes[id]
+	t.mu.RUnlock()
+	if ok {
+		return vp
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if vp, ok = t.panes[id]; ok {
+		return vp
+	}
+	vp = &paneViewport{}
+	t.panes[id] = vp
+	return vp
+}
+
+// prune drops trackers for pane IDs not in live.
+func (t *viewportTrackers) prune(live map[[16]byte]struct{}) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id := range t.panes {
+		if _, ok := live[id]; !ok {
+			delete(t.panes, id)
+		}
+	}
+}
+
+// snapshot returns a shallow copy of all currently dirty trackers.
+// It clears dirty on each tracker and returns the copied state.
+// Returned slice contains (id, copied state) pairs.
+func (t *viewportTrackers) snapshot() ([]snapshotEntry, map[[16]byte]*paneViewport) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var entries []snapshotEntry
+	raw := make(map[[16]byte]*paneViewport, len(t.panes))
+	for id, vp := range t.panes {
+		raw[id] = vp
+		vp.mu.Lock()
+		if vp.dirty {
+			entries = append(entries, snapshotEntry{
+				id: id,
+				vp: paneViewportCopy{
+					AltScreen:     vp.AltScreen,
+					ViewTopIdx:    vp.ViewTopIdx,
+					ViewBottomIdx: vp.ViewBottomIdx,
+					Rows:          vp.Rows,
+					Cols:          vp.Cols,
+					AutoFollow:    vp.AutoFollow,
+				},
+			})
+			vp.dirty = false
+		}
+		vp.mu.Unlock()
+	}
+	return entries, raw
+}
+
+type snapshotEntry struct {
+	id [16]byte
+	vp paneViewportCopy
+}
+
+type paneViewportCopy struct {
+	AltScreen     bool
+	ViewTopIdx    int64
+	ViewBottomIdx int64
+	Rows          uint16
+	Cols          uint16
+	AutoFollow    bool
+}
+
+// onTreeSnapshot initialises per-pane trackers from a MsgTreeSnapshot.
+// For any pane not yet tracked it sets a best-effort initial viewport.
+func (s *clientState) onTreeSnapshot(snap protocol.TreeSnapshot) {
+	live := make(map[[16]byte]struct{}, len(snap.Panes))
+	for _, p := range snap.Panes {
+		live[p.PaneID] = struct{}{}
+		if p.Width <= 0 || p.Height <= 0 {
+			continue
+		}
+		rows := uint16(p.Height)
+		cols := uint16(p.Width)
+		vp := s.viewports.get(p.PaneID)
+		vp.mu.Lock()
+		// Only initialise if this pane is brand-new.
+		if vp.Rows == 0 {
+			vp.AltScreen = false
+			vp.ViewTopIdx = 0
+			vp.ViewBottomIdx = int64(rows) - 1
+			vp.Rows = rows
+			vp.Cols = cols
+			vp.AutoFollow = true
+			vp.dirty = true
+		} else if vp.Rows != rows || vp.Cols != cols {
+			// Geometry changed — update dims and mark dirty.
+			vp.Rows = rows
+			vp.Cols = cols
+			vp.dirty = true
+		}
+		vp.mu.Unlock()
+	}
+	s.viewports.prune(live)
+}
+
+// onBufferDelta updates the viewport tracker for a pane after a delta arrives.
+func (s *clientState) onBufferDelta(delta protocol.BufferDelta) {
+	inAlt := delta.Flags&protocol.BufferDeltaAltScreen != 0
+	vp := s.viewports.get(delta.PaneID)
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+
+	// Alt-screen transitions.
+	if inAlt != vp.AltScreen {
+		vp.AltScreen = inAlt
+		vp.dirty = true
+		return
+	}
+
+	if inAlt {
+		// Nothing more to do for alt-screen.
+		return
+	}
+
+	if !vp.AutoFollow || vp.Rows == 0 {
+		return
+	}
+
+	// AutoFollow on main-screen: advance view to track the live bottom.
+	var maxGid int64 = -1
+	for _, row := range delta.Rows {
+		gid := delta.RowBase + int64(row.Row)
+		if gid > maxGid {
+			maxGid = gid
+		}
+	}
+	if maxGid < 0 || maxGid <= vp.knownBottomGid {
+		return
+	}
+	vp.knownBottomGid = maxGid
+	vp.ViewBottomIdx = maxGid
+	top := maxGid - int64(vp.Rows-1)
+	if top < 0 {
+		top = 0
+	}
+	vp.ViewTopIdx = top
+	vp.dirty = true
+}
+
+// onFetchRangeResponse clears the inflight flag and emits a pending fetch if one
+// was stashed. It returns a pending fetch request (lo, hi, true) if one should
+// be sent, otherwise (0,0,false).
+func (s *clientState) onFetchRangeResponse(paneID [16]byte) (lo, hi int64, send bool) {
+	vp := s.viewports.get(paneID)
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	vp.inflightFetch = false
+	if vp.pendingFetch != nil {
+		lo = vp.pendingFetch[0]
+		hi = vp.pendingFetch[1]
+		vp.pendingFetch = nil
+		vp.inflightFetch = true
+		return lo, hi, true
+	}
+	return 0, 0, false
+}
+
+// paneViewportFor returns a snapshot of the current viewport for a pane.
+// Used by the renderer to decide whether to use PaneCache.
+func (s *clientState) paneViewportFor(id [16]byte) (paneViewportCopy, bool) {
+	s.viewports.mu.RLock()
+	vp, ok := s.viewports.panes[id]
+	s.viewports.mu.RUnlock()
+	if !ok {
+		return paneViewportCopy{}, false
+	}
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.Rows == 0 {
+		return paneViewportCopy{}, false
+	}
+	return paneViewportCopy{
+		AltScreen:     vp.AltScreen,
+		ViewTopIdx:    vp.ViewTopIdx,
+		ViewBottomIdx: vp.ViewBottomIdx,
+		Rows:          vp.Rows,
+		Cols:          vp.Cols,
+		AutoFollow:    vp.AutoFollow,
+	}, true
+}
+
+// FlushFrame is called at the top of each render iteration. It:
+//  1. Snapshots dirty viewport trackers.
+//  2. Sends a MsgViewportUpdate for each dirty pane.
+//  3. Checks for missing rows in the overscan window via PaneCache.MissingRows.
+//  4. Issues MsgFetchRange when missing rows exist and no fetch is inflight.
+//  5. Evicts rows outside the hysteresis band from PaneCache.
+func FlushFrame(
+	state *clientState,
+	conn net.Conn,
+	writeMu *sync.Mutex,
+	sessionID [16]byte,
+) {
+	if conn == nil {
+		return
+	}
+	entries, rawPanes := state.viewports.snapshot()
+	for _, e := range entries {
+		id := e.id
+		vc := e.vp
+		if vc.Rows == 0 || vc.Cols == 0 {
+			// Guard: never emit zero-dimension viewports.
+			continue
+		}
+		// Encode and send MsgViewportUpdate.
+		upd := protocol.ViewportUpdate{
+			PaneID:         id,
+			AltScreen:      vc.AltScreen,
+			ViewTopIdx:     vc.ViewTopIdx,
+			ViewBottomIdx:  vc.ViewBottomIdx,
+			WrapSegmentIdx: 0,
+			Rows:           vc.Rows,
+			Cols:           vc.Cols,
+			AutoFollow:     vc.AutoFollow,
+		}
+		payload, err := protocol.EncodeViewportUpdate(upd)
+		if err != nil {
+			log.Printf("encode viewport update: %v", err)
+			continue
+		}
+		hdr := protocol.Header{
+			Version:   protocol.Version,
+			Type:      protocol.MsgViewportUpdate,
+			Flags:     protocol.FlagChecksum,
+			SessionID: sessionID,
+		}
+		if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
+			log.Printf("send viewport update: %v", err)
+			continue
+		}
+
+		if vc.AltScreen {
+			// No fetch range needed for alt-screen.
+			continue
+		}
+
+		// Compute overscan window: [ViewTopIdx - Rows, ViewBottomIdx + Rows].
+		overscan := int64(vc.Rows)
+		lo := vc.ViewTopIdx - overscan
+		if lo < 0 {
+			lo = 0
+		}
+		hi := vc.ViewBottomIdx + overscan
+
+		// Get PaneCache for missing-row query (acquire paneCachesMu before viewportMu).
+		pc := state.paneCacheFor(id)
+		miss := pc.MissingRows(lo, hi)
+
+		if len(miss) > 0 {
+			rawVP := rawPanes[id]
+			rawVP.mu.Lock()
+			if !rawVP.inflightFetch {
+				// Send the fetch now.
+				rawVP.inflightFetch = true
+				rawVP.mu.Unlock()
+				sendFetchRange(state, conn, writeMu, sessionID, id, miss[0], miss[len(miss)-1]+1)
+			} else {
+				// Stash as pending.
+				pf := [2]int64{miss[0], miss[len(miss)-1] + 1}
+				rawVP.pendingFetch = &pf
+				rawVP.mu.Unlock()
+			}
+		}
+
+		// Evict rows outside hysteresis band.
+		pc.Evict(vc.ViewTopIdx, vc.ViewBottomIdx, overscan)
+	}
+}
+
+// sendFetchRange encodes and sends a MsgFetchRange to the server.
+func sendFetchRange(
+	state *clientState,
+	conn net.Conn,
+	writeMu *sync.Mutex,
+	sessionID [16]byte,
+	paneID [16]byte,
+	lo, hi int64,
+) {
+	req := protocol.FetchRange{
+		RequestID: state.viewports.fetchID.Add(1),
+		PaneID:    paneID,
+		LoIdx:     lo,
+		HiIdx:     hi,
+	}
+	payload, err := protocol.EncodeFetchRange(req)
+	if err != nil {
+		log.Printf("encode fetch range: %v", err)
+		return
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgFetchRange,
+		Flags:     protocol.FlagChecksum,
+		SessionID: sessionID,
+	}
+	if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
+		log.Printf("send fetch range: %v", err)
+	}
+}

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -85,10 +85,12 @@ func (t *viewportTrackers) prune(live map[[16]byte]struct{}) {
 	}
 }
 
-// snapshot returns a shallow copy of all currently dirty trackers.
-// It clears dirty on each tracker and returns the copied state.
-// Returned slice contains (id, copied state) pairs.
-func (t *viewportTrackers) snapshot() ([]snapshotEntry, map[[16]byte]*paneViewport) {
+// snapshotDirty returns a shallow copy of all currently dirty trackers WITHOUT
+// clearing their dirty flag. The caller is responsible for calling clearDirty
+// after successful send — this split prevents a transient write failure from
+// silently dropping a viewport update (the pane would otherwise stay dark
+// with no retry until its viewport changed again).
+func (t *viewportTrackers) snapshotDirty() ([]snapshotEntry, map[[16]byte]*paneViewport) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	var entries []snapshotEntry
@@ -108,11 +110,33 @@ func (t *viewportTrackers) snapshot() ([]snapshotEntry, map[[16]byte]*paneViewpo
 					AutoFollow:    vp.AutoFollow,
 				},
 			})
-			vp.dirty = false
 		}
 		vp.mu.Unlock()
 	}
 	return entries, raw
+}
+
+// clearDirty clears the dirty flag for id iff the tracker's current state
+// still matches expected. If the user scrolled between snapshotDirty and the
+// successful send, the tracker will have been re-dirtied with new values —
+// clearing unconditionally would drop that update.
+func (t *viewportTrackers) clearDirty(id [16]byte, expected paneViewportCopy) {
+	t.mu.RLock()
+	vp, ok := t.panes[id]
+	t.mu.RUnlock()
+	if !ok {
+		return
+	}
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.AltScreen == expected.AltScreen &&
+		vp.ViewTopIdx == expected.ViewTopIdx &&
+		vp.ViewBottomIdx == expected.ViewBottomIdx &&
+		vp.Rows == expected.Rows &&
+		vp.Cols == expected.Cols &&
+		vp.AutoFollow == expected.AutoFollow {
+		vp.dirty = false
+	}
 }
 
 type snapshotEntry struct {
@@ -225,6 +249,20 @@ func (s *clientState) onFetchRangeResponse(paneID [16]byte) (lo, hi int64, send 
 	return 0, 0, false
 }
 
+// releaseInflight clears the inflightFetch reservation for paneID.  Call after
+// a sendFetchRange that returned false so the next frame can retry.
+func (s *clientState) releaseInflight(paneID [16]byte) {
+	s.viewports.mu.RLock()
+	vp, ok := s.viewports.panes[paneID]
+	s.viewports.mu.RUnlock()
+	if !ok {
+		return
+	}
+	vp.mu.Lock()
+	vp.inflightFetch = false
+	vp.mu.Unlock()
+}
+
 // paneViewportFor returns a snapshot of the current viewport for a pane.
 // Used by the renderer to decide whether to use PaneCache.
 func (s *clientState) paneViewportFor(id [16]byte) (paneViewportCopy, bool) {
@@ -267,7 +305,7 @@ func flushFrame(
 	if conn == nil {
 		return
 	}
-	entries, rawPanes := state.viewports.snapshot()
+	entries, rawPanes := state.viewports.snapshotDirty()
 
 	// Pass 1: pre-fetch PaneCaches for every non-alt-screen entry with
 	// non-zero dimensions. This ensures paneCachesMu is fully released before
@@ -317,8 +355,13 @@ func flushFrame(
 		}
 		if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
 			log.Printf("send viewport update: %v", err)
+			// Leave dirty flag set so a retry happens next frame.
 			continue
 		}
+		// Send succeeded — now safe to clear dirty.  If the user scrolled
+		// between snapshotDirty and here, clearDirty sees the mismatch and
+		// leaves the flag set so the newer state still gets sent.
+		state.viewports.clearDirty(id, vc)
 
 		if vc.AltScreen {
 			// No fetch range needed for alt-screen.
@@ -342,10 +385,18 @@ func flushFrame(
 			rawVP := rawPanes[id]
 			rawVP.mu.Lock()
 			if !rawVP.inflightFetch {
-				// Send the fetch now.
+				// Claim the inflight slot before releasing the lock so
+				// concurrent callers see the reservation.
 				rawVP.inflightFetch = true
 				rawVP.mu.Unlock()
-				sendFetchRange(state, conn, writeMu, sessionID, id, miss[0], miss[len(miss)-1]+1)
+				lo, hi := miss[0], miss[len(miss)-1]+1
+				if !sendFetchRange(state, conn, writeMu, sessionID, id, lo, hi) {
+					// Write failed — release the inflight slot so the next
+					// frame can retry instead of staying wedged forever.
+					rawVP.mu.Lock()
+					rawVP.inflightFetch = false
+					rawVP.mu.Unlock()
+				}
 			} else {
 				// Stash as pending.
 				pf := [2]int64{miss[0], miss[len(miss)-1] + 1}
@@ -359,7 +410,9 @@ func flushFrame(
 	}
 }
 
-// sendFetchRange encodes and sends a MsgFetchRange to the server.
+// sendFetchRange encodes and sends a MsgFetchRange to the server. Returns
+// true on success.  On false the caller must roll back any reservation
+// (e.g. inflightFetch) so the request can be retried on the next frame.
 func sendFetchRange(
 	state *clientState,
 	conn net.Conn,
@@ -367,7 +420,7 @@ func sendFetchRange(
 	sessionID [16]byte,
 	paneID [16]byte,
 	lo, hi int64,
-) {
+) bool {
 	req := protocol.FetchRange{
 		RequestID: state.viewports.fetchID.Add(1),
 		PaneID:    paneID,
@@ -377,7 +430,7 @@ func sendFetchRange(
 	payload, err := protocol.EncodeFetchRange(req)
 	if err != nil {
 		log.Printf("encode fetch range: %v", err)
-		return
+		return false
 	}
 	hdr := protocol.Header{
 		Version:   protocol.Version,
@@ -387,5 +440,7 @@ func sendFetchRange(
 	}
 	if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
 		log.Printf("send fetch range: %v", err)
+		return false
 	}
+	return true
 }

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -24,6 +24,15 @@ import (
 	"github.com/framegrace/texelation/protocol"
 )
 
+// pendingFetchRange is a deferred MsgFetchRange request stashed because
+// another fetch for the same pane was already inflight.  Replaced (not
+// queued) when a newer viewport comes in — the client only ever needs the
+// latest missing-rows window.
+type pendingFetchRange struct {
+	Lo int64
+	Hi int64
+}
+
 // paneViewport is the per-pane viewport state tracked on the client.
 type paneViewport struct {
 	mu sync.Mutex
@@ -38,8 +47,8 @@ type paneViewport struct {
 	// bookkeeping
 	dirty          bool
 	inflightFetch  bool
-	pendingFetch   *[2]int64 // nil when none; non-nil = {lo, hi}
-	knownBottomGid int64     // highest gid ever seen for this pane
+	pendingFetch   *pendingFetchRange // nil when none
+	knownBottomGid int64              // highest gid ever seen for this pane
 }
 
 // viewportTrackers holds all per-pane trackers plus a counter for FetchRange
@@ -240,8 +249,8 @@ func (s *clientState) onFetchRangeResponse(paneID [16]byte) (lo, hi int64, send 
 	defer vp.mu.Unlock()
 	vp.inflightFetch = false
 	if vp.pendingFetch != nil {
-		lo = vp.pendingFetch[0]
-		hi = vp.pendingFetch[1]
+		lo = vp.pendingFetch.Lo
+		hi = vp.pendingFetch.Hi
 		vp.pendingFetch = nil
 		vp.inflightFetch = true
 		return lo, hi, true
@@ -399,7 +408,7 @@ func flushFrame(
 				}
 			} else {
 				// Stash as pending.
-				pf := [2]int64{miss[0], miss[len(miss)-1] + 1}
+				pf := pendingFetchRange{Lo: miss[0], Hi: miss[len(miss)-1] + 1}
 				rawVP.pendingFetch = &pf
 				rawVP.mu.Unlock()
 			}

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 
 	"github.com/framegrace/texelation/client"
+	"github.com/framegrace/texelation/internal/debuglog"
 	"github.com/framegrace/texelation/protocol"
 )
 
@@ -29,8 +30,8 @@ import (
 // queued) when a newer viewport comes in — the client only ever needs the
 // latest missing-rows window.
 type pendingFetchRange struct {
-	Lo int64
-	Hi int64
+	lo int64
+	hi int64
 }
 
 // paneViewport is the per-pane viewport state tracked on the client.
@@ -145,7 +146,9 @@ func (t *viewportTrackers) clearDirty(id [16]byte, expected paneViewportCopy) {
 		vp.Cols == expected.Cols &&
 		vp.AutoFollow == expected.AutoFollow {
 		vp.dirty = false
+		return
 	}
+	debuglog.Printf("viewport clearDirty mismatch pane=%x: kept dirty (state changed since snapshot)", id[:4])
 }
 
 type snapshotEntry struct {
@@ -249,8 +252,8 @@ func (s *clientState) onFetchRangeResponse(paneID [16]byte) (lo, hi int64, send 
 	defer vp.mu.Unlock()
 	vp.inflightFetch = false
 	if vp.pendingFetch != nil {
-		lo = vp.pendingFetch.Lo
-		hi = vp.pendingFetch.Hi
+		lo = vp.pendingFetch.lo
+		hi = vp.pendingFetch.hi
 		vp.pendingFetch = nil
 		vp.inflightFetch = true
 		return lo, hi, true
@@ -275,7 +278,7 @@ func (s *clientState) restorePendingFetch(paneID [16]byte, lo, hi int64) {
 	defer vp.mu.Unlock()
 	vp.inflightFetch = false
 	if vp.pendingFetch == nil {
-		vp.pendingFetch = &pendingFetchRange{Lo: lo, Hi: hi}
+		vp.pendingFetch = &pendingFetchRange{lo: lo, hi: hi}
 	}
 }
 
@@ -371,20 +374,14 @@ func flushFrame(
 		}
 		if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
 			log.Printf("send viewport update: %v", err)
-			// Leave dirty flag set so a retry happens next frame.
 			continue
 		}
-		// Send succeeded — now safe to clear dirty.  If the user scrolled
-		// between snapshotDirty and here, clearDirty sees the mismatch and
-		// leaves the flag set so the newer state still gets sent.
 		state.viewports.clearDirty(id, vc)
 
 		if vc.AltScreen {
-			// No fetch range needed for alt-screen.
 			continue
 		}
 
-		// Compute overscan window: [ViewTopIdx - Rows, ViewBottomIdx + Rows].
 		overscan := int64(vc.Rows)
 		lo := vc.ViewTopIdx - overscan
 		if lo < 0 {
@@ -392,8 +389,6 @@ func flushFrame(
 		}
 		hi := vc.ViewBottomIdx + overscan
 
-		// Use the pre-fetched PaneCache; paneCachesMu has already been
-		// released before we touch vp.mu below.
 		pc := caches[id]
 		miss := pc.MissingRows(lo, hi)
 
@@ -415,7 +410,7 @@ func flushFrame(
 				}
 			} else {
 				// Stash as pending.
-				pf := pendingFetchRange{Lo: miss[0], Hi: miss[len(miss)-1] + 1}
+				pf := pendingFetchRange{lo: miss[0], hi: miss[len(miss)-1] + 1}
 				rawVP.pendingFetch = &pf
 				rawVP.mu.Unlock()
 			}

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -258,9 +258,13 @@ func (s *clientState) onFetchRangeResponse(paneID [16]byte) (lo, hi int64, send 
 	return 0, 0, false
 }
 
-// releaseInflight clears the inflightFetch reservation for paneID.  Call after
-// a sendFetchRange that returned false so the next frame can retry.
-func (s *clientState) releaseInflight(paneID [16]byte) {
+// restorePendingFetch clears the inflight reservation and re-stashes (lo, hi)
+// into pendingFetch so the next flushFrame retries. Used after the response
+// handler drained pendingFetch to re-issue a follow-up fetch and the write
+// failed. If a newer pendingFetch has already been stashed (concurrent
+// flushFrame observed missing rows), we leave it alone — the newer window
+// supersedes ours.
+func (s *clientState) restorePendingFetch(paneID [16]byte, lo, hi int64) {
 	s.viewports.mu.RLock()
 	vp, ok := s.viewports.panes[paneID]
 	s.viewports.mu.RUnlock()
@@ -268,8 +272,11 @@ func (s *clientState) releaseInflight(paneID [16]byte) {
 		return
 	}
 	vp.mu.Lock()
+	defer vp.mu.Unlock()
 	vp.inflightFetch = false
-	vp.mu.Unlock()
+	if vp.pendingFetch == nil {
+		vp.pendingFetch = &pendingFetchRange{Lo: lo, Hi: hi}
+	}
 }
 
 // paneViewportFor returns a snapshot of the current viewport for a pane.

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -574,6 +574,166 @@ func TestFlushFrame_NilConnIsNoop(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// Regression (Commit A #2): restorePendingFetch re-stashes (lo, hi) after
+// the response handler drained pendingFetch and the follow-up send failed.
+// --------------------------------------------------------------------------
+
+func TestRestorePendingFetch_RestoresDrainedWindow(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xB0)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	// Simulate: response arrived, pendingFetch was stashed, handler just
+	// drained it (inflight reserved, pendingFetch nil). Then sendFetchRange
+	// failed — we must restore so flushFrame retries next frame.
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	vp.inflightFetch = true
+	vp.pendingFetch = nil
+	vp.mu.Unlock()
+
+	state.restorePendingFetch(id, 500, 548)
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.inflightFetch {
+		t.Error("inflightFetch should be cleared by restorePendingFetch")
+	}
+	if vp.pendingFetch == nil {
+		t.Fatal("pendingFetch should have been restored, got nil")
+	}
+	if vp.pendingFetch.Lo != 500 || vp.pendingFetch.Hi != 548 {
+		t.Errorf("pendingFetch = [%d,%d), want [500,548)", vp.pendingFetch.Lo, vp.pendingFetch.Hi)
+	}
+}
+
+func TestRestorePendingFetch_DoesNotClobberNewerPending(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xB1)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	// Between onFetchRangeResponse and the send-failure, a concurrent
+	// flushFrame noticed new missing rows and stashed a newer window.
+	// restorePendingFetch must NOT overwrite it.
+	vp := state.viewports.get(id)
+	newer := pendingFetchRange{Lo: 900, Hi: 924}
+	vp.mu.Lock()
+	vp.inflightFetch = true
+	vp.pendingFetch = &newer
+	vp.mu.Unlock()
+
+	state.restorePendingFetch(id, 500, 548)
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.inflightFetch {
+		t.Error("inflightFetch should be cleared by restorePendingFetch")
+	}
+	if vp.pendingFetch == nil || vp.pendingFetch.Lo != 900 || vp.pendingFetch.Hi != 924 {
+		t.Errorf("pendingFetch = %+v, want [900,924)", vp.pendingFetch)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Regression: clearDirty state-mismatch guard leaves the dirty flag set when
+// the tracker was re-dirtied between snapshotDirty and the send completing.
+// --------------------------------------------------------------------------
+
+func TestClearDirty_GuardLeavesDirtySetOnMismatch(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xC0)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	// Snapshot the current state (dirty=true from init).
+	entries, _ := state.viewports.snapshotDirty()
+	if len(entries) != 1 {
+		t.Fatalf("snapshotDirty returned %d entries, want 1", len(entries))
+	}
+	expected := entries[0].vp
+
+	// Simulate the user scrolling AFTER snapshot but BEFORE clearDirty.
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	vp.ViewBottomIdx = expected.ViewBottomIdx + 100
+	vp.ViewTopIdx = vp.ViewBottomIdx - 23
+	vp.dirty = true
+	vp.mu.Unlock()
+
+	// clearDirty must see the mismatch and leave dirty=true.
+	state.viewports.clearDirty(id, expected)
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if !vp.dirty {
+		t.Error("clearDirty should leave dirty=true when state changed since snapshot")
+	}
+}
+
+func TestClearDirty_ClearsOnMatch(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xC1)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	entries, _ := state.viewports.snapshotDirty()
+	if len(entries) != 1 {
+		t.Fatalf("snapshotDirty returned %d entries, want 1", len(entries))
+	}
+	expected := entries[0].vp
+
+	state.viewports.clearDirty(id, expected)
+
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.dirty {
+		t.Error("clearDirty should clear dirty when state matches snapshot")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Regression: flushFrame releases inflight reservation when sendFetchRange's
+// Write fails so the next frame can retry instead of wedging the pane.
+// --------------------------------------------------------------------------
+
+// failingConn's Write always returns an error, letting us exercise the
+// rollback path in flushFrame and sendFetchRange.
+type failingConn struct{ testConn }
+
+func (f *failingConn) Write(_ []byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+func TestFlushFrame_ReleasesInflightOnSendFailure(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xD0)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	// Force a missing-rows window.
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	vp.ViewTopIdx = 1000
+	vp.ViewBottomIdx = 1023
+	vp.Rows = 24
+	vp.Cols = 80
+	vp.dirty = true
+	vp.inflightFetch = false
+	vp.mu.Unlock()
+
+	conn := &failingConn{}
+	var writeMu sync.Mutex
+	flushFrame(state, conn, &writeMu, [16]byte{})
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	// The viewport-update write fails first (before any inflight reservation),
+	// so inflight stays false — but the guarantee we're asserting is that no
+	// stuck reservation blocks retry on the next frame.
+	if vp.inflightFetch {
+		t.Error("inflightFetch should be false after send failure (retry must be unblocked)")
+	}
+}
+
+// --------------------------------------------------------------------------
 // Additional: TestFlushFrame_ZeroDimSkipped
 // --------------------------------------------------------------------------
 

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -220,6 +220,54 @@ func TestViewportTracker_AdvancesOnAutoFollowDelta(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// Regression: I3 — AutoFollow must advance even for the first delta at gid=0.
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_AutoFollowAdvancesFromGidZero(t *testing.T) {
+	state := makeStateWithViewports()
+	// Initialise a single pane from a tree snapshot (Rows=24).
+	id := paneID(0xA0)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	// Drain the initial dirty state via flushFrame so subsequent dirty
+	// assertions are clean. Use a testConn so nothing writes to a real socket.
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	flushFrame(state, conn, &writeMu, [16]byte{})
+
+	// First-ever BufferDelta at gid=0 on the main screen.
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 0,
+		Rows: []protocol.RowDelta{
+			{Row: 0},
+		},
+	}
+	state.onBufferDelta(delta)
+
+	vc, ok := state.paneViewportFor(id)
+	if !ok {
+		t.Fatal("paneViewportFor returned false after delta")
+	}
+	// With maxGid=0 and Rows=24: bottom=0, top=max(0, 0-23)=0.
+	if vc.ViewBottomIdx != 0 {
+		t.Errorf("ViewBottomIdx = %d, want 0", vc.ViewBottomIdx)
+	}
+	if vc.ViewTopIdx != 0 {
+		t.Errorf("ViewTopIdx = %d, want 0", vc.ViewTopIdx)
+	}
+
+	// Tracker must be marked dirty so flushFrame will emit a ViewportUpdate.
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	dirty := vp.dirty
+	vp.mu.Unlock()
+	if !dirty {
+		t.Error("dirty should be true after AutoFollow advance from gid=0")
+	}
+}
+
+// --------------------------------------------------------------------------
 // Part 5, item 3: TestViewportTracker_DetectsAltScreenFromDelta
 // --------------------------------------------------------------------------
 
@@ -290,7 +338,7 @@ func TestFlushFrame_SendsViewportUpdate(t *testing.T) {
 
 	conn := &testConn{}
 	var writeMu sync.Mutex
-	FlushFrame(state, conn, &writeMu, [16]byte{})
+	flushFrame(state, conn, &writeMu, [16]byte{})
 
 	n := conn.countType(protocol.MsgViewportUpdate)
 	if n != 1 {
@@ -319,7 +367,7 @@ func TestFlushFrame_CoalescesMultipleChangesInFrame(t *testing.T) {
 
 	conn := &testConn{}
 	var writeMu sync.Mutex
-	FlushFrame(state, conn, &writeMu, [16]byte{})
+	flushFrame(state, conn, &writeMu, [16]byte{})
 
 	// Must only emit one update per pane per frame (dirty was cleared once).
 	n := conn.countType(protocol.MsgViewportUpdate)
@@ -349,7 +397,7 @@ func TestFlushFrame_IssuesFetchForMissingRows(t *testing.T) {
 
 	conn := &testConn{}
 	var writeMu sync.Mutex
-	FlushFrame(state, conn, &writeMu, [16]byte{})
+	flushFrame(state, conn, &writeMu, [16]byte{})
 
 	n := conn.countType(protocol.MsgFetchRange)
 	if n != 1 {
@@ -379,7 +427,7 @@ func TestFlushFrame_AtMostOneInflightFetchPerPane(t *testing.T) {
 
 	conn := &testConn{}
 	var writeMu sync.Mutex
-	FlushFrame(state, conn, &writeMu, [16]byte{})
+	flushFrame(state, conn, &writeMu, [16]byte{})
 
 	// No new MsgFetchRange should be sent.
 	n := conn.countType(protocol.MsgFetchRange)
@@ -522,7 +570,7 @@ func TestFlushFrame_NilConnIsNoop(t *testing.T) {
 
 	var writeMu sync.Mutex
 	// Must not panic.
-	FlushFrame(state, nil, &writeMu, [16]byte{})
+	flushFrame(state, nil, &writeMu, [16]byte{})
 }
 
 // --------------------------------------------------------------------------
@@ -542,7 +590,7 @@ func TestFlushFrame_ZeroDimSkipped(t *testing.T) {
 
 	conn := &testConn{}
 	var writeMu sync.Mutex
-	FlushFrame(state, conn, &writeMu, [16]byte{})
+	flushFrame(state, conn, &writeMu, [16]byte{})
 
 	n := conn.countType(protocol.MsgViewportUpdate)
 	if n != 0 {

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -1,0 +1,551 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/viewport_tracker_test.go
+// Summary: Tests for the per-pane viewport tracker and FlushFrame emission.
+
+package clientruntime
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/client"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// --------------------------------------------------------------------------
+// testConn: minimal net.Conn that records writes to a buffer.
+// --------------------------------------------------------------------------
+
+type testConn struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (c *testConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(b)
+}
+func (c *testConn) Read(_ []byte) (int, error)         { return 0, io.EOF }
+func (c *testConn) Close() error                       { return nil }
+func (c *testConn) LocalAddr() net.Addr                { return nil }
+func (c *testConn) RemoteAddr() net.Addr               { return nil }
+func (c *testConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *testConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *testConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// bytes returns a copy of all data written so far.
+func (c *testConn) bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	b := make([]byte, c.buf.Len())
+	copy(b, c.buf.Bytes())
+	return b
+}
+
+// readMessages decodes all protocol frames written to the testConn.
+func (c *testConn) readMessages() []protocol.Header {
+	data := c.bytes()
+	// Parse manually: each frame starts with magic(4)+header(36 bytes = 40 total).
+	// See protocol.ReadMessage for the wire format.
+	var headers []protocol.Header
+	for len(data) >= 40 {
+		// Skip magic (4 bytes).
+		if binary.LittleEndian.Uint32(data[:4]) != 0x54584c01 {
+			break
+		}
+		data = data[4:]
+		if len(data) < 36 {
+			break
+		}
+		hdr := protocol.Header{}
+		hdr.Version = data[0]
+		hdr.Type = protocol.MessageType(data[1])
+		hdr.Flags = data[2]
+		hdr.Reserved = data[3]
+		copy(hdr.SessionID[:], data[4:20])
+		hdr.Sequence = binary.LittleEndian.Uint64(data[20:28])
+		hdr.PayloadLen = binary.LittleEndian.Uint32(data[28:32])
+		hdr.Checksum = binary.LittleEndian.Uint32(data[32:36])
+		data = data[36:]
+		payloadLen := int(hdr.PayloadLen)
+		if len(data) < payloadLen {
+			break
+		}
+		data = data[payloadLen:]
+		headers = append(headers, hdr)
+	}
+	return headers
+}
+
+// countType returns how many messages of the given type were written.
+func (c *testConn) countType(msgType protocol.MessageType) int {
+	n := 0
+	for _, h := range c.readMessages() {
+		if h.Type == msgType {
+			n++
+		}
+	}
+	return n
+}
+
+// --------------------------------------------------------------------------
+// Helpers to build test state and snapshots.
+// --------------------------------------------------------------------------
+
+func makeStateWithViewports() *clientState {
+	return &clientState{
+		cache:       client.NewBufferCache(),
+		paneCaches:  make(map[[16]byte]*client.PaneCache),
+		themeValues: make(map[string]map[string]interface{}),
+		viewports:   newViewportTrackers(),
+	}
+}
+
+func paneID(b byte) [16]byte {
+	var id [16]byte
+	id[0] = b
+	return id
+}
+
+func makeTreeSnapshot(id [16]byte, width, height int32) protocol.TreeSnapshot {
+	return protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{
+				PaneID: id,
+				Width:  width,
+				Height: height,
+			},
+		},
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 1: TestViewportTracker_InitializesFromSnapshot
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_InitializesFromSnapshot(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(1), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	vc, ok := state.paneViewportFor(paneID(1))
+	if !ok {
+		t.Fatal("paneViewportFor returned false after snapshot")
+	}
+	if vc.Rows != 24 {
+		t.Errorf("Rows = %d, want 24", vc.Rows)
+	}
+	if vc.Cols != 80 {
+		t.Errorf("Cols = %d, want 80", vc.Cols)
+	}
+	if !vc.AutoFollow {
+		t.Error("AutoFollow should be true on init")
+	}
+	if vc.AltScreen {
+		t.Error("AltScreen should be false on init")
+	}
+	if vc.ViewTopIdx != 0 {
+		t.Errorf("ViewTopIdx = %d, want 0", vc.ViewTopIdx)
+	}
+	// ViewBottomIdx should be Rows-1 = 23.
+	if vc.ViewBottomIdx != 23 {
+		t.Errorf("ViewBottomIdx = %d, want 23", vc.ViewBottomIdx)
+	}
+
+	// The tracker should be dirty so FlushFrame will emit.
+	vp := state.viewports.get(paneID(1))
+	vp.mu.Lock()
+	dirty := vp.dirty
+	vp.mu.Unlock()
+	if !dirty {
+		t.Error("dirty should be true after snapshot initialisation")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 2: TestViewportTracker_AdvancesOnAutoFollowDelta
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_AdvancesOnAutoFollowDelta(t *testing.T) {
+	state := makeStateWithViewports()
+	// Initialise pane with height=24 so rows is set.
+	snap := makeTreeSnapshot(paneID(2), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Clear dirty so we can detect the advance.
+	vp := state.viewports.get(paneID(2))
+	vp.mu.Lock()
+	vp.dirty = false
+	vp.mu.Unlock()
+
+	// Delta with gid = RowBase + Row = 1000 + 0 = 1000, higher than knownBottomGid=0.
+	delta := protocol.BufferDelta{
+		PaneID:  paneID(2),
+		RowBase: 1000,
+		Rows: []protocol.RowDelta{
+			{Row: 0},
+			{Row: 5},
+		},
+	}
+	state.onBufferDelta(delta)
+
+	vc, ok := state.paneViewportFor(paneID(2))
+	if !ok {
+		t.Fatal("paneViewportFor returned false")
+	}
+	// maxGid = 1000+5 = 1005; ViewBottomIdx should be 1005.
+	if vc.ViewBottomIdx != 1005 {
+		t.Errorf("ViewBottomIdx = %d, want 1005", vc.ViewBottomIdx)
+	}
+	// ViewTopIdx = 1005 - (24-1) = 982.
+	wantTop := int64(1005 - 23)
+	if vc.ViewTopIdx != wantTop {
+		t.Errorf("ViewTopIdx = %d, want %d", vc.ViewTopIdx, wantTop)
+	}
+
+	vp.mu.Lock()
+	dirty := vp.dirty
+	vp.mu.Unlock()
+	if !dirty {
+		t.Error("dirty should be true after AutoFollow advance")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 3: TestViewportTracker_DetectsAltScreenFromDelta
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_DetectsAltScreenFromDelta(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(3), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Clear dirty.
+	vp := state.viewports.get(paneID(3))
+	vp.mu.Lock()
+	vp.dirty = false
+	vp.mu.Unlock()
+
+	// Alt-screen delta.
+	delta := protocol.BufferDelta{
+		PaneID: paneID(3),
+		Flags:  protocol.BufferDeltaAltScreen,
+	}
+	state.onBufferDelta(delta)
+
+	vc, ok := state.paneViewportFor(paneID(3))
+	if !ok {
+		t.Fatal("paneViewportFor returned false")
+	}
+	if !vc.AltScreen {
+		t.Error("AltScreen should be true after alt-screen delta")
+	}
+
+	vp.mu.Lock()
+	dirty := vp.dirty
+	vp.mu.Unlock()
+	if !dirty {
+		t.Error("dirty should be true after alt-screen transition")
+	}
+
+	// Transition back to main screen.
+	vp.mu.Lock()
+	vp.dirty = false
+	vp.mu.Unlock()
+
+	mainDelta := protocol.BufferDelta{
+		PaneID: paneID(3),
+		Flags:  0, // main screen
+	}
+	state.onBufferDelta(mainDelta)
+
+	vc, _ = state.paneViewportFor(paneID(3))
+	if vc.AltScreen {
+		t.Error("AltScreen should be false after main-screen delta")
+	}
+	vp.mu.Lock()
+	dirty = vp.dirty
+	vp.mu.Unlock()
+	if !dirty {
+		t.Error("dirty should be true after alt→main transition")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 4: TestFlushFrame_SendsViewportUpdate
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_SendsViewportUpdate(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(4), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	FlushFrame(state, conn, &writeMu, [16]byte{})
+
+	n := conn.countType(protocol.MsgViewportUpdate)
+	if n != 1 {
+		t.Errorf("expected 1 MsgViewportUpdate, got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 5: TestFlushFrame_CoalescesMultipleChangesInFrame
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_CoalescesMultipleChangesInFrame(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(5), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Simulate multiple changes before FlushFrame.
+	vp := state.viewports.get(paneID(5))
+	for i := 0; i < 3; i++ {
+		vp.mu.Lock()
+		vp.ViewBottomIdx = int64(100 + i*10)
+		vp.ViewTopIdx = vp.ViewBottomIdx - 23
+		vp.dirty = true
+		vp.mu.Unlock()
+	}
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	FlushFrame(state, conn, &writeMu, [16]byte{})
+
+	// Must only emit one update per pane per frame (dirty was cleared once).
+	n := conn.countType(protocol.MsgViewportUpdate)
+	if n != 1 {
+		t.Errorf("expected exactly 1 MsgViewportUpdate per frame, got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 6: TestFlushFrame_IssuesFetchForMissingRows
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_IssuesFetchForMissingRows(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(6), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Manually set viewport to a range not in cache.
+	vp := state.viewports.get(paneID(6))
+	vp.mu.Lock()
+	vp.ViewTopIdx = 1000
+	vp.ViewBottomIdx = 1023
+	vp.Rows = 24
+	vp.Cols = 80
+	vp.dirty = true
+	vp.mu.Unlock()
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	FlushFrame(state, conn, &writeMu, [16]byte{})
+
+	n := conn.countType(protocol.MsgFetchRange)
+	if n != 1 {
+		t.Errorf("expected 1 MsgFetchRange, got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 7: TestFlushFrame_AtMostOneInflightFetchPerPane
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_AtMostOneInflightFetchPerPane(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(7), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Pre-set inflight to true.
+	vp := state.viewports.get(paneID(7))
+	vp.mu.Lock()
+	vp.ViewTopIdx = 1000
+	vp.ViewBottomIdx = 1023
+	vp.Rows = 24
+	vp.Cols = 80
+	vp.dirty = true
+	vp.inflightFetch = true
+	vp.mu.Unlock()
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	FlushFrame(state, conn, &writeMu, [16]byte{})
+
+	// No new MsgFetchRange should be sent.
+	n := conn.countType(protocol.MsgFetchRange)
+	if n != 0 {
+		t.Errorf("expected 0 MsgFetchRange with inflight=true, got %d", n)
+	}
+
+	// But pendingFetch should have been populated.
+	vp.mu.Lock()
+	pending := vp.pendingFetch
+	vp.mu.Unlock()
+	if pending == nil {
+		t.Error("pendingFetch should be set when inflight=true and rows are missing")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Part 5, item 8: TestFlushFrame_EmitsPendingFetchOnResponse
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_EmitsPendingFetchOnResponse(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(8), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Pre-set pending fetch (inflight is already false).
+	vp := state.viewports.get(paneID(8))
+	vp.mu.Lock()
+	pf := [2]int64{2000, 2024}
+	vp.pendingFetch = &pf
+	vp.inflightFetch = true // simulate: response arrives now.
+	vp.mu.Unlock()
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+
+	// Simulate the onFetchRangeResponse path.
+	lo, hi, send := state.onFetchRangeResponse(paneID(8))
+	if !send {
+		t.Fatal("onFetchRangeResponse should return send=true when pendingFetch is set")
+	}
+	if lo != 2000 || hi != 2024 {
+		t.Errorf("pending fetch range = [%d,%d), want [2000,2024)", lo, hi)
+	}
+
+	// Confirm inflight is now true and pending is cleared.
+	vp.mu.Lock()
+	inflight := vp.inflightFetch
+	pending := vp.pendingFetch
+	vp.mu.Unlock()
+	if !inflight {
+		t.Error("inflightFetch should be true after emitting pending fetch")
+	}
+	if pending != nil {
+		t.Error("pendingFetch should be nil after being consumed")
+	}
+
+	// Verify we can send the fetch range.
+	sendFetchRange(state, conn, &writeMu, [16]byte{}, paneID(8), lo, hi)
+	n := conn.countType(protocol.MsgFetchRange)
+	if n != 1 {
+		t.Errorf("expected 1 MsgFetchRange after consuming pending, got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Additional: TestViewportTracker_GeometryChangeMarksDirty
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_GeometryChangeMarksDirty(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(9), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// Clear dirty.
+	vp := state.viewports.get(paneID(9))
+	vp.mu.Lock()
+	vp.dirty = false
+	vp.mu.Unlock()
+
+	// Second snapshot with different dimensions.
+	snap2 := makeTreeSnapshot(paneID(9), 100, 30)
+	state.onTreeSnapshot(snap2)
+
+	vp.mu.Lock()
+	dirty := vp.dirty
+	rows := vp.Rows
+	cols := vp.Cols
+	vp.mu.Unlock()
+
+	if !dirty {
+		t.Error("dirty should be true after geometry change")
+	}
+	if rows != 30 {
+		t.Errorf("Rows = %d, want 30", rows)
+	}
+	if cols != 100 {
+		t.Errorf("Cols = %d, want 100", cols)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Additional: TestViewportTracker_PruneRemovesStalePane
+// --------------------------------------------------------------------------
+
+func TestViewportTracker_PruneRemovesStalePane(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(10), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	// New snapshot without paneID(10).
+	snap2 := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{PaneID: paneID(11), Width: 80, Height: 24},
+		},
+	}
+	state.onTreeSnapshot(snap2)
+
+	state.viewports.mu.RLock()
+	_, has10 := state.viewports.panes[paneID(10)]
+	_, has11 := state.viewports.panes[paneID(11)]
+	state.viewports.mu.RUnlock()
+
+	if has10 {
+		t.Error("paneID(10) should have been pruned")
+	}
+	if !has11 {
+		t.Error("paneID(11) should be present")
+	}
+}
+
+// --------------------------------------------------------------------------
+// Additional: TestFlushFrame_NilConnIsNoop
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_NilConnIsNoop(t *testing.T) {
+	state := makeStateWithViewports()
+	snap := makeTreeSnapshot(paneID(12), 80, 24)
+	state.onTreeSnapshot(snap)
+
+	var writeMu sync.Mutex
+	// Must not panic.
+	FlushFrame(state, nil, &writeMu, [16]byte{})
+}
+
+// --------------------------------------------------------------------------
+// Additional: TestFlushFrame_ZeroDimSkipped
+// --------------------------------------------------------------------------
+
+func TestFlushFrame_ZeroDimSkipped(t *testing.T) {
+	state := makeStateWithViewports()
+
+	// Manually insert a tracker with zero dims (pathological).
+	vp := state.viewports.get(paneID(13))
+	vp.mu.Lock()
+	vp.dirty = true
+	vp.Rows = 0
+	vp.Cols = 0
+	vp.mu.Unlock()
+
+	conn := &testConn{}
+	var writeMu sync.Mutex
+	FlushFrame(state, conn, &writeMu, [16]byte{})
+
+	n := conn.countType(protocol.MsgViewportUpdate)
+	if n != 0 {
+		t.Errorf("expected 0 MsgViewportUpdate for zero-dim pane, got %d", n)
+	}
+}

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -456,7 +456,7 @@ func TestFlushFrame_EmitsPendingFetchOnResponse(t *testing.T) {
 	// Pre-set pending fetch (inflight is already false).
 	vp := state.viewports.get(paneID(8))
 	vp.mu.Lock()
-	pf := [2]int64{2000, 2024}
+	pf := pendingFetchRange{Lo: 2000, Hi: 2024}
 	vp.pendingFetch = &pf
 	vp.inflightFetch = true // simulate: response arrives now.
 	vp.mu.Unlock()

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -456,7 +456,7 @@ func TestFlushFrame_EmitsPendingFetchOnResponse(t *testing.T) {
 	// Pre-set pending fetch (inflight is already false).
 	vp := state.viewports.get(paneID(8))
 	vp.mu.Lock()
-	pf := pendingFetchRange{Lo: 2000, Hi: 2024}
+	pf := pendingFetchRange{lo: 2000, hi: 2024}
 	vp.pendingFetch = &pf
 	vp.inflightFetch = true // simulate: response arrives now.
 	vp.mu.Unlock()
@@ -602,8 +602,8 @@ func TestRestorePendingFetch_RestoresDrainedWindow(t *testing.T) {
 	if vp.pendingFetch == nil {
 		t.Fatal("pendingFetch should have been restored, got nil")
 	}
-	if vp.pendingFetch.Lo != 500 || vp.pendingFetch.Hi != 548 {
-		t.Errorf("pendingFetch = [%d,%d), want [500,548)", vp.pendingFetch.Lo, vp.pendingFetch.Hi)
+	if vp.pendingFetch.lo != 500 || vp.pendingFetch.hi != 548 {
+		t.Errorf("pendingFetch = [%d,%d), want [500,548)", vp.pendingFetch.lo, vp.pendingFetch.hi)
 	}
 }
 
@@ -616,7 +616,7 @@ func TestRestorePendingFetch_DoesNotClobberNewerPending(t *testing.T) {
 	// flushFrame noticed new missing rows and stashed a newer window.
 	// restorePendingFetch must NOT overwrite it.
 	vp := state.viewports.get(id)
-	newer := pendingFetchRange{Lo: 900, Hi: 924}
+	newer := pendingFetchRange{lo: 900, hi: 924}
 	vp.mu.Lock()
 	vp.inflightFetch = true
 	vp.pendingFetch = &newer
@@ -629,7 +629,7 @@ func TestRestorePendingFetch_DoesNotClobberNewerPending(t *testing.T) {
 	if vp.inflightFetch {
 		t.Error("inflightFetch should be cleared by restorePendingFetch")
 	}
-	if vp.pendingFetch == nil || vp.pendingFetch.Lo != 900 || vp.pendingFetch.Hi != 924 {
+	if vp.pendingFetch == nil || vp.pendingFetch.lo != 900 || vp.pendingFetch.hi != 924 {
 		t.Errorf("pendingFetch = %+v, want [900,924)", vp.pendingFetch)
 	}
 }

--- a/internal/runtime/server/client_integration_test.go
+++ b/internal/runtime/server/client_integration_test.go
@@ -38,6 +38,14 @@ func TestClientResumeReceivesSnapshot(t *testing.T) {
 	}
 	defer desktop.Close()
 
+	// Bootstrap an active workspace with a pane so the server has something to
+	// snapshot; NewDesktopEngineWithDriver leaves the desktop empty because
+	// InitAppName is "" and no workspace has been activated yet.
+	desktop.SwitchToWorkspace(1)
+	if ws := desktop.ActiveWorkspace(); ws != nil {
+		ws.AddApp(app)
+	}
+
 	sink := NewDesktopSink(desktop)
 
 	firstClient, firstServer := net.Pipe()

--- a/internal/runtime/server/client_viewport.go
+++ b/internal/runtime/server/client_viewport.go
@@ -1,0 +1,65 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"sync"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// ClientViewport is the server's view of a single pane's state inside a client
+// session. Publisher uses it to clip BufferDelta rows at emit time.
+// ViewportUpdate.WrapSegmentIdx is intentionally not mirrored here — it is reserved
+// for Plan B resume; clipping only needs ViewTopIdx / ViewBottomIdx.
+type ClientViewport struct {
+	AltScreen     bool
+	ViewTopIdx    int64
+	ViewBottomIdx int64
+	Rows          uint16
+	Cols          uint16
+	AutoFollow    bool
+}
+
+// ClientViewports is the per-Session map of pane -> viewport.
+type ClientViewports struct {
+	mu       sync.RWMutex
+	byPaneID map[[16]byte]ClientViewport
+}
+
+func NewClientViewports() *ClientViewports {
+	return &ClientViewports{byPaneID: make(map[[16]byte]ClientViewport)}
+}
+
+func (c *ClientViewports) Apply(u protocol.ViewportUpdate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byPaneID[u.PaneID] = ClientViewport{
+		AltScreen:     u.AltScreen,
+		ViewTopIdx:    u.ViewTopIdx,
+		ViewBottomIdx: u.ViewBottomIdx,
+		Rows:          u.Rows,
+		Cols:          u.Cols,
+		AutoFollow:    u.AutoFollow,
+	}
+}
+
+func (c *ClientViewports) Get(paneID [16]byte) (ClientViewport, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.byPaneID[paneID]
+	return v, ok
+}
+
+// Snapshot returns a shallow copy of all viewports. Intended for publisher
+// fan-out; callers must treat the result as read-only.
+func (c *ClientViewports) Snapshot() map[[16]byte]ClientViewport {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[[16]byte]ClientViewport, len(c.byPaneID))
+	for k, v := range c.byPaneID {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/runtime/server/client_viewport_test.go
+++ b/internal/runtime/server/client_viewport_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestClientViewports_ApplyUpdate(t *testing.T) {
+	vs := NewClientViewports()
+	pane := [16]byte{1, 2, 3}
+	vs.Apply(protocol.ViewportUpdate{
+		PaneID:        pane,
+		ViewTopIdx:    100,
+		ViewBottomIdx: 123,
+		Rows:          24,
+		Cols:          80,
+		AutoFollow:    false,
+	})
+	got, ok := vs.Get(pane)
+	if !ok {
+		t.Fatal("viewport missing after Apply")
+	}
+	if got.ViewTopIdx != 100 || got.ViewBottomIdx != 123 || got.Rows != 24 {
+		t.Fatalf("unexpected state: %#v", got)
+	}
+}
+
+func TestSession_ApplyViewportUpdate(t *testing.T) {
+	s := NewSession([16]byte{7}, 0)
+	pane := [16]byte{7}
+	s.ApplyViewportUpdate(protocol.ViewportUpdate{
+		PaneID:        pane,
+		ViewTopIdx:    500,
+		ViewBottomIdx: 523,
+		Rows:          24,
+		Cols:          80,
+	})
+	got, ok := s.viewports.Get(pane)
+	if !ok || got.ViewTopIdx != 500 {
+		t.Fatalf("unexpected: %#v ok=%v", got, ok)
+	}
+}

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -168,6 +168,13 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 			return fmt.Errorf("decode viewport update: %w", err)
 		}
 		c.session.ApplyViewportUpdate(u)
+		// Publish so main-screen panes that were skipped by the no-viewport
+		// gate in publishSnapshotsLocked now render, and so scroll/resize
+		// viewport changes re-clip prev-buffer state without waiting for
+		// unrelated content to change.
+		if sink, ok := c.sink.(*DesktopSink); ok {
+			sink.Publish()
+		}
 	case protocol.MsgFetchRange:
 		if err := c.handleFetchRange(payload); err != nil {
 			return fmt.Errorf("fetch range: %w", err)
@@ -386,8 +393,10 @@ func (c *connection) handleFetchRange(payload []byte) error {
 
 	resp, err := ServeFetchRange(st, req, revision)
 	if err != nil {
-		log.Printf("server: ServeFetchRange pane %x: %v", req.PaneID[:4], err)
-		return sendStub(protocol.FetchRangeEmpty)
+		// Real server-side fault (programmer bug or store corruption).
+		// Don't mask as FetchRangeEmpty — the client would hot-loop
+		// re-requesting. Drop the connection; resume will recover.
+		return fmt.Errorf("ServeFetchRange pane %x: %w", req.PaneID[:4], err)
 	}
 
 	enc, err := protocol.EncodeFetchRangeResponse(resp)

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -168,6 +168,10 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 			return fmt.Errorf("decode viewport update: %w", err)
 		}
 		c.session.ApplyViewportUpdate(u)
+	case protocol.MsgFetchRange:
+		if err := c.handleFetchRange(payload); err != nil {
+			return fmt.Errorf("fetch range: %w", err)
+		}
 	default:
 		debugLog.Printf("%s ignoring message type %d", prefix, header.Type)
 	}
@@ -314,4 +318,83 @@ func (c *connection) requestClipboardData(mime string) []byte {
 		}
 	}
 	return nil
+}
+
+func (c *connection) handleFetchRange(payload []byte) error {
+	req, err := protocol.DecodeFetchRange(payload)
+	if err != nil {
+		return fmt.Errorf("decode: %w", err)
+	}
+
+	// sendStub sends a minimal response with the given flags and no rows.
+	sendStub := func(flags protocol.FetchRangeFlags) error {
+		stub := protocol.FetchRangeResponse{
+			RequestID: req.RequestID,
+			PaneID:    req.PaneID,
+			Flags:     flags,
+		}
+		enc, encErr := protocol.EncodeFetchRangeResponse(stub)
+		if encErr != nil {
+			return fmt.Errorf("encode stub: %w", encErr)
+		}
+		hdr := protocol.Header{
+			Version:   protocol.Version,
+			Type:      protocol.MsgFetchRangeResponse,
+			Flags:     protocol.FlagChecksum,
+			SessionID: c.session.ID(),
+		}
+		return c.writeMessage(hdr, enc)
+	}
+
+	sink, ok := c.sink.(*DesktopSink)
+	if !ok {
+		return sendStub(protocol.FetchRangeEmpty)
+	}
+	desktop := sink.Desktop()
+	if desktop == nil {
+		return sendStub(protocol.FetchRangeEmpty)
+	}
+
+	app := desktop.AppByID(req.PaneID)
+	if app == nil {
+		return sendStub(protocol.FetchRangeEmpty)
+	}
+
+	provider, ok := app.(fetchRangeProvider)
+	if !ok {
+		return sendStub(protocol.FetchRangeEmpty)
+	}
+
+	if provider.InAltScreen() {
+		return sendStub(protocol.FetchRangeAltScreenActive)
+	}
+
+	st := provider.SparseStore()
+	if st == nil {
+		return sendStub(protocol.FetchRangeEmpty)
+	}
+
+	pub := sink.Publisher()
+	var revision uint32
+	if pub != nil {
+		revision = pub.RevisionFor(req.PaneID)
+	}
+
+	resp, err := ServeFetchRange(st, req, revision)
+	if err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+
+	enc, err := protocol.EncodeFetchRangeResponse(resp)
+	if err != nil {
+		return fmt.Errorf("encode response: %w", err)
+	}
+
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgFetchRangeResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, enc)
 }

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -348,20 +348,24 @@ func (c *connection) handleFetchRange(payload []byte) error {
 
 	sink, ok := c.sink.(*DesktopSink)
 	if !ok {
+		debugLog.Printf("handleFetchRange pane %x: sink is not *DesktopSink (%T)", req.PaneID[:4], c.sink)
 		return sendStub(protocol.FetchRangeEmpty)
 	}
 	desktop := sink.Desktop()
 	if desktop == nil {
+		debugLog.Printf("handleFetchRange pane %x: desktop is nil", req.PaneID[:4])
 		return sendStub(protocol.FetchRangeEmpty)
 	}
 
 	app := desktop.AppByID(req.PaneID)
 	if app == nil {
+		debugLog.Printf("handleFetchRange pane %x: no app found for pane", req.PaneID[:4])
 		return sendStub(protocol.FetchRangeEmpty)
 	}
 
 	provider, ok := app.(fetchRangeProvider)
 	if !ok {
+		debugLog.Printf("handleFetchRange pane %x: app %T does not implement fetchRangeProvider", req.PaneID[:4], app)
 		return sendStub(protocol.FetchRangeEmpty)
 	}
 

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -9,6 +9,7 @@
 package server
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/framegrace/texelation/protocol"
@@ -161,6 +162,12 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 			return err
 		}
 		c.handleClientReady(ready)
+	case protocol.MsgViewportUpdate:
+		u, err := protocol.DecodeViewportUpdate(payload)
+		if err != nil {
+			return fmt.Errorf("decode viewport update: %w", err)
+		}
+		c.session.ApplyViewportUpdate(u)
 	default:
 		debugLog.Printf("%s ignoring message type %d", prefix, header.Type)
 	}

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -382,7 +382,8 @@ func (c *connection) handleFetchRange(payload []byte) error {
 
 	resp, err := ServeFetchRange(st, req, revision)
 	if err != nil {
-		return fmt.Errorf("serve: %w", err)
+		log.Printf("server: ServeFetchRange pane %x: %v", req.PaneID[:4], err)
+		return sendStub(protocol.FetchRangeEmpty)
 	}
 
 	enc, err := protocol.EncodeFetchRangeResponse(resp)

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -25,13 +25,14 @@ import (
 // DesktopPublisher captures desktop pane buffers and enqueues them as buffer
 // deltas on the associated session.
 type DesktopPublisher struct {
-	desktop     *texel.DesktopEngine
-	session     *Session
-	revisions   map[[16]byte]uint32
-	prevBuffers map[[16]byte][][]texel.Cell
-	observer    PublishObserver
-	mu          sync.RWMutex
-	notify      func()
+	desktop      *texel.DesktopEngine
+	session      *Session
+	revisions    map[[16]byte]uint32
+	prevBuffers  map[[16]byte][][]texel.Cell
+	lastViewport map[[16]byte]ClientViewport
+	observer     PublishObserver
+	mu           sync.RWMutex
+	notify       func()
 }
 
 // PublishObserver records desktop publish metrics for instrumentation.
@@ -41,10 +42,11 @@ type PublishObserver interface {
 
 func NewDesktopPublisher(desktop *texel.DesktopEngine, session *Session) *DesktopPublisher {
 	pub := &DesktopPublisher{
-		desktop:     desktop,
-		session:     session,
-		revisions:   make(map[[16]byte]uint32),
-		prevBuffers: make(map[[16]byte][][]texel.Cell),
+		desktop:      desktop,
+		session:      session,
+		revisions:    make(map[[16]byte]uint32),
+		prevBuffers:  make(map[[16]byte][][]texel.Cell),
+		lastViewport: make(map[[16]byte]ClientViewport),
 	}
 
 	// Set up graphics provider factory so panes can send image messages
@@ -67,6 +69,7 @@ func (p *DesktopPublisher) SetObserver(observer PublishObserver) {
 func (p *DesktopPublisher) ResetDiffState() {
 	p.mu.Lock()
 	p.prevBuffers = make(map[[16]byte][][]texel.Cell)
+	p.lastViewport = make(map[[16]byte]ClientViewport)
 	p.mu.Unlock()
 }
 
@@ -94,10 +97,27 @@ func (p *DesktopPublisher) Publish() error {
 	// if len(buffers) > 0 { log.Printf("DesktopPublisher: Publishing %d buffers", len(buffers)) }
 
 	for _, snap := range buffers {
+		vp, haveVP := p.session.Viewport(snap.ID)
+		// Main-screen panes require a viewport before we clip rows: the
+		// client will send one right after handshake. Alt-screen (or
+		// non-terminal / placeholder) panes don't need clipping and are
+		// always emitted.
+		if !snap.AltScreen && !haveVP {
+			continue
+		}
+		// If the viewport shifted since the last publish for this pane,
+		// rows previously out-of-window may now be in-window but unchanged;
+		// they must re-emit because the client has never seen them.
+		if haveVP {
+			if prevVP, ok := p.lastViewport[snap.ID]; !ok || prevVP != vp {
+				p.prevBuffers[snap.ID] = nil
+			}
+			p.lastViewport[snap.ID] = vp
+		}
 		rev := p.revisions[snap.ID] + 1
 		p.revisions[snap.ID] = rev
 		prev := p.prevBuffers[snap.ID]
-		delta := bufferToDelta(snap, prev, rev)
+		delta := bufferToDelta(snap, prev, rev, vp)
 		if len(delta.Rows) == 0 {
 			continue
 		}
@@ -128,21 +148,24 @@ func cloneBuffer(buf [][]texel.Cell) [][]texel.Cell {
 	return clone
 }
 
-func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32) protocol.BufferDelta {
+// bufferToDelta encodes a pane snapshot into a BufferDelta, emitting only
+// rows that (a) changed since prev and (b) fall inside the client's
+// resident window. Alt-screen (or non-terminal) panes bypass clipping:
+// Flags sets BufferDeltaAltScreen, RowBase stays 0, and Row is the flat
+// buffer index.
+//
+// Main-screen panes use RowGlobalIdx to key rows by globalIdx and clip to
+// [lo, hi] = [ViewTopIdx - overscan, ViewBottomIdx + overscan] where
+// overscan = vp.Rows (1× viewport). In AutoFollow we still use
+// ViewTopIdx/ViewBottomIdx since the client keeps them in sync with the
+// live bottom — no extra bookkeeping needed here.
+func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32, vp ClientViewport) protocol.BufferDelta {
 	styleMap := make(map[styleKey]uint16)
 	styles := make([]protocol.StyleEntry, 0)
 
-	rows := make([]protocol.RowDelta, 0, len(snap.Buffer))
-	for y, row := range snap.Buffer {
-		if len(row) == 0 {
-			continue
-		}
-		if y < len(prev) && rowsEqual(row, prev[y]) {
-			continue
-		}
+	encodeRow := func(row []texel.Cell) []protocol.CellSpan {
 		spans := make([]protocol.CellSpan, 0)
 		builders := make([]*strings.Builder, 0)
-
 		for x, cell := range row {
 			key, entry := convertCell(cell)
 			index, ok := styleMap[key]
@@ -151,28 +174,68 @@ func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32
 				index = uint16(len(styles) - 1)
 				styleMap[key] = index
 			}
-
 			if len(spans) == 0 || spans[len(spans)-1].StyleIndex != index {
 				spans = append(spans, protocol.CellSpan{StartCol: uint16(x), StyleIndex: index})
 				builders = append(builders, &strings.Builder{})
 			}
 			builders[len(builders)-1].WriteRune(cell.Ch)
 		}
-
 		for i := range spans {
 			spans[i].Text = builders[i].String()
 		}
-
-		rows = append(rows, protocol.RowDelta{Row: uint16(y), Spans: spans})
+		return spans
 	}
 
-	return protocol.BufferDelta{
+	rows := make([]protocol.RowDelta, 0, len(snap.Buffer))
+	delta := protocol.BufferDelta{
 		PaneID:   snap.ID,
 		Revision: revision,
 		Flags:    protocol.BufferDeltaNone,
-		Styles:   styles,
-		Rows:     rows,
 	}
+
+	if snap.AltScreen {
+		delta.Flags |= protocol.BufferDeltaAltScreen
+		for y, row := range snap.Buffer {
+			if len(row) == 0 {
+				continue
+			}
+			if y < len(prev) && rowsEqual(row, prev[y]) {
+				continue
+			}
+			rows = append(rows, protocol.RowDelta{Row: uint16(y), Spans: encodeRow(row)})
+		}
+		delta.Styles = styles
+		delta.Rows = rows
+		return delta
+	}
+
+	overscan := int64(vp.Rows)
+	lo := vp.ViewTopIdx - overscan
+	hi := vp.ViewBottomIdx + overscan
+	delta.RowBase = lo
+
+	for y, row := range snap.Buffer {
+		if len(row) == 0 {
+			continue
+		}
+		if y >= len(snap.RowGlobalIdx) {
+			continue
+		}
+		gid := snap.RowGlobalIdx[y]
+		if gid < 0 {
+			continue
+		}
+		if gid < lo || gid > hi {
+			continue
+		}
+		if y < len(prev) && rowsEqual(row, prev[y]) {
+			continue
+		}
+		rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: encodeRow(row)})
+	}
+	delta.Styles = styles
+	delta.Rows = rows
+	return delta
 }
 
 type styleKey struct {

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -124,6 +124,10 @@ func (p *DesktopPublisher) publishSnapshotsLocked(buffers []texel.PaneSnapshot) 
 		// non-terminal / placeholder) panes don't need clipping and are
 		// always emitted.
 		if !snap.AltScreen && !haveVP {
+			// Silent-skip is deliberate: the client will send a ViewportUpdate
+			// right after handshake, and connection_handler nudges Publish
+			// then.  Logging surfaces the transient state for diagnosis.
+			debugLog.Printf("publisher: pane %x waiting for viewport", snap.ID[:4])
 			continue
 		}
 		// Narrow prev-buffer invalidation: rows that were OUT of window

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -86,6 +86,10 @@ func (p *DesktopPublisher) RevisionFor(paneID [16]byte) uint32 {
 	return p.revisions[paneID]
 }
 
+// Publish reads SnapshotBuffers from the desktop engine, then delegates
+// to publishSnapshotsLocked for the per-pane encode + enqueue loop. The
+// split lets tests drive the encode path with synthetic snapshots without
+// spinning up a live desktop engine.
 func (p *DesktopPublisher) Publish() error {
 	if p.desktop == nil || p.session == nil {
 		return nil
@@ -96,6 +100,23 @@ func (p *DesktopPublisher) Publish() error {
 	buffers := p.desktop.SnapshotBuffers()
 	// if len(buffers) > 0 { log.Printf("DesktopPublisher: Publishing %d buffers", len(buffers)) }
 
+	if err := p.publishSnapshotsLocked(buffers); err != nil {
+		return err
+	}
+	elapsed := time.Since(start)
+	p.desktop.SetLastPublishDuration(elapsed)
+	if p.observer != nil {
+		p.observer.ObservePublish(p.session, len(buffers), elapsed)
+	}
+	if p.notify != nil {
+		p.notify()
+	}
+	return nil
+}
+
+// publishSnapshotsLocked runs the per-pane encode + enqueue loop for the
+// given snapshots. The caller must hold p.mu.
+func (p *DesktopPublisher) publishSnapshotsLocked(buffers []texel.PaneSnapshot) error {
 	for _, snap := range buffers {
 		vp, haveVP := p.session.Viewport(snap.ID)
 		// Main-screen panes require a viewport before we clip rows: the
@@ -105,11 +126,32 @@ func (p *DesktopPublisher) Publish() error {
 		if !snap.AltScreen && !haveVP {
 			continue
 		}
-		// If the viewport shifted since the last publish for this pane,
-		// rows previously out-of-window may now be in-window but unchanged;
-		// they must re-emit because the client has never seen them.
+		// Narrow prev-buffer invalidation: rows that were OUT of window
+		// and are now IN window with unchanged content would be wrongly
+		// skipped by rowsEqual, so we must force a re-emit in cases where
+		// that can happen. The only cases that require invalidation are:
+		//   - first viewport for this pane (no prior state);
+		//   - geometry change (Rows or Cols differ);
+		//   - AutoFollow mode toggled (window shape semantics change);
+		//   - manual scroll (AutoFollow=false and View indices shifted),
+		//     where the new window may expose unchanged content.
+		// In AutoFollow-to-AutoFollow with unchanged Rows/Cols, View
+		// indices advance every frame; we deliberately do NOT invalidate
+		// because new bottom rows differ in content and diff naturally
+		// via rowsEqual, and no previously-hidden row can become visible
+		// without content change.
 		if haveVP {
-			if prevVP, ok := p.lastViewport[snap.ID]; !ok || prevVP != vp {
+			prevVP, hadPrev := p.lastViewport[snap.ID]
+			shouldInvalidate := !hadPrev ||
+				prevVP.AutoFollow != vp.AutoFollow ||
+				prevVP.Rows != vp.Rows ||
+				prevVP.Cols != vp.Cols
+			if !shouldInvalidate && !vp.AutoFollow {
+				if prevVP.ViewTopIdx != vp.ViewTopIdx || prevVP.ViewBottomIdx != vp.ViewBottomIdx {
+					shouldInvalidate = true
+				}
+			}
+			if shouldInvalidate {
 				p.prevBuffers[snap.ID] = nil
 			}
 			p.lastViewport[snap.ID] = vp
@@ -127,14 +169,6 @@ func (p *DesktopPublisher) Publish() error {
 		if err := p.session.EnqueueDiff(delta); err != nil {
 			return err
 		}
-	}
-	elapsed := time.Since(start)
-	p.desktop.SetLastPublishDuration(elapsed)
-	if p.observer != nil {
-		p.observer.ObservePublish(p.session, len(buffers), elapsed)
-	}
-	if p.notify != nil {
-		p.notify()
 	}
 	return nil
 }

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -75,6 +75,14 @@ func (p *DesktopPublisher) SetNotifier(fn func()) {
 	p.notify = fn
 }
 
+// RevisionFor returns the latest revision stamped for paneID by Publish.
+// Returns 0 if the pane has not been published yet.
+func (p *DesktopPublisher) RevisionFor(paneID [16]byte) uint32 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.revisions[paneID]
+}
+
 func (p *DesktopPublisher) Publish() error {
 	if p.desktop == nil || p.session == nil {
 		return nil
@@ -270,7 +278,7 @@ func convertColor(color tcell.Color) (protocol.ColorModel, uint32) {
 		case tcell.ColorWhite:
 			paletteName = "text"
 		}
-		
+
 		if paletteName != "" {
 			themeColor := theme.ResolveColorName(paletteName)
 			if themeColor != tcell.ColorDefault {

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -30,7 +30,7 @@ type DesktopPublisher struct {
 	revisions   map[[16]byte]uint32
 	prevBuffers map[[16]byte][][]texel.Cell
 	observer    PublishObserver
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	notify      func()
 }
 
@@ -78,8 +78,8 @@ func (p *DesktopPublisher) SetNotifier(fn func()) {
 // RevisionFor returns the latest revision stamped for paneID by Publish.
 // Returns 0 if the pane has not been published yet.
 func (p *DesktopPublisher) RevisionFor(paneID [16]byte) uint32 {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.revisions[paneID]
 }
 

--- a/internal/runtime/server/desktop_publisher_test.go
+++ b/internal/runtime/server/desktop_publisher_test.go
@@ -9,9 +9,9 @@
 package server
 
 import (
-	texelcore "github.com/framegrace/texelui/core"
 	"testing"
 
+	texelcore "github.com/framegrace/texelui/core"
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/framegrace/texelation/protocol"
@@ -46,6 +46,31 @@ func (s *simpleApp) GetTitle() string               { return s.title }
 func (s *simpleApp) HandleKey(ev *tcell.EventKey)   {}
 func (s *simpleApp) SetRefreshNotifier(chan<- bool) {}
 
+// LastDelta decodes and returns the most recent BufferDelta enqueued on
+// the session for the given pane. Fails the test if none found.
+func sessionLastDelta(t *testing.T, s *Session, paneID [16]byte) protocol.BufferDelta {
+	t.Helper()
+	diffs := s.Pending(0)
+	var found *protocol.BufferDelta
+	for i := range diffs {
+		if diffs[i].Message.Type != protocol.MsgBufferDelta {
+			continue
+		}
+		decoded, err := protocol.DecodeBufferDelta(diffs[i].Payload)
+		if err != nil {
+			t.Fatalf("decode delta: %v", err)
+		}
+		if decoded.PaneID == paneID {
+			d := decoded
+			found = &d
+		}
+	}
+	if found == nil {
+		t.Fatalf("no BufferDelta for pane %x", paneID[:4])
+	}
+	return *found
+}
+
 func TestDesktopPublisherProducesDiffs(t *testing.T) {
 	driver := publisherScreenDriver{}
 	lifecycle := texel.NoopAppLifecycle{}
@@ -65,11 +90,14 @@ func TestDesktopPublisherProducesDiffs(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 
+	// simpleApp is not a RowGlobalIdxProvider, so its snapshot is marked
+	// AltScreen=true and published without needing a viewport. Expect at
+	// least one delta with the AltScreen flag set.
 	diffs := session.Pending(0)
 	if len(diffs) == 0 {
 		t.Fatalf("expected at least one diff")
 	}
-
+	sawAltScreen := false
 	for _, diff := range diffs {
 		if diff.Message.Type != protocol.MsgBufferDelta {
 			t.Fatalf("unexpected message type %v", diff.Message.Type)
@@ -81,5 +109,130 @@ func TestDesktopPublisherProducesDiffs(t *testing.T) {
 		if len(delta.Rows) == 0 {
 			t.Fatalf("expected rows in delta")
 		}
+		if delta.Flags&protocol.BufferDeltaAltScreen != 0 {
+			sawAltScreen = true
+		}
+	}
+	if !sawAltScreen {
+		t.Fatalf("expected at least one delta with BufferDeltaAltScreen flag (non-terminal app)")
+	}
+}
+
+// buildSyntheticSnap builds a PaneSnapshot with `rows` rows, each carrying
+// globalIdx = startGid + rowIndex. The snapshot is NOT alt-screen.
+func buildSyntheticSnap(paneID [16]byte, rows int, startGid int64) texel.PaneSnapshot {
+	buf := make([][]texel.Cell, rows)
+	gid := make([]int64, rows)
+	for y := 0; y < rows; y++ {
+		buf[y] = []texel.Cell{{Ch: rune('A' + (y % 26)), Style: tcell.StyleDefault}}
+		gid[y] = startGid + int64(y)
+	}
+	return texel.PaneSnapshot{
+		ID:           paneID,
+		Title:        "synthetic",
+		Buffer:       buf,
+		RowGlobalIdx: gid,
+		AltScreen:    false,
+	}
+}
+
+// buildSyntheticAltSnap builds a PaneSnapshot with `rows` x `cols` cells
+// and AltScreen=true (all globalIdxs -1).
+func buildSyntheticAltSnap(paneID [16]byte, rows, cols int) texel.PaneSnapshot {
+	buf := make([][]texel.Cell, rows)
+	gid := make([]int64, rows)
+	for y := 0; y < rows; y++ {
+		row := make([]texel.Cell, cols)
+		for x := 0; x < cols; x++ {
+			row[x] = texel.Cell{Ch: 'x', Style: tcell.StyleDefault}
+		}
+		buf[y] = row
+		gid[y] = -1
+	}
+	return texel.PaneSnapshot{
+		ID:           paneID,
+		Title:        "alt",
+		Buffer:       buf,
+		RowGlobalIdx: gid,
+		AltScreen:    true,
+	}
+}
+
+// publishSnaps drives a single encode+enqueue pass for the given snapshots
+// without needing a live DesktopEngine. Mirrors the relevant body of
+// DesktopPublisher.Publish for unit-testing bufferToDelta end-to-end.
+func publishSnaps(t *testing.T, session *Session, snaps []texel.PaneSnapshot) {
+	t.Helper()
+	for _, snap := range snaps {
+		vp, haveVP := session.Viewport(snap.ID)
+		if !snap.AltScreen && !haveVP {
+			continue
+		}
+		delta := bufferToDelta(snap, nil, 1, vp)
+		if len(delta.Rows) == 0 && !snap.AltScreen {
+			// Publisher would skip; mirror that.
+			continue
+		}
+		if err := session.EnqueueDiff(delta); err != nil {
+			t.Fatalf("enqueue diff: %v", err)
+		}
+	}
+}
+
+func TestPublisher_ClipsToViewport(t *testing.T) {
+	paneID := [16]byte{0xAA}
+	session := NewSession([16]byte{1}, 512)
+
+	session.ApplyViewportUpdate(protocol.ViewportUpdate{
+		PaneID:        paneID,
+		ViewTopIdx:    100,
+		ViewBottomIdx: 123,
+		Rows:          24,
+		Cols:          80,
+		AutoFollow:    false,
+	})
+
+	// Pane has 200 rows of content; globalIdxs run 0..199.
+	snap := buildSyntheticSnap(paneID, 200, 0)
+	publishSnaps(t, session, []texel.PaneSnapshot{snap})
+
+	delta := sessionLastDelta(t, session, paneID)
+	if delta.Flags&protocol.BufferDeltaAltScreen != 0 {
+		t.Fatalf("main-screen pane should not set AltScreen flag")
+	}
+	// Expect RowBase = ViewTopIdx - Rows = 100 - 24 = 76.
+	if delta.RowBase != 76 {
+		t.Fatalf("RowBase: got %d want 76", delta.RowBase)
+	}
+	if len(delta.Rows) == 0 {
+		t.Fatalf("expected rows in clipped delta")
+	}
+	for _, row := range delta.Rows {
+		globalIdx := delta.RowBase + int64(row.Row)
+		if globalIdx < 76 || globalIdx > 147 {
+			t.Fatalf("row %d (idx %d) outside resident window [76,147]", row.Row, globalIdx)
+		}
+	}
+	// Window is inclusive [76, 147] = 72 rows. Pane has content for each.
+	if len(delta.Rows) != 72 {
+		t.Fatalf("expected 72 rows in window, got %d", len(delta.Rows))
+	}
+}
+
+func TestPublisher_AltScreenSetsFlag(t *testing.T) {
+	paneID := [16]byte{0xBB}
+	session := NewSession([16]byte{2}, 512)
+	snap := buildSyntheticAltSnap(paneID, 24, 80)
+	publishSnaps(t, session, []texel.PaneSnapshot{snap})
+
+	delta := sessionLastDelta(t, session, paneID)
+	if delta.Flags&protocol.BufferDeltaAltScreen == 0 {
+		t.Fatalf("alt-screen pane should set AltScreen flag")
+	}
+	if delta.RowBase != 0 {
+		t.Fatalf("alt-screen pane should have RowBase=0, got %d", delta.RowBase)
+	}
+	if len(delta.Rows) != 24 {
+		t.Fatalf("alt-screen delta: want 24 rows, got %d", len(delta.Rows))
 	}
 }

--- a/internal/runtime/server/desktop_publisher_test.go
+++ b/internal/runtime/server/desktop_publisher_test.go
@@ -159,23 +159,21 @@ func buildSyntheticAltSnap(paneID [16]byte, rows, cols int) texel.PaneSnapshot {
 }
 
 // publishSnaps drives a single encode+enqueue pass for the given snapshots
-// without needing a live DesktopEngine. Mirrors the relevant body of
-// DesktopPublisher.Publish for unit-testing bufferToDelta end-to-end.
+// without needing a live DesktopEngine. It constructs a real
+// DesktopPublisher and invokes publishSnapshotsLocked so tests exercise
+// the production encode loop and automatically track any future changes.
 func publishSnaps(t *testing.T, session *Session, snaps []texel.PaneSnapshot) {
 	t.Helper()
-	for _, snap := range snaps {
-		vp, haveVP := session.Viewport(snap.ID)
-		if !snap.AltScreen && !haveVP {
-			continue
-		}
-		delta := bufferToDelta(snap, nil, 1, vp)
-		if len(delta.Rows) == 0 && !snap.AltScreen {
-			// Publisher would skip; mirror that.
-			continue
-		}
-		if err := session.EnqueueDiff(delta); err != nil {
-			t.Fatalf("enqueue diff: %v", err)
-		}
+	pub := &DesktopPublisher{
+		session:      session,
+		revisions:    make(map[[16]byte]uint32),
+		prevBuffers:  make(map[[16]byte][][]texel.Cell),
+		lastViewport: make(map[[16]byte]ClientViewport),
+	}
+	pub.mu.Lock()
+	defer pub.mu.Unlock()
+	if err := pub.publishSnapshotsLocked(snaps); err != nil {
+		t.Fatalf("publishSnapshotsLocked: %v", err)
 	}
 }
 

--- a/internal/runtime/server/desktop_sink.go
+++ b/internal/runtime/server/desktop_sink.go
@@ -111,8 +111,11 @@ func (d *DesktopSink) Publish() {
 	d.mu.Lock()
 	publisher := d.publisher
 	d.mu.Unlock()
-	if publisher != nil {
-		_ = publisher.Publish()
+	if publisher == nil {
+		return
+	}
+	if err := publisher.Publish(); err != nil {
+		log.Printf("desktop sink: publish failed: %v", err)
 	}
 }
 
@@ -123,7 +126,9 @@ func (d *DesktopSink) publish() {
 	if publisher == nil {
 		return
 	}
-	_ = publisher.Publish()
+	if err := publisher.Publish(); err != nil {
+		log.Printf("desktop sink: publish failed: %v", err)
+	}
 }
 
 func (d *DesktopSink) Snapshot() (protocol.TreeSnapshot, error) {

--- a/internal/runtime/server/encoding.go
+++ b/internal/runtime/server/encoding.go
@@ -1,0 +1,121 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"strings"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// parserStyleKey is the deduplication key for parser.Cell styles.
+type parserStyleKey struct {
+	attrFlags uint16
+	fgModel   protocol.ColorModel
+	fgValue   uint32
+	bgModel   protocol.ColorModel
+	bgValue   uint32
+}
+
+// styleTable accumulates unique StyleEntry values and returns their indices.
+type styleTable struct {
+	index        map[parserStyleKey]uint16
+	styleEntries []protocol.StyleEntry
+}
+
+func newStyleTable() *styleTable {
+	return &styleTable{
+		index: make(map[parserStyleKey]uint16),
+	}
+}
+
+// indexOf returns the index in the shared style table for the style encoded by
+// cell, adding a new entry if this style has not been seen before.
+func (t *styleTable) indexOf(cell parser.Cell) uint16 {
+	attrFlags := uint16(0)
+	if cell.Attr&parser.AttrBold != 0 {
+		attrFlags |= protocol.AttrBold
+	}
+	if cell.Attr&parser.AttrUnderline != 0 {
+		attrFlags |= protocol.AttrUnderline
+	}
+	if cell.Attr&parser.AttrReverse != 0 {
+		attrFlags |= protocol.AttrReverse
+	}
+	if cell.Attr&parser.AttrDim != 0 {
+		attrFlags |= protocol.AttrDim
+	}
+	if cell.Attr&parser.AttrItalic != 0 {
+		attrFlags |= protocol.AttrItalic
+	}
+
+	fgModel, fgValue := parserColorToProto(cell.FG)
+	bgModel, bgValue := parserColorToProto(cell.BG)
+
+	key := parserStyleKey{
+		attrFlags: attrFlags,
+		fgModel:   fgModel,
+		fgValue:   fgValue,
+		bgModel:   bgModel,
+		bgValue:   bgValue,
+	}
+	if idx, ok := t.index[key]; ok {
+		return idx
+	}
+	idx := uint16(len(t.styleEntries))
+	t.styleEntries = append(t.styleEntries, protocol.StyleEntry{
+		AttrFlags: attrFlags,
+		FgModel:   fgModel,
+		FgValue:   fgValue,
+		BgModel:   bgModel,
+		BgValue:   bgValue,
+	})
+	t.index[key] = idx
+	return idx
+}
+
+// entries returns the accumulated style entries in insertion order.
+func (t *styleTable) entries() []protocol.StyleEntry {
+	return t.styleEntries
+}
+
+// parserColorToProto converts a parser.Color to the protocol (ColorModel, value) pair.
+func parserColorToProto(c parser.Color) (protocol.ColorModel, uint32) {
+	switch c.Mode {
+	case parser.ColorModeDefault:
+		return protocol.ColorModelDefault, 0
+	case parser.ColorModeStandard:
+		return protocol.ColorModelANSI16, uint32(c.Value)
+	case parser.ColorMode256:
+		return protocol.ColorModelANSI256, uint32(c.Value)
+	case parser.ColorModeRGB:
+		return protocol.ColorModelRGB, (uint32(c.R) << 16) | (uint32(c.G) << 8) | uint32(c.B)
+	default:
+		return protocol.ColorModelDefault, 0
+	}
+}
+
+// encodeParserCellsToSpans groups consecutive cells with the same style into
+// CellSpan values. The caller owns the returned slice.
+func encodeParserCellsToSpans(cells []parser.Cell, t *styleTable) []protocol.CellSpan {
+	if len(cells) == 0 {
+		return nil
+	}
+	var spans []protocol.CellSpan
+	var builders []*strings.Builder
+
+	for x, cell := range cells {
+		idx := t.indexOf(cell)
+		if len(spans) == 0 || spans[len(spans)-1].StyleIndex != idx {
+			spans = append(spans, protocol.CellSpan{StartCol: uint16(x), StyleIndex: idx})
+			builders = append(builders, &strings.Builder{})
+		}
+		builders[len(builders)-1].WriteRune(cell.Rune)
+	}
+	for i := range spans {
+		spans[i].Text = builders[i].String()
+	}
+	return spans
+}

--- a/internal/runtime/server/encoding.go
+++ b/internal/runtime/server/encoding.go
@@ -4,11 +4,23 @@
 package server
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
 	"github.com/framegrace/texelation/protocol"
 )
+
+// maxStyleEntries is the maximum number of distinct styles a styleTable can
+// hold before indexOf returns errStyleTableFull.  The wire format uses uint16
+// indices, so 0xFFFF (65535) is the hard cap; we cap one below to keep
+// uint16 arithmetic safe.
+const maxStyleEntries = 0xFFFF
+
+// errStyleTableFull is returned by indexOf when the style table has reached
+// maxStyleEntries distinct entries. Callers should surface a partial result
+// and log the condition.
+var errStyleTableFull = errors.New("encode: style table full (>65534 distinct styles)")
 
 // parserStyleKey is the deduplication key for parser.Cell styles.
 type parserStyleKey struct {
@@ -33,7 +45,10 @@ func newStyleTable() *styleTable {
 
 // indexOf returns the index in the shared style table for the style encoded by
 // cell, adding a new entry if this style has not been seen before.
-func (t *styleTable) indexOf(cell parser.Cell) uint16 {
+// Returns errStyleTableFull if the table already has maxStyleEntries distinct
+// styles; the caller must short-circuit span building on that error to prevent
+// silent uint16 wraparound in the wire format.
+func (t *styleTable) indexOf(cell parser.Cell) (uint16, error) {
 	attrFlags := uint16(0)
 	if cell.Attr&parser.AttrBold != 0 {
 		attrFlags |= protocol.AttrBold
@@ -62,7 +77,10 @@ func (t *styleTable) indexOf(cell parser.Cell) uint16 {
 		bgValue:   bgValue,
 	}
 	if idx, ok := t.index[key]; ok {
-		return idx
+		return idx, nil
+	}
+	if len(t.styleEntries) >= maxStyleEntries {
+		return 0, errStyleTableFull
 	}
 	idx := uint16(len(t.styleEntries))
 	t.styleEntries = append(t.styleEntries, protocol.StyleEntry{
@@ -73,7 +91,7 @@ func (t *styleTable) indexOf(cell parser.Cell) uint16 {
 		BgValue:   bgValue,
 	})
 	t.index[key] = idx
-	return idx
+	return idx, nil
 }
 
 // entries returns the accumulated style entries in insertion order.
@@ -99,15 +117,24 @@ func parserColorToProto(c parser.Color) (protocol.ColorModel, uint32) {
 
 // encodeParserCellsToSpans groups consecutive cells with the same style into
 // CellSpan values. The caller owns the returned slice.
-func encodeParserCellsToSpans(cells []parser.Cell, t *styleTable) []protocol.CellSpan {
+// Returns errStyleTableFull if the style table overflows during encoding; in
+// that case the returned spans cover only the cells processed up to the error.
+func encodeParserCellsToSpans(cells []parser.Cell, t *styleTable) ([]protocol.CellSpan, error) {
 	if len(cells) == 0 {
-		return nil
+		return nil, nil
 	}
 	var spans []protocol.CellSpan
 	var builders []*strings.Builder
 
 	for x, cell := range cells {
-		idx := t.indexOf(cell)
+		idx, err := t.indexOf(cell)
+		if err != nil {
+			// Finalise text for spans built so far and return partial result.
+			for i := range spans {
+				spans[i].Text = builders[i].String()
+			}
+			return spans, err
+		}
 		if len(spans) == 0 || spans[len(spans)-1].StyleIndex != idx {
 			spans = append(spans, protocol.CellSpan{StartCol: uint16(x), StyleIndex: idx})
 			builders = append(builders, &strings.Builder{})
@@ -117,5 +144,5 @@ func encodeParserCellsToSpans(cells []parser.Cell, t *styleTable) []protocol.Cel
 	for i := range spans {
 		spans[i].Text = builders[i].String()
 	}
-	return spans
+	return spans, nil
 }

--- a/internal/runtime/server/encoding_test.go
+++ b/internal/runtime/server/encoding_test.go
@@ -20,13 +20,22 @@ func TestStyleTable_Dedup(t *testing.T) {
 	cellADup := parser.Cell{Rune: 'z', Attr: parser.AttrBold, FG: parser.Color{Mode: parser.ColorModeDefault}}
 	cellB := parser.Cell{Rune: 'b', Attr: parser.AttrUnderline, FG: parser.Color{Mode: parser.ColorModeDefault}}
 
-	idx0 := table.indexOf(cellA)
-	idx0Dup := table.indexOf(cellADup)
+	idx0, err := table.indexOf(cellA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	idx0Dup, err := table.indexOf(cellADup)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if idx0 != idx0Dup {
 		t.Fatalf("same style should yield same index: got %d and %d", idx0, idx0Dup)
 	}
 
-	idx1 := table.indexOf(cellB)
+	idx1, err := table.indexOf(cellB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if idx1 == idx0 {
 		t.Fatalf("different style should yield different index: both got %d", idx0)
 	}
@@ -46,7 +55,10 @@ func TestEncodeParserCellsToSpans_SpanBreaking(t *testing.T) {
 		{Rune: '!', Attr: parser.AttrUnderline},
 	}
 
-	spans := encodeParserCellsToSpans(cells, table)
+	spans, err := encodeParserCellsToSpans(cells, table)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(spans) != 2 {
 		t.Fatalf("expected 2 spans, got %d", len(spans))
 	}
@@ -128,7 +140,10 @@ func TestStyleTable_AttrMapping(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			table := newStyleTable()
 			cell := parser.Cell{Rune: 'x', Attr: tc.parserAttr}
-			idx := table.indexOf(cell)
+			idx, err := table.indexOf(cell)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			entries := table.entries()
 			if int(idx) >= len(entries) {
 				t.Fatalf("index %d out of range for entries len %d", idx, len(entries))
@@ -153,11 +168,58 @@ func TestStyleTable_AttrMapping(t *testing.T) {
 // and leaves the style table untouched.
 func TestEncodeParserCellsToSpans_Empty(t *testing.T) {
 	table := newStyleTable()
-	spans := encodeParserCellsToSpans(nil, table)
+	spans, err := encodeParserCellsToSpans(nil, table)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(spans) != 0 {
 		t.Fatalf("expected no spans for empty input, got %d", len(spans))
 	}
 	if len(table.entries()) != 0 {
 		t.Fatalf("expected no style entries for empty input, got %d", len(table.entries()))
+	}
+}
+
+// TestStyleTable_Overflow verifies that errStyleTableFull is returned when the
+// style table reaches maxStyleEntries distinct entries.  We pre-populate the
+// table to maxStyleEntries-1 (using synthetic unique FG values), add one more
+// to hit exactly maxStyleEntries, then verify the next call returns the error.
+//
+// Note: actually constructing 65535 distinct styles is expensive in a test.
+// We use a small synthetic approach: pre-populate the internal slice to the
+// cap directly, bypassing the map, then call indexOf with a fresh style.
+func TestStyleTable_Overflow(t *testing.T) {
+	table := newStyleTable()
+	// Pre-fill the entries slice to maxStyleEntries using synthetic unique RGB colors.
+	// We fill both the slice and the index map together via sequential indexOf calls
+	// for the first N distinct styles to ensure the map stays consistent.
+	// Since maxStyleEntries is 65535, iterating over all of them is feasible but
+	// slow (~100ms). We use a direct pre-population instead to keep the test fast.
+	//
+	// Direct pre-population: insert synthetic StyleEntries directly.
+	for i := 0; i < maxStyleEntries; i++ {
+		// Unique key: vary the FG value (uint32 covers >65535 values).
+		key := parserStyleKey{
+			fgModel: protocol.ColorModelRGB,
+			fgValue: uint32(i),
+		}
+		table.index[key] = uint16(i)
+		table.styleEntries = append(table.styleEntries, protocol.StyleEntry{
+			FgModel: protocol.ColorModelRGB,
+			FgValue: uint32(i),
+		})
+	}
+	if len(table.entries()) != maxStyleEntries {
+		t.Fatalf("pre-population: want %d entries, got %d", maxStyleEntries, len(table.entries()))
+	}
+
+	// Now request a brand-new style (fgValue=maxStyleEntries, which is not in the map).
+	newCell := parser.Cell{
+		Rune: 'X',
+		FG:   parser.Color{Mode: parser.ColorModeRGB, R: 0xFF, G: 0xFF, B: 0xFF},
+	}
+	_, err := table.indexOf(newCell)
+	if err == nil {
+		t.Fatal("expected errStyleTableFull, got nil")
 	}
 }

--- a/internal/runtime/server/encoding_test.go
+++ b/internal/runtime/server/encoding_test.go
@@ -1,0 +1,163 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// TestStyleTable_Dedup verifies that inserting the same cell style twice returns
+// the same index, and a different style produces a new index.
+func TestStyleTable_Dedup(t *testing.T) {
+	table := newStyleTable()
+
+	// cellA and cellADup differ only in Rune; style (Attr, colors) is identical.
+	cellA := parser.Cell{Rune: 'a', Attr: parser.AttrBold, FG: parser.Color{Mode: parser.ColorModeDefault}}
+	cellADup := parser.Cell{Rune: 'z', Attr: parser.AttrBold, FG: parser.Color{Mode: parser.ColorModeDefault}}
+	cellB := parser.Cell{Rune: 'b', Attr: parser.AttrUnderline, FG: parser.Color{Mode: parser.ColorModeDefault}}
+
+	idx0 := table.indexOf(cellA)
+	idx0Dup := table.indexOf(cellADup)
+	if idx0 != idx0Dup {
+		t.Fatalf("same style should yield same index: got %d and %d", idx0, idx0Dup)
+	}
+
+	idx1 := table.indexOf(cellB)
+	if idx1 == idx0 {
+		t.Fatalf("different style should yield different index: both got %d", idx0)
+	}
+	if len(table.entries()) != 2 {
+		t.Fatalf("expected 2 entries in style table, got %d", len(table.entries()))
+	}
+}
+
+// TestEncodeParserCellsToSpans_SpanBreaking verifies three cells A, A, B (differing
+// style on the third) produce exactly two spans with correct StartCol values.
+func TestEncodeParserCellsToSpans_SpanBreaking(t *testing.T) {
+	table := newStyleTable()
+
+	cells := []parser.Cell{
+		{Rune: 'H', Attr: parser.AttrBold},
+		{Rune: 'i', Attr: parser.AttrBold},
+		{Rune: '!', Attr: parser.AttrUnderline},
+	}
+
+	spans := encodeParserCellsToSpans(cells, table)
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(spans))
+	}
+	if spans[0].StartCol != 0 {
+		t.Fatalf("first span StartCol: got %d want 0", spans[0].StartCol)
+	}
+	if spans[0].Text != "Hi" {
+		t.Fatalf("first span Text: got %q want %q", spans[0].Text, "Hi")
+	}
+	if spans[1].StartCol != 2 {
+		t.Fatalf("second span StartCol: got %d want 2", spans[1].StartCol)
+	}
+	if spans[1].Text != "!" {
+		t.Fatalf("second span Text: got %q want %q", spans[1].Text, "!")
+	}
+}
+
+// TestParserColorToProto covers all four ColorMode → ColorModel mappings.
+func TestParserColorToProto(t *testing.T) {
+	tests := []struct {
+		name      string
+		color     parser.Color
+		wantModel protocol.ColorModel
+		wantValue uint32
+	}{
+		{
+			name:      "Default",
+			color:     parser.Color{Mode: parser.ColorModeDefault},
+			wantModel: protocol.ColorModelDefault,
+			wantValue: 0,
+		},
+		{
+			name:      "Standard ANSI16",
+			color:     parser.Color{Mode: parser.ColorModeStandard, Value: 3},
+			wantModel: protocol.ColorModelANSI16,
+			wantValue: 3,
+		},
+		{
+			name:      "256-color",
+			color:     parser.Color{Mode: parser.ColorMode256, Value: 200},
+			wantModel: protocol.ColorModelANSI256,
+			wantValue: 200,
+		},
+		{
+			name:      "RGB packed",
+			color:     parser.Color{Mode: parser.ColorModeRGB, R: 0x12, G: 0x34, B: 0x56},
+			wantModel: protocol.ColorModelRGB,
+			wantValue: (0x12 << 16) | (0x34 << 8) | 0x56,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotModel, gotValue := parserColorToProto(tc.color)
+			if gotModel != tc.wantModel {
+				t.Errorf("model: got %v want %v", gotModel, tc.wantModel)
+			}
+			if gotValue != tc.wantValue {
+				t.Errorf("value: got 0x%X want 0x%X", gotValue, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestStyleTable_AttrMapping verifies all five parser attrs map to the correct
+// protocol bits, Blink is not emitted, and AttrHasDynamic is never set.
+func TestStyleTable_AttrMapping(t *testing.T) {
+	attrCases := []struct {
+		name       string
+		parserAttr parser.Attribute
+		wantBit    uint16
+	}{
+		{"Bold", parser.AttrBold, protocol.AttrBold},
+		{"Underline", parser.AttrUnderline, protocol.AttrUnderline},
+		{"Reverse", parser.AttrReverse, protocol.AttrReverse},
+		{"Dim", parser.AttrDim, protocol.AttrDim},
+		{"Italic", parser.AttrItalic, protocol.AttrItalic},
+	}
+	for _, tc := range attrCases {
+		t.Run(tc.name, func(t *testing.T) {
+			table := newStyleTable()
+			cell := parser.Cell{Rune: 'x', Attr: tc.parserAttr}
+			idx := table.indexOf(cell)
+			entries := table.entries()
+			if int(idx) >= len(entries) {
+				t.Fatalf("index %d out of range for entries len %d", idx, len(entries))
+			}
+			entry := entries[idx]
+			if entry.AttrFlags&tc.wantBit == 0 {
+				t.Errorf("expected bit 0x%X set in AttrFlags 0x%X", tc.wantBit, entry.AttrFlags)
+			}
+			// Blink must not be set (parser has no Blink attr)
+			if entry.AttrFlags&protocol.AttrBlink != 0 {
+				t.Errorf("unexpected Blink bit in AttrFlags 0x%X", entry.AttrFlags)
+			}
+			// AttrHasDynamic must not be set
+			if entry.AttrFlags&protocol.AttrHasDynamic != 0 {
+				t.Errorf("unexpected AttrHasDynamic bit in AttrFlags 0x%X", entry.AttrFlags)
+			}
+		})
+	}
+}
+
+// TestEncodeParserCellsToSpans_Empty verifies empty input produces nil/empty spans
+// and leaves the style table untouched.
+func TestEncodeParserCellsToSpans_Empty(t *testing.T) {
+	table := newStyleTable()
+	spans := encodeParserCellsToSpans(nil, table)
+	if len(spans) != 0 {
+		t.Fatalf("expected no spans for empty input, got %d", len(spans))
+	}
+	if len(table.entries()) != 0 {
+		t.Fatalf("expected no style entries for empty input, got %d", len(table.entries()))
+	}
+}

--- a/internal/runtime/server/fetch_range_handler.go
+++ b/internal/runtime/server/fetch_range_handler.go
@@ -33,7 +33,7 @@ func ServeFetchRange(st *sparse.Store, req protocol.FetchRange, revision uint32)
 		return resp, nil
 	}
 	oldest := st.OldestRetained()
-	if oldest == -1 || req.LoIdx < oldest {
+	if oldest != -1 && req.LoIdx < oldest {
 		resp.Flags |= protocol.FetchRangeBelowRetention
 	}
 	table := newStyleTable()

--- a/internal/runtime/server/fetch_range_handler.go
+++ b/internal/runtime/server/fetch_range_handler.go
@@ -1,0 +1,60 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// fetchRangeProvider is implemented by apps that can serve scrollback fetches.
+// Live implementation: *texelterm.TexelTerm.
+type fetchRangeProvider interface {
+	InAltScreen() bool
+	SparseStore() *sparse.Store
+}
+
+// ServeFetchRange reads rows [lo, hi) from the sparse store and returns a
+// FetchRangeResponse stamped with the provided revision. Cold pages are
+// expected to have been faulted in by the Store's own persistence bridge
+// before this call; ServeFetchRange does not drive page loads itself.
+//
+// If any row in the range has globalIdx below Store.OldestRetained(), the
+// response flags include FetchRangeBelowRetention.
+func ServeFetchRange(st *sparse.Store, req protocol.FetchRange, revision uint32) (protocol.FetchRangeResponse, error) {
+	resp := protocol.FetchRangeResponse{
+		RequestID: req.RequestID,
+		PaneID:    req.PaneID,
+		Revision:  revision,
+	}
+	if req.LoIdx >= req.HiIdx {
+		resp.Flags |= protocol.FetchRangeEmpty
+		return resp, nil
+	}
+	oldest := st.OldestRetained()
+	if oldest == -1 || req.LoIdx < oldest {
+		resp.Flags |= protocol.FetchRangeBelowRetention
+	}
+	table := newStyleTable()
+	for idx := req.LoIdx; idx < req.HiIdx; idx++ {
+		cells := st.GetLine(idx)
+		if cells == nil {
+			continue
+		}
+		row := protocol.LogicalRow{
+			GlobalIdx: idx,
+			NoWrap:    st.RowNoWrap(idx),
+		}
+		row.Spans = encodeParserCellsToSpans(cells, table)
+		if n := len(cells); n > 0 && cells[n-1].Wrapped {
+			row.Wrapped = true
+		}
+		resp.Rows = append(resp.Rows, row)
+	}
+	resp.Styles = table.entries()
+	if len(resp.Rows) == 0 && resp.Flags&protocol.FetchRangeBelowRetention == 0 {
+		resp.Flags |= protocol.FetchRangeEmpty
+	}
+	return resp, nil
+}

--- a/internal/runtime/server/fetch_range_handler.go
+++ b/internal/runtime/server/fetch_range_handler.go
@@ -4,6 +4,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
 	"github.com/framegrace/texelation/protocol"
 )
@@ -46,7 +48,11 @@ func ServeFetchRange(st *sparse.Store, req protocol.FetchRange, revision uint32)
 			GlobalIdx: idx,
 			NoWrap:    st.RowNoWrap(idx),
 		}
-		row.Spans = encodeParserCellsToSpans(cells, table)
+		spans, encErr := encodeParserCellsToSpans(cells, table)
+		if encErr != nil {
+			return resp, fmt.Errorf("encode spans: %w", encErr)
+		}
+		row.Spans = spans
 		if n := len(cells); n > 0 && cells[n-1].Wrapped {
 			row.Wrapped = true
 		}

--- a/internal/runtime/server/fetch_range_handler_test.go
+++ b/internal/runtime/server/fetch_range_handler_test.go
@@ -34,6 +34,24 @@ func TestFetchRangeHandler_Basic(t *testing.T) {
 	}
 }
 
+func TestFetchRangeHandler_EmptyStoreNotBelowRetention(t *testing.T) {
+	st := sparse.NewStore(80)
+	// No writes — OldestRetained() returns -1.
+	resp, err := ServeFetchRange(st, protocol.FetchRange{
+		LoIdx: 0,
+		HiIdx: 10,
+	}, 0)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if resp.Flags&protocol.FetchRangeBelowRetention != 0 {
+		t.Fatalf("expected no BelowRetention flag on empty store, got flags=%b", resp.Flags)
+	}
+	if resp.Flags&protocol.FetchRangeEmpty == 0 {
+		t.Fatalf("expected FetchRangeEmpty flag on empty store, got flags=%b", resp.Flags)
+	}
+}
+
 func TestFetchRangeHandler_BelowRetention(t *testing.T) {
 	st := sparse.NewStore(80)
 	st.Set(500, 0, parser.Cell{Rune: 'a'})

--- a/internal/runtime/server/fetch_range_handler_test.go
+++ b/internal/runtime/server/fetch_range_handler_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestFetchRangeHandler_Basic(t *testing.T) {
+	st := sparse.NewStore(80)
+	st.Set(100, 0, parser.Cell{Rune: 'a'})
+	st.Set(101, 0, parser.Cell{Rune: 'b'})
+
+	resp, err := ServeFetchRange(st, protocol.FetchRange{
+		LoIdx: 100,
+		HiIdx: 102,
+	}, 42)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if resp.Revision != 42 {
+		t.Fatalf("revision: got %d want 42", resp.Revision)
+	}
+	if len(resp.Rows) != 2 {
+		t.Fatalf("rows: got %d want 2", len(resp.Rows))
+	}
+	if resp.Rows[0].GlobalIdx != 100 {
+		t.Fatalf("row[0].GlobalIdx: got %d want 100", resp.Rows[0].GlobalIdx)
+	}
+}
+
+func TestFetchRangeHandler_BelowRetention(t *testing.T) {
+	st := sparse.NewStore(80)
+	st.Set(500, 0, parser.Cell{Rune: 'a'})
+	resp, err := ServeFetchRange(st, protocol.FetchRange{
+		LoIdx: 0,
+		HiIdx: 10,
+	}, 1)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if resp.Flags&protocol.FetchRangeBelowRetention == 0 {
+		t.Fatalf("expected BelowRetention flag")
+	}
+}

--- a/internal/runtime/server/fetch_range_handler_test.go
+++ b/internal/runtime/server/fetch_range_handler_test.go
@@ -66,3 +66,117 @@ func TestFetchRangeHandler_BelowRetention(t *testing.T) {
 		t.Fatalf("expected BelowRetention flag")
 	}
 }
+
+func TestFetchRangeHandler_EmptyRange(t *testing.T) {
+	st := sparse.NewStore(80)
+	st.Set(50, 0, parser.Cell{Rune: 'x'})
+
+	req := protocol.FetchRange{
+		RequestID: 0xABCD,
+		PaneID:    [16]byte{0x01, 0x02},
+		LoIdx:     10,
+		HiIdx:     10, // empty range: lo == hi
+	}
+	resp, err := ServeFetchRange(st, req, 7)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if resp.Flags&protocol.FetchRangeEmpty == 0 {
+		t.Fatalf("expected FetchRangeEmpty flag, got flags=%b", resp.Flags)
+	}
+	if resp.RequestID != req.RequestID {
+		t.Fatalf("RequestID echo: got %d want %d", resp.RequestID, req.RequestID)
+	}
+	if resp.PaneID != req.PaneID {
+		t.Fatalf("PaneID echo mismatch")
+	}
+}
+
+func TestFetchRangeHandler_SparseHoles(t *testing.T) {
+	st := sparse.NewStore(80)
+	st.Set(100, 0, parser.Cell{Rune: 'a'})
+	// idx 101 intentionally omitted — sparse hole
+	st.Set(102, 0, parser.Cell{Rune: 'c'})
+
+	resp, err := ServeFetchRange(st, protocol.FetchRange{
+		LoIdx: 100,
+		HiIdx: 103,
+	}, 1)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if len(resp.Rows) != 2 {
+		t.Fatalf("rows: got %d want 2", len(resp.Rows))
+	}
+	if resp.Rows[0].GlobalIdx != 100 {
+		t.Fatalf("row[0].GlobalIdx: got %d want 100", resp.Rows[0].GlobalIdx)
+	}
+	if resp.Rows[1].GlobalIdx != 102 {
+		t.Fatalf("row[1].GlobalIdx: got %d want 102", resp.Rows[1].GlobalIdx)
+	}
+}
+
+func TestFetchRangeHandler_FlagPropagation(t *testing.T) {
+	st := sparse.NewStore(80)
+
+	// Row 200: last cell has Wrapped=true
+	st.Set(200, 0, parser.Cell{Rune: 'a'})
+	st.Set(200, 1, parser.Cell{Rune: 'b', Wrapped: true})
+
+	// Row 201: NoWrap set via SetRowNoWrap
+	st.Set(201, 0, parser.Cell{Rune: 'x'})
+	st.SetRowNoWrap(201, true)
+
+	resp, err := ServeFetchRange(st, protocol.FetchRange{
+		LoIdx: 200,
+		HiIdx: 202,
+	}, 1)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if len(resp.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(resp.Rows))
+	}
+
+	row200 := resp.Rows[0]
+	if row200.GlobalIdx != 200 {
+		t.Fatalf("row200 GlobalIdx: got %d want 200", row200.GlobalIdx)
+	}
+	if !row200.Wrapped {
+		t.Fatalf("row200: expected Wrapped=true")
+	}
+
+	row201 := resp.Rows[1]
+	if row201.GlobalIdx != 201 {
+		t.Fatalf("row201 GlobalIdx: got %d want 201", row201.GlobalIdx)
+	}
+	if !row201.NoWrap {
+		t.Fatalf("row201: expected NoWrap=true")
+	}
+}
+
+func TestFetchRangeHandler_RequestIDAndPaneIDEcho(t *testing.T) {
+	st := sparse.NewStore(80)
+	st.Set(0, 0, parser.Cell{Rune: 'z'})
+
+	paneID := [16]byte{
+		0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x01, 0x02, 0x03,
+		0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+	}
+	req := protocol.FetchRange{
+		RequestID: 0xCAFEBABE,
+		PaneID:    paneID,
+		LoIdx:     0,
+		HiIdx:     1,
+	}
+	resp, err := ServeFetchRange(st, req, 99)
+	if err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+	if resp.RequestID != 0xCAFEBABE {
+		t.Fatalf("RequestID: got 0x%X want 0xCAFEBABE", resp.RequestID)
+	}
+	if resp.PaneID != paneID {
+		t.Fatalf("PaneID mismatch: got %v want %v", resp.PaneID, paneID)
+	}
+}

--- a/internal/runtime/server/offline_resume_mem_test.go
+++ b/internal/runtime/server/offline_resume_mem_test.go
@@ -38,13 +38,31 @@ func (offlineScreenDriver) GetContent(int, int) (rune, []rune, tcell.Style, int)
 	return ' ', nil, tcell.StyleDefault, 1
 }
 
-type offlineApp struct{ title string }
+type offlineApp struct {
+	title string
+	// tick advances on every Render so consecutive publishes produce distinct
+	// BufferDeltas. The publisher diffs on content equality and skips empty
+	// deltas, so a static buffer would never enqueue anything past the first
+	// publish.
+	tick rune
+}
 
 func (o *offlineApp) Run() error            { return nil }
 func (o *offlineApp) Stop()                 {}
 func (o *offlineApp) Resize(cols, rows int) {}
+// nonDefaultStyle is any non-zero tcell.Style — BufferWidget.Draw skips cells
+// where style == (tcell.Style{}) (which is tcell.StyleDefault), so a literal
+// StyleDefault would render as a blank and nothing would change between
+// publishes. Foreground-white is enough to get the cell painted.
+var nonDefaultStyle = tcell.StyleDefault.Foreground(tcell.ColorWhite)
+
 func (o *offlineApp) Render() [][]texelcore.Cell {
-	return [][]texelcore.Cell{{{Ch: 'z', Style: tcell.StyleDefault}}}
+	if o.tick == 0 {
+		o.tick = 'a'
+	} else {
+		o.tick++
+	}
+	return [][]texelcore.Cell{{{Ch: o.tick, Style: nonDefaultStyle}}}
 }
 func (o *offlineApp) GetTitle() string               { return o.title }
 func (o *offlineApp) HandleKey(ev *tcell.EventKey)   {}
@@ -64,6 +82,15 @@ func TestOfflineRetentionAndResumeWithMemConn(t *testing.T) {
 	}
 	defer desktop.Close()
 
+	// Bootstrap an active workspace with a pane so the server has something to
+	// snapshot; NewDesktopEngineWithDriver leaves the desktop empty because
+	// InitAppName is "" and no workspace has been activated yet. Without this
+	// sendSnapshot sees Panes=0 and returns silently, hanging the client.
+	desktop.SwitchToWorkspace(1)
+	if ws := desktop.ActiveWorkspace(); ws != nil {
+		ws.AddApp(app)
+	}
+
 	sink := NewDesktopSink(desktop)
 	srv := &Server{manager: mgr, sink: sink, desktopSink: sink}
 
@@ -80,7 +107,15 @@ func TestOfflineRetentionAndResumeWithMemConn(t *testing.T) {
 		t.Fatalf("publisher not set after initial handshake")
 	}
 
+	// Invalidate each pane's render cache between publishes so the offlineApp
+	// observes distinct Render() ticks. Without this the render cache returns
+	// the same buffer across Publish() calls and the publisher skips empty
+	// deltas, leaving nothing for the retention limit to clamp.
+	ws := desktop.ActiveWorkspace()
 	for i := 0; i < 4; i++ {
+		if ws != nil {
+			ws.InvalidateRenderCaches()
+		}
 		if err := pub.Publish(); err != nil {
 			t.Fatalf("offline publish failed: %v", err)
 		}

--- a/internal/runtime/server/offline_resume_mem_test.go
+++ b/internal/runtime/server/offline_resume_mem_test.go
@@ -125,6 +125,15 @@ func TestOfflineRetentionAndResumeWithMemConn(t *testing.T) {
 		t.Fatalf("expected retention limit of 2 diffs, got %d", len(pending))
 	}
 
+	// Pre-resume: we pushed 4 publishes into a retention limit of 2, so the
+	// session must have dropped at least 2 diffs. Asserting this before
+	// resume catches a regression where retention silently stopped dropping
+	// (the post-resume check alone would still pass with DroppedDiffs == 1).
+	preResumeStats := session.Stats()
+	if preResumeStats.DroppedDiffs < 2 {
+		t.Fatalf("expected >= 2 DroppedDiffs before resume, got %d", preResumeStats.DroppedDiffs)
+	}
+
 	resumeClientFlow(t, srv, sink, desktop, session, lastSeq)
 
 	stats := session.Stats()

--- a/internal/runtime/server/session.go
+++ b/internal/runtime/server/session.go
@@ -55,13 +55,19 @@ type Session struct {
 	maxDiffs       int
 	droppedDiffs   uint64
 	lastDroppedSeq uint64
+	viewports      *ClientViewports
 }
 
 func NewSession(id [16]byte, maxDiffs int) *Session {
 	if maxDiffs < 0 {
 		maxDiffs = 0
 	}
-	return &Session{id: id, diffs: make([]DiffPacket, 0, 128), maxDiffs: maxDiffs}
+	return &Session{id: id, diffs: make([]DiffPacket, 0, 128), maxDiffs: maxDiffs, viewports: NewClientViewports()}
+}
+
+// ApplyViewportUpdate records the client's current viewport for a pane.
+func (s *Session) ApplyViewportUpdate(u protocol.ViewportUpdate) {
+	s.viewports.Apply(u)
 }
 
 func (s *Session) setMaxDiffs(limit int) {

--- a/internal/runtime/server/session.go
+++ b/internal/runtime/server/session.go
@@ -70,6 +70,12 @@ func (s *Session) ApplyViewportUpdate(u protocol.ViewportUpdate) {
 	s.viewports.Apply(u)
 }
 
+// Viewport returns the client-reported viewport for the given pane, or
+// false if the client has not sent one yet.
+func (s *Session) Viewport(paneID [16]byte) (ClientViewport, bool) {
+	return s.viewports.Get(paneID)
+}
+
 func (s *Session) setMaxDiffs(limit int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/runtime/server/session_test.go
+++ b/internal/runtime/server/session_test.go
@@ -59,7 +59,8 @@ func TestSessionRetentionLimit(t *testing.T) {
 		return protocol.BufferDelta{
 			PaneID:   id,
 			Revision: seq,
-			Rows:     []protocol.RowDelta{{Row: 0, Spans: []protocol.CellSpan{{Text: text}}}},
+			Styles:   []protocol.StyleEntry{{}},
+			Rows:     []protocol.RowDelta{{Row: 0, Spans: []protocol.CellSpan{{Text: text, StyleIndex: 0}}}},
 		}
 	}
 

--- a/internal/runtime/server/snapshot_store.go
+++ b/internal/runtime/server/snapshot_store.go
@@ -275,13 +275,31 @@ func (sp StoredPane) ToPaneSnapshot() texel.PaneSnapshot {
 	}
 
 	return texel.PaneSnapshot{
-		ID:        id,
-		Title:     sp.Title,
-		Buffer:    buffer,
-		Rect:      texel.Rectangle{X: sp.X, Y: sp.Y, Width: sp.Width, Height: sp.Height},
-		AppType:   sp.AppType,
-		AppConfig: cloneAppConfig(sp.AppConfig),
+		ID:           id,
+		Title:        sp.Title,
+		Buffer:       buffer,
+		RowGlobalIdx: rowGlobalIdxAllMinusOne(len(buffer)),
+		Rect:         texel.Rectangle{X: sp.X, Y: sp.Y, Width: sp.Width, Height: sp.Height},
+		AppType:      sp.AppType,
+		AppConfig:    cloneAppConfig(sp.AppConfig),
 	}
+}
+
+// rowGlobalIdxAllMinusOne returns a slice of length n with every entry set
+// to -1. Shared by PaneSnapshot reconstructors in this package (persisted
+// store and wire-protocol paths), which carry no main-screen scrollback
+// indices and must mark every row as non-main-screen content. The
+// PaneSnapshot invariant requires RowGlobalIdx parallel Buffer when Buffer
+// is non-nil.
+func rowGlobalIdxAllMinusOne(n int) []int64 {
+	if n <= 0 {
+		return nil
+	}
+	out := make([]int64, n)
+	for i := range out {
+		out[i] = -1
+	}
+	return out
 }
 
 func (sp StoredPane) toProtocolPane() protocol.PaneSnapshot {

--- a/internal/runtime/server/snapshot_store_test.go
+++ b/internal/runtime/server/snapshot_store_test.go
@@ -102,6 +102,14 @@ func TestStoredPaneConversionsPreserveContent(t *testing.T) {
 	if pane.AppType != "app" {
 		t.Fatalf("app type not preserved")
 	}
+	if len(pane.RowGlobalIdx) != len(pane.Buffer) {
+		t.Fatalf("RowGlobalIdx must parallel Buffer: len(RowGlobalIdx)=%d len(Buffer)=%d", len(pane.RowGlobalIdx), len(pane.Buffer))
+	}
+	for i, idx := range pane.RowGlobalIdx {
+		if idx != -1 {
+			t.Fatalf("expected reconstructed RowGlobalIdx[%d] == -1, got %d", i, idx)
+		}
+	}
 	pane.AppConfig["flag"] = false
 	if stored.AppConfig["flag"] != true {
 		t.Fatalf("app config should be cloned")

--- a/internal/runtime/server/tree_convert.go
+++ b/internal/runtime/server/tree_convert.go
@@ -48,12 +48,13 @@ func protocolToTreeCapture(snapshot protocol.TreeSnapshot) texel.TreeCapture {
 			}
 		}
 		capture.Panes[i] = texel.PaneSnapshot{
-			ID:        pane.PaneID,
-			Title:     pane.Title,
-			Buffer:    buffer,
-			Rect:      texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
-			AppType:   pane.AppType,
-			AppConfig: decodeAppConfig(pane.AppConfig),
+			ID:           pane.PaneID,
+			Title:        pane.Title,
+			Buffer:       buffer,
+			RowGlobalIdx: rowGlobalIdxAllMinusOne(len(buffer)),
+			Rect:         texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
+			AppType:      pane.AppType,
+			AppConfig:    decodeAppConfig(pane.AppConfig),
 		}
 	}
 	capture.Root = protocolNodeToCapture(snapshot.Root)

--- a/internal/runtime/server/tree_convert_test.go
+++ b/internal/runtime/server/tree_convert_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/tree_convert_test.go
+// Summary: Exercises protocol<->tree capture conversions for the server runtime.
+// Usage: Executed during `go test` to guard against regressions.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestProtocolToTreeCapturePopulatesRowGlobalIdx(t *testing.T) {
+	paneID := [16]byte{0x01, 0x02, 0x03}
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{
+				PaneID: paneID,
+				Title:  "pane",
+				Rows:   []string{"abc", "def", "ghi"},
+				X:      0, Y: 0, Width: 3, Height: 3,
+			},
+		},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+
+	capture := protocolToTreeCapture(snap)
+	if len(capture.Panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(capture.Panes))
+	}
+	pane := capture.Panes[0]
+	if len(pane.Buffer) != 3 {
+		t.Fatalf("expected buffer length 3, got %d", len(pane.Buffer))
+	}
+	if len(pane.RowGlobalIdx) != len(pane.Buffer) {
+		t.Fatalf("RowGlobalIdx must parallel Buffer: len(RowGlobalIdx)=%d len(Buffer)=%d", len(pane.RowGlobalIdx), len(pane.Buffer))
+	}
+	for i, idx := range pane.RowGlobalIdx {
+		if idx != -1 {
+			t.Fatalf("expected reconstructed RowGlobalIdx[%d] == -1, got %d", i, idx)
+		}
+	}
+}
+
+func TestProtocolToTreeCaptureEmptyRows(t *testing.T) {
+	// A pane with no rows produces a zero-length Buffer; the invariant
+	// holds trivially (len(RowGlobalIdx) == len(Buffer) == 0) whether
+	// RowGlobalIdx is nil or an empty slice.
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{PaneID: [16]byte{0xaa}, Title: "empty", Rows: nil, Width: 0, Height: 0},
+		},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+
+	capture := protocolToTreeCapture(snap)
+	pane := capture.Panes[0]
+	if len(pane.RowGlobalIdx) != len(pane.Buffer) {
+		t.Fatalf("invariant violated: len(RowGlobalIdx)=%d len(Buffer)=%d", len(pane.RowGlobalIdx), len(pane.Buffer))
+	}
+}

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -260,11 +260,12 @@ type memHarness struct {
 
 	readerDone chan struct{}
 
-	mu           sync.Mutex
-	rowsByGID    map[int64]protocol.RowDelta    // main-screen rows keyed by globalIdx
-	altRowsByIdx map[uint16][]protocol.CellSpan // alt-screen rows keyed by flat row index
-	fetchByReqID map[uint32]protocol.FetchRangeResponse
-	writeMu      sync.Mutex // client-side write serialization
+	mu             sync.Mutex
+	rowsByGID      map[int64]protocol.RowDelta    // main-screen rows keyed by globalIdx
+	altRowsByIdx   map[uint16][]protocol.CellSpan // alt-screen rows keyed by flat row index
+	fetchByReqID   map[uint32]protocol.FetchRangeResponse
+	rowBasesByPane map[[16]byte][]int64 // every RowBase observed per pane, in order
+	writeMu        sync.Mutex           // client-side write serialization
 }
 
 type vpScreenDriver struct {
@@ -308,16 +309,17 @@ func newMemHarness(t *testing.T, cols, rows int) *memHarness {
 	srv := &Server{manager: mgr, sink: sink, desktopSink: sink}
 
 	h := &memHarness{
-		t:            t,
-		desktop:      desktop,
-		sink:         sink,
-		mgr:          mgr,
-		srv:          srv,
-		fakeApp:      fakeApp,
-		rowsByGID:    make(map[int64]protocol.RowDelta),
-		altRowsByIdx: make(map[uint16][]protocol.CellSpan),
-		fetchByReqID: make(map[uint32]protocol.FetchRangeResponse),
-		readerDone:   make(chan struct{}),
+		t:              t,
+		desktop:        desktop,
+		sink:           sink,
+		mgr:            mgr,
+		srv:            srv,
+		fakeApp:        fakeApp,
+		rowsByGID:      make(map[int64]protocol.RowDelta),
+		altRowsByIdx:   make(map[uint16][]protocol.CellSpan),
+		fetchByReqID:   make(map[uint32]protocol.FetchRangeResponse),
+		rowBasesByPane: make(map[[16]byte][]int64),
+		readerDone:     make(chan struct{}),
 	}
 
 	// Find the pane ID assigned to the shell app by the desktop.
@@ -465,6 +467,9 @@ func (h *memHarness) clientReadLoop() {
 					h.altRowsByIdx[row.Row] = spans
 				}
 			} else {
+				// Record the RowBase so tests can assert the documented
+				// clip-offset invariant (RowBase == ViewTopIdx - Rows).
+				h.rowBasesByPane[delta.PaneID] = append(h.rowBasesByPane[delta.PaneID], delta.RowBase)
 				for _, row := range delta.Rows {
 					gid := delta.RowBase + int64(row.Row)
 					spansCopy := make([]protocol.CellSpan, len(row.Spans))
@@ -689,6 +694,59 @@ func TestIntegration_ClipsAndFetches(t *testing.T) {
 	}
 	if !containsSubstring(joined, "row-content") {
 		t.Fatalf("row 4923 missing expected content %q; got %q", "row-content", joined)
+	}
+
+	// Negative-assertion phase: prove the publisher actually clips rather
+	// than emitting the full render buffer. The render buffer still spans
+	// interior gids [4923..4944] (22 rows after border trim). Shrink the
+	// viewport so the overscan window is a strict subset of that range:
+	// with top=4930, bottom=4931, Rows=2, the publisher clips to
+	// [lo, hi] = [ViewTopIdx-Rows, ViewBottomIdx+Rows] = [4928, 4933].
+	// Interior gids 4923..4927 and 4934..4944 MUST be suppressed.
+	h.mu.Lock()
+	h.rowsByGID = make(map[int64]protocol.RowDelta)
+	h.rowBasesByPane[paneID] = nil
+	h.mu.Unlock()
+
+	const narrowTop, narrowBottom = int64(4930), int64(4931)
+	h.ApplyViewport(paneID, narrowTop, narrowBottom, false, false)
+	h.Publish()
+
+	// Wait for at least one in-window row to confirm the publisher ran
+	// under the narrow viewport. Row 4930 sits inside [4928, 4933].
+	h.AwaitRow(paneID, 4930, 3*time.Second)
+
+	// The Rows-geometry change from 24 to 2 invalidates prev-buffer dedup
+	// (see publishSnapshotsLocked), so every in-window gid should have
+	// re-emitted. Any out-of-window gid appearing here would prove the
+	// publisher ignored the viewport clip.
+	const narrowRows = int64(narrowBottom - narrowTop + 1)
+	lo := narrowTop - narrowRows
+	hi := narrowBottom + narrowRows
+	interiorLo, interiorHi := int64(4923), int64(4944)
+	h.mu.Lock()
+	for gid := interiorLo; gid <= interiorHi; gid++ {
+		if gid >= lo && gid <= hi {
+			continue
+		}
+		if _, present := h.rowsByGID[gid]; present {
+			h.mu.Unlock()
+			t.Fatalf("gid %d is outside clip window [%d,%d] but was still delivered — publisher did not clip", gid, lo, hi)
+		}
+	}
+	// Belt-and-suspenders: assert the wire-level RowBase invariant. The
+	// most recent delta for this pane must carry RowBase == ViewTopIdx -
+	// Rows (= lo). Paired with the Row = uint16(gid - lo) contract, this
+	// proves the clip math end-to-end.
+	bases := h.rowBasesByPane[paneID]
+	if len(bases) == 0 {
+		h.mu.Unlock()
+		t.Fatalf("no main-screen BufferDelta observed under narrow viewport")
+	}
+	latestBase := bases[len(bases)-1]
+	h.mu.Unlock()
+	if latestBase != lo {
+		t.Fatalf("latest RowBase = %d, want %d (ViewTopIdx - Rows)", latestBase, lo)
 	}
 
 	// Clear out collected rows for the fetch-back assertion so we don't

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -1,0 +1,757 @@
+//go:build integration
+// +build integration
+
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/viewport_integration_test.go
+// Summary: End-to-end memconn integration coverage for viewport clipping +
+//   FetchRange (Plan A / issue #199).
+// Usage: go test -tags=integration ./internal/runtime/server/ -run TestIntegration_
+// Notes: Uses a sparse-backed fake app so FetchRange has a real sparse.Store
+//   to serve from. The app satisfies RowGlobalIdxProvider, AltScreenProvider,
+//   and the private fetchRangeProvider interface; that's enough for the
+//   publisher clip path and the FetchRange handler.
+
+package server
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	texelcore "github.com/framegrace/texelui/core"
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+	"github.com/framegrace/texelation/internal/runtime/server/testutil"
+	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelation/texel"
+)
+
+// nonZeroStyle is the style we use for all cells in the fake app's buffers.
+// We deliberately avoid tcell.StyleDefault because the pane's BufferWidget
+// skips cells whose Style equals the zero-value tcell.Style{} — and
+// tcell.StyleDefault IS the zero value, so using it would silently drop
+// every cell we write. Setting any non-default attribute (color, bold, etc.)
+// makes the style non-zero and the cells render.
+var nonZeroStyle = tcell.StyleDefault.Foreground(tcell.ColorWhite)
+
+// sparseFakeApp is a minimal App impl that:
+//   - Holds a sparse.Store so the FetchRange handler has something to serve.
+//   - Exposes RowGlobalIdxProvider so the publisher emits main-screen deltas.
+//   - Exposes AltScreenProvider so we can flip alt-screen for the second test.
+//   - Renders a constant per-row label ("row-<gid>") plus its globalIdx so
+//     we can identify which rows the publisher emitted.
+type sparseFakeApp struct {
+	mu         sync.Mutex
+	width      int
+	height     int
+	renderRows [][]texelcore.Cell
+	rowGIDs    []int64 // parallel to renderRows; -1 if no main-screen gid
+	store      *sparse.Store
+	altScreen  bool
+	altBuf     [][]texelcore.Cell
+	notify     chan<- bool
+}
+
+func newSparseFakeApp(cols, rows int) *sparseFakeApp {
+	a := &sparseFakeApp{
+		width:  cols,
+		height: rows,
+		store:  sparse.NewStore(cols),
+	}
+	a.resetAltBuf()
+	return a
+}
+
+func (a *sparseFakeApp) resetAltBuf() {
+	a.altBuf = make([][]texelcore.Cell, a.height)
+	for y := range a.altBuf {
+		row := make([]texelcore.Cell, a.width)
+		for x := range row {
+			row[x] = texelcore.Cell{Ch: ' ', Style: nonZeroStyle}
+		}
+		a.altBuf[y] = row
+	}
+}
+
+// FeedRows appends main-screen rows at the given starting globalIdx. Each
+// row string is placed at (startGID + i). Both the render buffer (as the
+// most-recent <height> rows) and the sparse store are updated.
+func (a *sparseFakeApp) FeedRows(startGID int64, rows []string) {
+	a.mu.Lock()
+	for i, s := range rows {
+		gid := startGID + int64(i)
+		cells := stringToParserCells(s, a.width)
+		a.store.SetLine(gid, cells)
+	}
+	// Rebuild render slice from the last <height> rows of the written range.
+	maxGID := startGID + int64(len(rows)-1)
+	a.rebuildRenderFromStoreLocked(maxGID)
+	a.mu.Unlock()
+	a.markDirty()
+}
+
+// ScrollTo sets the render buffer to show the <height> rows ending at
+// bottomGID. Used to simulate the cursor being at a specific globalIdx.
+func (a *sparseFakeApp) ScrollTo(bottomGID int64) {
+	a.mu.Lock()
+	a.rebuildRenderFromStoreLocked(bottomGID)
+	a.mu.Unlock()
+	a.markDirty()
+}
+
+func (a *sparseFakeApp) rebuildRenderFromStoreLocked(bottomGID int64) {
+	a.renderRows = make([][]texelcore.Cell, a.height)
+	a.rowGIDs = make([]int64, a.height)
+	topGID := bottomGID - int64(a.height-1)
+	for y := 0; y < a.height; y++ {
+		gid := topGID + int64(y)
+		a.rowGIDs[y] = gid
+		cells := a.store.GetLine(gid)
+		row := make([]texelcore.Cell, a.width)
+		for x := range row {
+			row[x] = texelcore.Cell{Ch: ' ', Style: nonZeroStyle}
+		}
+		for x, c := range cells {
+			if x >= a.width {
+				break
+			}
+			row[x] = texelcore.Cell{Ch: c.Rune, Style: nonZeroStyle}
+		}
+		a.renderRows[y] = row
+	}
+}
+
+// EnterAltScreen flips to alt-screen mode and writes a single-line label.
+func (a *sparseFakeApp) EnterAltScreen(text string) {
+	a.mu.Lock()
+	a.altScreen = true
+	a.resetAltBuf()
+	for x, r := range text {
+		if x >= a.width {
+			break
+		}
+		a.altBuf[0][x] = texelcore.Cell{Ch: r, Style: nonZeroStyle}
+	}
+	a.mu.Unlock()
+	a.markDirty()
+}
+
+// App interface.
+func (a *sparseFakeApp) Run() error            { return nil }
+func (a *sparseFakeApp) Stop()                 {}
+func (a *sparseFakeApp) Resize(cols, rows int) {}
+func (a *sparseFakeApp) Render() [][]texelcore.Cell {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.altScreen {
+		out := make([][]texelcore.Cell, len(a.altBuf))
+		for y, row := range a.altBuf {
+			out[y] = make([]texelcore.Cell, len(row))
+			copy(out[y], row)
+		}
+		return out
+	}
+	if a.renderRows == nil {
+		// Default blank buffer so the pane has something to render before
+		// the test feeds it.
+		out := make([][]texelcore.Cell, a.height)
+		for y := range out {
+			out[y] = make([]texelcore.Cell, a.width)
+			for x := range out[y] {
+				out[y][x] = texelcore.Cell{Ch: ' ', Style: nonZeroStyle}
+			}
+		}
+		return out
+	}
+	out := make([][]texelcore.Cell, len(a.renderRows))
+	for y, row := range a.renderRows {
+		out[y] = make([]texelcore.Cell, len(row))
+		copy(out[y], row)
+	}
+	return out
+}
+func (a *sparseFakeApp) GetTitle() string             { return "sparseFake" }
+func (a *sparseFakeApp) HandleKey(ev *tcell.EventKey) {}
+func (a *sparseFakeApp) SetRefreshNotifier(ch chan<- bool) {
+	a.mu.Lock()
+	a.notify = ch
+	a.mu.Unlock()
+}
+
+// markDirty nudges the pane's refresh forwarder so it drops its cached
+// render and re-reads Render(). The send is blocking because we want the
+// pane's renderGen to have definitely ticked before the test proceeds to
+// take a snapshot; a non-blocking send could race with an in-flight
+// forwarder drain and be dropped silently.
+func (a *sparseFakeApp) markDirty() {
+	a.mu.Lock()
+	ch := a.notify
+	a.mu.Unlock()
+	if ch != nil {
+		ch <- true
+	}
+}
+
+// RowGlobalIdxProvider.
+func (a *sparseFakeApp) RowGlobalIdx() []int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.altScreen {
+		// No main-screen gids when in alt-screen.
+		out := make([]int64, a.height)
+		for i := range out {
+			out[i] = -1
+		}
+		return out
+	}
+	if a.rowGIDs == nil {
+		out := make([]int64, a.height)
+		for i := range out {
+			out[i] = -1
+		}
+		return out
+	}
+	out := make([]int64, len(a.rowGIDs))
+	copy(out, a.rowGIDs)
+	return out
+}
+
+// AltScreenProvider.
+func (a *sparseFakeApp) InAltScreen() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.altScreen
+}
+
+// Satisfies fetchRangeProvider (unexported — this file lives in the same
+// package, so that is fine).
+func (a *sparseFakeApp) SparseStore() *sparse.Store { return a.store }
+
+func stringToParserCells(s string, width int) []parser.Cell {
+	cells := make([]parser.Cell, 0, len(s))
+	for _, r := range s {
+		cells = append(cells, parser.Cell{Rune: r})
+		if len(cells) >= width {
+			break
+		}
+	}
+	return cells
+}
+
+// memHarness owns a server + single-client memconn and drives both sides.
+type memHarness struct {
+	t       *testing.T
+	desktop *texel.DesktopEngine
+	sink    *DesktopSink
+	mgr     *Manager
+	srv     *Server
+	session *Session
+	pub     *DesktopPublisher
+	fakeApp *sparseFakeApp
+	paneID  [16]byte
+
+	serverConn *testutil.MemConn
+	clientConn *testutil.MemConn
+
+	readerDone chan struct{}
+
+	mu           sync.Mutex
+	rowsByGID    map[int64]protocol.RowDelta    // main-screen rows keyed by globalIdx
+	altRowsByIdx map[uint16][]protocol.CellSpan // alt-screen rows keyed by flat row index
+	fetchByReqID map[uint32]protocol.FetchRangeResponse
+	writeMu      sync.Mutex // client-side write serialization
+}
+
+type vpScreenDriver struct {
+	cols, rows int
+}
+
+func (d vpScreenDriver) Init() error                                    { return nil }
+func (d vpScreenDriver) Fini()                                          {}
+func (d vpScreenDriver) Size() (int, int)                               { return d.cols, d.rows }
+func (d vpScreenDriver) SetStyle(tcell.Style)                           {}
+func (d vpScreenDriver) HideCursor()                                    {}
+func (d vpScreenDriver) Show()                                          {}
+func (d vpScreenDriver) PollEvent() tcell.Event                         { return nil }
+func (d vpScreenDriver) SetContent(int, int, rune, []rune, tcell.Style) {}
+func (d vpScreenDriver) GetContent(int, int) (rune, []rune, tcell.Style, int) {
+	return ' ', nil, nonZeroStyle, 1
+}
+
+// newMemHarness wires everything up and performs the initial handshake so
+// the test can immediately push viewports / feed rows / call FetchRange.
+func newMemHarness(t *testing.T, cols, rows int) *memHarness {
+	t.Helper()
+	fakeApp := newSparseFakeApp(cols, rows)
+	driver := vpScreenDriver{cols: cols, rows: rows}
+	lifecycle := texel.NoopAppLifecycle{}
+	shellFactory := func() texelcore.App { return fakeApp }
+	desktop, err := texel.NewDesktopEngineWithDriver(driver, shellFactory, "texelterm", &lifecycle)
+	if err != nil {
+		t.Fatalf("NewDesktopEngineWithDriver: %v", err)
+	}
+	t.Cleanup(func() {
+		desktop.Close()
+	})
+	// Create the default workspace and attach the shell app so a pane
+	// exists for the rest of the wiring to target.
+	desktop.SwitchToWorkspace(1)
+	desktop.SetViewportSize(cols, rows)
+
+	mgr := NewManager()
+	sink := NewDesktopSink(desktop)
+	srv := &Server{manager: mgr, sink: sink, desktopSink: sink}
+
+	h := &memHarness{
+		t:            t,
+		desktop:      desktop,
+		sink:         sink,
+		mgr:          mgr,
+		srv:          srv,
+		fakeApp:      fakeApp,
+		rowsByGID:    make(map[int64]protocol.RowDelta),
+		altRowsByIdx: make(map[uint16][]protocol.CellSpan),
+		fetchByReqID: make(map[uint32]protocol.FetchRangeResponse),
+		readerDone:   make(chan struct{}),
+	}
+
+	// Find the pane ID assigned to the shell app by the desktop.
+	var foundID [16]byte
+	for _, snap := range desktop.SnapshotBuffers() {
+		if snap.Title == fakeApp.GetTitle() {
+			foundID = snap.ID
+			break
+		}
+	}
+	if foundID == ([16]byte{}) {
+		t.Fatalf("could not locate pane hosting sparseFakeApp")
+	}
+	h.paneID = foundID
+
+	h.serverConn, h.clientConn = testutil.NewMemPipe(64)
+	t.Cleanup(func() {
+		_ = h.serverConn.Close()
+		_ = h.clientConn.Close()
+	})
+
+	serveErrCh := make(chan error, 1)
+	sessCh := make(chan *Session, 1)
+
+	go func() {
+		defer h.serverConn.Close()
+		sess, resuming, err := handleHandshake(h.serverConn, mgr)
+		if err != nil {
+			serveErrCh <- err
+			return
+		}
+		pub := NewDesktopPublisher(desktop, sess)
+		sink.SetPublisher(pub)
+		conn := newConnection(h.serverConn, sess, sink, resuming)
+		// Wire nudge so sendPending fires when publisher queues diffs.
+		pub.SetNotifier(conn.nudge)
+		h.mu.Lock()
+		h.session = sess
+		h.pub = pub
+		h.mu.Unlock()
+		sessCh <- sess
+		serveErrCh <- conn.serve()
+	}()
+
+	// Client-side handshake.
+	helloPayload, _ := protocol.EncodeHello(protocol.Hello{ClientName: "intg-client"})
+	h.writeFrame(protocol.MsgHello, helloPayload, [16]byte{})
+	if _, _, err := protocol.ReadMessage(h.clientConn); err != nil {
+		t.Fatalf("read welcome: %v", err)
+	}
+
+	connectReq, _ := protocol.EncodeConnectRequest(protocol.ConnectRequest{})
+	h.writeFrame(protocol.MsgConnectRequest, connectReq, [16]byte{})
+
+	// Read MsgConnectAccept (skip any non-target frames in case).
+	for {
+		hdr, payload, err := protocol.ReadMessage(h.clientConn)
+		if err != nil {
+			t.Fatalf("read connect accept: %v", err)
+		}
+		if hdr.Type == protocol.MsgConnectAccept {
+			if _, err := protocol.DecodeConnectAccept(payload); err != nil {
+				t.Fatalf("decode connect accept: %v", err)
+			}
+			break
+		}
+	}
+
+	select {
+	case <-sessCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("session did not materialize after handshake")
+	}
+
+	// Now spin up the client reader that stashes inbound frames for lookup.
+	go h.clientReadLoop()
+
+	// Collect the server-side teardown error on cleanup.
+	t.Cleanup(func() {
+		_ = h.clientConn.Close()
+		// Drain the serve goroutine.
+		select {
+		case err := <-serveErrCh:
+			if err != nil && err != io.EOF {
+				// Informational — shutdown races are benign.
+				t.Logf("server serve exit: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Log("server serve goroutine did not exit cleanly")
+		}
+		<-h.readerDone
+	})
+
+	return h
+}
+
+// writeFrame writes one protocol frame from the client side. Serialised.
+func (h *memHarness) writeFrame(msgType protocol.MessageType, payload []byte, sessionID [16]byte) {
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      msgType,
+		Flags:     protocol.FlagChecksum,
+		SessionID: sessionID,
+	}
+	if err := protocol.WriteMessage(h.clientConn, hdr, payload); err != nil {
+		h.t.Fatalf("write frame type=%v: %v", msgType, err)
+	}
+}
+
+func (h *memHarness) sessionID() [16]byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.session == nil {
+		return [16]byte{}
+	}
+	return h.session.ID()
+}
+
+// clientReadLoop reads inbound frames forever and files them into the
+// per-pane row maps / fetch response map.
+func (h *memHarness) clientReadLoop() {
+	defer close(h.readerDone)
+	for {
+		hdr, payload, err := protocol.ReadMessage(h.clientConn)
+		if err != nil {
+			return
+		}
+		switch hdr.Type {
+		case protocol.MsgBufferDelta:
+			delta, derr := protocol.DecodeBufferDelta(payload)
+			if derr != nil {
+				h.t.Logf("client decode buffer delta: %v", derr)
+				continue
+			}
+			if delta.PaneID != h.paneID {
+				continue
+			}
+			h.mu.Lock()
+			if delta.Flags&protocol.BufferDeltaAltScreen != 0 {
+				for _, row := range delta.Rows {
+					spans := make([]protocol.CellSpan, len(row.Spans))
+					copy(spans, row.Spans)
+					h.altRowsByIdx[row.Row] = spans
+				}
+			} else {
+				for _, row := range delta.Rows {
+					gid := delta.RowBase + int64(row.Row)
+					spansCopy := make([]protocol.CellSpan, len(row.Spans))
+					copy(spansCopy, row.Spans)
+					h.rowsByGID[gid] = protocol.RowDelta{Row: row.Row, Spans: spansCopy}
+				}
+			}
+			h.mu.Unlock()
+			// Ack the delta so the session queue stays bounded.
+			ackPayload, _ := protocol.EncodeBufferAck(protocol.BufferAck{Sequence: hdr.Sequence})
+			h.writeFrame(protocol.MsgBufferAck, ackPayload, h.sessionID())
+		case protocol.MsgFetchRangeResponse:
+			resp, derr := protocol.DecodeFetchRangeResponse(payload)
+			if derr != nil {
+				h.t.Logf("client decode fetch response: %v", derr)
+				continue
+			}
+			h.mu.Lock()
+			h.fetchByReqID[resp.RequestID] = resp
+			h.mu.Unlock()
+		default:
+			// Silently discard other messages (PaneFocus, StateUpdate, etc.).
+		}
+	}
+}
+
+// ApplyViewport sends MsgViewportUpdate and waits for the server to record it.
+func (h *memHarness) ApplyViewport(paneID [16]byte, top, bottom int64, autoFollow bool, altScreen bool) {
+	vp := protocol.ViewportUpdate{
+		PaneID:        paneID,
+		AltScreen:     altScreen,
+		ViewTopIdx:    top,
+		ViewBottomIdx: bottom,
+		Rows:          uint16(bottom - top + 1),
+		Cols:          uint16(h.fakeApp.width),
+		AutoFollow:    autoFollow,
+	}
+	payload, err := protocol.EncodeViewportUpdate(vp)
+	if err != nil {
+		h.t.Fatalf("encode viewport update: %v", err)
+	}
+	h.writeFrame(protocol.MsgViewportUpdate, payload, h.sessionID())
+
+	// Poll until the session shows the viewport — the server applies it
+	// asynchronously in the serve loop.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, ok := h.session.Viewport(paneID); ok {
+			if got.ViewTopIdx == top && got.ViewBottomIdx == bottom && got.AutoFollow == autoFollow {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	h.t.Fatalf("server did not record viewport top=%d bottom=%d within 2s", top, bottom)
+}
+
+// Publish triggers the publisher and flushes pending diffs onto the wire.
+func (h *memHarness) Publish() {
+	h.sink.Publish()
+}
+
+// AwaitRow waits for a main-screen row with globalIdx == gid to arrive from
+// the server. Returns the first matching RowDelta.
+func (h *memHarness) AwaitRow(paneID [16]byte, gid int64, timeout time.Duration) protocol.RowDelta {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		rd, ok := h.rowsByGID[gid]
+		h.mu.Unlock()
+		if ok {
+			return rd
+		}
+		// Nudge publish every few polls in case the server was waiting on us.
+		h.Publish()
+		time.Sleep(10 * time.Millisecond)
+	}
+	h.mu.Lock()
+	seen := make([]int64, 0, len(h.rowsByGID))
+	for k := range h.rowsByGID {
+		seen = append(seen, k)
+	}
+	h.mu.Unlock()
+	h.t.Fatalf("did not receive row for globalIdx=%d within %v (saw %d rows, first gids=%v)", gid, timeout, len(seen), truncate(seen, 20))
+	return protocol.RowDelta{}
+}
+
+func truncate(xs []int64, n int) []int64 {
+	if len(xs) <= n {
+		return xs
+	}
+	return xs[:n]
+}
+
+// AwaitAltRow waits for an alt-screen row with the given flat index and
+// whose decoded text contains want.
+func (h *memHarness) AwaitAltRow(paneID [16]byte, row uint16, want string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		spans, ok := h.altRowsByIdx[row]
+		h.mu.Unlock()
+		if ok && spansContain(spans, want) {
+			return
+		}
+		h.Publish()
+		time.Sleep(10 * time.Millisecond)
+	}
+	h.mu.Lock()
+	keys := make([]uint16, 0, len(h.altRowsByIdx))
+	for k := range h.altRowsByIdx {
+		keys = append(keys, k)
+	}
+	// Dump row=1 content if we have it.
+	var r1 string
+	if spans, ok := h.altRowsByIdx[1]; ok {
+		for _, s := range spans {
+			r1 += s.Text
+		}
+	}
+	nRows := len(h.rowsByGID)
+	h.mu.Unlock()
+	h.t.Fatalf("did not receive alt row=%d containing %q within %v (altKeys=%v row1=%q mainRows=%d)", row, want, timeout, keys, r1, nRows)
+}
+
+func spansContain(spans []protocol.CellSpan, want string) bool {
+	// Concatenate all spans in the row and check for want anywhere inside.
+	// Pane renders add border characters at column 0 / width-1, so we can't
+	// rely on want being at the start of the first span.
+	var joined string
+	for _, s := range spans {
+		joined += s.Text
+	}
+	return containsSubstring(joined, want)
+}
+
+func containsSubstring(s, sub string) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// FetchRangeSync blocks until a FetchRangeResponse matching the RequestID we
+// send arrives on the wire.
+func (h *memHarness) FetchRangeSync(paneID [16]byte, lo, hi int64) protocol.FetchRangeResponse {
+	reqID := uint32(time.Now().UnixNano() & 0xffffffff)
+	req := protocol.FetchRange{
+		RequestID: reqID,
+		PaneID:    paneID,
+		LoIdx:     lo,
+		HiIdx:     hi,
+	}
+	payload, err := protocol.EncodeFetchRange(req)
+	if err != nil {
+		h.t.Fatalf("encode fetch range: %v", err)
+	}
+	h.writeFrame(protocol.MsgFetchRange, payload, h.sessionID())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		resp, ok := h.fetchByReqID[reqID]
+		h.mu.Unlock()
+		if ok {
+			return resp
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	h.t.Fatalf("no fetch response for request %d within 2s", reqID)
+	return protocol.FetchRangeResponse{}
+}
+
+func TestIntegration_ClipsAndFetches(t *testing.T) {
+	const cols, rows = 80, 24
+	h := newMemHarness(t, cols, rows)
+	paneID := h.paneID
+
+	// Feed 5000 rows (gids 0..4999) and point the cursor at row 4999.
+	feed := make([]string, 5000)
+	for i := range feed {
+		feed[i] = "row-content"
+	}
+	h.fakeApp.FeedRows(0, feed)
+
+	// Scroll the app so that gid 4923 is the bottom-most interior row.
+	// With a 1-cell border and 24 total rows, interior rows are 1..22
+	// (22 rows). rebuildRenderFromStoreLocked sets rowGIDs[i] = topGID+i
+	// over 0..23, then capturePaneSnapshot drops the first and last (the
+	// borders), so interior gids become [topGID+0 .. topGID+21] where
+	// topGID = bottomGID - (height-1) = bottomGID - 23. If we ScrollTo
+	// bottom=4945, interior gids span [4922..4943]. 4923 falls in that
+	// range.
+	h.fakeApp.ScrollTo(4945)
+
+	// Client viewport says we're looking at main-screen rows 4900..4923
+	// (24 rows), AutoFollow=true. This gives an overscan window of
+	// [4900-24, 4923+24] = [4876, 4947], so all interior gids qualify.
+	h.ApplyViewport(paneID, 4900, 4923, true, false)
+	if _, ok := h.session.Viewport(paneID); !ok {
+		t.Fatalf("server did not record viewport for pane")
+	}
+	h.Publish()
+
+	// Assert the publisher emitted row 4923, which sits at the bottom
+	// edge of the client's reported viewport, with the expected content.
+	rd := h.AwaitRow(paneID, 4923, 3*time.Second)
+	if len(rd.Spans) == 0 {
+		t.Fatalf("row 4923 arrived but had no spans")
+	}
+	var joined string
+	for _, s := range rd.Spans {
+		joined += s.Text
+	}
+	if !containsSubstring(joined, "row-content") {
+		t.Fatalf("row 4923 missing expected content %q; got %q", "row-content", joined)
+	}
+
+	// Clear out collected rows for the fetch-back assertion so we don't
+	// false-positive on a stale earlier delta.
+	h.mu.Lock()
+	h.rowsByGID = make(map[int64]protocol.RowDelta)
+	h.mu.Unlock()
+
+	// Scroll back. With AutoFollow=false the server does not walk the
+	// render window backwards for us — the client must issue FetchRange
+	// to get the back-scrolled rows. Do that explicitly.
+	h.ApplyViewport(paneID, 3900, 3923, false, false)
+	resp := h.FetchRangeSync(paneID, 3900, 3924)
+	if resp.Flags&protocol.FetchRangeAltScreenActive != 0 {
+		t.Fatalf("unexpected AltScreenActive flag on main-screen fetch")
+	}
+	if len(resp.Rows) == 0 {
+		t.Fatalf("fetch returned no rows for [3900,3924) — flags=%v", resp.Flags)
+	}
+	found := false
+	for _, r := range resp.Rows {
+		if r.GlobalIdx == 3900 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("fetch response did not include globalIdx=3900; gids=%v", gidList(resp.Rows))
+	}
+}
+
+func TestIntegration_AltScreenOptsOut(t *testing.T) {
+	const cols, rows = 80, 24
+	h := newMemHarness(t, cols, rows)
+	paneID := h.paneID
+
+	// Push the app into alt-screen with a single labelled row.
+	h.fakeApp.EnterAltScreen("hello alt")
+
+	// Alt-screen panes do not need a viewport to emit, but Plan A's
+	// connection_handler accepts one either way; send one for completeness.
+	h.ApplyViewport(paneID, 0, int64(rows-1), true, true)
+	h.Publish()
+
+	// Row 1 of the alt buffer (the pane renders the app inside a 1-cell
+	// border, so app row 0 lands at pane row 1) should carry "hello alt".
+	h.AwaitAltRow(paneID, 1, "hello alt", 3*time.Second)
+
+	// A FetchRange against a pane in alt-screen must come back with
+	// FetchRangeAltScreenActive set and no rows.
+	resp := h.FetchRangeSync(paneID, 0, 100)
+	if resp.Flags&protocol.FetchRangeAltScreenActive == 0 {
+		t.Fatalf("expected FetchRangeAltScreenActive flag; got flags=%v", resp.Flags)
+	}
+	if len(resp.Rows) != 0 {
+		t.Fatalf("alt-screen fetch should return no rows; got %d", len(resp.Rows))
+	}
+}
+
+func gidList(rows []protocol.LogicalRow) []int64 {
+	out := make([]int64, len(rows))
+	for i, r := range rows {
+		out[i] = r.GlobalIdx
+	}
+	return out
+}

--- a/protocol/buffer_delta.go
+++ b/protocol/buffer_delta.go
@@ -220,6 +220,9 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 			if len(textBytes) > 0xFFFF {
 				return nil, ErrInvalidSpan
 			}
+			if int(span.StyleIndex) >= len(delta.Styles) {
+				return nil, ErrStyleIndexOutOfRange
+			}
 			if err := binary.Write(buf, binary.LittleEndian, span.StartCol); err != nil {
 				return nil, err
 			}

--- a/protocol/buffer_delta.go
+++ b/protocol/buffer_delta.go
@@ -19,7 +19,8 @@ import (
 type BufferDeltaFlags uint8
 
 const (
-	BufferDeltaNone BufferDeltaFlags = 0
+	BufferDeltaNone      BufferDeltaFlags = 0
+	BufferDeltaAltScreen BufferDeltaFlags = 1 << 0
 )
 
 // ColorModel represents how colours are encoded for a style.
@@ -92,6 +93,7 @@ type BufferDelta struct {
 	PaneID   [16]byte
 	Revision uint32
 	Flags    BufferDeltaFlags
+	RowBase  int64
 	Styles   []StyleEntry
 	Rows     []RowDelta
 }
@@ -109,6 +111,9 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 		return nil, err
 	}
 	buf.WriteByte(byte(delta.Flags))
+	if err := binary.Write(buf, binary.LittleEndian, delta.RowBase); err != nil {
+		return nil, err
+	}
 
 	if len(delta.Styles) > 0xFFFF || len(delta.Rows) > 0xFFFF {
 		return nil, ErrBufferTooLarge
@@ -201,13 +206,14 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 // DecodeBufferDelta reverses EncodeBufferDelta.
 func DecodeBufferDelta(b []byte) (BufferDelta, error) {
 	var delta BufferDelta
-	if len(b) < 21 { // paneID(16)+revision(4)+flags(1)
+	if len(b) < 29 { // paneID(16)+revision(4)+flags(1)+rowBase(8)
 		return delta, ErrPayloadShort
 	}
 	copy(delta.PaneID[:], b[:16])
 	delta.Revision = binary.LittleEndian.Uint32(b[16:20])
 	delta.Flags = BufferDeltaFlags(b[20])
-	b = b[21:]
+	delta.RowBase = int64(binary.LittleEndian.Uint64(b[21:29]))
+	b = b[29:]
 
 	if len(b) < 2 {
 		return delta, ErrPayloadShort

--- a/protocol/buffer_delta.go
+++ b/protocol/buffer_delta.go
@@ -99,8 +99,10 @@ type BufferDelta struct {
 }
 
 var (
-	ErrBufferTooLarge = errors.New("protocol: buffer delta exceeds limits")
-	ErrInvalidSpan    = errors.New("protocol: invalid span")
+	ErrBufferTooLarge          = errors.New("protocol: buffer delta exceeds limits")
+	ErrInvalidSpan             = errors.New("protocol: invalid span")
+	ErrStyleIndexOutOfRange    = errors.New("protocol: span style index out of range")
+	ErrUnsupportedDynamicColor = errors.New("protocol: dynamic colors unsupported in this message type")
 )
 
 // EncodeBufferDelta serialises the delta into a compact binary representation.
@@ -140,25 +142,60 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 		}
 		if style.AttrFlags&AttrHasDynamic != 0 {
 			for _, d := range [2]DynColorDesc{style.DynFG, style.DynBG} {
-				buf.WriteByte(d.Type)
-				binary.Write(buf, binary.LittleEndian, d.Base)
-				binary.Write(buf, binary.LittleEndian, d.Target)
-				buf.WriteByte(d.Easing)
-				binary.Write(buf, binary.LittleEndian, d.Speed)
-				binary.Write(buf, binary.LittleEndian, d.Min)
-				binary.Write(buf, binary.LittleEndian, d.Max)
+				if err := buf.WriteByte(d.Type); err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.LittleEndian, d.Base); err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.LittleEndian, d.Target); err != nil {
+					return nil, err
+				}
+				if err := buf.WriteByte(d.Easing); err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.LittleEndian, d.Speed); err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.LittleEndian, d.Min); err != nil {
+					return nil, err
+				}
+				if err := binary.Write(buf, binary.LittleEndian, d.Max); err != nil {
+					return nil, err
+				}
 				// Gradient stops (variable length, only for Type >= 4)
 				if d.Type >= 4 {
-					buf.WriteByte(uint8(len(d.Stops)))
+					if len(d.Stops) > 0xFF {
+						return nil, ErrBufferTooLarge
+					}
+					if err := buf.WriteByte(uint8(len(d.Stops))); err != nil {
+						return nil, err
+					}
 					for _, s := range d.Stops {
-						binary.Write(buf, binary.LittleEndian, s.Position)
-						buf.WriteByte(s.Color.Type)
-						binary.Write(buf, binary.LittleEndian, s.Color.Base)
-						binary.Write(buf, binary.LittleEndian, s.Color.Target)
-						buf.WriteByte(s.Color.Easing)
-						binary.Write(buf, binary.LittleEndian, s.Color.Speed)
-						binary.Write(buf, binary.LittleEndian, s.Color.Min)
-						binary.Write(buf, binary.LittleEndian, s.Color.Max)
+						if err := binary.Write(buf, binary.LittleEndian, s.Position); err != nil {
+							return nil, err
+						}
+						if err := buf.WriteByte(s.Color.Type); err != nil {
+							return nil, err
+						}
+						if err := binary.Write(buf, binary.LittleEndian, s.Color.Base); err != nil {
+							return nil, err
+						}
+						if err := binary.Write(buf, binary.LittleEndian, s.Color.Target); err != nil {
+							return nil, err
+						}
+						if err := buf.WriteByte(s.Color.Easing); err != nil {
+							return nil, err
+						}
+						if err := binary.Write(buf, binary.LittleEndian, s.Color.Speed); err != nil {
+							return nil, err
+						}
+						if err := binary.Write(buf, binary.LittleEndian, s.Color.Min); err != nil {
+							return nil, err
+						}
+						if err := binary.Write(buf, binary.LittleEndian, s.Color.Max); err != nil {
+							return nil, err
+						}
 					}
 				}
 			}
@@ -299,6 +336,9 @@ func DecodeBufferDelta(b []byte) (BufferDelta, error) {
 			}
 			text := string(b[:textLen])
 			b = b[textLen:]
+			if int(styleIndex) >= int(styleCount) {
+				return delta, ErrStyleIndexOutOfRange
+			}
 			spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
 		}
 		delta.Rows[i] = RowDelta{Row: row, Spans: spans}

--- a/protocol/buffer_delta_test.go
+++ b/protocol/buffer_delta_test.go
@@ -232,3 +232,41 @@ func TestBufferDelta_RowBaseRoundTrip(t *testing.T) {
 		t.Fatalf("RowBase: got %d want %d", out.RowBase, in.RowBase)
 	}
 }
+
+// Regression: encoders must reject a StyleIndex that points past the Styles
+// table. Symmetric with the decode-side check — catches producer bugs at the
+// serialization boundary rather than shipping invalid bytes.
+func TestEncodeBufferDeltaRejectsStyleIndexOutOfRange(t *testing.T) {
+	cases := []struct {
+		name  string
+		delta BufferDelta
+	}{
+		{
+			name: "no styles, any index",
+			delta: BufferDelta{
+				Rows: []RowDelta{{Row: 0, Spans: []CellSpan{{Text: "x", StyleIndex: 0}}}},
+			},
+		},
+		{
+			name: "index equals length",
+			delta: BufferDelta{
+				Styles: []StyleEntry{{}},
+				Rows:   []RowDelta{{Row: 0, Spans: []CellSpan{{Text: "x", StyleIndex: 1}}}},
+			},
+		},
+		{
+			name: "index past end",
+			delta: BufferDelta{
+				Styles: []StyleEntry{{}, {}},
+				Rows:   []RowDelta{{Row: 0, Spans: []CellSpan{{Text: "x", StyleIndex: 99}}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := EncodeBufferDelta(tc.delta); err != ErrStyleIndexOutOfRange {
+				t.Errorf("EncodeBufferDelta err = %v, want ErrStyleIndexOutOfRange", err)
+			}
+		})
+	}
+}

--- a/protocol/buffer_delta_test.go
+++ b/protocol/buffer_delta_test.go
@@ -188,3 +188,47 @@ func TestBufferDeltaInvalid(t *testing.T) {
 		t.Fatalf("expected error for short payload")
 	}
 }
+
+func TestBufferDelta_AltScreenFlagRoundTrip(t *testing.T) {
+	in := BufferDelta{
+		PaneID: [16]byte{9},
+		Flags:  BufferDeltaAltScreen,
+		Rows:   []RowDelta{{Row: 3, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+		Styles: []StyleEntry{{AttrFlags: 0}},
+	}
+	raw, err := EncodeBufferDelta(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeBufferDelta(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Flags&BufferDeltaAltScreen == 0 {
+		t.Fatalf("AltScreen flag lost")
+	}
+}
+
+func TestBufferDelta_RowBaseRoundTrip(t *testing.T) {
+	in := BufferDelta{
+		PaneID:   [16]byte{1, 2, 3},
+		Revision: 42,
+		Flags:    BufferDeltaNone,
+		RowBase:  1_234_567,
+		Rows: []RowDelta{
+			{Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "hello", StyleIndex: 0}}},
+		},
+		Styles: []StyleEntry{{AttrFlags: 0}},
+	}
+	raw, err := EncodeBufferDelta(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeBufferDelta(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RowBase != in.RowBase {
+		t.Fatalf("RowBase: got %d want %d", out.RowBase, in.RowBase)
+	}
+}

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -62,7 +62,9 @@ func EncodeFetchRange(f FetchRange) ([]byte, error) {
 	if err := binary.Write(buf, binary.LittleEndian, f.RequestID); err != nil {
 		return nil, err
 	}
-	buf.Write(f.PaneID[:])
+	if _, err := buf.Write(f.PaneID[:]); err != nil {
+		return nil, err
+	}
 	if err := binary.Write(buf, binary.LittleEndian, f.LoIdx); err != nil {
 		return nil, err
 	}
@@ -100,11 +102,15 @@ func EncodeFetchRangeResponse(r FetchRangeResponse) ([]byte, error) {
 	if err := binary.Write(buf, binary.LittleEndian, r.RequestID); err != nil {
 		return nil, err
 	}
-	buf.Write(r.PaneID[:])
+	if _, err := buf.Write(r.PaneID[:]); err != nil {
+		return nil, err
+	}
 	if err := binary.Write(buf, binary.LittleEndian, r.Revision); err != nil {
 		return nil, err
 	}
-	buf.WriteByte(byte(r.Flags))
+	if err := buf.WriteByte(byte(r.Flags)); err != nil {
+		return nil, err
+	}
 
 	if len(r.Styles) > 0xFFFF || len(r.Rows) > 0xFFFF {
 		return nil, ErrBufferTooLarge

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -18,6 +18,21 @@ var (
 )
 
 // FetchRangeFlags is a bitmask set on FetchRangeResponse.
+//
+// Flag semantics and valid combinations:
+//
+//   - FetchRangeAltScreenActive is mutually exclusive with all other flags.
+//     When the pane is in alt-screen the server short-circuits before checking
+//     retention or row content, so BelowRetention and Empty are never set.
+//
+//   - FetchRangeBelowRetention and FetchRangeEmpty may legitimately co-occur.
+//     This happens when part of the requested range has been evicted from the
+//     retention window and the remaining resident rows happen to lie outside
+//     [LoIdx, HiIdx) — the response has no rows but the client should know
+//     that some content was evicted, not merely absent.
+//
+//   - Clients must ignore unknown bits for forward-compatibility.  Future
+//     versions of the protocol may add new flags without a version bump.
 type FetchRangeFlags uint8
 
 const (

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -6,6 +6,15 @@ package protocol
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+)
+
+var (
+	// ErrFetchRangeInverted is returned when LoIdx > HiIdx.
+	// Note: LoIdx == HiIdx is a valid empty range and is allowed.
+	ErrFetchRangeInverted = errors.New("protocol: fetch range lo > hi")
+	// ErrFetchRangeNegative is returned when LoIdx < 0.
+	ErrFetchRangeNegative = errors.New("protocol: fetch range lo index is negative")
 )
 
 // FetchRangeFlags is a bitmask set on FetchRangeResponse.
@@ -77,6 +86,12 @@ func DecodeFetchRange(b []byte) (FetchRange, error) {
 	f.LoIdx = int64(binary.LittleEndian.Uint64(b[20:28]))
 	f.HiIdx = int64(binary.LittleEndian.Uint64(b[28:36]))
 	f.AsOfRevision = binary.LittleEndian.Uint32(b[36:40])
+	if f.LoIdx < 0 {
+		return FetchRange{}, ErrFetchRangeNegative
+	}
+	if f.LoIdx > f.HiIdx {
+		return FetchRange{}, ErrFetchRangeInverted
+	}
 	return f, nil
 }
 

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -200,6 +200,9 @@ func EncodeFetchRangeResponse(r FetchRangeResponse) ([]byte, error) {
 			if len(textBytes) > 0xFFFF {
 				return nil, ErrInvalidSpan
 			}
+			if int(span.StyleIndex) >= len(r.Styles) {
+				return nil, ErrStyleIndexOutOfRange
+			}
 			if err := binary.Write(buf, binary.LittleEndian, span.StartCol); err != nil {
 				return nil, err
 			}

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -72,7 +72,22 @@ type FetchRangeResponse struct {
 	Rows      []LogicalRow
 }
 
+// Validate rejects malformed FetchRange requests.  Applied symmetrically on
+// encode and decode.
+func (f FetchRange) Validate() error {
+	if f.LoIdx < 0 {
+		return ErrFetchRangeNegative
+	}
+	if f.LoIdx > f.HiIdx {
+		return ErrFetchRangeInverted
+	}
+	return nil
+}
+
 func EncodeFetchRange(f FetchRange) ([]byte, error) {
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
 	buf := bytes.NewBuffer(make([]byte, 0, 40))
 	if err := binary.Write(buf, binary.LittleEndian, f.RequestID); err != nil {
 		return nil, err
@@ -138,7 +153,7 @@ func EncodeFetchRangeResponse(r FetchRangeResponse) ([]byte, error) {
 	for _, s := range r.Styles {
 		// Dynamic colors are not supported in FetchRange rows for v1.
 		if s.AttrFlags&AttrHasDynamic != 0 {
-			return nil, ErrBufferTooLarge
+			return nil, ErrUnsupportedDynamicColor
 		}
 		if err := binary.Write(buf, binary.LittleEndian, s.AttrFlags); err != nil {
 			return nil, err
@@ -231,7 +246,7 @@ func DecodeFetchRangeResponse(b []byte) (FetchRangeResponse, error) {
 		r.Styles[i].BgValue = binary.LittleEndian.Uint32(b[8:12])
 		b = b[12:]
 		if r.Styles[i].AttrFlags&AttrHasDynamic != 0 {
-			return r, ErrPayloadShort // unsupported in v1
+			return r, ErrUnsupportedDynamicColor
 		}
 	}
 
@@ -262,6 +277,9 @@ func DecodeFetchRangeResponse(b []byte) (FetchRangeResponse, error) {
 			b = b[6:]
 			if len(b) < int(textLen) {
 				return r, ErrPayloadShort
+			}
+			if int(styleIndex) >= int(styleCount) {
+				return r, ErrStyleIndexOutOfRange
 			}
 			spans[s] = CellSpan{StartCol: startCol, Text: string(b[:textLen]), StyleIndex: styleIndex}
 			b = b[textLen:]

--- a/protocol/fetch_range.go
+++ b/protocol/fetch_range.go
@@ -1,0 +1,236 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// FetchRangeFlags is a bitmask set on FetchRangeResponse.
+type FetchRangeFlags uint8
+
+const (
+	FetchRangeNone            FetchRangeFlags = 0
+	FetchRangeAltScreenActive FetchRangeFlags = 1 << 0
+	FetchRangeBelowRetention  FetchRangeFlags = 1 << 1
+	FetchRangeEmpty           FetchRangeFlags = 1 << 2
+)
+
+// FetchRange is a client → server request for a slice of scrollback.
+// LoIdx is inclusive; HiIdx is exclusive. AsOfRevision is informational
+// (server stamps the response with its own Revision at read time).
+type FetchRange struct {
+	RequestID    uint32
+	PaneID       [16]byte
+	LoIdx        int64
+	HiIdx        int64
+	AsOfRevision uint32
+}
+
+// LogicalRow is one row in a FetchRangeResponse. Spans use the same shared
+// Styles table as BufferDelta rows.
+type LogicalRow struct {
+	GlobalIdx int64
+	Wrapped   bool
+	NoWrap    bool
+	Spans     []CellSpan
+}
+
+// FetchRangeResponse is the server → client reply.
+type FetchRangeResponse struct {
+	RequestID uint32
+	PaneID    [16]byte
+	Revision  uint32
+	Flags     FetchRangeFlags
+	Styles    []StyleEntry
+	Rows      []LogicalRow
+}
+
+func EncodeFetchRange(f FetchRange) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 40))
+	if err := binary.Write(buf, binary.LittleEndian, f.RequestID); err != nil {
+		return nil, err
+	}
+	buf.Write(f.PaneID[:])
+	if err := binary.Write(buf, binary.LittleEndian, f.LoIdx); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, f.HiIdx); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, f.AsOfRevision); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeFetchRange(b []byte) (FetchRange, error) {
+	var f FetchRange
+	// 4 + 16 + 8 + 8 + 4 = 40
+	if len(b) < 40 {
+		return f, ErrPayloadShort
+	}
+	f.RequestID = binary.LittleEndian.Uint32(b[:4])
+	copy(f.PaneID[:], b[4:20])
+	f.LoIdx = int64(binary.LittleEndian.Uint64(b[20:28]))
+	f.HiIdx = int64(binary.LittleEndian.Uint64(b[28:36]))
+	f.AsOfRevision = binary.LittleEndian.Uint32(b[36:40])
+	return f, nil
+}
+
+func EncodeFetchRangeResponse(r FetchRangeResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 64))
+	if err := binary.Write(buf, binary.LittleEndian, r.RequestID); err != nil {
+		return nil, err
+	}
+	buf.Write(r.PaneID[:])
+	if err := binary.Write(buf, binary.LittleEndian, r.Revision); err != nil {
+		return nil, err
+	}
+	buf.WriteByte(byte(r.Flags))
+
+	if len(r.Styles) > 0xFFFF || len(r.Rows) > 0xFFFF {
+		return nil, ErrBufferTooLarge
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Styles))); err != nil {
+		return nil, err
+	}
+	// Reuse the same inline style-entry encoding as BufferDelta — factor out
+	// if the duplication grows. For now it's two sites.
+	for _, s := range r.Styles {
+		// Dynamic colors are not supported in FetchRange rows for v1.
+		if s.AttrFlags&AttrHasDynamic != 0 {
+			return nil, ErrBufferTooLarge
+		}
+		if err := binary.Write(buf, binary.LittleEndian, s.AttrFlags); err != nil {
+			return nil, err
+		}
+		if err := buf.WriteByte(byte(s.FgModel)); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, s.FgValue); err != nil {
+			return nil, err
+		}
+		if err := buf.WriteByte(byte(s.BgModel)); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, s.BgValue); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Rows))); err != nil {
+		return nil, err
+	}
+	for _, row := range r.Rows {
+		if err := binary.Write(buf, binary.LittleEndian, row.GlobalIdx); err != nil {
+			return nil, err
+		}
+		var flags uint8
+		if row.Wrapped {
+			flags |= 1 << 0
+		}
+		if row.NoWrap {
+			flags |= 1 << 1
+		}
+		if err := buf.WriteByte(flags); err != nil {
+			return nil, err
+		}
+		if len(row.Spans) > 0xFFFF {
+			return nil, ErrBufferTooLarge
+		}
+		if err := binary.Write(buf, binary.LittleEndian, uint16(len(row.Spans))); err != nil {
+			return nil, err
+		}
+		for _, span := range row.Spans {
+			textBytes := []byte(span.Text)
+			if len(textBytes) > 0xFFFF {
+				return nil, ErrInvalidSpan
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StartCol); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, uint16(len(textBytes))); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StyleIndex); err != nil {
+				return nil, err
+			}
+			if _, err := buf.Write(textBytes); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeFetchRangeResponse(b []byte) (FetchRangeResponse, error) {
+	var r FetchRangeResponse
+	// 4 + 16 + 4 + 1 = 25
+	if len(b) < 25 {
+		return r, ErrPayloadShort
+	}
+	r.RequestID = binary.LittleEndian.Uint32(b[:4])
+	copy(r.PaneID[:], b[4:20])
+	r.Revision = binary.LittleEndian.Uint32(b[20:24])
+	r.Flags = FetchRangeFlags(b[24])
+	b = b[25:]
+
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	styleCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	r.Styles = make([]StyleEntry, styleCount)
+	for i := 0; i < int(styleCount); i++ {
+		if len(b) < 12 {
+			return r, ErrPayloadShort
+		}
+		r.Styles[i].AttrFlags = binary.LittleEndian.Uint16(b[:2])
+		r.Styles[i].FgModel = ColorModel(b[2])
+		r.Styles[i].FgValue = binary.LittleEndian.Uint32(b[3:7])
+		r.Styles[i].BgModel = ColorModel(b[7])
+		r.Styles[i].BgValue = binary.LittleEndian.Uint32(b[8:12])
+		b = b[12:]
+		if r.Styles[i].AttrFlags&AttrHasDynamic != 0 {
+			return r, ErrPayloadShort // unsupported in v1
+		}
+	}
+
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	rowCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	r.Rows = make([]LogicalRow, rowCount)
+	for i := 0; i < int(rowCount); i++ {
+		if len(b) < 11 { // globalIdx(8)+flags(1)+spanCount(2)
+			return r, ErrPayloadShort
+		}
+		r.Rows[i].GlobalIdx = int64(binary.LittleEndian.Uint64(b[:8]))
+		rowFlags := b[8]
+		r.Rows[i].Wrapped = rowFlags&(1<<0) != 0
+		r.Rows[i].NoWrap = rowFlags&(1<<1) != 0
+		spanCount := binary.LittleEndian.Uint16(b[9:11])
+		b = b[11:]
+		spans := make([]CellSpan, spanCount)
+		for s := 0; s < int(spanCount); s++ {
+			if len(b) < 6 {
+				return r, ErrPayloadShort
+			}
+			startCol := binary.LittleEndian.Uint16(b[:2])
+			textLen := binary.LittleEndian.Uint16(b[2:4])
+			styleIndex := binary.LittleEndian.Uint16(b[4:6])
+			b = b[6:]
+			if len(b) < int(textLen) {
+				return r, ErrPayloadShort
+			}
+			spans[s] = CellSpan{StartCol: startCol, Text: string(b[:textLen]), StyleIndex: styleIndex}
+			b = b[textLen:]
+		}
+		r.Rows[i].Spans = spans
+	}
+	return r, nil
+}

--- a/protocol/fetch_range_test.go
+++ b/protocol/fetch_range_test.go
@@ -114,3 +114,33 @@ func TestFetchRangeResponse_RoundTrip(t *testing.T) {
 		t.Fatalf("mismatch:\n got %#v\n want %#v", out, in)
 	}
 }
+
+// Regression: EncodeFetchRangeResponse must reject a StyleIndex that points
+// past the Styles table, symmetric with the decode-side check.
+func TestEncodeFetchRangeResponseRejectsStyleIndexOutOfRange(t *testing.T) {
+	cases := []struct {
+		name string
+		resp FetchRangeResponse
+	}{
+		{
+			name: "no styles, any index",
+			resp: FetchRangeResponse{
+				Rows: []LogicalRow{{Spans: []CellSpan{{Text: "x", StyleIndex: 0}}}},
+			},
+		},
+		{
+			name: "index equals length",
+			resp: FetchRangeResponse{
+				Styles: []StyleEntry{{}},
+				Rows:   []LogicalRow{{Spans: []CellSpan{{Text: "x", StyleIndex: 1}}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := EncodeFetchRangeResponse(tc.resp); err != ErrStyleIndexOutOfRange {
+				t.Errorf("EncodeFetchRangeResponse err = %v, want ErrStyleIndexOutOfRange", err)
+			}
+		})
+	}
+}

--- a/protocol/fetch_range_test.go
+++ b/protocol/fetch_range_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -24,6 +25,58 @@ func TestFetchRange_RoundTrip(t *testing.T) {
 	if out != in {
 		t.Fatalf("mismatch: %#v vs %#v", out, in)
 	}
+}
+
+func TestDecodeFetchRange_Validation(t *testing.T) {
+	good := FetchRange{
+		RequestID: 1,
+		LoIdx:     10,
+		HiIdx:     20,
+	}
+
+	t.Run("lo > hi rejected", func(t *testing.T) {
+		bad := good
+		bad.LoIdx = 30 // > HiIdx
+		raw, err := EncodeFetchRange(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeFetchRange(raw)
+		if !errors.Is(err, ErrFetchRangeInverted) {
+			t.Fatalf("expected ErrFetchRangeInverted, got %v", err)
+		}
+	})
+
+	t.Run("lo == hi accepted (empty range)", func(t *testing.T) {
+		eq := good
+		eq.LoIdx = 15
+		eq.HiIdx = 15
+		raw, err := EncodeFetchRange(eq)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		out, err := DecodeFetchRange(raw)
+		if err != nil {
+			t.Fatalf("lo==hi should be accepted, got error: %v", err)
+		}
+		if out.LoIdx != out.HiIdx {
+			t.Fatalf("round-trip of empty range mismatch")
+		}
+	})
+
+	t.Run("negative lo rejected", func(t *testing.T) {
+		bad := good
+		bad.LoIdx = -1
+		bad.HiIdx = 10
+		raw, err := EncodeFetchRange(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeFetchRange(raw)
+		if !errors.Is(err, ErrFetchRangeNegative) {
+			t.Fatalf("expected ErrFetchRangeNegative, got %v", err)
+		}
+	})
 }
 
 func TestFetchRangeResponse_RoundTrip(t *testing.T) {

--- a/protocol/fetch_range_test.go
+++ b/protocol/fetch_range_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/binary"
 	"errors"
 	"reflect"
 	"testing"
@@ -27,31 +28,35 @@ func TestFetchRange_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestDecodeFetchRange_Validation(t *testing.T) {
-	good := FetchRange{
-		RequestID: 1,
-		LoIdx:     10,
-		HiIdx:     20,
-	}
+func TestFetchRange_Validation(t *testing.T) {
+	// Encode enforces Validate() symmetrically with Decode so malformed
+	// FetchRange requests never make it onto the wire in the first place.
+	// Decode must still reject them in case a peer violates the contract.
 
-	t.Run("lo > hi rejected", func(t *testing.T) {
-		bad := good
-		bad.LoIdx = 30 // > HiIdx
-		raw, err := EncodeFetchRange(bad)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
+	t.Run("lo > hi rejected on encode", func(t *testing.T) {
+		_, err := EncodeFetchRange(FetchRange{LoIdx: 30, HiIdx: 20})
+		if !errors.Is(err, ErrFetchRangeInverted) {
+			t.Fatalf("expected ErrFetchRangeInverted on encode, got %v", err)
 		}
+	})
+
+	t.Run("lo > hi rejected on decode", func(t *testing.T) {
+		// Encode a valid payload then hand-edit LoIdx in place so the wire
+		// bytes carry an invariant violation the decoder must catch.
+		raw, err := EncodeFetchRange(FetchRange{LoIdx: 10, HiIdx: 20})
+		if err != nil {
+			t.Fatalf("encode good: %v", err)
+		}
+		var lo int64 = 30
+		binary.LittleEndian.PutUint64(raw[20:28], uint64(lo))
 		_, err = DecodeFetchRange(raw)
 		if !errors.Is(err, ErrFetchRangeInverted) {
-			t.Fatalf("expected ErrFetchRangeInverted, got %v", err)
+			t.Fatalf("expected ErrFetchRangeInverted on decode, got %v", err)
 		}
 	})
 
 	t.Run("lo == hi accepted (empty range)", func(t *testing.T) {
-		eq := good
-		eq.LoIdx = 15
-		eq.HiIdx = 15
-		raw, err := EncodeFetchRange(eq)
+		raw, err := EncodeFetchRange(FetchRange{LoIdx: 15, HiIdx: 15})
 		if err != nil {
 			t.Fatalf("encode: %v", err)
 		}
@@ -64,17 +69,23 @@ func TestDecodeFetchRange_Validation(t *testing.T) {
 		}
 	})
 
-	t.Run("negative lo rejected", func(t *testing.T) {
-		bad := good
-		bad.LoIdx = -1
-		bad.HiIdx = 10
-		raw, err := EncodeFetchRange(bad)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
+	t.Run("negative lo rejected on encode", func(t *testing.T) {
+		_, err := EncodeFetchRange(FetchRange{LoIdx: -1, HiIdx: 10})
+		if !errors.Is(err, ErrFetchRangeNegative) {
+			t.Fatalf("expected ErrFetchRangeNegative on encode, got %v", err)
 		}
+	})
+
+	t.Run("negative lo rejected on decode", func(t *testing.T) {
+		raw, err := EncodeFetchRange(FetchRange{LoIdx: 5, HiIdx: 10})
+		if err != nil {
+			t.Fatalf("encode good: %v", err)
+		}
+		var neg int64 = -1
+		binary.LittleEndian.PutUint64(raw[20:28], uint64(neg))
 		_, err = DecodeFetchRange(raw)
 		if !errors.Is(err, ErrFetchRangeNegative) {
-			t.Fatalf("expected ErrFetchRangeNegative, got %v", err)
+			t.Fatalf("expected ErrFetchRangeNegative on decode, got %v", err)
 		}
 	})
 }

--- a/protocol/fetch_range_test.go
+++ b/protocol/fetch_range_test.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFetchRange_RoundTrip(t *testing.T) {
+	in := FetchRange{
+		RequestID:    7,
+		PaneID:       [16]byte{0xAA},
+		LoIdx:        1_000,
+		HiIdx:        1_050,
+		AsOfRevision: 42,
+	}
+	raw, err := EncodeFetchRange(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeFetchRange(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("mismatch: %#v vs %#v", out, in)
+	}
+}
+
+func TestFetchRangeResponse_RoundTrip(t *testing.T) {
+	in := FetchRangeResponse{
+		RequestID: 7,
+		PaneID:    [16]byte{0xAA},
+		Revision:  99,
+		Flags:     FetchRangeNone,
+		Rows: []LogicalRow{
+			{GlobalIdx: 1_000, Wrapped: false, NoWrap: false, Spans: []CellSpan{{StartCol: 0, Text: "hi", StyleIndex: 0}}},
+			{GlobalIdx: 1_001, Wrapped: true, Spans: []CellSpan{{StartCol: 0, Text: "continuation", StyleIndex: 0}}},
+		},
+		Styles: []StyleEntry{{AttrFlags: 0}},
+	}
+	raw, err := EncodeFetchRangeResponse(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeFetchRangeResponse(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("mismatch:\n got %#v\n want %#v", out, in)
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Version is the negotiated protocol version implemented by this package.
-const Version uint8 = 0
+const Version uint8 = 1
 
 // MessageType enumerates the canonical message categories exchanged between
 // client and server.

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -65,6 +65,7 @@ const (
 	MsgImagePlace
 	MsgImageDelete
 	MsgImageReset
+	MsgViewportUpdate
 )
 
 // Header describes the fixed portion of every frame exchanged over the wire.

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -66,6 +66,8 @@ const (
 	MsgImageDelete
 	MsgImageReset
 	MsgViewportUpdate
+	MsgFetchRange
+	MsgFetchRangeResponse
 )
 
 // Header describes the fixed portion of every frame exchanged over the wire.

--- a/protocol/viewport.go
+++ b/protocol/viewport.go
@@ -33,7 +33,9 @@ type ViewportUpdate struct {
 
 func EncodeViewportUpdate(v ViewportUpdate) ([]byte, error) {
 	buf := bytes.NewBuffer(make([]byte, 0, 45))
-	buf.Write(v.PaneID[:])
+	if _, err := buf.Write(v.PaneID[:]); err != nil {
+		return nil, err
+	}
 	var bools uint8
 	if v.AltScreen {
 		bools |= 1 << 0
@@ -41,7 +43,9 @@ func EncodeViewportUpdate(v ViewportUpdate) ([]byte, error) {
 	if v.AutoFollow {
 		bools |= 1 << 1
 	}
-	buf.WriteByte(bools)
+	if err := buf.WriteByte(bools); err != nil {
+		return nil, err
+	}
 	if err := binary.Write(buf, binary.LittleEndian, v.ViewTopIdx); err != nil {
 		return nil, err
 	}

--- a/protocol/viewport.go
+++ b/protocol/viewport.go
@@ -31,7 +31,23 @@ type ViewportUpdate struct {
 	AutoFollow     bool
 }
 
+// Validate rejects malformed ViewportUpdates.  Applied symmetrically on
+// encode and decode so bugs surface at the producer rather than being
+// encoded on the wire and caught only at the receiver.
+func (v ViewportUpdate) Validate() error {
+	if v.Rows == 0 || v.Cols == 0 {
+		return ErrViewportZeroDim
+	}
+	if !v.AltScreen && v.ViewTopIdx > v.ViewBottomIdx {
+		return ErrViewportInverted
+	}
+	return nil
+}
+
 func EncodeViewportUpdate(v ViewportUpdate) ([]byte, error) {
+	if err := v.Validate(); err != nil {
+		return nil, err
+	}
 	buf := bytes.NewBuffer(make([]byte, 0, 45))
 	if _, err := buf.Write(v.PaneID[:]); err != nil {
 		return nil, err

--- a/protocol/viewport.go
+++ b/protocol/viewport.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// ViewportUpdate is sent by the client whenever its per-pane viewport changes
+// (scroll, resize, alt-screen enter/exit). The server uses it to clip
+// subsequent BufferDeltas.
+type ViewportUpdate struct {
+	PaneID         [16]byte
+	AltScreen      bool
+	ViewTopIdx     int64
+	ViewBottomIdx  int64
+	WrapSegmentIdx uint16
+	Rows           uint16
+	Cols           uint16
+	AutoFollow     bool
+}
+
+func EncodeViewportUpdate(v ViewportUpdate) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 45))
+	buf.Write(v.PaneID[:])
+	var bools uint8
+	if v.AltScreen {
+		bools |= 1 << 0
+	}
+	if v.AutoFollow {
+		bools |= 1 << 1
+	}
+	buf.WriteByte(bools)
+	if err := binary.Write(buf, binary.LittleEndian, v.ViewTopIdx); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, v.ViewBottomIdx); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, v.WrapSegmentIdx); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, v.Rows); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, v.Cols); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeViewportUpdate(b []byte) (ViewportUpdate, error) {
+	var v ViewportUpdate
+	// 16 + 1 + 8 + 8 + 2 + 2 + 2 = 39
+	if len(b) < 39 {
+		return v, ErrPayloadShort
+	}
+	copy(v.PaneID[:], b[:16])
+	bools := b[16]
+	v.AltScreen = bools&(1<<0) != 0
+	v.AutoFollow = bools&(1<<1) != 0
+	v.ViewTopIdx = int64(binary.LittleEndian.Uint64(b[17:25]))
+	v.ViewBottomIdx = int64(binary.LittleEndian.Uint64(b[25:33]))
+	v.WrapSegmentIdx = binary.LittleEndian.Uint16(b[33:35])
+	v.Rows = binary.LittleEndian.Uint16(b[35:37])
+	v.Cols = binary.LittleEndian.Uint16(b[37:39])
+	return v, nil
+}

--- a/protocol/viewport.go
+++ b/protocol/viewport.go
@@ -6,6 +6,15 @@ package protocol
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+)
+
+var (
+	// ErrViewportInverted is returned when ViewTopIdx > ViewBottomIdx in a
+	// non-alt-screen ViewportUpdate.
+	ErrViewportInverted = errors.New("protocol: viewport top > bottom")
+	// ErrViewportZeroDim is returned when Rows or Cols is zero.
+	ErrViewportZeroDim = errors.New("protocol: viewport has zero dimension")
 )
 
 // ViewportUpdate is sent by the client whenever its per-pane viewport changes
@@ -66,5 +75,11 @@ func DecodeViewportUpdate(b []byte) (ViewportUpdate, error) {
 	v.WrapSegmentIdx = binary.LittleEndian.Uint16(b[33:35])
 	v.Rows = binary.LittleEndian.Uint16(b[35:37])
 	v.Cols = binary.LittleEndian.Uint16(b[37:39])
+	if !v.AltScreen && v.ViewTopIdx > v.ViewBottomIdx {
+		return ViewportUpdate{}, ErrViewportInverted
+	}
+	if v.Rows == 0 || v.Cols == 0 {
+		return ViewportUpdate{}, ErrViewportZeroDim
+	}
 	return v, nil
 }

--- a/protocol/viewport_test.go
+++ b/protocol/viewport_test.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestViewportUpdate_RoundTrip(t *testing.T) {
 	in := ViewportUpdate{
@@ -24,4 +27,67 @@ func TestViewportUpdate_RoundTrip(t *testing.T) {
 	if out != in {
 		t.Fatalf("round-trip mismatch:\n got  %#v\n want %#v", out, in)
 	}
+}
+
+func TestDecodeViewportUpdate_Validation(t *testing.T) {
+	// Helper: encode a valid ViewportUpdate then corrupt a field.
+	good := ViewportUpdate{
+		ViewTopIdx:    100,
+		ViewBottomIdx: 200,
+		Rows:          24,
+		Cols:          80,
+	}
+
+	t.Run("inverted top>bottom rejected when not altscreen", func(t *testing.T) {
+		bad := good
+		bad.ViewTopIdx = 300 // > ViewBottomIdx
+		raw, err := EncodeViewportUpdate(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeViewportUpdate(raw)
+		if !errors.Is(err, ErrViewportInverted) {
+			t.Fatalf("expected ErrViewportInverted, got %v", err)
+		}
+	})
+
+	t.Run("inverted allowed when altscreen", func(t *testing.T) {
+		bad := good
+		bad.AltScreen = true
+		bad.ViewTopIdx = 300 // > ViewBottomIdx — OK in alt-screen
+		raw, err := EncodeViewportUpdate(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeViewportUpdate(raw)
+		if err != nil {
+			t.Fatalf("alt-screen inverted should be accepted, got error: %v", err)
+		}
+	})
+
+	t.Run("zero rows rejected", func(t *testing.T) {
+		bad := good
+		bad.Rows = 0
+		raw, err := EncodeViewportUpdate(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeViewportUpdate(raw)
+		if !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim, got %v", err)
+		}
+	})
+
+	t.Run("zero cols rejected", func(t *testing.T) {
+		bad := good
+		bad.Cols = 0
+		raw, err := EncodeViewportUpdate(bad)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		_, err = DecodeViewportUpdate(raw)
+		if !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim, got %v", err)
+		}
+	})
 }

--- a/protocol/viewport_test.go
+++ b/protocol/viewport_test.go
@@ -1,0 +1,27 @@
+package protocol
+
+import "testing"
+
+func TestViewportUpdate_RoundTrip(t *testing.T) {
+	in := ViewportUpdate{
+		PaneID:         [16]byte{0xDE, 0xAD, 0xBE, 0xEF},
+		AltScreen:      false,
+		ViewTopIdx:     1_000,
+		ViewBottomIdx:  1_023,
+		WrapSegmentIdx: 2,
+		Rows:           24,
+		Cols:           80,
+		AutoFollow:     true,
+	}
+	raw, err := EncodeViewportUpdate(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeViewportUpdate(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch:\n got  %#v\n want %#v", out, in)
+	}
+}

--- a/protocol/viewport_test.go
+++ b/protocol/viewport_test.go
@@ -29,6 +29,70 @@ func TestViewportUpdate_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestViewportUpdate_BoolCombos exercises all four (AltScreen, AutoFollow)
+// combinations and verifies they all round-trip correctly.
+func TestViewportUpdate_BoolCombos(t *testing.T) {
+	base := ViewportUpdate{
+		PaneID:         [16]byte{0x01},
+		ViewTopIdx:     50,
+		ViewBottomIdx:  74,
+		WrapSegmentIdx: 0,
+		Rows:           25,
+		Cols:           80,
+	}
+	cases := []struct {
+		altScreen  bool
+		autoFollow bool
+	}{
+		{false, false},
+		{false, true},
+		{true, false},
+		{true, true},
+	}
+	for _, tc := range cases {
+		v := base
+		v.AltScreen = tc.altScreen
+		v.AutoFollow = tc.autoFollow
+		raw, err := EncodeViewportUpdate(v)
+		if err != nil {
+			t.Fatalf("encode altScreen=%v autoFollow=%v: %v", tc.altScreen, tc.autoFollow, err)
+		}
+		out, err := DecodeViewportUpdate(raw)
+		if err != nil {
+			t.Fatalf("decode altScreen=%v autoFollow=%v: %v", tc.altScreen, tc.autoFollow, err)
+		}
+		if out != v {
+			t.Fatalf("altScreen=%v autoFollow=%v: round-trip mismatch\n got  %#v\n want %#v",
+				tc.altScreen, tc.autoFollow, out, v)
+		}
+	}
+}
+
+// TestViewportUpdate_WrapSegmentIdx verifies zero and nonzero WrapSegmentIdx round-trip.
+func TestViewportUpdate_WrapSegmentIdx(t *testing.T) {
+	base := ViewportUpdate{
+		ViewTopIdx:    0,
+		ViewBottomIdx: 23,
+		Rows:          24,
+		Cols:          80,
+	}
+
+	for _, wsi := range []uint16{0, 1, 0xFFFF} {
+		base.WrapSegmentIdx = wsi
+		raw, err := EncodeViewportUpdate(base)
+		if err != nil {
+			t.Fatalf("encode WrapSegmentIdx=%d: %v", wsi, err)
+		}
+		out, err := DecodeViewportUpdate(raw)
+		if err != nil {
+			t.Fatalf("decode WrapSegmentIdx=%d: %v", wsi, err)
+		}
+		if out.WrapSegmentIdx != wsi {
+			t.Fatalf("WrapSegmentIdx=%d: got %d after round-trip", wsi, out.WrapSegmentIdx)
+		}
+	}
+}
+
 func TestDecodeViewportUpdate_Validation(t *testing.T) {
 	// Helper: encode a valid ViewportUpdate then corrupt a field.
 	good := ViewportUpdate{

--- a/protocol/viewport_test.go
+++ b/protocol/viewport_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"encoding/binary"
 	"errors"
 	"testing"
 )
@@ -93,8 +94,10 @@ func TestViewportUpdate_WrapSegmentIdx(t *testing.T) {
 	}
 }
 
-func TestDecodeViewportUpdate_Validation(t *testing.T) {
-	// Helper: encode a valid ViewportUpdate then corrupt a field.
+func TestViewportUpdate_Validation(t *testing.T) {
+	// Validation is symmetric: Encode refuses malformed messages so peers
+	// cannot inject them, and Decode refuses bad wire bytes from a buggy
+	// peer.  Exercise both halves for each invariant.
 	good := ViewportUpdate{
 		ViewTopIdx:    100,
 		ViewBottomIdx: 200,
@@ -102,56 +105,74 @@ func TestDecodeViewportUpdate_Validation(t *testing.T) {
 		Cols:          80,
 	}
 
-	t.Run("inverted top>bottom rejected when not altscreen", func(t *testing.T) {
+	t.Run("inverted top>bottom rejected on encode", func(t *testing.T) {
 		bad := good
-		bad.ViewTopIdx = 300 // > ViewBottomIdx
-		raw, err := EncodeViewportUpdate(bad)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
+		bad.ViewTopIdx = 300
+		if _, err := EncodeViewportUpdate(bad); !errors.Is(err, ErrViewportInverted) {
+			t.Fatalf("expected ErrViewportInverted on encode, got %v", err)
 		}
-		_, err = DecodeViewportUpdate(raw)
-		if !errors.Is(err, ErrViewportInverted) {
-			t.Fatalf("expected ErrViewportInverted, got %v", err)
+	})
+
+	t.Run("inverted top>bottom rejected on decode", func(t *testing.T) {
+		raw, err := EncodeViewportUpdate(good)
+		if err != nil {
+			t.Fatalf("encode good: %v", err)
+		}
+		var top int64 = 300
+		binary.LittleEndian.PutUint64(raw[17:25], uint64(top))
+		if _, err := DecodeViewportUpdate(raw); !errors.Is(err, ErrViewportInverted) {
+			t.Fatalf("expected ErrViewportInverted on decode, got %v", err)
 		}
 	})
 
 	t.Run("inverted allowed when altscreen", func(t *testing.T) {
-		bad := good
-		bad.AltScreen = true
-		bad.ViewTopIdx = 300 // > ViewBottomIdx — OK in alt-screen
-		raw, err := EncodeViewportUpdate(bad)
+		v := good
+		v.AltScreen = true
+		v.ViewTopIdx = 300 // > ViewBottomIdx — OK in alt-screen
+		raw, err := EncodeViewportUpdate(v)
 		if err != nil {
 			t.Fatalf("encode: %v", err)
 		}
-		_, err = DecodeViewportUpdate(raw)
-		if err != nil {
+		if _, err := DecodeViewportUpdate(raw); err != nil {
 			t.Fatalf("alt-screen inverted should be accepted, got error: %v", err)
 		}
 	})
 
-	t.Run("zero rows rejected", func(t *testing.T) {
+	t.Run("zero rows rejected on encode", func(t *testing.T) {
 		bad := good
 		bad.Rows = 0
-		raw, err := EncodeViewportUpdate(bad)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
-		}
-		_, err = DecodeViewportUpdate(raw)
-		if !errors.Is(err, ErrViewportZeroDim) {
-			t.Fatalf("expected ErrViewportZeroDim, got %v", err)
+		if _, err := EncodeViewportUpdate(bad); !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim on encode, got %v", err)
 		}
 	})
 
-	t.Run("zero cols rejected", func(t *testing.T) {
+	t.Run("zero rows rejected on decode", func(t *testing.T) {
+		raw, err := EncodeViewportUpdate(good)
+		if err != nil {
+			t.Fatalf("encode good: %v", err)
+		}
+		binary.LittleEndian.PutUint16(raw[35:37], 0)
+		if _, err := DecodeViewportUpdate(raw); !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim on decode, got %v", err)
+		}
+	})
+
+	t.Run("zero cols rejected on encode", func(t *testing.T) {
 		bad := good
 		bad.Cols = 0
-		raw, err := EncodeViewportUpdate(bad)
-		if err != nil {
-			t.Fatalf("encode: %v", err)
+		if _, err := EncodeViewportUpdate(bad); !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim on encode, got %v", err)
 		}
-		_, err = DecodeViewportUpdate(raw)
-		if !errors.Is(err, ErrViewportZeroDim) {
-			t.Fatalf("expected ErrViewportZeroDim, got %v", err)
+	})
+
+	t.Run("zero cols rejected on decode", func(t *testing.T) {
+		raw, err := EncodeViewportUpdate(good)
+		if err != nil {
+			t.Fatalf("encode good: %v", err)
+		}
+		binary.LittleEndian.PutUint16(raw[37:39], 0)
+		if _, err := DecodeViewportUpdate(raw); !errors.Is(err, ErrViewportZeroDim) {
+			t.Fatalf("expected ErrViewportZeroDim on decode, got %v", err)
 		}
 	})
 }

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -12,7 +12,11 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
+	"github.com/framegrace/texelation/config"
 	"github.com/framegrace/texelation/internal/debuglog"
+	"github.com/framegrace/texelation/internal/keybind"
+	"github.com/framegrace/texelation/registry"
+	"github.com/framegrace/texelui/theme"
 	"github.com/gdamore/tcell/v2"
 	"golang.org/x/term"
 	"log"
@@ -23,10 +27,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"github.com/framegrace/texelation/config"
-	"github.com/framegrace/texelation/internal/keybind"
-	"github.com/framegrace/texelation/registry"
-	"github.com/framegrace/texelui/theme"
 	"time"
 )
 
@@ -124,15 +124,15 @@ type DesktopEngine struct {
 	clipboard          map[string][]byte
 	clipboardMime      string
 	clipboardPending   bool // True when clipboard has changed and needs to be sent to client
-	focusMu              sync.RWMutex
-	focusListeners       []DesktopFocusListener
-	paneStateMu          sync.RWMutex
-	paneStateListeners   []PaneStateListener
-	snapshotFactories    map[string]SnapshotFactory
-	viewportMu           sync.RWMutex
-	viewportWidth        int
-	viewportHeight       int
-	hasViewport          bool
+	focusMu            sync.RWMutex
+	focusListeners     []DesktopFocusListener
+	paneStateMu        sync.RWMutex
+	paneStateListeners []PaneStateListener
+	snapshotFactories  map[string]SnapshotFactory
+	viewportMu         sync.RWMutex
+	viewportWidth      int
+	viewportHeight     int
+	hasViewport        bool
 
 	// pendingAppStarts tracks panes from snapshot restore that need to be started
 	// once we receive actual viewport dimensions from the client.
@@ -184,10 +184,10 @@ func (d *DesktopEngine) SetKeybindings(r *keybind.Registry) {
 
 // PaneStateSnapshot captures dynamic pane flags for external consumers.
 type PaneStateSnapshot struct {
-	ID               [16]byte
-	Active           bool
-	Resizing         bool
-	ZOrder           int
+	ID           [16]byte
+	Active       bool
+	Resizing     bool
+	ZOrder       int
 	HandlesMouse bool
 }
 
@@ -835,24 +835,40 @@ func (d *DesktopEngine) forEachPane(fn func(*pane)) {
 	}
 }
 
+// AppByID returns the App attached to the pane with the given ID, or nil if
+// no such pane exists. Used by the client/server runtime to route per-pane
+// messages (e.g. FetchRange) to their target app.
+func (d *DesktopEngine) AppByID(id [16]byte) App {
+	var result App
+	d.forEachPane(func(p *pane) {
+		if result != nil {
+			return
+		}
+		if p.ID() == id {
+			result = p.app
+		}
+	})
+	return result
+}
+
 // PaneStates returns the current pane flags across all workspaces.
 func (d *DesktopEngine) PaneStates() []PaneStateSnapshot {
 	states := make([]PaneStateSnapshot, 0)
 	d.forEachPane(func(p *pane) {
 		states = append(states, PaneStateSnapshot{
-			ID:               p.ID(),
-			Active:           p.IsActive,
-			Resizing:         p.IsResizing,
-			ZOrder:           p.ZOrder,
+			ID:           p.ID(),
+			Active:       p.IsActive,
+			Resizing:     p.IsResizing,
+			ZOrder:       p.ZOrder,
 			HandlesMouse: p.handlesMouseEvents(),
 		})
 	})
 	for _, fp := range d.floatingPanels {
 		states = append(states, PaneStateSnapshot{
-			ID:               fp.id,
-			Active:           true,
-			Resizing:         false,
-			ZOrder:           ZOrderFloating,
+			ID:           fp.id,
+			Active:       true,
+			Resizing:     false,
+			ZOrder:       ZOrderFloating,
 			HandlesMouse: false,
 		})
 	}

--- a/texel/globalidx_provider.go
+++ b/texel/globalidx_provider.go
@@ -17,3 +17,12 @@ package texel
 type RowGlobalIdxProvider interface {
 	RowGlobalIdx() []int64
 }
+
+// AltScreenProvider is optionally implemented by apps whose underlying
+// terminal may switch into an alt-screen buffer (e.g. vim, less). Returns
+// true when the app's rendered content does not correspond to main-screen
+// scrollback. Publisher uses this to stamp BufferDelta.Flags with
+// BufferDeltaAltScreen and to skip viewport clipping for such panes.
+type AltScreenProvider interface {
+	InAltScreen() bool
+}

--- a/texel/globalidx_provider.go
+++ b/texel/globalidx_provider.go
@@ -1,0 +1,19 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texel/globalidx_provider.go
+// Summary: Optional App interface for per-row sparse-store globalIdx mapping.
+// Usage: Used by capturePaneSnapshot to populate PaneSnapshot.RowGlobalIdx.
+// Notes: Only terminal-like apps backed by a sparse store need to implement
+//   this; everything else defaults to "no globalIdx" (-1).
+
+package texel
+
+// RowGlobalIdxProvider is optionally implemented by apps whose rendered
+// content rows map 1:1 onto a main-screen sparse-store globalIdx. Returns
+// a slice of length == len(app.Render()) where entry [y] is the globalIdx
+// of row y of the app's last-rendered buffer, or -1 if that row has no
+// main-screen globalIdx (e.g. alt-screen, status/scrollbar decorations).
+type RowGlobalIdxProvider interface {
+	RowGlobalIdx() []int64
+}

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -10,8 +10,8 @@ package texel
 import (
 	"log"
 
-	"github.com/gdamore/tcell/v2"
 	"github.com/framegrace/texelui/theme"
+	"github.com/gdamore/tcell/v2"
 )
 
 // PaneSnapshot captures the render buffer for a pane along with a stable ID.
@@ -26,9 +26,15 @@ type PaneSnapshot struct {
 	Title        string
 	Buffer       [][]Cell
 	RowGlobalIdx []int64
-	Rect         Rectangle
-	AppType      string
-	AppConfig    map[string]interface{}
+	// AltScreen is true when the pane's rendered buffer should not be
+	// viewport-clipped against main-screen globalIdx space. Set when the
+	// pane's app is in alt-screen mode, or when the app is not a
+	// RowGlobalIdxProvider at all (non-terminal apps, statusbar, floating
+	// overlays). Clients keyed on flat row indices see RowBase=0.
+	AltScreen bool
+	Rect      Rectangle
+	AppType   string
+	AppConfig map[string]interface{}
 }
 
 // Rectangle stores pane position and size in screen coordinates.
@@ -48,11 +54,11 @@ type WorkspaceMetadata struct {
 
 // TreeCapture represents a snapshot of the desktop layout tree.
 type TreeCapture struct {
-	Panes              []PaneSnapshot
-	Root               *TreeNodeCapture         // Deprecated: use WorkspaceRoots
-	WorkspaceRoots     map[int]*TreeNodeCapture // Map of workspace ID to its tree root
-	ActiveWorkspaceID  int
-	WorkspaceMetadata  []WorkspaceMetadata
+	Panes             []PaneSnapshot
+	Root              *TreeNodeCapture         // Deprecated: use WorkspaceRoots
+	WorkspaceRoots    map[int]*TreeNodeCapture // Map of workspace ID to its tree root
+	ActiveWorkspaceID int
+	WorkspaceMetadata []WorkspaceMetadata
 }
 
 // TreeNodeCapture stores split metadata or references a leaf pane by index.
@@ -66,7 +72,7 @@ type TreeNodeCapture struct {
 // SnapshotBuffers collects the current buffers for all panes in the active workspace.
 func (d *DesktopEngine) SnapshotBuffers() []PaneSnapshot {
 	var panes []PaneSnapshot
-	
+
 	// Only capture active workspace for rendering
 	if d.activeWorkspace != nil && d.activeWorkspace.tree != nil {
 		// d.recalculateLayout() // REMOVED: This causes race condition with SwitchToWorkspace
@@ -104,14 +110,14 @@ func (d *DesktopEngine) SnapshotForClient() TreeCapture {
 	var capture TreeCapture
 	// Default to empty if nothing to capture
 	capture.WorkspaceRoots = make(map[int]*TreeNodeCapture)
-	
+
 	if d.activeWorkspace == nil || d.activeWorkspace.tree == nil {
 		return capture
 	}
-	
+
 	// We do NOT recalculate layout here to avoid the race condition fixed previously
 	// The layout should already be valid from the logic operations (AddApp, etc.)
-	
+
 	paneIndex := make(map[*pane]int)
 	capture.Panes = make([]PaneSnapshot, 0)
 	capture.ActiveWorkspaceID = d.activeWorkspace.id
@@ -135,7 +141,7 @@ func (d *DesktopEngine) SnapshotForClient() TreeCapture {
 			collect(child)
 		}
 	}
-	
+
 	if d.activeWorkspace.tree.Root != nil {
 		collect(d.activeWorkspace.tree.Root)
 		capture.Root = buildTreeCapture(d.activeWorkspace.tree.Root, paneIndex)
@@ -217,15 +223,15 @@ func (d *DesktopEngine) CaptureTree() TreeCapture {
 	var capture TreeCapture
 	// Default to empty if nothing to capture
 	capture.WorkspaceRoots = make(map[int]*TreeNodeCapture)
-	
+
 	if len(d.workspaces) == 0 {
 		return capture
 	}
-	
+
 	d.recalculateLayout()
 	paneIndex := make(map[*pane]int)
 	capture.Panes = make([]PaneSnapshot, 0)
-	
+
 	if d.activeWorkspace != nil {
 		capture.ActiveWorkspaceID = d.activeWorkspace.id
 	}
@@ -235,7 +241,7 @@ func (d *DesktopEngine) CaptureTree() TreeCapture {
 		if ws == nil || ws.tree == nil || ws.tree.Root == nil {
 			return nil
 		}
-		
+
 		var collect func(*Node)
 		collect = func(n *Node) {
 			if n == nil {
@@ -258,7 +264,7 @@ func (d *DesktopEngine) CaptureTree() TreeCapture {
 				collect(child)
 			}
 		}
-		
+
 		collect(ws.tree.Root)
 		return buildTreeCapture(ws.tree.Root, paneIndex)
 	}
@@ -320,8 +326,9 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		// Terminal-like apps expose per-row globalIdxs for their rendered
 		// content. The content buffer sits inside a 1-cell border at (1,1),
 		// so offset entries by +1 and stop short of the bottom-border row.
-		if provider, ok := p.app.(RowGlobalIdxProvider); ok {
-			appIdx := provider.RowGlobalIdx()
+		rowProvider, hasRowProvider := p.app.(RowGlobalIdxProvider)
+		if hasRowProvider {
+			appIdx := rowProvider.RowGlobalIdx()
 			h := len(buf)
 			// Last writable interior row is h-2 (h-1 is the bottom border).
 			maxInteriorRow := h - 2
@@ -333,10 +340,19 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 				snap.RowGlobalIdx[dst] = gi
 			}
 		}
+		// A pane is alt-screen from the publisher's perspective when it
+		// reports alt-screen OR it has no globalIdx mapping at all (non-
+		// terminal apps). In both cases clients key rows by flat index.
+		if !hasRowProvider {
+			snap.AltScreen = true
+		} else if altProvider, ok := p.app.(AltScreenProvider); ok && altProvider.InAltScreen() {
+			snap.AltScreen = true
+		}
 	} else {
 		// Mark as placeholder
 		snap.AppType = "placeholder"
 		snap.Title = "Loading..."
+		snap.AltScreen = true
 	}
 	return snap
 }
@@ -420,6 +436,7 @@ func (d *DesktopEngine) captureStatusPaneSnapshots() []PaneSnapshot {
 			Title:        sp.app.GetTitle(),
 			Buffer:       cloned,
 			RowGlobalIdx: allMinusOne(len(cloned)),
+			AltScreen:    true,
 			Rect:         rect,
 		}
 		if provider, ok := sp.app.(SnapshotProvider); ok {
@@ -464,7 +481,7 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 		// Calculate dimensions with border (padding 1 on each side)
 		contentW := fp.width
 		contentH := fp.height
-		
+
 		// Sanity check buffer size vs requested size, clip if needed
 		if len(buf) < contentH {
 			contentH = len(buf)
@@ -507,7 +524,7 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 			for range title {
 				titleRuneCount++
 			}
-			
+
 			maxTitleLen := borderW - 4
 			if titleRuneCount > maxTitleLen {
 				// Truncate
@@ -515,11 +532,13 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 				title = string(r[:maxTitleLen])
 				titleRuneCount = maxTitleLen
 			}
-			
+
 			// Center title
 			startX := (borderW - (titleRuneCount + 2)) / 2
-			if startX < 1 { startX = 1 }
-			
+			if startX < 1 {
+				startX = 1
+			}
+
 			titleStr := " " + title + " "
 			for i, ch := range titleStr {
 				if startX+i < borderW-1 {
@@ -530,10 +549,14 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 
 		// Copy content into center
 		for y := 0; y < contentH; y++ {
-			if y >= len(buf) { break }
+			if y >= len(buf) {
+				break
+			}
 			row := buf[y]
 			for x := 0; x < contentW; x++ {
-				if x >= len(row) { break }
+				if x >= len(row) {
+					break
+				}
 				out[y+1][x+1] = row[x]
 			}
 		}
@@ -551,6 +574,7 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 			Title:        fp.app.GetTitle(),
 			Buffer:       out,
 			RowGlobalIdx: allMinusOne(len(out)),
+			AltScreen:    true,
 			Rect:         rect,
 		}
 		if provider, ok := fp.app.(SnapshotProvider); ok {

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -15,13 +15,20 @@ import (
 )
 
 // PaneSnapshot captures the render buffer for a pane along with a stable ID.
+// RowGlobalIdx is a parallel slice to Buffer: RowGlobalIdx[y] is the
+// sparse-store globalIdx that row y of Buffer corresponds to, or -1 if that
+// row does not map onto a main-screen scrollback row (borders, padding,
+// statusbar, scrollbar decorations, alt-screen, status panes, floating
+// panels, non-terminal apps). When Buffer is non-nil, len(RowGlobalIdx)
+// must equal len(Buffer).
 type PaneSnapshot struct {
-	ID        [16]byte
-	Title     string
-	Buffer    [][]Cell
-	Rect      Rectangle
-	AppType   string
-	AppConfig map[string]interface{}
+	ID           [16]byte
+	Title        string
+	Buffer       [][]Cell
+	RowGlobalIdx []int64
+	Rect         Rectangle
+	AppType      string
+	AppConfig    map[string]interface{}
 }
 
 // Rectangle stores pane position and size in screen coordinates.
@@ -292,9 +299,10 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 	buf := p.renderBuffer(false)
 	id := p.ID()
 	snap := PaneSnapshot{
-		ID:     id,
-		Title:  p.getTitle(),
-		Buffer: buf,
+		ID:           id,
+		Title:        p.getTitle(),
+		Buffer:       buf,
+		RowGlobalIdx: allMinusOne(len(buf)),
 		Rect: Rectangle{
 			X:      p.absX0,
 			Y:      p.absY0,
@@ -309,12 +317,42 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 			snap.AppType = appType
 			snap.AppConfig = cloneAppConfig(config)
 		}
+		// Terminal-like apps expose per-row globalIdxs for their rendered
+		// content. The content buffer sits inside a 1-cell border at (1,1),
+		// so offset entries by +1 and stop short of the bottom-border row.
+		if provider, ok := p.app.(RowGlobalIdxProvider); ok {
+			appIdx := provider.RowGlobalIdx()
+			h := len(buf)
+			// Last writable interior row is h-2 (h-1 is the bottom border).
+			maxInteriorRow := h - 2
+			for i, gi := range appIdx {
+				dst := 1 + i
+				if dst > maxInteriorRow {
+					break
+				}
+				snap.RowGlobalIdx[dst] = gi
+			}
+		}
 	} else {
 		// Mark as placeholder
 		snap.AppType = "placeholder"
 		snap.Title = "Loading..."
 	}
 	return snap
+}
+
+// allMinusOne returns a slice of length n filled with -1. Used as the
+// default RowGlobalIdx for rows that do not map onto a sparse-store
+// globalIdx (borders, padding, non-terminal app content, etc.).
+func allMinusOne(n int) []int64 {
+	if n <= 0 {
+		return nil
+	}
+	out := make([]int64, n)
+	for i := range out {
+		out[i] = -1
+	}
+	return out
 }
 
 func (d *DesktopEngine) captureStatusPaneSnapshots() []PaneSnapshot {
@@ -378,10 +416,11 @@ func (d *DesktopEngine) captureStatusPaneSnapshots() []PaneSnapshot {
 
 		cloned := cloneBuffer(buf, rect.Height, rect.Width)
 		snap := PaneSnapshot{
-			ID:     sp.id,
-			Title:  sp.app.GetTitle(),
-			Buffer: cloned,
-			Rect:   rect,
+			ID:           sp.id,
+			Title:        sp.app.GetTitle(),
+			Buffer:       cloned,
+			RowGlobalIdx: allMinusOne(len(cloned)),
+			Rect:         rect,
 		}
 		if provider, ok := sp.app.(SnapshotProvider); ok {
 			appType, cfg := provider.SnapshotMetadata()
@@ -508,10 +547,11 @@ func (d *DesktopEngine) captureFloatingPanelSnapshots() []PaneSnapshot {
 		}
 
 		snap := PaneSnapshot{
-			ID:     fp.id,
-			Title:  fp.app.GetTitle(),
-			Buffer: out,
-			Rect:   rect,
+			ID:           fp.id,
+			Title:        fp.app.GetTitle(),
+			Buffer:       out,
+			RowGlobalIdx: allMinusOne(len(out)),
+			Rect:         rect,
 		}
 		if provider, ok := fp.app.(SnapshotProvider); ok {
 			appType, cfg := provider.SnapshotMetadata()

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -1,0 +1,106 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package texel
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// snapshotTestApp is a minimal non-terminal App for snapshot tests. It
+// returns a fixed-size rendered buffer and does not implement
+// RowGlobalIdxProvider — so its rows must default to -1 in the snapshot.
+type snapshotTestApp struct {
+	title    string
+	cols     int
+	rows     int
+	notifier chan<- bool
+}
+
+func (a *snapshotTestApp) Run() error                       { return nil }
+func (a *snapshotTestApp) Stop()                            {}
+func (a *snapshotTestApp) Resize(cols, rows int)            { a.cols, a.rows = cols, rows }
+func (a *snapshotTestApp) GetTitle() string                 { return a.title }
+func (a *snapshotTestApp) HandleKey(*tcell.EventKey)        {}
+func (a *snapshotTestApp) SetRefreshNotifier(c chan<- bool) { a.notifier = c }
+func (a *snapshotTestApp) Render() [][]Cell {
+	rows := a.rows
+	cols := a.cols
+	if rows <= 0 {
+		rows = 1
+	}
+	if cols <= 0 {
+		cols = 1
+	}
+	out := make([][]Cell, rows)
+	for y := range out {
+		out[y] = make([]Cell, cols)
+		for x := range out[y] {
+			out[y][x] = Cell{Ch: ' ', Style: tcell.StyleDefault}
+		}
+	}
+	return out
+}
+
+// newSnapshotTestPane constructs a bare pane with a mock app for snapshot
+// tests. The pane rectangle is set directly rather than through a workspace
+// so we avoid pulling in DesktopEngine / layout machinery.
+func newSnapshotTestPane(w, h int) *pane {
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = w, h
+	// Inner app content sits at (1,1) inside a (w,h) border.
+	app := &snapshotTestApp{title: "mock", cols: w - 2, rows: h - 2}
+	p.app = app
+	return p
+}
+
+func TestPaneSnapshot_RowGlobalIdxInvariant(t *testing.T) {
+	p := newSnapshotTestPane(20, 6)
+	snap := capturePaneSnapshot(p)
+
+	if snap.Buffer == nil {
+		t.Fatal("expected non-nil buffer for pane snapshot")
+	}
+	if len(snap.RowGlobalIdx) != len(snap.Buffer) {
+		t.Fatalf("len(RowGlobalIdx)=%d, len(Buffer)=%d — must match",
+			len(snap.RowGlobalIdx), len(snap.Buffer))
+	}
+
+	// Mock (non-terminal) app: every row must be -1 since the app does
+	// not implement RowGlobalIdxProvider.
+	for y, gi := range snap.RowGlobalIdx {
+		if gi != -1 {
+			t.Errorf("row %d globalIdx = %d, want -1 for non-terminal app", y, gi)
+		}
+	}
+
+	// Borders at the first and last rows must be -1 regardless of app type.
+	h := len(snap.Buffer)
+	if h >= 1 && snap.RowGlobalIdx[0] != -1 {
+		t.Errorf("top border row: globalIdx = %d, want -1", snap.RowGlobalIdx[0])
+	}
+	if h >= 2 && snap.RowGlobalIdx[h-1] != -1 {
+		t.Errorf("bottom border row: globalIdx = %d, want -1", snap.RowGlobalIdx[h-1])
+	}
+}
+
+// TestPaneSnapshot_RowGlobalIdxLengthMatchesBuffer exercises the invariant
+// across a few pane sizes, including the degenerate "pane too small to
+// decorate" case where the buffer is still produced but has no borders.
+func TestPaneSnapshot_RowGlobalIdxLengthMatchesBuffer(t *testing.T) {
+	for _, sz := range []struct{ w, h int }{
+		{10, 5},
+		{20, 8},
+		{4, 4},
+	} {
+		p := newSnapshotTestPane(sz.w, sz.h)
+		snap := capturePaneSnapshot(p)
+		if len(snap.RowGlobalIdx) != len(snap.Buffer) {
+			t.Errorf("size %dx%d: len(RowGlobalIdx)=%d, len(Buffer)=%d",
+				sz.w, sz.h, len(snap.RowGlobalIdx), len(snap.Buffer))
+		}
+	}
+}

--- a/texel/workspace.go
+++ b/texel/workspace.go
@@ -156,10 +156,10 @@ func (w *Workspace) Refresh() {
 }
 
 // InvalidateRenderCaches synchronously marks every leaf pane in the workspace
-// dirty so the next renderBuffer() call bypasses its cached prevBuf. Used by
-// tests that drive pub.Publish() directly and need each call to observe
-// distinct app buffer content — the normal refresh-forwarder path is async
-// and races with Publish.
+// dirty, forcing the next renderBuffer() call to bypass its cached prevBuf.
+// The asynchronous refresh-forwarder only invalidates in response to events;
+// callers that drive publish cycles directly (without the forwarder) need
+// this to observe per-cycle changes in app buffers.
 func (w *Workspace) InvalidateRenderCaches() {
 	if w.tree == nil {
 		return

--- a/texel/workspace.go
+++ b/texel/workspace.go
@@ -155,6 +155,20 @@ func (w *Workspace) Refresh() {
 	}
 }
 
+// InvalidateRenderCaches synchronously marks every leaf pane in the workspace
+// dirty so the next renderBuffer() call bypasses its cached prevBuf. Used by
+// tests that drive pub.Publish() directly and need each call to observe
+// distinct app buffer content — the normal refresh-forwarder path is async
+// and races with Publish.
+func (w *Workspace) InvalidateRenderCaches() {
+	if w.tree == nil {
+		return
+	}
+	forEachLeafPane(w.tree.Root, func(p *pane) {
+		p.markDirty()
+	})
+}
+
 func (w *Workspace) Broadcast(event Event) {
 	w.dispatcher.Broadcast(event)
 }


### PR DESCRIPTION
## Summary
- Adds `RowBase int64` + `BufferDeltaAltScreen` flag to `BufferDelta`; every main-screen delta is now viewport-clipped to the per-client window + 1× overscan (Row = `uint16(gid - lo)` where `lo = ViewTopIdx - Rows`).
- New `MsgViewportUpdate` (client → server, 39-byte fixed payload) and `MsgFetchRange` / `MsgFetchRangeResponse` (on-demand scrollback; alt-screen opts out via `FetchRangeAltScreenActive`).
- Client-side sparse `PaneCache` keyed by globalIdx replaces row-index `BufferCache` lookups on the render path; `BufferCache` stays as fallback during transition.
- Protocol version bumped 0 → 1 in lockstep (no mixed-version path); old clients reconnect via the supervisor.
- Per-frame ``flushFrame`` coalesces `MsgViewportUpdate` + at-most-one-inflight `MsgFetchRange` per pane with AutoFollow tracking of the live tail.

## Plan & spec
- Plan: `docs/superpowers/plans/2026-04-21-issue-199-plan-a-viewport-clipping-fetchrange.md`
- Spec: `docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md`

## Test plan
- [x] Unit: `go test ./internal/runtime/client/... ./internal/runtime/server/... ./client/... ./protocol/... ./apps/texelterm/parser/sparse/...` — all green.
- [x] Integration: `go test -tags=integration ./internal/runtime/server/ -run TestIntegration_` — both viewport tests pass in <0.1s each.
  - \`TestIntegration_ClipsAndFetches\` proves clipping via (a) negative-assertion on out-of-window gids under a narrow viewport and (b) wire-level \`RowBase == ViewTopIdx - Rows\` invariant check.
  - \`TestIntegration_AltScreenOptsOut\` verifies the \`FetchRangeAltScreenActive\` opt-out.
- [ ] Manual: \`texelation\` with a live long-scrollback session (Claude/AI agent) — expected follow-up.

## Known pre-existing issue
\`TestClientResumeReceivesSnapshot\` (integration-tagged) hangs at baseline on main; confirmed by reverting that file to main's version — the hang persists. Not introduced by this branch.

## Follow-up plans (separate PRs)
- Plan B: viewport-aware resume (precise wrap-segment anchor).
- Plan C: server-side selection/copy (\`ResolveBoundary\`, \`CaptureSelection\`).
- Plan D: cross-restart persistence of \`PaneViewportState\`.
- Plan E: statusbar \"fetch pending\" indicator.