### PR TITLE
Pane border / decoration row rendering (#199)

### DIFF
--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -1099,11 +1099,12 @@ func (v *VTerm) LastPromptHeight() int {
 // RepositionForPromptOverwrite positions the cursor at `promptLine` column 0
 // so a freshly-spawned shell's first prompt overwrites the stored prompt 1:1
 // instead of rendering on the row where the previous session left off. When
-// `promptLine` is at or past the current writeTop and within the viewport,
-// the cursor is moved in place. When it's above writeTop (viewport-capped
-// history), writeTop is rewound so the prompt line lands at row 0. No-op
-// if the main screen is absent, `promptLine` is unknown (<0), or the target
-// lies below the bottom of the current viewport.
+// `promptLine` is within the current viewport, the cursor is moved in place.
+// When it's outside the viewport (either above due to history-cap, OR below
+// because the vterm hasn't yet been resized to the pane's full height at
+// recovery time), writeTop is repositioned so the prompt line lands at row
+// 0 of the visible area. No-op if the main screen is absent or `promptLine`
+// is unknown (<0).
 func (v *VTerm) RepositionForPromptOverwrite(promptLine int64) {
 	if v.mainScreen == nil || promptLine < 0 {
 		return
@@ -1115,8 +1116,13 @@ func (v *VTerm) RepositionForPromptOverwrite(promptLine int64) {
 		v.mainScreen.RewindWriteTop(promptLine)
 		targetRow = 0
 	case promptLine >= curTop+int64(v.height):
-		// Prompt sits past the viewport bottom — nothing sensible to do.
-		return
+		// Prompt sits past the viewport bottom — common when the vterm
+		// is still at its pre-resize default size at recovery time.
+		// Rewind so the new shell's first prompt lands at row 0 instead
+		// of wherever the cursor happened to be (which would create the
+		// "duplicated prompt" visual on first start).
+		v.mainScreen.RewindWriteTop(promptLine)
+		targetRow = 0
 	default:
 		targetRow = int(promptLine - curTop)
 	}

--- a/client/buffercache.go
+++ b/client/buffercache.go
@@ -650,6 +650,9 @@ func (c *BufferCache) ResetRevisions() {
 	defer c.mu.Unlock()
 	for _, pane := range c.panes {
 		pane.Revision = 0
+		pane.rowsMu.Lock()
+		pane.decorRows = nil
+		pane.rowsMu.Unlock()
 	}
 }
 

--- a/client/buffercache.go
+++ b/client/buffercache.go
@@ -219,18 +219,49 @@ func (c *BufferCache) ApplyDelta(delta protocol.BufferDelta) {
 		}
 		pane.rows[rowIdx] = row
 	}
-	pane.rowsMu.Unlock()
-
-	// Mark pane and specific rows as dirty for incremental rendering.
-	pane.Dirty = true
-	if pane.DirtyRows == nil && len(delta.Rows) < int(pane.Rect.Height) {
-		pane.DirtyRows = make(map[int]bool, len(delta.Rows))
-	}
-	if pane.DirtyRows != nil {
-		for _, rowDelta := range delta.Rows {
-			pane.DirtyRows[int(rowDelta.Row)] = true
+	if len(delta.DecorRows) > 0 {
+		if pane.decorRows == nil {
+			pane.decorRows = make(map[uint16][]Cell, len(delta.DecorRows))
+		}
+		for _, rowDelta := range delta.DecorRows {
+			row := pane.decorRows[rowDelta.RowIdx]
+			for _, span := range rowDelta.Spans {
+				start := int(span.StartCol)
+				textRunes := []rune(span.Text)
+				needed := start + len(textRunes)
+				row = ensureRowLength(row, needed)
+				style := tcell.StyleDefault
+				var dynFG, dynBG protocol.DynColorDesc
+				if int(span.StyleIndex) < len(styles) {
+					style = styles[span.StyleIndex]
+				}
+				if int(span.StyleIndex) < len(delta.Styles) {
+					entry := delta.Styles[span.StyleIndex]
+					if entry.AttrFlags&protocol.AttrHasDynamic != 0 {
+						dynFG = entry.DynFG
+						dynBG = entry.DynBG
+					}
+				}
+				for i, r := range textRunes {
+					row[start+i] = Cell{Ch: r, Style: style, DynFG: dynFG, DynBG: dynBG}
+				}
+			}
+			pane.decorRows[rowDelta.RowIdx] = row
 		}
 	}
+	pane.rowsMu.Unlock()
+
+	pane.Dirty = true
+	// Force full re-render whenever a delta touches this pane. The pre-
+	// existing per-row dirty map (DirtyRows) was keyed inconsistently:
+	// content rows used (gid - RowBase), decoration rows would be keyed by
+	// absolute rowIdx — mixing the two key spaces silently produced wrong
+	// re-renders. Setting DirtyRows = nil unconditionally tells the
+	// renderer "the whole pane needs paint," which is correct and avoids
+	// the mixed-key bug. The perf cost is small (decoration row writes
+	// are rare; content-row writes already invalidate via the gid-keyed
+	// PaneCache, not DirtyRows).
+	pane.DirtyRows = nil
 
 	// Check if any style in the delta has animated dynamic colors.
 	for _, entry := range delta.Styles {

--- a/client/buffercache.go
+++ b/client/buffercache.go
@@ -25,6 +25,7 @@ type PaneState struct {
 	UpdatedAt        time.Time
 	rowsMu           sync.RWMutex
 	rows             map[int][]Cell
+	decorRows        map[uint16][]Cell // unexported; guarded by rowsMu (decoration: borders + app statusbar)
 	Title            string
 	Rect             clientRect
 	Active           bool
@@ -32,10 +33,39 @@ type PaneState struct {
 	ZOrder           int
 	HandlesSelection bool
 
+	// Content bounds (populated from PaneSnapshot). For non-altScreen panes,
+	// rowIdx in [ContentTopRow, ContentTopRow + NumContentRows - 1] maps to
+	// gid via the viewport tracker; rowIdx outside that range reads from
+	// decorRows via DecorRowAt. NumContentRows == 0 means the pane has zero
+	// content rows (status panes, all-decoration apps).
+	ContentTopRow  uint16
+	NumContentRows uint16
+
 	// Dirty tracking for incremental rendering.
 	Dirty       bool         // true when pane has new content since last render
 	DirtyRows   map[int]bool // nil = all rows dirty; non-nil = only listed rows
 	HasAnimated bool         // true if any cell has animated DynFG/DynBG
+}
+
+// DecorRowAt returns a *copy* of the cells for an absolute decoration
+// rowIdx, or (nil, false) if no decoration has been applied to that row.
+// Returning a copy (rather than the internal slice) means the renderer can
+// hold the result across the frame without racing concurrent ApplyDelta
+// writes to the same rowIdx. Allocation is bounded — at most ~4 decoration
+// rows × pane width per render frame.
+func (p *PaneState) DecorRowAt(rowIdx uint16) ([]Cell, bool) {
+	if p == nil {
+		return nil, false
+	}
+	p.rowsMu.RLock()
+	defer p.rowsMu.RUnlock()
+	src, ok := p.decorRows[rowIdx]
+	if !ok {
+		return nil, false
+	}
+	out := make([]Cell, len(src))
+	copy(out, src)
+	return out, true
 }
 
 // ClearDirty resets the dirty flags after rendering.
@@ -233,6 +263,8 @@ func (c *BufferCache) ApplySnapshot(snapshot protocol.TreeSnapshot) {
 			c.panes[paneSnap.PaneID] = pane
 		}
 		pane.Title = paneSnap.Title
+		pane.ContentTopRow = paneSnap.ContentTopRow
+		pane.NumContentRows = paneSnap.NumContentRows
 		pane.UpdatedAt = time.Now().UTC()
 		if paneSnap.Revision != 0 || pane.Revision == 0 {
 			pane.Revision = paneSnap.Revision

--- a/client/buffercache_test.go
+++ b/client/buffercache_test.go
@@ -9,6 +9,8 @@
 package client
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -375,5 +377,90 @@ func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
 	}
 	if len(row9) != 4 || row9[3].Ch != '+' {
 		t.Fatalf("rowIdx 9 content wrong: %+v", row9)
+	}
+}
+
+func TestApplyDelta_ConcurrentDecorRowsReadWrite(t *testing.T) {
+	// Race-detector regression test: concurrently apply decoration deltas
+	// while a renderer-shaped goroutine reads via DecorRowAt. Without the
+	// rowsMu coverage on decorRows, this would flag under -race.
+	cache := NewBufferCache()
+	id := [16]byte{0xab}
+
+	// Seed the pane so DecorRowAt has a target.
+	cache.ApplyDelta(protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+		},
+	})
+	pane := cache.PaneByID(id)
+	if pane == nil {
+		t.Fatal("pane not registered")
+	}
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer goroutine: repeated ApplyDelta with new decoration cells.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			cache.ApplyDelta(protocol.BufferDelta{
+				PaneID:   id,
+				Revision: uint32(i + 2),
+				Styles:   []protocol.StyleEntry{{}},
+				DecorRows: []protocol.DecorRowDelta{
+					{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: fmt.Sprintf("%c", 'a'+i%26), StyleIndex: 0}}},
+				},
+			})
+		}
+	}()
+
+	// Reader goroutine: continuously fetch DecorRowAt(0).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			row, ok := pane.DecorRowAt(0)
+			if ok && len(row) > 0 {
+				_ = row[0].Ch // touch the cell so the race detector sees the read
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestResetRevisions_ClearsDecorRows(t *testing.T) {
+	cache := NewBufferCache()
+	id := [16]byte{0xab}
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 7,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+		},
+	}
+	cache.ApplyDelta(delta)
+	if pane := cache.PaneByID(id); pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	if _, ok := cache.PaneByID(id).DecorRowAt(0); !ok {
+		t.Fatalf("pre-reset: expected DecorRowAt(0) populated")
+	}
+	cache.ResetRevisions()
+	pane := cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane gone after reset")
+	}
+	if _, ok := pane.DecorRowAt(0); ok {
+		t.Fatalf("expected decoration cache cleared after ResetRevisions")
+	}
+	if pane.Revision != 0 {
+		t.Fatalf("expected Revision=0, got %d", pane.Revision)
 	}
 }

--- a/client/buffercache_test.go
+++ b/client/buffercache_test.go
@@ -324,3 +324,27 @@ func TestPaneState_DirtyOnDelta(t *testing.T) {
 		t.Error("row 0 should not be dirty")
 	}
 }
+
+func TestApplySnapshot_PopulatesContentBounds(t *testing.T) {
+	cache := NewBufferCache()
+	id := [16]byte{0xab}
+	snapshot := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID:         id,
+			Title:          "t",
+			Width:          10,
+			Height:         6,
+			ContentTopRow:  1,
+			NumContentRows: 4,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	cache.ApplySnapshot(snapshot)
+	pane := cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("content bounds not applied: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+}

--- a/client/buffercache_test.go
+++ b/client/buffercache_test.go
@@ -314,14 +314,11 @@ func TestPaneState_DirtyOnDelta(t *testing.T) {
 	if !pane.Dirty {
 		t.Error("expected pane dirty after delta")
 	}
-	if pane.DirtyRows == nil {
-		t.Error("expected specific DirtyRows after delta")
-	}
-	if !pane.DirtyRows[5] || !pane.DirtyRows[10] {
-		t.Error("expected rows 5 and 10 dirty")
-	}
-	if pane.DirtyRows[0] {
-		t.Error("row 0 should not be dirty")
+	// ApplyDelta unconditionally clears DirtyRows to force a full re-render.
+	// The previous per-row dirty map mixed key spaces (gid-relative content
+	// rows vs absolute decoration rowIdx) and is no longer used.
+	if pane.DirtyRows != nil {
+		t.Error("expected DirtyRows nil (full re-render) after delta")
 	}
 }
 
@@ -346,5 +343,37 @@ func TestApplySnapshot_PopulatesContentBounds(t *testing.T) {
 	}
 	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
 		t.Fatalf("content bounds not applied: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+}
+
+func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
+	cache := NewBufferCache()
+	id := [16]byte{0xab}
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 1,
+		Styles: []protocol.StyleEntry{
+			{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault},
+		},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+			{RowIdx: 9, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+		},
+	}
+	cache.ApplyDelta(delta)
+	pane := cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	row0, ok0 := pane.DecorRowAt(0)
+	row9, ok9 := pane.DecorRowAt(9)
+	if !ok0 || !ok9 {
+		t.Fatalf("expected DecorRowAt(0) and DecorRowAt(9) to be present")
+	}
+	if len(row0) != 4 || row0[0].Ch != '+' {
+		t.Fatalf("rowIdx 0 content wrong: %+v", row0)
+	}
+	if len(row9) != 4 || row9[3].Ch != '+' {
+		t.Fatalf("rowIdx 9 content wrong: %+v", row9)
 	}
 }

--- a/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
+++ b/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
@@ -1,0 +1,2007 @@
+# Pane Border / Decoration Row Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make pane top/bottom borders and app decoration rows (texterm internal statusbar) actually render on the client, fixing the pre-existing `bufferToDelta gid<0` filter bug surfaced by Plan D2's daemon-restart rehydrate path.
+
+**Architecture:** Server stays authoritative for all visible cells. Wire format gains `protocol.PaneSnapshot.{ContentTopRow, ContentBottomRow}` so the client can map rowIdx ↔ gid for content rows, and `protocol.BufferDelta.DecorRows` so border + app-decoration cells (anything where `RowGlobalIdx[y] < 0`) ride alongside content. Client renders via two-layer composite: gid-keyed `PaneCache` for content rowIdx in `[ContentTopRow, ContentBottomRow]`, positional decoration cache otherwise. Protocol bumps v2 → v3.
+
+**Tech Stack:** Go 1.24, custom binary protocol (`protocol/`), `internal/runtime/server`, `internal/runtime/client`, `client` package, `texel` package. Tests use `go test`; integration tests use `internal/runtime/server/testutil/memconn.go`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-issue-199-pane-decoration-rendering-design.md`
+
+**Branch:** `feature/issue-199-pane-decoration-rendering` (already created off main).
+
+---
+
+## File Structure
+
+| File | Responsibility | Lines (current) |
+|------|---------------|-----------------|
+| `protocol/protocol.go` | Protocol version constant | bump 2→3 |
+| `protocol/buffer_delta.go` | `BufferDelta` type + encode/decode + `DecorRows` field | ~352 |
+| `protocol/messages.go` | `PaneSnapshot` type + tree snapshot encode/decode + content bound fields | ~1050 |
+| `texel/snapshot.go` | `texel.PaneSnapshot` type + `capturePaneSnapshot` content bound computation | ~600 |
+| `internal/runtime/server/tree_convert.go` | Bridge `texel.PaneSnapshot` ↔ `protocol.PaneSnapshot` | ~150 |
+| `internal/runtime/server/desktop_publisher.go` | `bufferToDelta`: route gid<0 rows into `DecorRows` | ~330 |
+| `client/buffercache.go` | `PaneState.{ContentTopRow, ContentBottomRow, DecorRows}`; `ApplySnapshot` populates content bounds; `ApplyDelta` populates `DecorRows`; `ResetRevisions` clears it | ~600 |
+| `internal/runtime/client/viewport_tracker.go` | `onBufferDelta`: `top` calc uses `numContentRows` from PaneState | ~280 |
+| `internal/runtime/client/renderer.go` | `rowSourceForPane`: two-layer lookup (content gid / decoration positional) | ~550 |
+
+---
+
+## Task 1: Protocol — `BufferDelta.DecorRows` field + encode/decode
+
+**Files:**
+- Modify: `protocol/buffer_delta.go` (struct definition around line 92, encoder around line 109, decoder around line 247)
+- Test: `protocol/buffer_delta_test.go`
+
+**Goal:** Round-trip an empty and non-empty `DecorRows` slice.
+
+- [ ] **Step 1: Add the failing test (red).**
+
+Append to `protocol/buffer_delta_test.go`:
+
+```go
+func TestEncodeDecodeBufferDelta_DecorRoundTrip(t *testing.T) {
+	original := protocol.BufferDelta{
+		PaneID:   [16]byte{0xab, 0xcd},
+		Revision: 7,
+		Flags:    protocol.BufferDeltaNone,
+		RowBase:  100,
+		Styles: []protocol.StyleEntry{
+			{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault},
+		},
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "hi", StyleIndex: 0}}},
+		},
+		DecorRows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+			{Row: 22, Spans: []protocol.CellSpan{{StartCol: 0, Text: "-", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := protocol.EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("round-trip mismatch:\n  want %+v\n  got  %+v", original, decoded)
+	}
+}
+
+func TestEncodeDecodeBufferDelta_EmptyDecorRoundTrip(t *testing.T) {
+	original := protocol.BufferDelta{
+		PaneID:   [16]byte{0xff},
+		Revision: 1,
+		Flags:    protocol.BufferDeltaAltScreen,
+		RowBase:  0,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		Rows:     []protocol.RowDelta{{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+		// DecorRows intentionally nil
+	}
+	encoded, err := protocol.EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(decoded.DecorRows) != 0 {
+		t.Fatalf("expected empty DecorRows, got %+v", decoded.DecorRows)
+	}
+}
+```
+
+If `reflect` and `protocol` aren't imported in this file already, add them.
+
+- [ ] **Step 2: Run the test — verify it fails.**
+
+```bash
+go test ./protocol/ -run TestEncodeDecodeBufferDelta_DecorRoundTrip -v
+```
+
+Expected: FAIL with `unknown field DecorRows in struct literal`.
+
+- [ ] **Step 3: Add `DecorRows` field to `BufferDelta`.**
+
+In `protocol/buffer_delta.go`, modify the `BufferDelta` struct to:
+
+```go
+type BufferDelta struct {
+	PaneID    [16]byte
+	Revision  uint32
+	Flags     BufferDeltaFlags
+	RowBase   int64
+	Styles    []StyleEntry
+	Rows      []RowDelta
+	DecorRows []RowDelta // rows keyed by absolute rowIdx (not gid - RowBase). Borders + app decoration.
+}
+```
+
+- [ ] **Step 4: Extend the encoder.**
+
+In `EncodeBufferDelta` (`protocol/buffer_delta.go` ~line 244, just before `return buf.Bytes(), nil`), append:
+
+```go
+	if len(delta.DecorRows) > 0xFFFF {
+		return nil, ErrBufferTooLarge
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(delta.DecorRows))); err != nil {
+		return nil, err
+	}
+	for _, row := range delta.DecorRows {
+		if len(row.Spans) > 0xFFFF {
+			return nil, ErrBufferTooLarge
+		}
+		if err := binary.Write(buf, binary.LittleEndian, row.Row); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, uint16(len(row.Spans))); err != nil {
+			return nil, err
+		}
+		for _, span := range row.Spans {
+			textBytes := []byte(span.Text)
+			if len(textBytes) > 0xFFFF {
+				return nil, ErrInvalidSpan
+			}
+			if int(span.StyleIndex) >= len(delta.Styles) {
+				return nil, ErrStyleIndexOutOfRange
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StartCol); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, uint16(len(textBytes))); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StyleIndex); err != nil {
+				return nil, err
+			}
+			if len(textBytes) > 0 {
+				if _, err := buf.Write(textBytes); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+```
+
+- [ ] **Step 5: Extend the decoder.**
+
+In `DecodeBufferDelta`, just before `return delta, nil` at the end (~line 350), append:
+
+```go
+	if len(b) < 2 {
+		// Pre-v3 wire (no DecorRows tail). Treat as empty.
+		return delta, nil
+	}
+	decorCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if decorCount == 0 {
+		if len(b) != 0 {
+			return delta, ErrPayloadShort
+		}
+		return delta, nil
+	}
+	delta.DecorRows = make([]RowDelta, decorCount)
+	for i := 0; i < int(decorCount); i++ {
+		if len(b) < 4 {
+			return delta, ErrPayloadShort
+		}
+		row := binary.LittleEndian.Uint16(b[:2])
+		spanCount := binary.LittleEndian.Uint16(b[2:4])
+		b = b[4:]
+		spans := make([]CellSpan, spanCount)
+		for s := 0; s < int(spanCount); s++ {
+			if len(b) < 6 {
+				return delta, ErrPayloadShort
+			}
+			startCol := binary.LittleEndian.Uint16(b[:2])
+			textLen := binary.LittleEndian.Uint16(b[2:4])
+			styleIndex := binary.LittleEndian.Uint16(b[4:6])
+			b = b[6:]
+			if len(b) < int(textLen) {
+				return delta, ErrPayloadShort
+			}
+			text := string(b[:textLen])
+			b = b[textLen:]
+			if int(styleIndex) >= int(styleCount) {
+				return delta, ErrStyleIndexOutOfRange
+			}
+			spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
+		}
+		delta.DecorRows[i] = RowDelta{Row: row, Spans: spans}
+	}
+	if len(b) != 0 {
+		return delta, ErrPayloadShort
+	}
+```
+
+Note: the "pre-v3 wire" comment is intentional — the decoder treats a missing `DecorRows` tail as empty. We are NOT supporting v2 clients; the `Version=3` handshake will refuse them. This branch is for hand-crafted test fixtures that don't include the tail.
+
+Also: `delta, nil` at the very end of the function should now happen only after the new tail is fully consumed. Replace the existing `return delta, nil` at end-of-func with the appended block above (which itself returns at the end).
+
+- [ ] **Step 6: Run the test — verify it passes.**
+
+```bash
+go test ./protocol/ -run TestEncodeDecodeBufferDelta -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the entire protocol test suite to confirm no regressions.**
+
+```bash
+go test ./protocol/ -v
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add protocol/buffer_delta.go protocol/buffer_delta_test.go
+git commit -m "$(cat <<'EOF'
+protocol: add BufferDelta.DecorRows field with codec round-trip
+
+Decoration rows ride alongside content rows but are keyed by absolute
+rowIdx, not (gid - RowBase). Used for borders and app decoration rows
+that have no main-screen globalIdx.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Protocol — `PaneSnapshot.ContentTopRow` / `ContentBottomRow` + encode/decode
+
+**Files:**
+- Modify: `protocol/messages.go` (struct ~line 193, `EncodeTreeSnapshot` ~line 961, `DecodeTreeSnapshot` ~line 1013)
+- Test: `protocol/messages_test.go`
+
+**Goal:** Round-trip the new fields through `EncodeTreeSnapshot` / `DecodeTreeSnapshot`.
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `protocol/messages_test.go`:
+
+```go
+func TestEncodeDecodeTreeSnapshot_ContentBoundsRoundTrip(t *testing.T) {
+	original := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{
+				PaneID:           [16]byte{0xaa},
+				Revision:         3,
+				Title:            "term",
+				Rows:             nil,
+				X:                0, Y: 0, Width: 80, Height: 24,
+				AppType:          "texelterm",
+				AppConfig:        "",
+				ContentTopRow:    1,
+				ContentBottomRow: 21,
+			},
+		},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	encoded, err := protocol.EncodeTreeSnapshot(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeTreeSnapshot(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].ContentBottomRow != 21 {
+		t.Fatalf("content bounds mismatch: got top=%d bottom=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].ContentBottomRow)
+	}
+}
+
+func TestEncodeDecodeTreeSnapshot_ZeroContentSentinel(t *testing.T) {
+	original := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID:           [16]byte{0xbb},
+			Title:            "all-decor",
+			ContentTopRow:    1,
+			ContentBottomRow: 0, // sentinel: no content rows
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	encoded, err := protocol.EncodeTreeSnapshot(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeTreeSnapshot(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].ContentBottomRow != 0 {
+		t.Fatalf("sentinel mismatch: got top=%d bottom=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].ContentBottomRow)
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./protocol/ -run TestEncodeDecodeTreeSnapshot_ContentBoundsRoundTrip -v
+```
+
+Expected: FAIL with `unknown field ContentTopRow in struct literal`.
+
+- [ ] **Step 3: Add fields to `PaneSnapshot`.**
+
+In `protocol/messages.go` (~line 193), modify struct to:
+
+```go
+type PaneSnapshot struct {
+	PaneID           [16]byte
+	Revision         uint32
+	Title            string
+	Rows             []string
+	X                int32
+	Y                int32
+	Width            int32
+	Height           int32
+	AppType          string
+	AppConfig        string
+	ContentTopRow    uint16 // first content rowIdx; for the zero-content sentinel see ContentBottomRow
+	ContentBottomRow uint16 // last content rowIdx; if < ContentTopRow, pane has no content rows
+}
+```
+
+- [ ] **Step 4: Extend `EncodeTreeSnapshot`.**
+
+In `protocol/messages.go` (~line 1003), inside the per-pane loop, after `if err := encodeString(buf, pane.AppConfig); err != nil { return nil, err }`, append:
+
+```go
+		if err := binary.Write(buf, binary.LittleEndian, pane.ContentTopRow); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, pane.ContentBottomRow); err != nil {
+			return nil, err
+		}
+```
+
+- [ ] **Step 5: Extend `DecodeTreeSnapshot`.**
+
+In `protocol/messages.go` (~line 1056), after the existing block:
+
+```go
+		config, remaining, err := decodeString(remaining)
+		if err != nil {
+			return snapshot, err
+		}
+		pane.AppType = appType
+		pane.AppConfig = config
+```
+
+Add:
+
+```go
+		if len(remaining) < 4 {
+			return snapshot, ErrPayloadShort
+		}
+		pane.ContentTopRow = binary.LittleEndian.Uint16(remaining[0:2])
+		pane.ContentBottomRow = binary.LittleEndian.Uint16(remaining[2:4])
+		remaining = remaining[4:]
+```
+
+- [ ] **Step 6: Run — verify pass.**
+
+```bash
+go test ./protocol/ -run TestEncodeDecodeTreeSnapshot -v
+```
+
+Expected: PASS for both new tests.
+
+- [ ] **Step 7: Run all protocol tests.**
+
+```bash
+go test ./protocol/ -v
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add protocol/messages.go protocol/messages_test.go
+git commit -m "$(cat <<'EOF'
+protocol: add PaneSnapshot.ContentTopRow/ContentBottomRow
+
+Tells the client which rowIdx range maps to gids vs decoration. Bottom
+< Top is the zero-content sentinel for all-decoration panes.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Protocol — bump `Version` to 3
+
+**Files:**
+- Modify: `protocol/protocol.go` (line 35)
+- Test: `protocol/protocol_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `protocol/protocol_test.go`:
+
+```go
+func TestProtocolVersionIs3(t *testing.T) {
+	if protocol.Version != 3 {
+		t.Fatalf("expected Version=3, got %d", protocol.Version)
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./protocol/ -run TestProtocolVersionIs3 -v
+```
+
+Expected: FAIL with `expected Version=3, got 2`.
+
+- [ ] **Step 3: Bump version.**
+
+In `protocol/protocol.go` line 35, change `const Version uint8 = 2` to `const Version uint8 = 3`.
+
+- [ ] **Step 4: Run — verify pass.**
+
+```bash
+go test ./protocol/ -run TestProtocolVersionIs3 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full protocol suite.**
+
+```bash
+go test ./protocol/ -v
+```
+
+Expected: ALL PASS. If any other test asserts `Version == 2`, update it to 3.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add protocol/protocol.go protocol/protocol_test.go
+git commit -m "$(cat <<'EOF'
+protocol: bump Version 2 -> 3 for decoration rows + content bounds
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `texel.PaneSnapshot` content bounds + `capturePaneSnapshot` populates them
+
+**Files:**
+- Modify: `texel/snapshot.go` (struct around line 24, `capturePaneSnapshot` around line 304)
+- Test: `texel/snapshot_test.go` (create if missing)
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to (or create) `texel/snapshot_test.go`:
+
+```go
+package texel
+
+import (
+	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
+)
+
+func TestCapturePaneSnapshot_ContentBoundsComputed(t *testing.T) {
+	// Simulate a snapshot's RowGlobalIdx layout for a 6-row pane:
+	// [0]=-1 (top border), [1..3]=content gids, [4]=-1 (app statusbar), [5]=-1 (bottom border)
+	rowIdx := []int64{-1, 100, 101, 102, -1, -1}
+	top, bottom := computeContentBounds(rowIdx)
+	if top != 1 || bottom != 3 {
+		t.Fatalf("expected top=1 bottom=3, got top=%d bottom=%d", top, bottom)
+	}
+}
+
+func TestCapturePaneSnapshot_ContentBoundsAllDecoration(t *testing.T) {
+	// All -1 rows: zero content, sentinel top=1 bottom=0.
+	rowIdx := []int64{-1, -1, -1}
+	top, bottom := computeContentBounds(rowIdx)
+	if top != 1 || bottom != 0 {
+		t.Fatalf("expected sentinel top=1 bottom=0, got top=%d bottom=%d", top, bottom)
+	}
+}
+
+func TestCapturePaneSnapshot_ContentBoundsEmpty(t *testing.T) {
+	// Empty slice: sentinel top=1 bottom=0 (degenerate but well-defined).
+	top, bottom := computeContentBounds(nil)
+	if top != 1 || bottom != 0 {
+		t.Fatalf("expected sentinel top=1 bottom=0, got top=%d bottom=%d", top, bottom)
+	}
+}
+
+// Suppress unused import on platforms where texelcore isn't used in this file.
+var _ texelcore.Cell
+```
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./texel/ -run TestCapturePaneSnapshot_ContentBounds -v
+```
+
+Expected: FAIL with `undefined: computeContentBounds`.
+
+- [ ] **Step 3: Add fields to `texel.PaneSnapshot`.**
+
+In `texel/snapshot.go` (~line 24), update struct to:
+
+```go
+type PaneSnapshot struct {
+	ID           [16]byte
+	Title        string
+	Buffer       [][]Cell
+	RowGlobalIdx []int64
+	AltScreen    bool
+	Rect         Rectangle
+	AppType      string
+	AppConfig    map[string]interface{}
+	// ContentTopRow is the first rowIdx in Buffer with RowGlobalIdx[y] >= 0.
+	// ContentBottomRow is the last such rowIdx. If ContentBottomRow < ContentTopRow,
+	// the pane has zero content rows (e.g., status panes, all-decoration apps).
+	// For alt-screen panes these fields are populated but unused — clients
+	// render alt-screen positionally regardless.
+	ContentTopRow    uint16
+	ContentBottomRow uint16
+}
+```
+
+- [ ] **Step 4: Add `computeContentBounds` helper.**
+
+In `texel/snapshot.go` near `allMinusOne` (~line 360), add:
+
+```go
+// computeContentBounds returns (top, bottom) where rowIdx is the
+// inclusive range with RowGlobalIdx[y] >= 0. If no row has gid>=0, returns
+// (1, 0) as the zero-content sentinel.
+func computeContentBounds(rowIdx []int64) (uint16, uint16) {
+	top := -1
+	bottom := -1
+	for y, gid := range rowIdx {
+		if gid < 0 {
+			continue
+		}
+		if top < 0 {
+			top = y
+		}
+		bottom = y
+	}
+	if top < 0 {
+		return 1, 0 // sentinel: zero content rows
+	}
+	return uint16(top), uint16(bottom)
+}
+```
+
+- [ ] **Step 5: Run — verify the unit tests pass.**
+
+```bash
+go test ./texel/ -run TestCapturePaneSnapshot_ContentBounds -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Wire `computeContentBounds` into `capturePaneSnapshot`.**
+
+In `texel/snapshot.go` `capturePaneSnapshot` (~line 351, just before `return snap` at the end), add:
+
+```go
+	snap.ContentTopRow, snap.ContentBottomRow = computeContentBounds(snap.RowGlobalIdx)
+```
+
+- [ ] **Step 7: Add an integration-shape test for capturePaneSnapshot via the existing texterm path.**
+
+If a test already exists that builds a real `*pane` with a `RowGlobalIdxProvider`, extend it to assert ContentBounds. Otherwise add a fresh test using a minimal fake provider:
+
+Append to `texel/snapshot_test.go`:
+
+```go
+type fakeRowProvider struct {
+	gids []int64
+}
+
+func (f *fakeRowProvider) RowGlobalIdx() []int64 { return f.gids }
+
+// (No-op other texel.App methods required to satisfy the App interface in
+// this test would go in a fixture file. For pure computeContentBounds
+// coverage, the unit tests above are sufficient.)
+```
+
+This step is informational — `computeContentBounds` already has direct unit coverage. Skip if the file structure makes adding a real-pane fixture intrusive.
+
+- [ ] **Step 8: Run all texel tests.**
+
+```bash
+go test ./texel/ -v
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add texel/snapshot.go texel/snapshot_test.go
+git commit -m "$(cat <<'EOF'
+texel: capturePaneSnapshot computes Content{Top,Bottom}Row from RowGlobalIdx
+
+Bottom < Top sentinel signals zero content rows (status panes, all-
+decoration apps). Used by tree_convert to populate the protocol
+PaneSnapshot.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `treeCaptureToProtocol` passes through content bounds
+
+**Files:**
+- Modify: `internal/runtime/server/tree_convert.go` (lines 19-37, the forward translator; lines 39+, the reverse translator)
+- Test: `internal/runtime/server/tree_convert_test.go` (create if missing)
+
+- [ ] **Step 1: Add the failing test.**
+
+Create `internal/runtime/server/tree_convert_test.go` (or append if it exists):
+
+```go
+package server
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/texel"
+)
+
+func TestTreeCaptureToProtocol_PassesContentBounds(t *testing.T) {
+	capture := texel.TreeCapture{
+		Panes: []texel.PaneSnapshot{{
+			ID:               [16]byte{0xab},
+			Title:            "t",
+			ContentTopRow:    2,
+			ContentBottomRow: 17,
+		}},
+	}
+	snap := treeCaptureToProtocol(capture)
+	if len(snap.Panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(snap.Panes))
+	}
+	if snap.Panes[0].ContentTopRow != 2 || snap.Panes[0].ContentBottomRow != 17 {
+		t.Fatalf("content bounds not passed through: top=%d bottom=%d",
+			snap.Panes[0].ContentTopRow, snap.Panes[0].ContentBottomRow)
+	}
+}
+```
+
+(Note: `texel.TreeCapture` is the existing intermediate type used by `treeCaptureToProtocol` — verify that `texel.PaneSnapshot` exposed via `texel.TreeCapture.Panes` matches the type modified in Task 4. Inspect `texel/snapshot.go` for the `TreeCapture` definition if needed.)
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./internal/runtime/server/ -run TestTreeCaptureToProtocol_PassesContentBounds -v
+```
+
+Expected: FAIL — values are zero (default) because the bridge doesn't copy them.
+
+- [ ] **Step 3: Update `treeCaptureToProtocol`.**
+
+In `internal/runtime/server/tree_convert.go` (line 22), modify the per-pane construction to:
+
+```go
+	for i, pane := range capture.Panes {
+		snapshot.Panes[i] = protocol.PaneSnapshot{
+			PaneID:           pane.ID,
+			Revision:         0,
+			Title:            pane.Title,
+			Rows:             nil,
+			X:                int32(pane.Rect.X),
+			Y:                int32(pane.Rect.Y),
+			Width:            int32(pane.Rect.Width),
+			Height:           int32(pane.Rect.Height),
+			AppType:          pane.AppType,
+			AppConfig:        encodeAppConfig(pane.AppConfig),
+			ContentTopRow:    pane.ContentTopRow,
+			ContentBottomRow: pane.ContentBottomRow,
+		}
+	}
+```
+
+- [ ] **Step 4: Update `protocolToTreeCapture` (reverse direction).**
+
+In `internal/runtime/server/tree_convert.go` (~line 39), modify the per-pane construction:
+
+```go
+	capture.Panes[i] = texel.PaneSnapshot{
+		ID:               pane.PaneID,
+		Title:            pane.Title,
+		Buffer:           buffer,
+		RowGlobalIdx:     rowGlobalIdxAllMinusOne(len(buffer)),
+		Rect:             texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
+		AppType:          pane.AppType,
+		AppConfig:        decodeAppConfig(pane.AppConfig),
+		ContentTopRow:    pane.ContentTopRow,
+		ContentBottomRow: pane.ContentBottomRow,
+	}
+```
+
+- [ ] **Step 5: Run — verify pass.**
+
+```bash
+go test ./internal/runtime/server/ -run TestTreeCaptureToProtocol_PassesContentBounds -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run package tests.**
+
+```bash
+go test ./internal/runtime/server/ -count=1
+```
+
+Expected: ALL PASS (server-side tests are extensive; expect this to take ~30s).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add internal/runtime/server/tree_convert.go internal/runtime/server/tree_convert_test.go
+git commit -m "$(cat <<'EOF'
+server: tree_convert passes Content{Top,Bottom}Row through both directions
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `bufferToDelta` routes gid<0 rows into `DecorRows`
+
+**Files:**
+- Modify: `internal/runtime/server/desktop_publisher.go` (the `for y, row := range snap.Buffer` loop ~line 296-313)
+- Test: `internal/runtime/server/desktop_publisher_test.go` (the file may be named differently — check existing tests for `bufferToDelta`)
+
+- [ ] **Step 1: Locate existing `bufferToDelta` tests.**
+
+```bash
+grep -rln "bufferToDelta" internal/runtime/server/*_test.go
+```
+
+Use the file that surfaces. If none exists, create `internal/runtime/server/desktop_publisher_test.go`.
+
+- [ ] **Step 2: Add the failing test.**
+
+Append (or create with appropriate package boilerplate):
+
+```go
+func TestBufferToDelta_DecorationRowsIncluded(t *testing.T) {
+	// 5-row buffer: rowIdx 0 = top border (-1), rowIdx 1..3 = content gids,
+	// rowIdx 4 = bottom border (-1).
+	rows := [][]texel.Cell{
+		{{Ch: '+'}, {Ch: '-'}, {Ch: '+'}}, // border
+		{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}}, // content
+		{{Ch: 'd'}, {Ch: 'e'}, {Ch: 'f'}}, // content
+		{{Ch: 'g'}, {Ch: 'h'}, {Ch: 'i'}}, // content
+		{{Ch: '+'}, {Ch: '-'}, {Ch: '+'}}, // border
+	}
+	snap := texel.PaneSnapshot{
+		ID:               [16]byte{0xab},
+		Buffer:           rows,
+		RowGlobalIdx:     []int64{-1, 100, 101, 102, -1},
+		ContentTopRow:    1,
+		ContentBottomRow: 3,
+	}
+	vp := ClientViewport{Rows: 3, AutoFollow: true}
+	prev := [][]texel.Cell(nil)
+
+	delta := bufferToDelta(snap, vp, prev, 1)
+
+	// Expect 2 decoration rows: rowIdx 0 (top border) and rowIdx 4 (bottom border).
+	if len(delta.DecorRows) != 2 {
+		t.Fatalf("expected 2 DecorRows, got %d: %+v", len(delta.DecorRows), delta.DecorRows)
+	}
+	gotIdx := map[uint16]bool{delta.DecorRows[0].Row: true, delta.DecorRows[1].Row: true}
+	if !gotIdx[0] || !gotIdx[4] {
+		t.Fatalf("expected decoration rows at rowIdx 0 and 4, got %v", gotIdx)
+	}
+	// Content rows still present.
+	if len(delta.Rows) != 3 {
+		t.Fatalf("expected 3 content Rows, got %d", len(delta.Rows))
+	}
+}
+
+func TestBufferToDelta_DecorationRowsDiffed(t *testing.T) {
+	rows := [][]texel.Cell{
+		{{Ch: '+'}}, // border
+		{{Ch: 'a'}}, // content
+		{{Ch: '+'}}, // border
+	}
+	snap := texel.PaneSnapshot{
+		ID:               [16]byte{0xab},
+		Buffer:           rows,
+		RowGlobalIdx:     []int64{-1, 100, -1},
+		ContentTopRow:    1,
+		ContentBottomRow: 1,
+	}
+	vp := ClientViewport{Rows: 1, AutoFollow: true}
+	// prev identical => no rows or DecorRows should ship.
+	prev := [][]texel.Cell{
+		{{Ch: '+'}},
+		{{Ch: 'a'}},
+		{{Ch: '+'}},
+	}
+
+	delta := bufferToDelta(snap, vp, prev, 1)
+	if len(delta.DecorRows) != 0 {
+		t.Fatalf("expected 0 DecorRows when borders unchanged, got %d", len(delta.DecorRows))
+	}
+	if len(delta.Rows) != 0 {
+		t.Fatalf("expected 0 content Rows when content unchanged, got %d", len(delta.Rows))
+	}
+}
+
+func TestBufferToDelta_DecorationRowsDiffPartial(t *testing.T) {
+	rows := [][]texel.Cell{
+		{{Ch: '+'}}, // border (will change)
+		{{Ch: 'a'}}, // content
+		{{Ch: '+'}}, // border (unchanged)
+	}
+	snap := texel.PaneSnapshot{
+		ID:               [16]byte{0xab},
+		Buffer:           rows,
+		RowGlobalIdx:     []int64{-1, 100, -1},
+		ContentTopRow:    1,
+		ContentBottomRow: 1,
+	}
+	vp := ClientViewport{Rows: 1, AutoFollow: true}
+	prev := [][]texel.Cell{
+		{{Ch: '#'}}, // different from current — should ship
+		{{Ch: 'a'}}, // same — skip
+		{{Ch: '+'}}, // same — skip
+	}
+	delta := bufferToDelta(snap, vp, prev, 1)
+	if len(delta.DecorRows) != 1 || delta.DecorRows[0].Row != 0 {
+		t.Fatalf("expected 1 DecorRows entry at rowIdx 0, got %+v", delta.DecorRows)
+	}
+}
+
+func TestBufferToDelta_TexelTermInternalStatusbar(t *testing.T) {
+	// 6-row layout: rowIdx 0 = top border, [1..3] = content, rowIdx 4 = app
+	// internal statusbar (gid=-1), rowIdx 5 = bottom border. Mirrors the real
+	// texelterm pane shape that surfaced the bug.
+	rows := [][]texel.Cell{
+		{{Ch: '+'}},
+		{{Ch: 'a'}},
+		{{Ch: 'b'}},
+		{{Ch: 'c'}},
+		{{Ch: 'S'}}, // app statusbar
+		{{Ch: '+'}},
+	}
+	snap := texel.PaneSnapshot{
+		ID:               [16]byte{0xab},
+		Buffer:           rows,
+		RowGlobalIdx:     []int64{-1, 100, 101, 102, -1, -1},
+		ContentTopRow:    1,
+		ContentBottomRow: 3,
+	}
+	vp := ClientViewport{Rows: 3, AutoFollow: true}
+	delta := bufferToDelta(snap, vp, nil, 1)
+	got := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		got[r.Row] = true
+	}
+	if !got[0] || !got[4] || !got[5] {
+		t.Fatalf("expected DecorRows at rowIdx 0, 4, 5 (top + statusbar + bottom), got %v", got)
+	}
+}
+
+func TestBufferToDelta_AltScreenLeavesDecorRowsEmpty(t *testing.T) {
+	rows := [][]texel.Cell{{{Ch: 'x'}}}
+	snap := texel.PaneSnapshot{
+		ID:           [16]byte{0xab},
+		Buffer:       rows,
+		RowGlobalIdx: []int64{-1},
+		AltScreen:    true,
+	}
+	vp := ClientViewport{Rows: 1, AltScreen: true}
+	delta := bufferToDelta(snap, vp, nil, 1)
+	if len(delta.DecorRows) != 0 {
+		t.Fatalf("alt-screen must not emit DecorRows, got %d", len(delta.DecorRows))
+	}
+}
+```
+
+(The exact `ClientViewport` field names and `bufferToDelta` signature must match existing code — read the function signature at `internal/runtime/server/desktop_publisher.go:206` (or near there) and adapt the test calls. The test author should preserve the public-API arguments the function actually takes.)
+
+- [ ] **Step 3: Run — verify failure.**
+
+```bash
+go test ./internal/runtime/server/ -run TestBufferToDelta_Decoration -v
+```
+
+Expected: FAIL — `DecorRows` is empty because the publisher still drops gid<0 rows.
+
+- [ ] **Step 4: Modify `bufferToDelta`.**
+
+In `internal/runtime/server/desktop_publisher.go` find the row-iteration loop (around line 296-313) which currently is:
+
+```go
+for y, row := range snap.Buffer {
+	if len(row) == 0 {
+		continue
+	}
+	if y >= len(snap.RowGlobalIdx) {
+		continue
+	}
+	gid := snap.RowGlobalIdx[y]
+	if gid < 0 {
+		continue
+	}
+	if gid < lo || gid > hi {
+		continue
+	}
+	if y < len(prev) && rowsEqual(row, prev[y]) {
+		continue
+	}
+	rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: encodeRow(row)})
+}
+delta.Styles = styles
+delta.Rows = rows
+return delta
+```
+
+Replace with:
+
+```go
+var decorRows []protocol.RowDelta
+for y, row := range snap.Buffer {
+	if len(row) == 0 {
+		continue
+	}
+	if y >= len(snap.RowGlobalIdx) {
+		continue
+	}
+	if y < len(prev) && rowsEqual(row, prev[y]) {
+		continue
+	}
+	gid := snap.RowGlobalIdx[y]
+	if gid < 0 {
+		// Decoration row: borders, app statusbars. Alt-screen panes
+		// emit nothing here because RowGlobalIdx is all -1 AND we
+		// take the existing alt-screen positional path elsewhere.
+		if snap.AltScreen {
+			continue
+		}
+		decorRows = append(decorRows, protocol.RowDelta{
+			Row:   uint16(y),
+			Spans: encodeRow(row),
+		})
+		continue
+	}
+	if gid < lo || gid > hi {
+		continue
+	}
+	rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: encodeRow(row)})
+}
+delta.Styles = styles
+delta.Rows = rows
+delta.DecorRows = decorRows
+return delta
+```
+
+Note the diff check moves *before* the gid check so it fires for both content and decoration rows. The `snap.AltScreen` guard prevents alt-screen panes (whose RowGlobalIdx is all -1) from spamming decoration rows; the existing alt-screen path handles them positionally via `delta.Flags & BufferDeltaAltScreen`.
+
+- [ ] **Step 5: Run — verify pass.**
+
+```bash
+go test ./internal/runtime/server/ -run TestBufferToDelta_Decoration -v
+```
+
+Expected: PASS for all three new tests.
+
+- [ ] **Step 6: Run server package tests.**
+
+```bash
+go test ./internal/runtime/server/ -count=1
+```
+
+Expected: ALL PASS. If a Plan A integration test like `TestIntegration_ClipsAndFetches` regresses (because it now sees `DecorRows`), inspect it and either add a `len(delta.DecorRows) == 0` assertion or update the assertion to account for them.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add internal/runtime/server/desktop_publisher.go internal/runtime/server/desktop_publisher_test.go
+git commit -m "$(cat <<'EOF'
+server: bufferToDelta routes gid<0 rows into DecorRows
+
+Borders and app decoration rows now reach the client as positional
+RowDeltas alongside content. Diff is positional and applies to both
+layers. Alt-screen panes opt out (existing positional flag path
+already covers them).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `client.PaneState` gains content-bound + decoration-cache fields
+
+**Files:**
+- Modify: `client/buffercache.go` (struct ~line 22)
+- Test: `client/buffercache_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `client/buffercache_test.go`:
+
+```go
+func TestApplySnapshot_PopulatesContentBounds(t *testing.T) {
+	cache := client.NewBufferCache()
+	id := [16]byte{0xab}
+	snapshot := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID:           id,
+			Title:            "t",
+			Width:            10, Height: 6,
+			ContentTopRow:    1,
+			ContentBottomRow: 4,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	cache.ApplySnapshot(snapshot)
+	pane := cache.Pane(id)
+	if pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
+		t.Fatalf("content bounds not applied: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+	}
+}
+```
+
+If `cache.Pane(id)` accessor doesn't exist, use whatever inspector the existing tests use (e.g., reading via `cache.AllPanes()`).
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./client/ -run TestApplySnapshot_PopulatesContentBounds -v
+```
+
+Expected: FAIL with `pane.ContentTopRow undefined`.
+
+- [ ] **Step 3: Add fields to `PaneState`.**
+
+In `client/buffercache.go` (~line 22), update struct:
+
+```go
+type PaneState struct {
+	ID               [16]byte
+	Revision         uint32
+	UpdatedAt        time.Time
+	rowsMu           sync.RWMutex
+	rows             map[int][]Cell
+	Title            string
+	Rect             clientRect
+	Active           bool
+	Resizing         bool
+	ZOrder           int
+	HandlesSelection bool
+
+	// Content bounds (populated from PaneSnapshot). For non-altScreen panes,
+	// rowIdx in [ContentTopRow, ContentBottomRow] maps to gid via the
+	// viewport tracker; rowIdx outside reads from DecorRows. If
+	// ContentBottomRow < ContentTopRow, the pane has zero content rows.
+	ContentTopRow    uint16
+	ContentBottomRow uint16
+
+	// DecorRows holds positional decoration cells (borders + app statusbars).
+	// Keyed by absolute rowIdx. Populated from BufferDelta.DecorRows.
+	DecorRows map[uint16][]Cell
+
+	// Dirty tracking for incremental rendering.
+	Dirty       bool
+	DirtyRows   map[int]bool
+	HasAnimated bool
+}
+```
+
+- [ ] **Step 4: Update `ApplySnapshot` to copy content bounds.**
+
+In `client/buffercache.go` `ApplySnapshot` (~line 235), after `pane.Title = paneSnap.Title`, add:
+
+```go
+		pane.ContentTopRow = paneSnap.ContentTopRow
+		pane.ContentBottomRow = paneSnap.ContentBottomRow
+```
+
+- [ ] **Step 5: Run — verify pass.**
+
+```bash
+go test ./client/ -run TestApplySnapshot_PopulatesContentBounds -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add client/buffercache.go client/buffercache_test.go
+git commit -m "$(cat <<'EOF'
+client: PaneState carries Content{Top,Bottom}Row + DecorRows fields
+
+ApplySnapshot copies content bounds from the protocol pane snapshot.
+DecorRows is populated by ApplyDelta (next commit).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `BufferCache.ApplyDelta` populates `DecorRows`
+
+**Files:**
+- Modify: `client/buffercache.go` `ApplyDelta` (~line 149)
+- Test: `client/buffercache_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `client/buffercache_test.go`:
+
+```go
+func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
+	cache := client.NewBufferCache()
+	id := [16]byte{0xab}
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 1,
+		Styles: []protocol.StyleEntry{
+			{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault},
+		},
+		DecorRows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+			{Row: 9, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+		},
+	}
+	cache.ApplyDelta(delta)
+	pane := cache.Pane(id)
+	if pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	if len(pane.DecorRows) != 2 {
+		t.Fatalf("expected 2 decor rows, got %d: %+v", len(pane.DecorRows), pane.DecorRows)
+	}
+	if len(pane.DecorRows[0]) != 4 || pane.DecorRows[0][0].Ch != '+' {
+		t.Fatalf("rowIdx 0 content wrong: %+v", pane.DecorRows[0])
+	}
+	if len(pane.DecorRows[9]) != 4 || pane.DecorRows[9][3].Ch != '+' {
+		t.Fatalf("rowIdx 9 content wrong: %+v", pane.DecorRows[9])
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./client/ -run TestApplyDelta_PopulatesDecorRows -v
+```
+
+Expected: FAIL — `pane.DecorRows` is nil.
+
+- [ ] **Step 3: Update `ApplyDelta`.**
+
+In `client/buffercache.go` `ApplyDelta` (~line 149), within the function, just before `pane.Revision = delta.Revision` near the bottom, insert:
+
+```go
+	if len(delta.DecorRows) > 0 {
+		if pane.DecorRows == nil {
+			pane.DecorRows = make(map[uint16][]Cell, len(delta.DecorRows))
+		}
+		for _, rowDelta := range delta.DecorRows {
+			row := pane.DecorRows[rowDelta.Row]
+			for _, span := range rowDelta.Spans {
+				start := int(span.StartCol)
+				textRunes := []rune(span.Text)
+				needed := start + len(textRunes)
+				row = ensureRowLength(row, needed)
+				style := tcell.StyleDefault
+				var dynFG, dynBG protocol.DynColorDesc
+				if int(span.StyleIndex) < len(styles) {
+					style = styles[span.StyleIndex]
+				}
+				if int(span.StyleIndex) < len(delta.Styles) {
+					entry := delta.Styles[span.StyleIndex]
+					if entry.AttrFlags&protocol.AttrHasDynamic != 0 {
+						dynFG = entry.DynFG
+						dynBG = entry.DynBG
+					}
+				}
+				for i, r := range textRunes {
+					row[start+i] = Cell{Ch: r, Style: style, DynFG: dynFG, DynBG: dynBG}
+				}
+			}
+			pane.DecorRows[rowDelta.Row] = row
+		}
+		pane.Dirty = true
+		// DecorRow changes invalidate row-level dirty tracking; force a
+		// full re-render of this pane.
+		pane.DirtyRows = nil
+	}
+```
+
+This mirrors the content-row apply loop above it but writes into `pane.DecorRows` instead of `pane.rows`.
+
+- [ ] **Step 4: Run — verify pass.**
+
+```bash
+go test ./client/ -run TestApplyDelta_PopulatesDecorRows -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run client package tests.**
+
+```bash
+go test ./client/ -count=1
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add client/buffercache.go client/buffercache_test.go
+git commit -m "$(cat <<'EOF'
+client: ApplyDelta populates PaneState.DecorRows
+
+DecorRows is keyed by absolute rowIdx, mirrors the content-row apply
+loop. Changes force pane.DirtyRows=nil (full re-render) since rowIdx-
+keyed decoration writes don't fit the existing gid-based row dirty
+tracking.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `ResetRevisions` clears `DecorRows`
+
+**Files:**
+- Modify: `client/buffercache.go` `ResetRevisions` (~line 585)
+- Test: `client/buffercache_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `client/buffercache_test.go`:
+
+```go
+func TestResetRevisions_ClearsDecorRows(t *testing.T) {
+	cache := client.NewBufferCache()
+	id := [16]byte{0xab}
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 7,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		DecorRows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+		},
+	}
+	cache.ApplyDelta(delta)
+	if pane := cache.Pane(id); pane == nil || len(pane.DecorRows) != 1 {
+		t.Fatalf("pre-reset: expected 1 DecorRows entry, got %+v", pane)
+	}
+	cache.ResetRevisions()
+	pane := cache.Pane(id)
+	if pane == nil {
+		t.Fatalf("pane gone after reset")
+	}
+	if len(pane.DecorRows) != 0 {
+		t.Fatalf("expected DecorRows cleared, got %d entries", len(pane.DecorRows))
+	}
+	if pane.Revision != 0 {
+		t.Fatalf("expected Revision=0, got %d", pane.Revision)
+	}
+}
+```
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test ./client/ -run TestResetRevisions_ClearsDecorRows -v
+```
+
+Expected: FAIL — DecorRows still has 1 entry after reset.
+
+- [ ] **Step 3: Update `ResetRevisions`.**
+
+In `client/buffercache.go` (~line 585), modify to:
+
+```go
+func (c *BufferCache) ResetRevisions() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, pane := range c.panes {
+		pane.Revision = 0
+		pane.DecorRows = nil
+	}
+}
+```
+
+- [ ] **Step 4: Run — verify pass.**
+
+```bash
+go test ./client/ -run TestResetRevisions_ClearsDecorRows -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add client/buffercache.go client/buffercache_test.go
+git commit -m "$(cat <<'EOF'
+client: ResetRevisions clears PaneState.DecorRows
+
+On session reuse / new publisher (Plan D2 path), the next delta will
+republish all decoration rows. Stale chrome would otherwise survive
+across publishers.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `viewport_tracker.onBufferDelta` uses `numContentRows`
+
+**Files:**
+- Modify: `internal/runtime/client/viewport_tracker.go` `onBufferDelta` (~line 250-275)
+- Test: `internal/runtime/client/viewport_tracker_test.go` (or extend the existing tracker tests)
+
+- [ ] **Step 1: Locate the existing tracker test file.**
+
+```bash
+ls internal/runtime/client/ | grep viewport
+```
+
+Use `viewport_tracker_test.go` if present; otherwise the existing test file pattern in this directory.
+
+- [ ] **Step 2: Add the failing test.**
+
+Append:
+
+```go
+func TestOnBufferDelta_TopUsesContentRowCount(t *testing.T) {
+	state := newClientStateForTest(t) // helper from existing tests
+	id := [16]byte{0xab}
+	// Pane has H=10 rows; ContentTopRow=1, ContentBottomRow=8 → 8 content rows.
+	state.cache.ApplySnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 5, Height: 10,
+			ContentTopRow: 1, ContentBottomRow: 8,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+	state.viewports.get(id).Rows = 10
+	state.viewports.get(id).Cols = 5
+	state.viewports.get(id).AutoFollow = true
+
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 0,
+		Styles:  []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: 7}, // gid = RowBase + 7 = 7 (maxGid)
+		},
+	}
+	state.onBufferDelta(delta, false)
+	vp := state.viewports.get(id)
+	// numContentRows = 8 → top = 7 - (8-1) = 0
+	if vp.ViewTopIdx != 0 {
+		t.Fatalf("expected ViewTopIdx=0 (8 content rows), got %d", vp.ViewTopIdx)
+	}
+}
+```
+
+If `newClientStateForTest` helper doesn't exist, build the minimum state inline. Inspect existing tests in the file for their setup pattern.
+
+- [ ] **Step 3: Run — verify failure.**
+
+```bash
+go test ./internal/runtime/client/ -run TestOnBufferDelta_TopUsesContentRowCount -v
+```
+
+Expected: FAIL — `vp.ViewTopIdx` will be `7 - (10-1) = -2` clamped to 0, but the failure is in the math derivation, not the clamp. To make the failure crisp, change the test to use a larger maxGid where the bug shows up: set `Rows: []protocol.RowDelta{{Row: 100}}` and `RowBase: 0`. With old code: top = 100 - 9 = 91. With new code: top = 100 - 7 = 93.
+
+Replace the `Rows: []protocol.RowDelta{{Row: 7}}` line and the assertion to:
+
+```go
+		Rows: []protocol.RowDelta{{Row: 100}},
+```
+
+```go
+	if vp.ViewTopIdx != 93 {
+		t.Fatalf("expected ViewTopIdx=93 (maxGid=100, 8 content rows), got %d", vp.ViewTopIdx)
+	}
+```
+
+Re-run; expected: FAIL with `expected ViewTopIdx=93, got 91`.
+
+- [ ] **Step 4: Update `onBufferDelta`.**
+
+In `internal/runtime/client/viewport_tracker.go` (~line 263), change:
+
+```go
+	top := maxGid - int64(vp.Rows-1)
+```
+
+to:
+
+```go
+	pane := s.cache.Pane(delta.PaneID)
+	numContentRows := int64(vp.Rows)
+	if pane != nil && pane.ContentBottomRow >= pane.ContentTopRow {
+		numContentRows = int64(pane.ContentBottomRow) - int64(pane.ContentTopRow) + 1
+	}
+	if numContentRows <= 0 {
+		return
+	}
+	top := maxGid - (numContentRows - 1)
+```
+
+(Verify `s.cache` is the access path to `BufferCache` from `clientState`; if it's named differently, adjust. Inspect `internal/runtime/client/state.go` or the surrounding file for the field name.)
+
+- [ ] **Step 5: Run — verify pass.**
+
+```bash
+go test ./internal/runtime/client/ -run TestOnBufferDelta_TopUsesContentRowCount -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run client runtime tests.**
+
+```bash
+go test ./internal/runtime/client/ -count=1
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add internal/runtime/client/viewport_tracker.go internal/runtime/client/viewport_tracker_test.go
+git commit -m "$(cat <<'EOF'
+client: onBufferDelta computes top from numContentRows, not vp.Rows
+
+vp.Rows includes border/decoration rows; numContentRows excludes them.
+This stops the viewport top from being offset by the count of non-
+content rows. Falls back to vp.Rows if the pane has no ContentBottom/
+Top yet (pre-snapshot delta — should not happen in production).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: `renderer.rowSourceForPane` two-layer lookup
+
+**Files:**
+- Modify: `internal/runtime/client/renderer.go` `rowSourceForPane` (~line 165-189)
+- Test: `internal/runtime/client/renderer_test.go` (or wherever renderer tests live)
+
+- [ ] **Step 1: Locate renderer tests.**
+
+```bash
+ls internal/runtime/client/ | grep -E "render(er)?_test"
+```
+
+Use the surfaced file or create `renderer_test.go`.
+
+- [ ] **Step 2: Add the failing test.**
+
+Append:
+
+```go
+func TestRowSourceForPane_DecorationLayer(t *testing.T) {
+	state := newClientStateForTest(t)
+	id := [16]byte{0xab}
+	// Pane H=5, ContentTopRow=1, ContentBottomRow=3.
+	state.cache.ApplySnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 4, Height: 5,
+			ContentTopRow: 1, ContentBottomRow: 3,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+	// Apply a delta with 1 content row (gid=10) and 2 decoration rows (rowIdx 0 + 4).
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 10,
+		Styles:  []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "C", StyleIndex: 0}}},
+		},
+		DecorRows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "T", StyleIndex: 0}}},
+			{Row: 4, Spans: []protocol.CellSpan{{StartCol: 0, Text: "B", StyleIndex: 0}}},
+		},
+	}
+	state.cache.ApplyDelta(delta)
+	state.onBufferDelta(delta, false)
+
+	pane := state.cache.Pane(id)
+	if pane == nil {
+		t.Fatalf("pane missing")
+	}
+
+	// rowIdx 0 → decoration "T"
+	src := rowSourceForPane(state, pane, 0)
+	if len(src) == 0 || src[0].Ch != 'T' {
+		t.Fatalf("rowIdx 0 expected decoration 'T', got %+v", src)
+	}
+	// rowIdx 1 → content "C" (gid 10)
+	src = rowSourceForPane(state, pane, 1)
+	if len(src) == 0 || src[0].Ch != 'C' {
+		t.Fatalf("rowIdx 1 expected content 'C', got %+v", src)
+	}
+	// rowIdx 4 → decoration "B"
+	src = rowSourceForPane(state, pane, 4)
+	if len(src) == 0 || src[0].Ch != 'B' {
+		t.Fatalf("rowIdx 4 expected decoration 'B', got %+v", src)
+	}
+}
+
+func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {
+	state := newClientStateForTest(t)
+	id := [16]byte{0xab}
+	state.cache.ApplySnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 4, Height: 5,
+			ContentTopRow: 1, ContentBottomRow: 3,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+	pane := state.cache.Pane(id)
+	src := rowSourceForPane(state, pane, 0)
+	if src != nil {
+		t.Fatalf("expected nil for decoration miss, got %+v", src)
+	}
+}
+```
+
+- [ ] **Step 3: Run — verify failure.**
+
+```bash
+go test ./internal/runtime/client/ -run TestRowSourceForPane_Decoration -v
+```
+
+Expected: FAIL — `rowIdx 0` returns content (or nil), not decoration.
+
+- [ ] **Step 4: Update `rowSourceForPane`.**
+
+In `internal/runtime/client/renderer.go` (~line 165), replace function body:
+
+```go
+func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []client.Cell {
+	if state.viewports == nil {
+		return pane.RowCellsDirect(rowIdx)
+	}
+	vc, ok := state.paneViewportFor(pane.ID)
+	if !ok {
+		return pane.RowCellsDirect(rowIdx)
+	}
+	pc := state.paneCacheFor(pane.ID)
+	if vc.AltScreen {
+		row, found := pc.AltRowAt(rowIdx)
+		if !found {
+			return pane.RowCellsDirect(rowIdx)
+		}
+		return row
+	}
+
+	// Decoration layer: rowIdx outside the content-bound range reads from
+	// PaneState.DecorRows (positional).
+	if rowIdx < int(pane.ContentTopRow) || rowIdx > int(pane.ContentBottomRow) {
+		if pane.DecorRows != nil {
+			if row, ok := pane.DecorRows[uint16(rowIdx)]; ok {
+				return row
+			}
+		}
+		return nil
+	}
+
+	// Content layer: rowIdx mapped via gid lookup.
+	contentRowIdx := rowIdx - int(pane.ContentTopRow)
+	gid := vc.ViewTopIdx + int64(contentRowIdx)
+	row, found := pc.RowAt(gid)
+	if !found {
+		// Row not yet in cache (fetch is en route). Render blank rather than
+		// showing stale BufferCache content at a mismatched globalIdx.
+		return nil
+	}
+	return row
+}
+```
+
+- [ ] **Step 5: Run — verify pass.**
+
+```bash
+go test ./internal/runtime/client/ -run TestRowSourceForPane_Decoration -v
+```
+
+Expected: PASS for both tests.
+
+- [ ] **Step 6: Run client runtime tests.**
+
+```bash
+go test ./internal/runtime/client/ -count=1
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add internal/runtime/client/renderer.go internal/runtime/client/renderer_test.go
+git commit -m "$(cat <<'EOF'
+client: rowSourceForPane two-layer lookup (content gid / decoration positional)
+
+rowIdx in [ContentTopRow, ContentBottomRow] reads from PaneCache via
+gid; outside the range reads from PaneState.DecorRows positionally.
+A content-layer miss returns nil (preserves Plan A's no-stale-content
+behavior); a decoration-layer miss also returns nil (renders blank;
+should hit after the first delta).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Integration — borders render on clean start
+
+**Files:**
+- Modify: `internal/runtime/server/viewport_integration_test.go` (extend with new test cases)
+- Helper: existing memconn harness
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `internal/runtime/server/viewport_integration_test.go` (or create a sibling `decoration_integration_test.go`):
+
+```go
+func TestIntegration_PaneRendersAllFourBorders_CleanStart(t *testing.T) {
+	// Build a minimal harness with a single texterm-shaped pane.
+	// Use the existing helper that produces a sparseFakeApp + memconn
+	// pair (search the file for sparseFakeApp + buildHarness).
+	h := buildIntegrationHarness(t, harnessOpts{
+		paneRows: 6,
+		paneCols: 10,
+		// fake provides RowGlobalIdx so capturePaneSnapshot computes
+		// ContentTopRow=1, ContentBottomRow=4 (top border + 4 content + bottom border).
+	})
+	defer h.Close()
+	h.WaitForFirstDelta(t)
+
+	// Inspect what the client sees:
+	delta := h.LastDelta(t)
+	if len(delta.DecorRows) == 0 {
+		t.Fatal("expected DecorRows with at least 2 entries (top + bottom borders)")
+	}
+	rowIdxs := make(map[uint16]bool, len(delta.DecorRows))
+	for _, r := range delta.DecorRows {
+		rowIdxs[r.Row] = true
+	}
+	if !rowIdxs[0] || !rowIdxs[5] {
+		t.Fatalf("expected border decoration rows at rowIdx 0 and 5, got %v", rowIdxs)
+	}
+
+	// Verify content bounds reached the client cache.
+	pane := h.ClientCache().Pane(h.PaneID())
+	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
+		t.Fatalf("client content bounds wrong: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+	}
+}
+```
+
+If `buildIntegrationHarness`, `WaitForFirstDelta`, `LastDelta`, `ClientCache`, `PaneID` don't exist as helpers, look at how existing tests like `TestIntegration_ClipsAndFetches` set up their fixtures and reuse the same pattern. The test author may need to extract a small helper from an existing test if no shared one exists yet.
+
+- [ ] **Step 2: Run — verify failure.**
+
+```bash
+go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_CleanStart -v
+```
+
+Expected: FAIL — initially the harness may not exist or the assertions fail.
+
+- [ ] **Step 3: Make the test green.**
+
+Most of the wiring should already work after Tasks 1-11. If the test fails for harness-shape reasons, build the missing helpers as the smallest possible addition — do NOT introduce a generalised harness; copy the inline shape used by existing tests.
+
+If the assertions fail (e.g., border rowIdx don't match), inspect why — likely the fake app's `RowGlobalIdx` doesn't put -1 at the expected slots. Adjust the fake to mirror what a real texterm produces.
+
+- [ ] **Step 4: Run — verify pass.**
+
+```bash
+go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_CleanStart -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add internal/runtime/server/viewport_integration_test.go
+git commit -m "$(cat <<'EOF'
+test(server): integration — pane renders all four borders on clean start
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Integration — borders render after daemon-restart rehydrate
+
+**Files:**
+- Modify: `internal/runtime/server/viewport_integration_test.go` (or the same file used in Task 12)
+
+- [ ] **Step 1: Add the failing test.**
+
+This test is the Plan D2 cross-restart cycle adapted to assert decoration rows. Find the existing Plan D2 cross-restart integration test (search for `TestD2_FullCrossRestartCycle` or `TestIntegration_D2`) and extend it, OR create a sibling that exercises the same cycle:
+
+```go
+func TestIntegration_PaneRendersAllFourBorders_AfterRehydrate(t *testing.T) {
+	// 1. Boot fresh daemon, attach client, get initial render.
+	// 2. Simulate daemon restart: tear down + boot a new server backed by
+	//    the same persistence dir (mirrors Plan D2 harness).
+	// 3. Reconnect with the persisted sessionID via MsgResumeRequest.
+	// 4. Assert the post-resume BufferDelta carries border DecorRows AND
+	//    the client renders them at rowIdx 0 and H-1.
+	// (See TestD2_FullCrossRestartCycle for the harness pattern.)
+
+	h := buildD2Harness(t, harnessOpts{paneRows: 6, paneCols: 10})
+	defer h.Close()
+	h.WaitForFirstDelta(t)
+	sessionID := h.SessionID()
+	h.RestartDaemon(t)
+	h.Reconnect(t, sessionID)
+
+	delta := h.WaitForPostResumeDelta(t)
+	rowIdxs := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		rowIdxs[r.Row] = true
+	}
+	if !rowIdxs[0] || !rowIdxs[5] {
+		t.Fatalf("post-rehydrate delta missing border DecorRows, got %v", rowIdxs)
+	}
+}
+```
+
+The exact helper names must mirror the existing Plan D2 test harness. If the existing harness uses different names, adapt.
+
+- [ ] **Step 2-4: Verify red, green, run.**
+
+```bash
+go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_AfterRehydrate -v
+```
+
+Expect FAIL initially (harness setup or missing assertions); make it green.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add internal/runtime/server/viewport_integration_test.go
+git commit -m "$(cat <<'EOF'
+test(server): integration — pane renders all four borders after daemon restart
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Integration — borders + decoration render when scrolled mid-history
+
+**Files:**
+- Modify: `internal/runtime/server/viewport_integration_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+```go
+func TestIntegration_PaneRendersAllFourBorders_ScrolledMidHistory(t *testing.T) {
+	h := buildIntegrationHarness(t, harnessOpts{paneRows: 6, paneCols: 10})
+	defer h.Close()
+	h.WaitForFirstDelta(t)
+
+	// Push several pages of content so the client can scroll back.
+	for i := 0; i < 50; i++ {
+		h.AppendContentRow(t, fmt.Sprintf("line-%d", i))
+	}
+	h.WaitForLatestDelta(t)
+	// Scroll the client off the live edge (autoFollow=false, viewBottom mid-history).
+	h.SetClientViewport(t, ClientViewportOpts{
+		AutoFollow:    false,
+		ViewBottomIdx: 10,
+	})
+	h.WaitForFetchRangeRoundTrip(t)
+
+	pane := h.ClientCache().Pane(h.PaneID())
+	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
+		t.Fatalf("scrolled state lost content bounds: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+	}
+	if len(pane.DecorRows) < 2 {
+		t.Fatalf("scrolled state lost decoration rows: %+v", pane.DecorRows)
+	}
+}
+```
+
+- [ ] **Step 2-5: Red, green, run, commit.**
+
+Same shape as Tasks 12-13.
+
+```bash
+git commit -m "$(cat <<'EOF'
+test(server): integration — borders survive mid-history scroll
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Integration — focus change repaints borders via DecorRows
+
+**Files:**
+- Modify: `internal/runtime/server/viewport_integration_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+```go
+func TestIntegration_FocusChangeRepaintsBorders(t *testing.T) {
+	h := buildIntegrationHarness(t, harnessOpts{
+		paneRows: 6, paneCols: 10,
+		twoPanes: true, // harness must support a 2-pane setup
+	})
+	defer h.Close()
+	h.WaitForFirstDelta(t)
+	h.DrainDeltas(t) // ignore initial deltas
+
+	// Toggle focus from pane A to pane B.
+	h.FocusPane(t, h.PaneB())
+
+	// Both panes should emit DecorRows for their border style change.
+	deltaA := h.NextDeltaFor(t, h.PaneA())
+	deltaB := h.NextDeltaFor(t, h.PaneB())
+	if len(deltaA.DecorRows) == 0 {
+		t.Fatalf("pane A focus loss did not emit DecorRows")
+	}
+	if len(deltaB.DecorRows) == 0 {
+		t.Fatalf("pane B focus gain did not emit DecorRows")
+	}
+}
+```
+
+- [ ] **Step 2-5: Red, green, run, commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+test(server): integration — focus change ships border DecorRows
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Manual e2e + effects-compatibility check
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Build the canonical binary.**
+
+```bash
+make build
+```
+
+Expected: `./bin/texelation`, `./bin/texel-server`, `./bin/texel-client` all build cleanly.
+
+- [ ] **Step 2: Reset session state.**
+
+```bash
+./bin/texelation --reset-state
+# Confirm "yes" when prompted.
+```
+
+- [ ] **Step 3: Start fresh, exercise the texterm pane.**
+
+```bash
+./bin/texelation
+```
+
+Then in the running session:
+
+1. Confirm a single texterm pane is visible with all 4 borders rendered (top, bottom, left, right).
+2. Confirm content sits inside the borders (no offset; top row of typed text appears immediately under the top border, not 3 rows down).
+3. Confirm the texterm internal statusbar renders content (typically just above the bottom border).
+4. Type a few commands; scroll back; scroll forward — borders remain visible throughout.
+
+- [ ] **Step 4: Daemon-restart rehydrate.**
+
+While `texelation` is running:
+
+```bash
+ps aux | grep texel-server  # find the daemon PID
+kill -9 <pid>                # crash the daemon (texelation supervisor restarts it)
+```
+
+After the supervisor brings the daemon back:
+
+1. Confirm all 4 borders are visible from the first paint.
+2. Confirm content is positioned correctly inside borders.
+3. Confirm the texterm internal statusbar renders.
+
+- [ ] **Step 5: Focus change check.**
+
+Split the pane (Ctrl-A then `s` or `v` per the keybinding) → focus the new pane via Ctrl-A then arrow.
+
+1. Confirm the previously-focused pane's border style transitions to inactive (per theme `pane.active` binding).
+2. Confirm the newly-focused pane's border style transitions to active.
+3. If the theme has a `fadeTint` effect bound to `pane.active`, confirm the transition is animated, not snap. (A failure here would suggest decoration deltas aren't reaching the client per animation tick — debug at server `bufferToDelta` instrumentation.)
+
+- [ ] **Step 6: Resize check.**
+
+Resize the terminal window to a dramatically different size. Borders must remain visible and content must reflow correctly inside them. ContentTopRow / ContentBottomRow recompute should keep the rowIdx ↔ gid map consistent.
+
+- [ ] **Step 7: Document the verification.**
+
+Write the verification observations into the PR description when opening it. Note any deviations from expected behavior.
+
+No commit for this task — verification only.
+
+---
+
+## Self-Review Checklist (run before declaring the plan done)
+
+- [ ] **Spec coverage:** every test the spec lists maps to a task (Tasks 1, 2, 6, 7, 8, 9, 10, 11, 12-15). Every type/field the spec introduces (`ContentTopRow`, `ContentBottomRow`, `DecorRows`, `numContentRows`, `computeContentBounds`) is defined exactly once and referenced consistently.
+- [ ] **Type consistency:** field types (`uint16`), method names (`ApplyDelta`, `ApplySnapshot`, `ResetRevisions`), and protocol names (`RowDelta`, `BufferDelta`, `PaneSnapshot`) match between earlier and later tasks.
+- [ ] **No placeholders:** every code block is complete; no "TBD" or "fill in" steps.
+- [ ] **Decoration contiguity invariant** is documented in spec; tests rely on it.
+- [ ] **`Bottom < Top` zero-content sentinel** is consistently treated: server emits `(1, 0)` for empty; client checks `pane.ContentBottomRow >= pane.ContentTopRow` before doing the math.
+- [ ] **Alt-screen path** is unchanged for non-decoration cells; `bufferToDelta` short-circuits decoration emission for `snap.AltScreen=true`.
+- [ ] **Race-detector run** before opening PR: `go test -race -count=1 ./protocol/ ./client/ ./internal/runtime/...`. Address any new races.
+- [ ] **Manual e2e Task 16** completed; observations noted in PR description.

--- a/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
+++ b/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make pane top/bottom borders and app decoration rows (texterm internal statusbar) actually render on the client, fixing the pre-existing `bufferToDelta gid<0` filter bug surfaced by Plan D2's daemon-restart rehydrate path.
 
-**Architecture:** Server stays authoritative for all visible cells. Wire format gains `protocol.PaneSnapshot.{ContentTopRow, ContentBottomRow}` so the client can map rowIdx ↔ gid for content rows, and `protocol.BufferDelta.DecorRows` so border + app-decoration cells (anything where `RowGlobalIdx[y] < 0`) ride alongside content. Client renders via two-layer composite: gid-keyed `PaneCache` for content rowIdx in `[ContentTopRow, ContentBottomRow]`, positional decoration cache otherwise. Protocol bumps v2 → v3.
+**Architecture:** Server stays authoritative for all visible cells. Wire format gains `protocol.PaneSnapshot.{ContentTopRow, NumContentRows}` (zero-content panes use `NumContentRows == 0` — no overloaded sentinel) and `protocol.BufferDelta.DecorRows` of new distinct type `DecorRowDelta` (with a `RowIdx` field carrying absolute rowIdx, so the compiler refuses to mix it with content `RowDelta`). Client renders via two-layer composite: gid-keyed `PaneCache` for content rowIdx in `[ContentTopRow, ContentTopRow+NumContentRows-1]`, positional decoration cache (under `rowsMu`) otherwise. Protocol bumps v2 → v3, no v2 fallback in the decoder.
 
 **Tech Stack:** Go 1.24, custom binary protocol (`protocol/`), `internal/runtime/server`, `internal/runtime/client`, `client` package, `texel` package. Tests use `go test`; integration tests use `internal/runtime/server/testutil/memconn.go`.
 
@@ -19,26 +19,27 @@
 | File | Responsibility | Lines (current) |
 |------|---------------|-----------------|
 | `protocol/protocol.go` | Protocol version constant | bump 2→3 |
-| `protocol/buffer_delta.go` | `BufferDelta` type + encode/decode + `DecorRows` field | ~352 |
-| `protocol/messages.go` | `PaneSnapshot` type + tree snapshot encode/decode + content bound fields | ~1050 |
-| `texel/snapshot.go` | `texel.PaneSnapshot` type + `capturePaneSnapshot` content bound computation | ~600 |
+| `protocol/buffer_delta.go` | `BufferDelta` type + new `DecorRowDelta` type + encode/decode | ~352 |
+| `protocol/messages.go` | `PaneSnapshot.{ContentTopRow, NumContentRows}` + tree snapshot encode/decode | ~1050 |
+| `texel/snapshot.go` | `texel.PaneSnapshot.{ContentTopRow, NumContentRows}` + `capturePaneSnapshot` populates them | ~600 |
 | `internal/runtime/server/tree_convert.go` | Bridge `texel.PaneSnapshot` ↔ `protocol.PaneSnapshot` | ~150 |
-| `internal/runtime/server/desktop_publisher.go` | `bufferToDelta`: route gid<0 rows into `DecorRows` | ~330 |
-| `client/buffercache.go` | `PaneState.{ContentTopRow, ContentBottomRow, DecorRows}`; `ApplySnapshot` populates content bounds; `ApplyDelta` populates `DecorRows`; `ResetRevisions` clears it | ~600 |
-| `internal/runtime/client/viewport_tracker.go` | `onBufferDelta`: `top` calc uses `numContentRows` from PaneState | ~280 |
-| `internal/runtime/client/renderer.go` | `rowSourceForPane`: two-layer lookup (content gid / decoration positional) | ~550 |
+| `internal/runtime/server/desktop_publisher.go` | `bufferToDelta`: route gid<0 rows into `DecorRows` (typed `DecorRowDelta`) | ~330 |
+| `client/buffercache.go` | `PaneState.{ContentTopRow, NumContentRows, decorRows}` (decorRows unexported, guarded by `rowsMu`); `DecorRowAt` accessor; `ApplyDelta` populates; `ResetRevisions` clears | ~600 |
+| `internal/runtime/client/viewport_tracker.go` | `onBufferDelta`: `top` calc uses `pane.NumContentRows`; logs + skips on `pane==nil` | ~280 |
+| `internal/runtime/client/renderer.go` | `rowSourceForPane`: two-layer lookup; logs once per (paneID, rowIdx) on decoration miss | ~550 |
+| `internal/runtime/server/viewport_integration_test.go` | Extend `memHarness` with multi-pane + cross-restart support (Task 11.5) | ~870 |
 
 ---
 
-## Task 1: Protocol — `BufferDelta.DecorRows` field + encode/decode
+## Task 1: Protocol — `DecorRowDelta` type + `BufferDelta.DecorRows` + encode/decode
 
 **Files:**
 - Modify: `protocol/buffer_delta.go` (struct definition around line 92, encoder around line 109, decoder around line 247)
 - Test: `protocol/buffer_delta_test.go`
 
-**Goal:** Round-trip an empty and non-empty `DecorRows` slice.
+**Goal:** Round-trip an empty and non-empty `DecorRows` slice using the new `DecorRowDelta` type, with `ErrPayloadShort` on truncated payloads.
 
-- [ ] **Step 1: Add the failing test (red).**
+- [ ] **Step 1: Add the failing tests (red).**
 
 Append to `protocol/buffer_delta_test.go`:
 
@@ -55,9 +56,9 @@ func TestEncodeDecodeBufferDelta_DecorRoundTrip(t *testing.T) {
 		Rows: []protocol.RowDelta{
 			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "hi", StyleIndex: 0}}},
 		},
-		DecorRows: []protocol.RowDelta{
-			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
-			{Row: 22, Spans: []protocol.CellSpan{{StartCol: 0, Text: "-", StyleIndex: 0}}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+			{RowIdx: 22, Spans: []protocol.CellSpan{{StartCol: 0, Text: "-", StyleIndex: 0}}},
 		},
 	}
 	encoded, err := protocol.EncodeBufferDelta(original)
@@ -95,9 +96,27 @@ func TestEncodeDecodeBufferDelta_EmptyDecorRoundTrip(t *testing.T) {
 		t.Fatalf("expected empty DecorRows, got %+v", decoded.DecorRows)
 	}
 }
+
+func TestDecodeBufferDelta_TruncatedDecorTailErrPayloadShort(t *testing.T) {
+	// Build a valid v3 payload then chop the trailing 2-byte decor count.
+	original := protocol.BufferDelta{
+		PaneID:   [16]byte{0x01},
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		Rows:     []protocol.RowDelta{{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+	}
+	encoded, err := protocol.EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	truncated := encoded[:len(encoded)-2]
+	if _, err := protocol.DecodeBufferDelta(truncated); !errors.Is(err, protocol.ErrPayloadShort) {
+		t.Fatalf("expected ErrPayloadShort on truncated v3, got %v", err)
+	}
+}
 ```
 
-If `reflect` and `protocol` aren't imported in this file already, add them.
+If `reflect`, `errors`, and `protocol` aren't imported in this file already, add them.
 
 - [ ] **Step 2: Run the test — verify it fails.**
 
@@ -107,9 +126,22 @@ go test ./protocol/ -run TestEncodeDecodeBufferDelta_DecorRoundTrip -v
 
 Expected: FAIL with `unknown field DecorRows in struct literal`.
 
-- [ ] **Step 3: Add `DecorRows` field to `BufferDelta`.**
+- [ ] **Step 3: Add `DecorRowDelta` type + `BufferDelta.DecorRows` field.**
 
-In `protocol/buffer_delta.go`, modify the `BufferDelta` struct to:
+In `protocol/buffer_delta.go`, just before the existing `BufferDelta` struct, add:
+
+```go
+// DecorRowDelta carries a single positional decoration row (border, app
+// statusbar). RowIdx is the absolute rowIdx in the pane buffer — distinct
+// from RowDelta.Row, which is gid - RowBase. Wire byte layout matches
+// RowDelta exactly; the type is separate to prevent accidental mixing.
+type DecorRowDelta struct {
+	RowIdx uint16
+	Spans  []CellSpan
+}
+```
+
+Modify the `BufferDelta` struct to:
 
 ```go
 type BufferDelta struct {
@@ -119,7 +151,7 @@ type BufferDelta struct {
 	RowBase   int64
 	Styles    []StyleEntry
 	Rows      []RowDelta
-	DecorRows []RowDelta // rows keyed by absolute rowIdx (not gid - RowBase). Borders + app decoration.
+	DecorRows []DecorRowDelta // rows keyed by absolute rowIdx (borders + app decoration)
 }
 ```
 
@@ -138,7 +170,7 @@ In `EncodeBufferDelta` (`protocol/buffer_delta.go` ~line 244, just before `retur
 		if len(row.Spans) > 0xFFFF {
 			return nil, ErrBufferTooLarge
 		}
-		if err := binary.Write(buf, binary.LittleEndian, row.Row); err != nil {
+		if err := binary.Write(buf, binary.LittleEndian, row.RowIdx); err != nil {
 			return nil, err
 		}
 		if err := binary.Write(buf, binary.LittleEndian, uint16(len(row.Spans))); err != nil {
@@ -170,60 +202,60 @@ In `EncodeBufferDelta` (`protocol/buffer_delta.go` ~line 244, just before `retur
 	}
 ```
 
+The encoder always emits the 2-byte `DecorRows` count (zero when empty), so a v3 payload always has a tail. The decoder will reject any payload missing it.
+
 - [ ] **Step 5: Extend the decoder.**
 
-In `DecodeBufferDelta`, just before `return delta, nil` at the end (~line 350), append:
+In `DecodeBufferDelta`, **replace** the existing `return delta, nil` at the end (~line 350) with:
 
 ```go
+	// v3 tail: DecorRows. The 2-byte count is mandatory — no v2 fallback.
 	if len(b) < 2 {
-		// Pre-v3 wire (no DecorRows tail). Treat as empty.
-		return delta, nil
+		return delta, ErrPayloadShort
 	}
 	decorCount := binary.LittleEndian.Uint16(b[:2])
 	b = b[2:]
-	if decorCount == 0 {
-		if len(b) != 0 {
-			return delta, ErrPayloadShort
-		}
-		return delta, nil
-	}
-	delta.DecorRows = make([]RowDelta, decorCount)
-	for i := 0; i < int(decorCount); i++ {
-		if len(b) < 4 {
-			return delta, ErrPayloadShort
-		}
-		row := binary.LittleEndian.Uint16(b[:2])
-		spanCount := binary.LittleEndian.Uint16(b[2:4])
-		b = b[4:]
-		spans := make([]CellSpan, spanCount)
-		for s := 0; s < int(spanCount); s++ {
-			if len(b) < 6 {
+	if decorCount > 0 {
+		delta.DecorRows = make([]DecorRowDelta, decorCount)
+		for i := 0; i < int(decorCount); i++ {
+			if len(b) < 4 {
 				return delta, ErrPayloadShort
 			}
-			startCol := binary.LittleEndian.Uint16(b[:2])
-			textLen := binary.LittleEndian.Uint16(b[2:4])
-			styleIndex := binary.LittleEndian.Uint16(b[4:6])
-			b = b[6:]
-			if len(b) < int(textLen) {
-				return delta, ErrPayloadShort
+			rowIdx := binary.LittleEndian.Uint16(b[:2])
+			spanCount := binary.LittleEndian.Uint16(b[2:4])
+			b = b[4:]
+			spans := make([]CellSpan, spanCount)
+			for s := 0; s < int(spanCount); s++ {
+				if len(b) < 6 {
+					return delta, ErrPayloadShort
+				}
+				startCol := binary.LittleEndian.Uint16(b[:2])
+				textLen := binary.LittleEndian.Uint16(b[2:4])
+				styleIndex := binary.LittleEndian.Uint16(b[4:6])
+				b = b[6:]
+				if len(b) < int(textLen) {
+					return delta, ErrPayloadShort
+				}
+				text := string(b[:textLen])
+				b = b[textLen:]
+				if int(styleIndex) >= int(styleCount) {
+					return delta, ErrStyleIndexOutOfRange
+				}
+				spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
 			}
-			text := string(b[:textLen])
-			b = b[textLen:]
-			if int(styleIndex) >= int(styleCount) {
-				return delta, ErrStyleIndexOutOfRange
-			}
-			spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
+			delta.DecorRows[i] = DecorRowDelta{RowIdx: rowIdx, Spans: spans}
 		}
-		delta.DecorRows[i] = RowDelta{Row: row, Spans: spans}
 	}
 	if len(b) != 0 {
 		return delta, ErrPayloadShort
 	}
+	return delta, nil
 ```
 
-Note: the "pre-v3 wire" comment is intentional — the decoder treats a missing `DecorRows` tail as empty. We are NOT supporting v2 clients; the `Version=3` handshake will refuse them. This branch is for hand-crafted test fixtures that don't include the tail.
+Two correctness points:
 
-Also: `delta, nil` at the very end of the function should now happen only after the new tail is fully consumed. Replace the existing `return delta, nil` at end-of-func with the appended block above (which itself returns at the end).
+1. The block ends with an explicit `return delta, nil` for the success path — no falling off the end of the function.
+2. A truncated v3 payload (missing the 2-byte count, or short during per-row decode) returns `ErrPayloadShort`. There is no v2 silent-accept path. Per project policy, no backward compat — bumping `Version` from 2 to 3 already refuses old clients at handshake.
 
 - [ ] **Step 6: Run the test — verify it passes.**
 
@@ -259,7 +291,7 @@ EOF
 
 ---
 
-## Task 2: Protocol — `PaneSnapshot.ContentTopRow` / `ContentBottomRow` + encode/decode
+## Task 2: Protocol — `PaneSnapshot.ContentTopRow` / `NumContentRows` + encode/decode
 
 **Files:**
 - Modify: `protocol/messages.go` (struct ~line 193, `EncodeTreeSnapshot` ~line 961, `DecodeTreeSnapshot` ~line 1013)
@@ -276,15 +308,15 @@ func TestEncodeDecodeTreeSnapshot_ContentBoundsRoundTrip(t *testing.T) {
 	original := protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{
 			{
-				PaneID:           [16]byte{0xaa},
-				Revision:         3,
-				Title:            "term",
-				Rows:             nil,
-				X:                0, Y: 0, Width: 80, Height: 24,
-				AppType:          "texelterm",
-				AppConfig:        "",
-				ContentTopRow:    1,
-				ContentBottomRow: 21,
+				PaneID:         [16]byte{0xaa},
+				Revision:       3,
+				Title:          "term",
+				Rows:           nil,
+				X:              0, Y: 0, Width: 80, Height: 24,
+				AppType:        "texelterm",
+				AppConfig:      "",
+				ContentTopRow:  1,
+				NumContentRows: 21,
 			},
 		},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
@@ -297,18 +329,18 @@ func TestEncodeDecodeTreeSnapshot_ContentBoundsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].ContentBottomRow != 21 {
-		t.Fatalf("content bounds mismatch: got top=%d bottom=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].ContentBottomRow)
+	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].NumContentRows != 21 {
+		t.Fatalf("content bounds mismatch: got top=%d num=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].NumContentRows)
 	}
 }
 
-func TestEncodeDecodeTreeSnapshot_ZeroContentSentinel(t *testing.T) {
+func TestEncodeDecodeTreeSnapshot_ZeroContent(t *testing.T) {
 	original := protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{{
-			PaneID:           [16]byte{0xbb},
-			Title:            "all-decor",
-			ContentTopRow:    1,
-			ContentBottomRow: 0, // sentinel: no content rows
+			PaneID:         [16]byte{0xbb},
+			Title:          "all-decor",
+			ContentTopRow:  0,
+			NumContentRows: 0, // unambiguous: no content rows
 		}},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
 	}
@@ -320,8 +352,8 @@ func TestEncodeDecodeTreeSnapshot_ZeroContentSentinel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].ContentBottomRow != 0 {
-		t.Fatalf("sentinel mismatch: got top=%d bottom=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].ContentBottomRow)
+	if decoded.Panes[0].ContentTopRow != 0 || decoded.Panes[0].NumContentRows != 0 {
+		t.Fatalf("zero-content mismatch: got top=%d num=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].NumContentRows)
 	}
 }
 ```
@@ -340,18 +372,18 @@ In `protocol/messages.go` (~line 193), modify struct to:
 
 ```go
 type PaneSnapshot struct {
-	PaneID           [16]byte
-	Revision         uint32
-	Title            string
-	Rows             []string
-	X                int32
-	Y                int32
-	Width            int32
-	Height           int32
-	AppType          string
-	AppConfig        string
-	ContentTopRow    uint16 // first content rowIdx; for the zero-content sentinel see ContentBottomRow
-	ContentBottomRow uint16 // last content rowIdx; if < ContentTopRow, pane has no content rows
+	PaneID         [16]byte
+	Revision       uint32
+	Title          string
+	Rows           []string
+	X              int32
+	Y              int32
+	Width          int32
+	Height         int32
+	AppType        string
+	AppConfig      string
+	ContentTopRow  uint16 // first content rowIdx (ignored when NumContentRows == 0)
+	NumContentRows uint16 // count of content rows; 0 means the pane is all-decoration
 }
 ```
 
@@ -363,7 +395,7 @@ In `protocol/messages.go` (~line 1003), inside the per-pane loop, after `if err 
 		if err := binary.Write(buf, binary.LittleEndian, pane.ContentTopRow); err != nil {
 			return nil, err
 		}
-		if err := binary.Write(buf, binary.LittleEndian, pane.ContentBottomRow); err != nil {
+		if err := binary.Write(buf, binary.LittleEndian, pane.NumContentRows); err != nil {
 			return nil, err
 		}
 ```
@@ -388,7 +420,7 @@ Add:
 			return snapshot, ErrPayloadShort
 		}
 		pane.ContentTopRow = binary.LittleEndian.Uint16(remaining[0:2])
-		pane.ContentBottomRow = binary.LittleEndian.Uint16(remaining[2:4])
+		pane.NumContentRows = binary.LittleEndian.Uint16(remaining[2:4])
 		remaining = remaining[4:]
 ```
 
@@ -413,10 +445,11 @@ Expected: ALL PASS.
 ```bash
 git add protocol/messages.go protocol/messages_test.go
 git commit -m "$(cat <<'EOF'
-protocol: add PaneSnapshot.ContentTopRow/ContentBottomRow
+protocol: add PaneSnapshot.ContentTopRow/NumContentRows
 
-Tells the client which rowIdx range maps to gids vs decoration. Bottom
-< Top is the zero-content sentinel for all-decoration panes.
+Tells the client which rowIdx range maps to gids vs decoration.
+NumContentRows == 0 is the unambiguous zero-content state for
+all-decoration panes — no overloaded sentinel.
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -505,29 +538,27 @@ import (
 )
 
 func TestCapturePaneSnapshot_ContentBoundsComputed(t *testing.T) {
-	// Simulate a snapshot's RowGlobalIdx layout for a 6-row pane:
-	// [0]=-1 (top border), [1..3]=content gids, [4]=-1 (app statusbar), [5]=-1 (bottom border)
+	// 6-row pane: [0]=-1 (top border), [1..3]=content, [4]=-1 (app statusbar), [5]=-1 (bottom border)
 	rowIdx := []int64{-1, 100, 101, 102, -1, -1}
-	top, bottom := computeContentBounds(rowIdx)
-	if top != 1 || bottom != 3 {
-		t.Fatalf("expected top=1 bottom=3, got top=%d bottom=%d", top, bottom)
+	top, num := computeContentBounds(rowIdx)
+	if top != 1 || num != 3 {
+		t.Fatalf("expected top=1 num=3, got top=%d num=%d", top, num)
 	}
 }
 
 func TestCapturePaneSnapshot_ContentBoundsAllDecoration(t *testing.T) {
-	// All -1 rows: zero content, sentinel top=1 bottom=0.
+	// All -1 rows: zero content, top=0 num=0.
 	rowIdx := []int64{-1, -1, -1}
-	top, bottom := computeContentBounds(rowIdx)
-	if top != 1 || bottom != 0 {
-		t.Fatalf("expected sentinel top=1 bottom=0, got top=%d bottom=%d", top, bottom)
+	top, num := computeContentBounds(rowIdx)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected top=0 num=0, got top=%d num=%d", top, num)
 	}
 }
 
 func TestCapturePaneSnapshot_ContentBoundsEmpty(t *testing.T) {
-	// Empty slice: sentinel top=1 bottom=0 (degenerate but well-defined).
-	top, bottom := computeContentBounds(nil)
-	if top != 1 || bottom != 0 {
-		t.Fatalf("expected sentinel top=1 bottom=0, got top=%d bottom=%d", top, bottom)
+	top, num := computeContentBounds(nil)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected top=0 num=0, got top=%d num=%d", top, num)
 	}
 }
 
@@ -558,12 +589,12 @@ type PaneSnapshot struct {
 	AppType      string
 	AppConfig    map[string]interface{}
 	// ContentTopRow is the first rowIdx in Buffer with RowGlobalIdx[y] >= 0.
-	// ContentBottomRow is the last such rowIdx. If ContentBottomRow < ContentTopRow,
-	// the pane has zero content rows (e.g., status panes, all-decoration apps).
-	// For alt-screen panes these fields are populated but unused — clients
-	// render alt-screen positionally regardless.
-	ContentTopRow    uint16
-	ContentBottomRow uint16
+	// NumContentRows is the count of indices with RowGlobalIdx[y] >= 0.
+	// NumContentRows == 0 means zero content rows (status panes, all-decoration apps);
+	// in that case ContentTopRow is meaningless. For alt-screen panes the fields
+	// are populated but unused — clients render alt-screen positionally regardless.
+	ContentTopRow  uint16
+	NumContentRows uint16
 }
 ```
 
@@ -572,12 +603,13 @@ type PaneSnapshot struct {
 In `texel/snapshot.go` near `allMinusOne` (~line 360), add:
 
 ```go
-// computeContentBounds returns (top, bottom) where rowIdx is the
-// inclusive range with RowGlobalIdx[y] >= 0. If no row has gid>=0, returns
-// (1, 0) as the zero-content sentinel.
+// computeContentBounds returns (ContentTopRow, NumContentRows) for the
+// given RowGlobalIdx slice. If no row has gid>=0, returns (0, 0).
+// Assumes contiguity: callers must ensure all gid>=0 rows form a single
+// contiguous block (enforced by capturePaneSnapshot construction).
 func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 	top := -1
-	bottom := -1
+	last := -1
 	for y, gid := range rowIdx {
 		if gid < 0 {
 			continue
@@ -585,12 +617,12 @@ func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 		if top < 0 {
 			top = y
 		}
-		bottom = y
+		last = y
 	}
 	if top < 0 {
-		return 1, 0 // sentinel: zero content rows
+		return 0, 0
 	}
-	return uint16(top), uint16(bottom)
+	return uint16(top), uint16(last - top + 1)
 }
 ```
 
@@ -607,7 +639,7 @@ Expected: PASS.
 In `texel/snapshot.go` `capturePaneSnapshot` (~line 351, just before `return snap` at the end), add:
 
 ```go
-	snap.ContentTopRow, snap.ContentBottomRow = computeContentBounds(snap.RowGlobalIdx)
+	snap.ContentTopRow, snap.NumContentRows = computeContentBounds(snap.RowGlobalIdx)
 ```
 
 - [ ] **Step 7: Add an integration-shape test for capturePaneSnapshot via the existing texterm path.**
@@ -643,9 +675,9 @@ Expected: ALL PASS.
 ```bash
 git add texel/snapshot.go texel/snapshot_test.go
 git commit -m "$(cat <<'EOF'
-texel: capturePaneSnapshot computes Content{Top,Bottom}Row from RowGlobalIdx
+texel: capturePaneSnapshot computes ContentTopRow + NumContentRows
 
-Bottom < Top sentinel signals zero content rows (status panes, all-
+NumContentRows == 0 signals zero content rows (status panes, all-
 decoration apps). Used by tree_convert to populate the protocol
 PaneSnapshot.
 
@@ -678,19 +710,19 @@ import (
 func TestTreeCaptureToProtocol_PassesContentBounds(t *testing.T) {
 	capture := texel.TreeCapture{
 		Panes: []texel.PaneSnapshot{{
-			ID:               [16]byte{0xab},
-			Title:            "t",
-			ContentTopRow:    2,
-			ContentBottomRow: 17,
+			ID:             [16]byte{0xab},
+			Title:          "t",
+			ContentTopRow:  2,
+			NumContentRows: 16,
 		}},
 	}
 	snap := treeCaptureToProtocol(capture)
 	if len(snap.Panes) != 1 {
 		t.Fatalf("expected 1 pane, got %d", len(snap.Panes))
 	}
-	if snap.Panes[0].ContentTopRow != 2 || snap.Panes[0].ContentBottomRow != 17 {
-		t.Fatalf("content bounds not passed through: top=%d bottom=%d",
-			snap.Panes[0].ContentTopRow, snap.Panes[0].ContentBottomRow)
+	if snap.Panes[0].ContentTopRow != 2 || snap.Panes[0].NumContentRows != 16 {
+		t.Fatalf("content bounds not passed through: top=%d num=%d",
+			snap.Panes[0].ContentTopRow, snap.Panes[0].NumContentRows)
 	}
 }
 ```
@@ -712,18 +744,18 @@ In `internal/runtime/server/tree_convert.go` (line 22), modify the per-pane cons
 ```go
 	for i, pane := range capture.Panes {
 		snapshot.Panes[i] = protocol.PaneSnapshot{
-			PaneID:           pane.ID,
-			Revision:         0,
-			Title:            pane.Title,
-			Rows:             nil,
-			X:                int32(pane.Rect.X),
-			Y:                int32(pane.Rect.Y),
-			Width:            int32(pane.Rect.Width),
-			Height:           int32(pane.Rect.Height),
-			AppType:          pane.AppType,
-			AppConfig:        encodeAppConfig(pane.AppConfig),
-			ContentTopRow:    pane.ContentTopRow,
-			ContentBottomRow: pane.ContentBottomRow,
+			PaneID:         pane.ID,
+			Revision:       0,
+			Title:          pane.Title,
+			Rows:           nil,
+			X:              int32(pane.Rect.X),
+			Y:              int32(pane.Rect.Y),
+			Width:          int32(pane.Rect.Width),
+			Height:         int32(pane.Rect.Height),
+			AppType:        pane.AppType,
+			AppConfig:      encodeAppConfig(pane.AppConfig),
+			ContentTopRow:  pane.ContentTopRow,
+			NumContentRows: pane.NumContentRows,
 		}
 	}
 ```
@@ -734,15 +766,15 @@ In `internal/runtime/server/tree_convert.go` (~line 39), modify the per-pane con
 
 ```go
 	capture.Panes[i] = texel.PaneSnapshot{
-		ID:               pane.PaneID,
-		Title:            pane.Title,
-		Buffer:           buffer,
-		RowGlobalIdx:     rowGlobalIdxAllMinusOne(len(buffer)),
-		Rect:             texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
-		AppType:          pane.AppType,
-		AppConfig:        decodeAppConfig(pane.AppConfig),
-		ContentTopRow:    pane.ContentTopRow,
-		ContentBottomRow: pane.ContentBottomRow,
+		ID:             pane.PaneID,
+		Title:          pane.Title,
+		Buffer:         buffer,
+		RowGlobalIdx:   rowGlobalIdxAllMinusOne(len(buffer)),
+		Rect:           texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
+		AppType:        pane.AppType,
+		AppConfig:      decodeAppConfig(pane.AppConfig),
+		ContentTopRow:  pane.ContentTopRow,
+		NumContentRows: pane.NumContentRows,
 	}
 ```
 
@@ -767,7 +799,7 @@ Expected: ALL PASS (server-side tests are extensive; expect this to take ~30s).
 ```bash
 git add internal/runtime/server/tree_convert.go internal/runtime/server/tree_convert_test.go
 git commit -m "$(cat <<'EOF'
-server: tree_convert passes Content{Top,Bottom}Row through both directions
+server: tree_convert passes ContentTopRow + NumContentRows through both directions
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -806,26 +838,24 @@ func TestBufferToDelta_DecorationRowsIncluded(t *testing.T) {
 		{{Ch: '+'}, {Ch: '-'}, {Ch: '+'}}, // border
 	}
 	snap := texel.PaneSnapshot{
-		ID:               [16]byte{0xab},
-		Buffer:           rows,
-		RowGlobalIdx:     []int64{-1, 100, 101, 102, -1},
-		ContentTopRow:    1,
-		ContentBottomRow: 3,
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, 101, 102, -1},
+		ContentTopRow:  1,
+		NumContentRows: 3,
 	}
 	vp := ClientViewport{Rows: 3, AutoFollow: true}
 	prev := [][]texel.Cell(nil)
 
 	delta := bufferToDelta(snap, vp, prev, 1)
 
-	// Expect 2 decoration rows: rowIdx 0 (top border) and rowIdx 4 (bottom border).
 	if len(delta.DecorRows) != 2 {
 		t.Fatalf("expected 2 DecorRows, got %d: %+v", len(delta.DecorRows), delta.DecorRows)
 	}
-	gotIdx := map[uint16]bool{delta.DecorRows[0].Row: true, delta.DecorRows[1].Row: true}
+	gotIdx := map[uint16]bool{delta.DecorRows[0].RowIdx: true, delta.DecorRows[1].RowIdx: true}
 	if !gotIdx[0] || !gotIdx[4] {
 		t.Fatalf("expected decoration rows at rowIdx 0 and 4, got %v", gotIdx)
 	}
-	// Content rows still present.
 	if len(delta.Rows) != 3 {
 		t.Fatalf("expected 3 content Rows, got %d", len(delta.Rows))
 	}
@@ -838,20 +868,18 @@ func TestBufferToDelta_DecorationRowsDiffed(t *testing.T) {
 		{{Ch: '+'}}, // border
 	}
 	snap := texel.PaneSnapshot{
-		ID:               [16]byte{0xab},
-		Buffer:           rows,
-		RowGlobalIdx:     []int64{-1, 100, -1},
-		ContentTopRow:    1,
-		ContentBottomRow: 1,
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, -1},
+		ContentTopRow:  1,
+		NumContentRows: 1,
 	}
 	vp := ClientViewport{Rows: 1, AutoFollow: true}
-	// prev identical => no rows or DecorRows should ship.
 	prev := [][]texel.Cell{
 		{{Ch: '+'}},
 		{{Ch: 'a'}},
 		{{Ch: '+'}},
 	}
-
 	delta := bufferToDelta(snap, vp, prev, 1)
 	if len(delta.DecorRows) != 0 {
 		t.Fatalf("expected 0 DecorRows when borders unchanged, got %d", len(delta.DecorRows))
@@ -868,48 +896,47 @@ func TestBufferToDelta_DecorationRowsDiffPartial(t *testing.T) {
 		{{Ch: '+'}}, // border (unchanged)
 	}
 	snap := texel.PaneSnapshot{
-		ID:               [16]byte{0xab},
-		Buffer:           rows,
-		RowGlobalIdx:     []int64{-1, 100, -1},
-		ContentTopRow:    1,
-		ContentBottomRow: 1,
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, -1},
+		ContentTopRow:  1,
+		NumContentRows: 1,
 	}
 	vp := ClientViewport{Rows: 1, AutoFollow: true}
 	prev := [][]texel.Cell{
-		{{Ch: '#'}}, // different from current — should ship
-		{{Ch: 'a'}}, // same — skip
-		{{Ch: '+'}}, // same — skip
+		{{Ch: '#'}}, // different
+		{{Ch: 'a'}}, // same
+		{{Ch: '+'}}, // same
 	}
 	delta := bufferToDelta(snap, vp, prev, 1)
-	if len(delta.DecorRows) != 1 || delta.DecorRows[0].Row != 0 {
+	if len(delta.DecorRows) != 1 || delta.DecorRows[0].RowIdx != 0 {
 		t.Fatalf("expected 1 DecorRows entry at rowIdx 0, got %+v", delta.DecorRows)
 	}
 }
 
 func TestBufferToDelta_TexelTermInternalStatusbar(t *testing.T) {
 	// 6-row layout: rowIdx 0 = top border, [1..3] = content, rowIdx 4 = app
-	// internal statusbar (gid=-1), rowIdx 5 = bottom border. Mirrors the real
-	// texelterm pane shape that surfaced the bug.
+	// internal statusbar (gid=-1), rowIdx 5 = bottom border.
 	rows := [][]texel.Cell{
 		{{Ch: '+'}},
 		{{Ch: 'a'}},
 		{{Ch: 'b'}},
 		{{Ch: 'c'}},
-		{{Ch: 'S'}}, // app statusbar
+		{{Ch: 'S'}},
 		{{Ch: '+'}},
 	}
 	snap := texel.PaneSnapshot{
-		ID:               [16]byte{0xab},
-		Buffer:           rows,
-		RowGlobalIdx:     []int64{-1, 100, 101, 102, -1, -1},
-		ContentTopRow:    1,
-		ContentBottomRow: 3,
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, 101, 102, -1, -1},
+		ContentTopRow:  1,
+		NumContentRows: 3,
 	}
 	vp := ClientViewport{Rows: 3, AutoFollow: true}
 	delta := bufferToDelta(snap, vp, nil, 1)
 	got := map[uint16]bool{}
 	for _, r := range delta.DecorRows {
-		got[r.Row] = true
+		got[r.RowIdx] = true
 	}
 	if !got[0] || !got[4] || !got[5] {
 		t.Fatalf("expected DecorRows at rowIdx 0, 4, 5 (top + statusbar + bottom), got %v", got)
@@ -974,7 +1001,7 @@ return delta
 Replace with:
 
 ```go
-var decorRows []protocol.RowDelta
+var decorRows []protocol.DecorRowDelta
 for y, row := range snap.Buffer {
 	if len(row) == 0 {
 		continue
@@ -982,20 +1009,21 @@ for y, row := range snap.Buffer {
 	if y >= len(snap.RowGlobalIdx) {
 		continue
 	}
+	gid := snap.RowGlobalIdx[y]
+	// Alt-screen panes have RowGlobalIdx all -1; skip decoration emission
+	// before the rowsEqual cost. The existing alt-screen positional path
+	// (BufferDeltaAltScreen flag) handles them.
+	if snap.AltScreen && gid < 0 {
+		continue
+	}
 	if y < len(prev) && rowsEqual(row, prev[y]) {
 		continue
 	}
-	gid := snap.RowGlobalIdx[y]
 	if gid < 0 {
-		// Decoration row: borders, app statusbars. Alt-screen panes
-		// emit nothing here because RowGlobalIdx is all -1 AND we
-		// take the existing alt-screen positional path elsewhere.
-		if snap.AltScreen {
-			continue
-		}
-		decorRows = append(decorRows, protocol.RowDelta{
-			Row:   uint16(y),
-			Spans: encodeRow(row),
+		// Decoration row (border or app statusbar) — positional.
+		decorRows = append(decorRows, protocol.DecorRowDelta{
+			RowIdx: uint16(y),
+			Spans:  encodeRow(row),
 		})
 		continue
 	}
@@ -1010,7 +1038,10 @@ delta.DecorRows = decorRows
 return delta
 ```
 
-Note the diff check moves *before* the gid check so it fires for both content and decoration rows. The `snap.AltScreen` guard prevents alt-screen panes (whose RowGlobalIdx is all -1) from spamming decoration rows; the existing alt-screen path handles them positionally via `delta.Flags & BufferDeltaAltScreen`.
+Two ordering points:
+
+1. The `snap.AltScreen && gid < 0` short-circuit fires *before* `rowsEqual` so alt-screen panes never pay the diff comparison for decoration rows. This avoids the per-row regression a reviewer flagged.
+2. For non-altScreen panes, the `rowsEqual` diff fires for both content and decoration paths (they share the positional `prev[y]` storage), so unchanged decoration rows don't re-ship.
 
 - [ ] **Step 5: Run — verify pass.**
 
@@ -1050,7 +1081,7 @@ EOF
 ## Task 7: `client.PaneState` gains content-bound + decoration-cache fields
 
 **Files:**
-- Modify: `client/buffercache.go` (struct ~line 22)
+- Modify: `client/buffercache.go` (struct ~line 22, `ApplySnapshot` ~line 222, add `DecorRowAt` accessor)
 - Test: `client/buffercache_test.go`
 
 - [ ] **Step 1: Add the failing test.**
@@ -1063,11 +1094,11 @@ func TestApplySnapshot_PopulatesContentBounds(t *testing.T) {
 	id := [16]byte{0xab}
 	snapshot := protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{{
-			PaneID:           id,
-			Title:            "t",
-			Width:            10, Height: 6,
-			ContentTopRow:    1,
-			ContentBottomRow: 4,
+			PaneID:         id,
+			Title:          "t",
+			Width:          10, Height: 6,
+			ContentTopRow:  1,
+			NumContentRows: 4,
 		}},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
 	}
@@ -1076,8 +1107,8 @@ func TestApplySnapshot_PopulatesContentBounds(t *testing.T) {
 	if pane == nil {
 		t.Fatalf("pane not registered")
 	}
-	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
-		t.Fatalf("content bounds not applied: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("content bounds not applied: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
 	}
 }
 ```
@@ -1092,7 +1123,7 @@ go test ./client/ -run TestApplySnapshot_PopulatesContentBounds -v
 
 Expected: FAIL with `pane.ContentTopRow undefined`.
 
-- [ ] **Step 3: Add fields to `PaneState`.**
+- [ ] **Step 3: Add fields + `DecorRowAt` accessor to `PaneState`.**
 
 In `client/buffercache.go` (~line 22), update struct:
 
@@ -1103,6 +1134,7 @@ type PaneState struct {
 	UpdatedAt        time.Time
 	rowsMu           sync.RWMutex
 	rows             map[int][]Cell
+	decorRows        map[uint16][]Cell // unexported; guarded by rowsMu (decoration: borders + app statusbar)
 	Title            string
 	Rect             clientRect
 	Active           bool
@@ -1111,20 +1143,31 @@ type PaneState struct {
 	HandlesSelection bool
 
 	// Content bounds (populated from PaneSnapshot). For non-altScreen panes,
-	// rowIdx in [ContentTopRow, ContentBottomRow] maps to gid via the
-	// viewport tracker; rowIdx outside reads from DecorRows. If
-	// ContentBottomRow < ContentTopRow, the pane has zero content rows.
-	ContentTopRow    uint16
-	ContentBottomRow uint16
-
-	// DecorRows holds positional decoration cells (borders + app statusbars).
-	// Keyed by absolute rowIdx. Populated from BufferDelta.DecorRows.
-	DecorRows map[uint16][]Cell
+	// rowIdx in [ContentTopRow, ContentTopRow + NumContentRows - 1] maps to
+	// gid via the viewport tracker; rowIdx outside that range reads from
+	// decorRows via DecorRowAt. NumContentRows == 0 means the pane has zero
+	// content rows (status panes, all-decoration apps).
+	ContentTopRow  uint16
+	NumContentRows uint16
 
 	// Dirty tracking for incremental rendering.
 	Dirty       bool
 	DirtyRows   map[int]bool
 	HasAnimated bool
+}
+
+// DecorRowAt returns the cells for an absolute decoration rowIdx, or
+// (nil, false) if no decoration has been applied to that row. Read under
+// rowsMu.RLock(). The returned slice is a direct reference to internal
+// state; callers must not retain or modify it across frame boundaries.
+func (p *PaneState) DecorRowAt(rowIdx uint16) ([]Cell, bool) {
+	if p == nil {
+		return nil, false
+	}
+	p.rowsMu.RLock()
+	defer p.rowsMu.RUnlock()
+	cells, ok := p.decorRows[rowIdx]
+	return cells, ok
 }
 ```
 
@@ -1134,7 +1177,7 @@ In `client/buffercache.go` `ApplySnapshot` (~line 235), after `pane.Title = pane
 
 ```go
 		pane.ContentTopRow = paneSnap.ContentTopRow
-		pane.ContentBottomRow = paneSnap.ContentBottomRow
+		pane.NumContentRows = paneSnap.NumContentRows
 ```
 
 - [ ] **Step 5: Run — verify pass.**
@@ -1150,10 +1193,11 @@ Expected: PASS.
 ```bash
 git add client/buffercache.go client/buffercache_test.go
 git commit -m "$(cat <<'EOF'
-client: PaneState carries Content{Top,Bottom}Row + DecorRows fields
+client: PaneState carries ContentTopRow + NumContentRows + decorRows
 
+decorRows is unexported and guarded by rowsMu; access via DecorRowAt.
 ApplySnapshot copies content bounds from the protocol pane snapshot.
-DecorRows is populated by ApplyDelta (next commit).
+ApplyDelta populates decorRows (next commit).
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -1182,9 +1226,9 @@ func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
 		Styles: []protocol.StyleEntry{
 			{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault},
 		},
-		DecorRows: []protocol.RowDelta{
-			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
-			{Row: 9, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
+			{RowIdx: 9, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+--+", StyleIndex: 0}}},
 		},
 	}
 	cache.ApplyDelta(delta)
@@ -1192,14 +1236,16 @@ func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
 	if pane == nil {
 		t.Fatalf("pane not registered")
 	}
-	if len(pane.DecorRows) != 2 {
-		t.Fatalf("expected 2 decor rows, got %d: %+v", len(pane.DecorRows), pane.DecorRows)
+	row0, ok0 := pane.DecorRowAt(0)
+	row9, ok9 := pane.DecorRowAt(9)
+	if !ok0 || !ok9 {
+		t.Fatalf("expected DecorRowAt(0) and DecorRowAt(9) to be present")
 	}
-	if len(pane.DecorRows[0]) != 4 || pane.DecorRows[0][0].Ch != '+' {
-		t.Fatalf("rowIdx 0 content wrong: %+v", pane.DecorRows[0])
+	if len(row0) != 4 || row0[0].Ch != '+' {
+		t.Fatalf("rowIdx 0 content wrong: %+v", row0)
 	}
-	if len(pane.DecorRows[9]) != 4 || pane.DecorRows[9][3].Ch != '+' {
-		t.Fatalf("rowIdx 9 content wrong: %+v", pane.DecorRows[9])
+	if len(row9) != 4 || row9[3].Ch != '+' {
+		t.Fatalf("rowIdx 9 content wrong: %+v", row9)
 	}
 }
 ```
@@ -1210,19 +1256,19 @@ func TestApplyDelta_PopulatesDecorRows(t *testing.T) {
 go test ./client/ -run TestApplyDelta_PopulatesDecorRows -v
 ```
 
-Expected: FAIL — `pane.DecorRows` is nil.
+Expected: FAIL — DecorRowAt returns (nil, false).
 
 - [ ] **Step 3: Update `ApplyDelta`.**
 
-In `client/buffercache.go` `ApplyDelta` (~line 149), within the function, just before `pane.Revision = delta.Revision` near the bottom, insert:
+In `client/buffercache.go` `ApplyDelta` (~line 149), the existing code acquires `pane.rowsMu.Lock()` for the content-row write and releases it before the dirty-tracking block. **Extend that critical section** to also cover decoration rows: keep `pane.rowsMu` locked through the new `decorRows` write. Concretely, after the content-row apply loop and *before* `pane.rowsMu.Unlock()`, add:
 
 ```go
 	if len(delta.DecorRows) > 0 {
-		if pane.DecorRows == nil {
-			pane.DecorRows = make(map[uint16][]Cell, len(delta.DecorRows))
+		if pane.decorRows == nil {
+			pane.decorRows = make(map[uint16][]Cell, len(delta.DecorRows))
 		}
 		for _, rowDelta := range delta.DecorRows {
-			row := pane.DecorRows[rowDelta.Row]
+			row := pane.decorRows[rowDelta.RowIdx]
 			for _, span := range rowDelta.Spans {
 				start := int(span.StartCol)
 				textRunes := []rune(span.Text)
@@ -1244,16 +1290,23 @@ In `client/buffercache.go` `ApplyDelta` (~line 149), within the function, just b
 					row[start+i] = Cell{Ch: r, Style: style, DynFG: dynFG, DynBG: dynBG}
 				}
 			}
-			pane.DecorRows[rowDelta.Row] = row
+			pane.decorRows[rowDelta.RowIdx] = row
 		}
+	}
+```
+
+After `pane.rowsMu.Unlock()`, in the dirty-flag block, add:
+
+```go
+	if len(delta.DecorRows) > 0 {
 		pane.Dirty = true
-		// DecorRow changes invalidate row-level dirty tracking; force a
+		// Decoration changes invalidate row-level dirty tracking; force a
 		// full re-render of this pane.
 		pane.DirtyRows = nil
 	}
 ```
 
-This mirrors the content-row apply loop above it but writes into `pane.DecorRows` instead of `pane.rows`.
+**Lock discipline:** all writes to `pane.decorRows` happen under `pane.rowsMu.Lock()`; all reads go through `DecorRowAt` which takes `pane.rowsMu.RLock()`. The renderer (Task 11) must not access `pane.decorRows` directly.
 
 - [ ] **Step 4: Run — verify pass.**
 
@@ -1308,21 +1361,24 @@ func TestResetRevisions_ClearsDecorRows(t *testing.T) {
 		PaneID:   id,
 		Revision: 7,
 		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
-		DecorRows: []protocol.RowDelta{
-			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
 		},
 	}
 	cache.ApplyDelta(delta)
-	if pane := cache.Pane(id); pane == nil || len(pane.DecorRows) != 1 {
-		t.Fatalf("pre-reset: expected 1 DecorRows entry, got %+v", pane)
+	if pane := cache.Pane(id); pane == nil {
+		t.Fatalf("pane not registered")
+	}
+	if _, ok := cache.Pane(id).DecorRowAt(0); !ok {
+		t.Fatalf("pre-reset: expected DecorRowAt(0) populated")
 	}
 	cache.ResetRevisions()
 	pane := cache.Pane(id)
 	if pane == nil {
 		t.Fatalf("pane gone after reset")
 	}
-	if len(pane.DecorRows) != 0 {
-		t.Fatalf("expected DecorRows cleared, got %d entries", len(pane.DecorRows))
+	if _, ok := pane.DecorRowAt(0); ok {
+		t.Fatalf("expected decoration cache cleared after ResetRevisions")
 	}
 	if pane.Revision != 0 {
 		t.Fatalf("expected Revision=0, got %d", pane.Revision)
@@ -1336,7 +1392,7 @@ func TestResetRevisions_ClearsDecorRows(t *testing.T) {
 go test ./client/ -run TestResetRevisions_ClearsDecorRows -v
 ```
 
-Expected: FAIL — DecorRows still has 1 entry after reset.
+Expected: FAIL — decoration row still present after reset.
 
 - [ ] **Step 3: Update `ResetRevisions`.**
 
@@ -1348,10 +1404,14 @@ func (c *BufferCache) ResetRevisions() {
 	defer c.mu.Unlock()
 	for _, pane := range c.panes {
 		pane.Revision = 0
-		pane.DecorRows = nil
+		pane.rowsMu.Lock()
+		pane.decorRows = nil
+		pane.rowsMu.Unlock()
 	}
 }
 ```
+
+The per-pane `rowsMu.Lock()` ensures the renderer doesn't observe a torn map mid-clear. Holding both `c.mu` and `pane.rowsMu` is safe — `c.mu` is always acquired first throughout the package.
 
 - [ ] **Step 4: Run — verify pass.**
 
@@ -1393,7 +1453,7 @@ ls internal/runtime/client/ | grep viewport
 
 Use `viewport_tracker_test.go` if present; otherwise the existing test file pattern in this directory.
 
-- [ ] **Step 2: Add the failing test.**
+- [ ] **Step 2: Add the failing tests.**
 
 Append:
 
@@ -1401,11 +1461,11 @@ Append:
 func TestOnBufferDelta_TopUsesContentRowCount(t *testing.T) {
 	state := newClientStateForTest(t) // helper from existing tests
 	id := [16]byte{0xab}
-	// Pane has H=10 rows; ContentTopRow=1, ContentBottomRow=8 → 8 content rows.
+	// Pane has H=10 rows; ContentTopRow=1, NumContentRows=8 → 8 content rows.
 	state.cache.ApplySnapshot(protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{{
 			PaneID: id, Width: 5, Height: 10,
-			ContentTopRow: 1, ContentBottomRow: 8,
+			ContentTopRow: 1, NumContentRows: 8,
 		}},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
 	})
@@ -1417,15 +1477,54 @@ func TestOnBufferDelta_TopUsesContentRowCount(t *testing.T) {
 		PaneID:  id,
 		RowBase: 0,
 		Styles:  []protocol.StyleEntry{{}},
-		Rows: []protocol.RowDelta{
-			{Row: 7}, // gid = RowBase + 7 = 7 (maxGid)
-		},
+		Rows:    []protocol.RowDelta{{Row: 100}}, // maxGid = 100; old math: 100-9=91, new math: 100-7=93
 	}
 	state.onBufferDelta(delta, false)
-	vp := state.viewports.get(id)
-	// numContentRows = 8 → top = 7 - (8-1) = 0
-	if vp.ViewTopIdx != 0 {
-		t.Fatalf("expected ViewTopIdx=0 (8 content rows), got %d", vp.ViewTopIdx)
+	if vp := state.viewports.get(id); vp.ViewTopIdx != 93 {
+		t.Fatalf("expected ViewTopIdx=93 (maxGid=100, 8 content rows), got %d", vp.ViewTopIdx)
+	}
+}
+
+func TestOnBufferDelta_PaneNilSkipsAndLogs(t *testing.T) {
+	state := newClientStateForTest(t)
+	id := [16]byte{0xab}
+	// Do NOT call ApplySnapshot; pane is absent from the cache.
+	state.viewports.get(id).Rows = 10
+	state.viewports.get(id).AutoFollow = true
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 0,
+		Styles:  []protocol.StyleEntry{{}},
+		Rows:    []protocol.RowDelta{{Row: 100}},
+	}
+	state.onBufferDelta(delta, false)
+	// Viewport must NOT advance silently using vp.Rows fallback.
+	if vp := state.viewports.get(id); vp.ViewTopIdx != 0 {
+		t.Fatalf("expected ViewTopIdx unchanged (=0) when pane is absent, got %d", vp.ViewTopIdx)
+	}
+}
+
+func TestOnBufferDelta_ZeroContentRowsReturnsEarly(t *testing.T) {
+	state := newClientStateForTest(t)
+	id := [16]byte{0xab}
+	// Status pane: NumContentRows == 0
+	state.cache.ApplySnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 5, Height: 1,
+			ContentTopRow: 0, NumContentRows: 0,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+	state.viewports.get(id).Rows = 1
+	state.viewports.get(id).AutoFollow = true
+	delta := protocol.BufferDelta{
+		PaneID: id, RowBase: 0,
+		Styles: []protocol.StyleEntry{{}},
+		Rows:   []protocol.RowDelta{{Row: 0}},
+	}
+	state.onBufferDelta(delta, false)
+	if vp := state.viewports.get(id); vp.ViewTopIdx != 0 {
+		t.Fatalf("expected ViewTopIdx unchanged (=0) for zero-content pane, got %d", vp.ViewTopIdx)
 	}
 }
 ```
@@ -1435,24 +1534,10 @@ If `newClientStateForTest` helper doesn't exist, build the minimum state inline.
 - [ ] **Step 3: Run — verify failure.**
 
 ```bash
-go test ./internal/runtime/client/ -run TestOnBufferDelta_TopUsesContentRowCount -v
+go test ./internal/runtime/client/ -run TestOnBufferDelta -v
 ```
 
-Expected: FAIL — `vp.ViewTopIdx` will be `7 - (10-1) = -2` clamped to 0, but the failure is in the math derivation, not the clamp. To make the failure crisp, change the test to use a larger maxGid where the bug shows up: set `Rows: []protocol.RowDelta{{Row: 100}}` and `RowBase: 0`. With old code: top = 100 - 9 = 91. With new code: top = 100 - 7 = 93.
-
-Replace the `Rows: []protocol.RowDelta{{Row: 7}}` line and the assertion to:
-
-```go
-		Rows: []protocol.RowDelta{{Row: 100}},
-```
-
-```go
-	if vp.ViewTopIdx != 93 {
-		t.Fatalf("expected ViewTopIdx=93 (maxGid=100, 8 content rows), got %d", vp.ViewTopIdx)
-	}
-```
-
-Re-run; expected: FAIL with `expected ViewTopIdx=93, got 91`.
+Expected: FAIL with `expected ViewTopIdx=93, got 91` for the first test.
 
 - [ ] **Step 4: Update `onBufferDelta`.**
 
@@ -1466,17 +1551,23 @@ to:
 
 ```go
 	pane := s.cache.Pane(delta.PaneID)
-	numContentRows := int64(vp.Rows)
-	if pane != nil && pane.ContentBottomRow >= pane.ContentTopRow {
-		numContentRows = int64(pane.ContentBottomRow) - int64(pane.ContentTopRow) + 1
-	}
-	if numContentRows <= 0 {
+	if pane == nil {
+		// Delta arrived before the snapshot populated the cache. Silent
+		// fallback to vp.Rows would reintroduce Issue #199 misalignment;
+		// skip and log loudly instead.
+		log.Printf("client: onBufferDelta: pane %x not in cache; skipping viewport advance", delta.PaneID)
 		return
 	}
+	if pane.NumContentRows == 0 {
+		// Zero-content pane (status panes, all-decoration apps) — no
+		// viewport to advance.
+		return
+	}
+	numContentRows := int64(pane.NumContentRows)
 	top := maxGid - (numContentRows - 1)
 ```
 
-(Verify `s.cache` is the access path to `BufferCache` from `clientState`; if it's named differently, adjust. Inspect `internal/runtime/client/state.go` or the surrounding file for the field name.)
+(Verify `s.cache` is the access path to `BufferCache` from `clientState`. Add `import "log"` at the top of the file if not already imported. If `s.cache.Pane` doesn't exist, use whichever inspector the existing tests use.)
 
 - [ ] **Step 5: Run — verify pass.**
 
@@ -1527,7 +1618,7 @@ ls internal/runtime/client/ | grep -E "render(er)?_test"
 
 Use the surfaced file or create `renderer_test.go`.
 
-- [ ] **Step 2: Add the failing test.**
+- [ ] **Step 2: Add the failing tests.**
 
 Append:
 
@@ -1535,28 +1626,32 @@ Append:
 func TestRowSourceForPane_DecorationLayer(t *testing.T) {
 	state := newClientStateForTest(t)
 	id := [16]byte{0xab}
-	// Pane H=5, ContentTopRow=1, ContentBottomRow=3.
+	// Pane H=5, ContentTopRow=1, NumContentRows=3 (rowIdx 1..3 are content).
 	state.cache.ApplySnapshot(protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{{
 			PaneID: id, Width: 4, Height: 5,
-			ContentTopRow: 1, ContentBottomRow: 3,
+			ContentTopRow: 1, NumContentRows: 3,
 		}},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
 	})
-	// Apply a delta with 1 content row (gid=10) and 2 decoration rows (rowIdx 0 + 4).
+
+	// Seed the viewport tracker via onBufferDelta so the gid math lines up.
+	// onBufferDelta calls cache.ApplyDelta internally — do NOT also call
+	// state.cache.ApplyDelta or the delta is applied twice.
 	delta := protocol.BufferDelta{
 		PaneID:  id,
 		RowBase: 10,
 		Styles:  []protocol.StyleEntry{{}},
 		Rows: []protocol.RowDelta{
+			// Content row: gid 10 (= RowBase + Row). With NumContentRows=3,
+			// onBufferDelta will set ViewTopIdx = 10 - 2 = 8.
 			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "C", StyleIndex: 0}}},
 		},
-		DecorRows: []protocol.RowDelta{
-			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "T", StyleIndex: 0}}},
-			{Row: 4, Spans: []protocol.CellSpan{{StartCol: 0, Text: "B", StyleIndex: 0}}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "T", StyleIndex: 0}}},
+			{RowIdx: 4, Spans: []protocol.CellSpan{{StartCol: 0, Text: "B", StyleIndex: 0}}},
 		},
 	}
-	state.cache.ApplyDelta(delta)
 	state.onBufferDelta(delta, false)
 
 	pane := state.cache.Pane(id)
@@ -1565,19 +1660,18 @@ func TestRowSourceForPane_DecorationLayer(t *testing.T) {
 	}
 
 	// rowIdx 0 → decoration "T"
-	src := rowSourceForPane(state, pane, 0)
-	if len(src) == 0 || src[0].Ch != 'T' {
+	if src := rowSourceForPane(state, pane, 0); len(src) == 0 || src[0].Ch != 'T' {
 		t.Fatalf("rowIdx 0 expected decoration 'T', got %+v", src)
 	}
-	// rowIdx 1 → content "C" (gid 10)
-	src = rowSourceForPane(state, pane, 1)
-	if len(src) == 0 || src[0].Ch != 'C' {
-		t.Fatalf("rowIdx 1 expected content 'C', got %+v", src)
-	}
 	// rowIdx 4 → decoration "B"
-	src = rowSourceForPane(state, pane, 4)
-	if len(src) == 0 || src[0].Ch != 'B' {
+	if src := rowSourceForPane(state, pane, 4); len(src) == 0 || src[0].Ch != 'B' {
 		t.Fatalf("rowIdx 4 expected decoration 'B', got %+v", src)
+	}
+	// rowIdx 1 → content row (gid = ViewTopIdx + (rowIdx - ContentTopRow) = 8 + 0 = 8)
+	// PaneCache should have gid 10 from the delta; gid 8 is a miss → nil.
+	// To exercise the content-layer path with a hit, also test rowIdx 3 → gid 10:
+	if src := rowSourceForPane(state, pane, 3); len(src) == 0 || src[0].Ch != 'C' {
+		t.Fatalf("rowIdx 3 expected content 'C' (gid 10), got %+v", src)
 	}
 }
 
@@ -1587,7 +1681,7 @@ func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {
 	state.cache.ApplySnapshot(protocol.TreeSnapshot{
 		Panes: []protocol.PaneSnapshot{{
 			PaneID: id, Width: 4, Height: 5,
-			ContentTopRow: 1, ContentBottomRow: 3,
+			ContentTopRow: 1, NumContentRows: 3,
 		}},
 		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
 	})
@@ -1629,14 +1723,14 @@ func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []
 		return row
 	}
 
-	// Decoration layer: rowIdx outside the content-bound range reads from
-	// PaneState.DecorRows (positional).
-	if rowIdx < int(pane.ContentTopRow) || rowIdx > int(pane.ContentBottomRow) {
-		if pane.DecorRows != nil {
-			if row, ok := pane.DecorRows[uint16(rowIdx)]; ok {
-				return row
-			}
+	// Decoration layer: rowIdx outside the content range reads from the
+	// pane's decoration cache (positional).
+	contentEnd := int(pane.ContentTopRow) + int(pane.NumContentRows) // exclusive
+	if pane.NumContentRows == 0 || rowIdx < int(pane.ContentTopRow) || rowIdx >= contentEnd {
+		if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
+			return row
 		}
+		state.logDecorationMissOnce(pane.ID, uint16(rowIdx))
 		return nil
 	}
 
@@ -1647,9 +1741,47 @@ func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []
 	if !found {
 		// Row not yet in cache (fetch is en route). Render blank rather than
 		// showing stale BufferCache content at a mismatched globalIdx.
+		// No log here — content-layer misses are normal during FetchRange.
 		return nil
 	}
 	return row
+}
+```
+
+Add a one-time-per-(paneID, rowIdx) logger to `clientState` (in `internal/runtime/client/state.go` or wherever `clientState` is defined):
+
+```go
+// decorationMissKey is the dedup key for once-per-pane-row decoration miss logging.
+type decorationMissKey struct {
+	paneID [16]byte
+	rowIdx uint16
+}
+
+// logDecorationMissOnce emits a log line the first time the renderer
+// observes a decoration cache miss for a given (paneID, rowIdx). Subsequent
+// misses for the same key are silent.
+func (s *clientState) logDecorationMissOnce(paneID [16]byte, rowIdx uint16) {
+	s.decorMissMu.Lock()
+	defer s.decorMissMu.Unlock()
+	if s.decorMissSeen == nil {
+		s.decorMissSeen = make(map[decorationMissKey]struct{})
+	}
+	key := decorationMissKey{paneID: paneID, rowIdx: rowIdx}
+	if _, seen := s.decorMissSeen[key]; seen {
+		return
+	}
+	s.decorMissSeen[key] = struct{}{}
+	log.Printf("client: decoration cache miss for pane %x rowIdx %d (rendering blank); subsequent misses suppressed", paneID, rowIdx)
+}
+```
+
+Add the corresponding fields to `clientState`:
+
+```go
+type clientState struct {
+	// ... existing fields ...
+	decorMissMu   sync.Mutex
+	decorMissSeen map[decorationMissKey]struct{}
 }
 ```
 
@@ -1676,7 +1808,7 @@ git add internal/runtime/client/renderer.go internal/runtime/client/renderer_tes
 git commit -m "$(cat <<'EOF'
 client: rowSourceForPane two-layer lookup (content gid / decoration positional)
 
-rowIdx in [ContentTopRow, ContentBottomRow] reads from PaneCache via
+rowIdx in [ContentTopRow, ContentTopRow+NumContentRows-1] reads from PaneCache via
 gid; outside the range reads from PaneState.DecorRows positionally.
 A content-layer miss returns nil (preserves Plan A's no-stale-content
 behavior); a decoration-layer miss also returns nil (renders blank;
@@ -1689,71 +1821,211 @@ EOF
 
 ---
 
-## Task 12: Integration — borders render on clean start
+## Task 11.5: Extend `memHarness` with the helpers Tasks 12–15 need
+
+**Why this task exists.** The existing `memHarness` in `internal/runtime/server/viewport_integration_test.go` (around line 280) is single-pane and single-`sparseFakeApp`. The plan's integration tests need: a way to inspect the client's `BufferCache` for content bounds + decoration cache, a way to wait for the next or latest delta for a given pane, a way to switch focus between two panes, and a way to drive a daemon restart for the rehydrate test. Rather than fabricate these helpers ad hoc inside each test, add them once on `memHarness` so the tests stay readable.
+
+Read the existing harness end-to-end before adding fields. Match its naming (`Publish`, `AwaitRow`, `ApplyViewport`) and its locking discipline (`h.mu` guards `rowsByGID` etc.).
 
 **Files:**
-- Modify: `internal/runtime/server/viewport_integration_test.go` (extend with new test cases)
-- Helper: existing memconn harness
+- Modify: `internal/runtime/server/viewport_integration_test.go` (add fields and methods to `memHarness`; add an option struct or constructor variant for two-pane setup)
 
-- [ ] **Step 1: Add the failing test.**
+- [ ] **Step 1: Add a client-side `BufferCache` to the harness.**
 
-Append to `internal/runtime/server/viewport_integration_test.go` (or create a sibling `decoration_integration_test.go`):
+The harness's existing `clientReadLoop` decodes `MsgBufferDelta` and `MsgTreeSnapshot` directly into `rowsByGID` / `altRowsByIdx`. To exercise the client-side `PaneState.{ContentTopRow, NumContentRows, decorRows}` path, also feed each decoded message into a real `client.BufferCache`:
 
 ```go
-func TestIntegration_PaneRendersAllFourBorders_CleanStart(t *testing.T) {
-	// Build a minimal harness with a single texterm-shaped pane.
-	// Use the existing helper that produces a sparseFakeApp + memconn
-	// pair (search the file for sparseFakeApp + buildHarness).
-	h := buildIntegrationHarness(t, harnessOpts{
-		paneRows: 6,
-		paneCols: 10,
-		// fake provides RowGlobalIdx so capturePaneSnapshot computes
-		// ContentTopRow=1, ContentBottomRow=4 (top border + 4 content + bottom border).
-	})
-	defer h.Close()
-	h.WaitForFirstDelta(t)
+type memHarness struct {
+	// ... existing fields ...
+	clientCache *client.BufferCache
+}
+```
 
-	// Inspect what the client sees:
-	delta := h.LastDelta(t)
-	if len(delta.DecorRows) == 0 {
-		t.Fatal("expected DecorRows with at least 2 entries (top + bottom borders)")
-	}
-	rowIdxs := make(map[uint16]bool, len(delta.DecorRows))
-	for _, r := range delta.DecorRows {
-		rowIdxs[r.Row] = true
-	}
-	if !rowIdxs[0] || !rowIdxs[5] {
-		t.Fatalf("expected border decoration rows at rowIdx 0 and 5, got %v", rowIdxs)
-	}
+Initialize in `newMemHarness`:
 
-	// Verify content bounds reached the client cache.
-	pane := h.ClientCache().Pane(h.PaneID())
-	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
-		t.Fatalf("client content bounds wrong: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+```go
+h.clientCache = client.NewBufferCache()
+```
+
+In `clientReadLoop`'s `MsgBufferDelta` case, after decoding, call `h.clientCache.ApplyDelta(delta)`. In the `MsgTreeSnapshot` case, after decoding, call `h.clientCache.ApplySnapshot(snap)`.
+
+Add a method:
+
+```go
+func (h *memHarness) ClientPane(id [16]byte) *client.PaneState {
+	return h.clientCache.Pane(id)
+}
+```
+
+- [ ] **Step 2: Add `LatestDeltaForPane` / `WaitForDelta` helpers.**
+
+The existing `AwaitRow` waits for a specific gid. For decoration assertions we need the most-recent full delta (so we can iterate `DecorRows`). Add:
+
+```go
+type lastDeltaTracker struct {
+	mu       sync.Mutex
+	byPane   map[[16]byte]protocol.BufferDelta
+	cond     *sync.Cond
+}
+
+// (initialize in newMemHarness; populate in clientReadLoop's MsgBufferDelta
+// case after the cache.ApplyDelta call.)
+
+func (h *memHarness) WaitForDelta(t *testing.T, paneID [16]byte, timeout time.Duration) protocol.BufferDelta {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	h.lastDelta.mu.Lock()
+	defer h.lastDelta.mu.Unlock()
+	for {
+		if d, ok := h.lastDelta.byPane[paneID]; ok {
+			return d
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatalf("WaitForDelta: timeout waiting for pane %x", paneID)
+		}
+		// Cond.Wait drops the mutex; reacquires before returning.
+		// Use a Cond bound to h.lastDelta.mu.
+		// (If sync.Cond seems heavy here, a simple per-pane channel works too.)
 	}
 }
 ```
 
-If `buildIntegrationHarness`, `WaitForFirstDelta`, `LastDelta`, `ClientCache`, `PaneID` don't exist as helpers, look at how existing tests like `TestIntegration_ClipsAndFetches` set up their fixtures and reuse the same pattern. The test author may need to extract a small helper from an existing test if no shared one exists yet.
+Pick whichever shape (Cond, channel, polling with `time.Sleep`) fits the existing patterns in the file.
+
+- [ ] **Step 3: Add daemon-restart helper.**
+
+Look at `TestD2_FullCrossRestartCycle` in `internal/runtime/server/d2_cross_restart_integration_test.go` for the existing pattern. Extract the common boot sequence into a helper on the harness:
+
+```go
+// Restart shuts the in-process server down, recreates the Manager+Server
+// pointing at the same persistence dir, and reconnects the client.
+func (h *memHarness) Restart(t *testing.T) {
+	t.Helper()
+	// 1. Close existing serverConn / readerDone.
+	// 2. Construct a new Manager with the same persistBasedir.
+	// 3. Wire a new DesktopPublisher + Server.
+	// 4. Open a new memconn pair and rebind h.serverConn / h.clientConn.
+	// 5. Replay handshake (MsgHello / MsgWelcome / MsgResumeRequest with persisted sessionID).
+}
+```
+
+Implementation lives next to `newMemHarness`; reuse the bits from `TestD2_FullCrossRestartCycle`.
+
+- [ ] **Step 4: Add two-pane variant.**
+
+Either a separate `newMemHarnessTwoPanes(t, cols, rows)` that wires two `sparseFakeApp` instances under a horizontal split, or an option struct passed to `newMemHarness`:
+
+```go
+type memHarnessOpts struct {
+	cols, rows int
+	twoPanes   bool
+}
+func newMemHarnessOpts(t *testing.T, opts memHarnessOpts) *memHarness { ... }
+```
+
+For the two-pane case, after `desktop.SwitchToWorkspace(1)`, split the workspace via the desktop's split API (look at `desktop_engine_core.go` for the actual call) and attach a second fake app. Track both pane IDs:
+
+```go
+type memHarness struct {
+	// ... existing fields ...
+	paneIDs []  [16]byte // [0] = original; [1] = right after split (when twoPanes=true)
+}
+```
+
+Add `FocusPane(paneID [16]byte)` that drives the desktop's focus change.
+
+- [ ] **Step 5: Verify the harness compiles + existing tests still pass.**
+
+```bash
+go test ./internal/runtime/server/ -run TestIntegration_ -count=1 -v
+```
+
+Expected: PASS for all existing viewport integration tests. The new helpers haven't been wired into any test yet — this step just confirms no regressions.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add internal/runtime/server/viewport_integration_test.go
+git commit -m "$(cat <<'EOF'
+test(server): extend memHarness for decoration + multi-pane + restart
+
+Adds client.BufferCache, WaitForDelta, Restart, and two-pane support
+to memHarness so subsequent integration tests can exercise the
+decoration rendering paths without bespoke fixtures.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Integration — borders render on clean start
+
+**Files:**
+- Modify: `internal/runtime/server/viewport_integration_test.go`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append to `internal/runtime/server/viewport_integration_test.go`:
+
+```go
+func TestPaneRenders_AllFourBorders_CleanStart(t *testing.T) {
+	h := newMemHarness(t, 10, 6)
+	defer h.serverConn.Close()
+	// First publish primes the buffer + ships the initial deltas.
+	h.Publish()
+
+	delta := h.WaitForDelta(t, h.paneID, 2*time.Second)
+	if len(delta.DecorRows) == 0 {
+		t.Fatal("expected DecorRows for at least the top + bottom borders")
+	}
+	rowIdxs := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		rowIdxs[r.RowIdx] = true
+	}
+	if !rowIdxs[0] || !rowIdxs[5] {
+		t.Fatalf("expected decoration rows at rowIdx 0 and 5, got %v", rowIdxs)
+	}
+
+	// Verify content bounds reached the client cache.
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane %x", h.paneID)
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("client content bounds wrong: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+
+	// And the cache has decoration rows for both borders.
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 0")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 5")
+	}
+}
+```
+
+If the `sparseFakeApp` doesn't naturally produce `RowGlobalIdx` matching `(top=1, num=4)` for a 6-row pane, adjust its `RowGlobalIdx()` method (search the file for `func (a *sparseFakeApp) RowGlobalIdx`) so the bottom row reports `-1` (statusbar / bottom border slot).
 
 - [ ] **Step 2: Run — verify failure.**
 
 ```bash
-go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_CleanStart -v
+go test ./internal/runtime/server/ -run TestPaneRenders_AllFourBorders_CleanStart -v
 ```
 
-Expected: FAIL — initially the harness may not exist or the assertions fail.
+Expected: FAIL initially.
 
 - [ ] **Step 3: Make the test green.**
 
-Most of the wiring should already work after Tasks 1-11. If the test fails for harness-shape reasons, build the missing helpers as the smallest possible addition — do NOT introduce a generalised harness; copy the inline shape used by existing tests.
-
-If the assertions fail (e.g., border rowIdx don't match), inspect why — likely the fake app's `RowGlobalIdx` doesn't put -1 at the expected slots. Adjust the fake to mirror what a real texterm produces.
+Tasks 1-11 + 11.5 should make this pass without further publisher changes. If the assertions fail because `sparseFakeApp` doesn't model the bottom statusbar, adjust the fake.
 
 - [ ] **Step 4: Run — verify pass.**
 
 ```bash
-go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_CleanStart -v
+go test ./internal/runtime/server/ -run TestPaneRenders_AllFourBorders_CleanStart -v
 ```
 
 Expected: PASS.
@@ -1775,56 +2047,64 @@ EOF
 ## Task 13: Integration — borders render after daemon-restart rehydrate
 
 **Files:**
-- Modify: `internal/runtime/server/viewport_integration_test.go` (or the same file used in Task 12)
+- Modify: `internal/runtime/server/viewport_integration_test.go`
 
 - [ ] **Step 1: Add the failing test.**
 
-This test is the Plan D2 cross-restart cycle adapted to assert decoration rows. Find the existing Plan D2 cross-restart integration test (search for `TestD2_FullCrossRestartCycle` or `TestIntegration_D2`) and extend it, OR create a sibling that exercises the same cycle:
-
 ```go
-func TestIntegration_PaneRendersAllFourBorders_AfterRehydrate(t *testing.T) {
-	// 1. Boot fresh daemon, attach client, get initial render.
-	// 2. Simulate daemon restart: tear down + boot a new server backed by
-	//    the same persistence dir (mirrors Plan D2 harness).
-	// 3. Reconnect with the persisted sessionID via MsgResumeRequest.
-	// 4. Assert the post-resume BufferDelta carries border DecorRows AND
-	//    the client renders them at rowIdx 0 and H-1.
-	// (See TestD2_FullCrossRestartCycle for the harness pattern.)
+func TestPaneRenders_AllFourBorders_AfterRehydrate(t *testing.T) {
+	h := newMemHarness(t, 10, 6)
+	defer h.serverConn.Close()
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+	sessionID := h.sessionID()
 
-	h := buildD2Harness(t, harnessOpts{paneRows: 6, paneCols: 10})
-	defer h.Close()
-	h.WaitForFirstDelta(t)
-	sessionID := h.SessionID()
-	h.RestartDaemon(t)
-	h.Reconnect(t, sessionID)
+	// Daemon restart: rebuild the server in place and reconnect.
+	h.Restart(t)
+	// (Restart internally replays MsgHello + MsgResumeRequest using sessionID.)
+	_ = sessionID
 
-	delta := h.WaitForPostResumeDelta(t)
+	h.Publish()
+	delta := h.WaitForDelta(t, h.paneID, 2*time.Second)
+
 	rowIdxs := map[uint16]bool{}
 	for _, r := range delta.DecorRows {
-		rowIdxs[r.Row] = true
+		rowIdxs[r.RowIdx] = true
 	}
 	if !rowIdxs[0] || !rowIdxs[5] {
 		t.Fatalf("post-rehydrate delta missing border DecorRows, got %v", rowIdxs)
 	}
+
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane after rehydrate")
+	}
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 0 after rehydrate")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 5 after rehydrate")
+	}
+	// Statusbar at rowIdx 4 (H-2) should also be a decoration row.
+	if _, ok := pane.DecorRowAt(4); !ok {
+		t.Fatalf("client decoration cache missing texterm-style internal statusbar at rowIdx 4")
+	}
 }
 ```
 
-The exact helper names must mirror the existing Plan D2 test harness. If the existing harness uses different names, adapt.
-
-- [ ] **Step 2-4: Verify red, green, run.**
+- [ ] **Step 2-4: Red, green, run.**
 
 ```bash
-go test -tags=integration ./internal/runtime/server/ -run TestIntegration_PaneRendersAllFourBorders_AfterRehydrate -v
+go test ./internal/runtime/server/ -run TestPaneRenders_AllFourBorders_AfterRehydrate -v
 ```
 
-Expect FAIL initially (harness setup or missing assertions); make it green.
+Expected: FAIL initially; PASS after Task 11.5's `Restart` is implemented.
 
 - [ ] **Step 5: Commit.**
 
 ```bash
-git add internal/runtime/server/viewport_integration_test.go
 git commit -m "$(cat <<'EOF'
-test(server): integration — pane renders all four borders after daemon restart
+test(server): integration — pane renders all four borders + statusbar after daemon restart
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -1841,40 +2121,47 @@ EOF
 - [ ] **Step 1: Add the failing test.**
 
 ```go
-func TestIntegration_PaneRendersAllFourBorders_ScrolledMidHistory(t *testing.T) {
-	h := buildIntegrationHarness(t, harnessOpts{paneRows: 6, paneCols: 10})
-	defer h.Close()
-	h.WaitForFirstDelta(t)
+func TestPaneRenders_AllFourBorders_ScrolledMidHistory(t *testing.T) {
+	h := newMemHarness(t, 10, 6)
+	defer h.serverConn.Close()
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
 
-	// Push several pages of content so the client can scroll back.
+	// Append several screens of content via the fake app's writer.
 	for i := 0; i < 50; i++ {
-		h.AppendContentRow(t, fmt.Sprintf("line-%d", i))
+		h.fakeApp.AppendLine(fmt.Sprintf("line-%d", i))
+		h.Publish()
 	}
-	h.WaitForLatestDelta(t)
-	// Scroll the client off the live edge (autoFollow=false, viewBottom mid-history).
-	h.SetClientViewport(t, ClientViewportOpts{
-		AutoFollow:    false,
-		ViewBottomIdx: 10,
-	})
-	h.WaitForFetchRangeRoundTrip(t)
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
 
-	pane := h.ClientCache().Pane(h.PaneID())
-	if pane.ContentTopRow != 1 || pane.ContentBottomRow != 4 {
-		t.Fatalf("scrolled state lost content bounds: top=%d bottom=%d", pane.ContentTopRow, pane.ContentBottomRow)
+	// Scroll off the live edge: autoFollow=false, viewBottom mid-history.
+	h.ApplyViewport(h.paneID, 10, 15, false, false)
+	h.Publish()
+	// Optionally wait for a fetch-range round-trip if the harness has one.
+
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane")
 	}
-	if len(pane.DecorRows) < 2 {
-		t.Fatalf("scrolled state lost decoration rows: %+v", pane.DecorRows)
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("scrolled state lost content bounds: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("scrolled state lost top border decoration")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("scrolled state lost bottom border decoration")
 	}
 }
 ```
 
-- [ ] **Step 2-5: Red, green, run, commit.**
+If `sparseFakeApp` lacks `AppendLine`, add it as a thin wrapper over the existing append API. Match the existing fake-app patterns in the file.
 
-Same shape as Tasks 12-13.
+- [ ] **Step 2-5: Red, green, run, commit.**
 
 ```bash
 git commit -m "$(cat <<'EOF'
-test(server): integration — borders survive mid-history scroll
+test(server): integration — borders + bounds survive mid-history scroll
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -1891,21 +2178,22 @@ EOF
 - [ ] **Step 1: Add the failing test.**
 
 ```go
-func TestIntegration_FocusChangeRepaintsBorders(t *testing.T) {
-	h := buildIntegrationHarness(t, harnessOpts{
-		paneRows: 6, paneCols: 10,
-		twoPanes: true, // harness must support a 2-pane setup
-	})
-	defer h.Close()
-	h.WaitForFirstDelta(t)
-	h.DrainDeltas(t) // ignore initial deltas
+func TestPaneRenders_FocusChangeRepaintsBorders(t *testing.T) {
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: 10, rows: 6, twoPanes: true})
+	defer h.serverConn.Close()
+	h.Publish()
+	h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
+	h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
 
-	// Toggle focus from pane A to pane B.
-	h.FocusPane(t, h.PaneB())
+	// Snapshot what we've seen so subsequent WaitForDelta returns only NEW deltas.
+	h.ResetDeltaTracker(h.paneIDs[0])
+	h.ResetDeltaTracker(h.paneIDs[1])
 
-	// Both panes should emit DecorRows for their border style change.
-	deltaA := h.NextDeltaFor(t, h.PaneA())
-	deltaB := h.NextDeltaFor(t, h.PaneB())
+	h.FocusPane(h.paneIDs[1])
+	h.Publish()
+
+	deltaA := h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
+	deltaB := h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
 	if len(deltaA.DecorRows) == 0 {
 		t.Fatalf("pane A focus loss did not emit DecorRows")
 	}
@@ -1915,11 +2203,13 @@ func TestIntegration_FocusChangeRepaintsBorders(t *testing.T) {
 }
 ```
 
+`ResetDeltaTracker` is a small helper on the harness that clears the entry for a pane in the `lastDelta` map so the next `WaitForDelta` blocks until a fresh delta arrives. Add it as part of the Task 11.5 helpers or here, whichever lands first.
+
 - [ ] **Step 2-5: Red, green, run, commit.**
 
 ```bash
 git commit -m "$(cat <<'EOF'
-test(server): integration — focus change ships border DecorRows
+test(server): integration — focus change ships border DecorRows for both panes
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -1985,7 +2275,7 @@ Split the pane (Ctrl-A then `s` or `v` per the keybinding) → focus the new pan
 
 - [ ] **Step 6: Resize check.**
 
-Resize the terminal window to a dramatically different size. Borders must remain visible and content must reflow correctly inside them. ContentTopRow / ContentBottomRow recompute should keep the rowIdx ↔ gid map consistent.
+Resize the terminal window to a dramatically different size. Borders must remain visible and content must reflow correctly inside them. ContentTopRow / NumContentRows recompute should keep the rowIdx ↔ gid map consistent.
 
 - [ ] **Step 7: Document the verification.**
 
@@ -1997,11 +2287,13 @@ No commit for this task — verification only.
 
 ## Self-Review Checklist (run before declaring the plan done)
 
-- [ ] **Spec coverage:** every test the spec lists maps to a task (Tasks 1, 2, 6, 7, 8, 9, 10, 11, 12-15). Every type/field the spec introduces (`ContentTopRow`, `ContentBottomRow`, `DecorRows`, `numContentRows`, `computeContentBounds`) is defined exactly once and referenced consistently.
+- [ ] **Spec coverage:** every test the spec lists maps to a task (Tasks 1, 2, 6, 7, 8, 9, 10, 11, 12-15). Every type/field the spec introduces (`ContentTopRow`, `NumContentRows`, `DecorRowDelta`, `DecorRows`, `decorRows`, `DecorRowAt`, `computeContentBounds`, `logDecorationMissOnce`) is defined exactly once and referenced consistently.
 - [ ] **Type consistency:** field types (`uint16`), method names (`ApplyDelta`, `ApplySnapshot`, `ResetRevisions`), and protocol names (`RowDelta`, `BufferDelta`, `PaneSnapshot`) match between earlier and later tasks.
 - [ ] **No placeholders:** every code block is complete; no "TBD" or "fill in" steps.
 - [ ] **Decoration contiguity invariant** is documented in spec; tests rely on it.
-- [ ] **`Bottom < Top` zero-content sentinel** is consistently treated: server emits `(1, 0)` for empty; client checks `pane.ContentBottomRow >= pane.ContentTopRow` before doing the math.
+- [ ] **Zero-content state** is consistently treated: server emits `NumContentRows == 0`; client `onBufferDelta` returns early; client `rowSourceForPane` reads decoration for every rowIdx; no overloaded sentinel.
+- [ ] **`decorRows` lock discipline:** all writes under `pane.rowsMu.Lock()`; all reads via `DecorRowAt` (which takes `pane.rowsMu.RLock()`); `ResetRevisions` takes per-pane `rowsMu.Lock()` before nilling; renderer never touches `pane.decorRows` directly.
+- [ ] **Decoder rejects truncated v3:** `len(b) < 2` for the `DecorRows` count returns `ErrPayloadShort`; no v2 silent-accept fallback (project policy: no backward compat).
 - [ ] **Alt-screen path** is unchanged for non-decoration cells; `bufferToDelta` short-circuits decoration emission for `snap.AltScreen=true`.
 - [ ] **Race-detector run** before opening PR: `go test -race -count=1 ./protocol/ ./client/ ./internal/runtime/...`. Address any new races.
 - [ ] **Manual e2e Task 16** completed; observations noted in PR description.

--- a/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
+++ b/docs/superpowers/plans/2026-04-27-issue-199-pane-decoration-rendering.md
@@ -27,6 +27,7 @@
 | `client/buffercache.go` | `PaneState.{ContentTopRow, NumContentRows, decorRows}` (decorRows unexported, guarded by `rowsMu`); `DecorRowAt` accessor; `ApplyDelta` populates; `ResetRevisions` clears | ~600 |
 | `internal/runtime/client/viewport_tracker.go` | `onBufferDelta`: `top` calc uses `pane.NumContentRows`; logs + skips on `pane==nil` | ~280 |
 | `internal/runtime/client/renderer.go` | `rowSourceForPane`: two-layer lookup; logs once per (paneID, rowIdx) on decoration miss | ~550 |
+| `internal/runtime/client/post_resume_reset.go` | Also call `state.resetDecorationMissTracker()` after `cache.ResetRevisions()` | ~30 |
 | `internal/runtime/server/viewport_integration_test.go` | Extend `memHarness` with multi-pane + cross-restart support (Task 11.5) | ~870 |
 
 ---
@@ -112,6 +113,49 @@ func TestDecodeBufferDelta_TruncatedDecorTailErrPayloadShort(t *testing.T) {
 	truncated := encoded[:len(encoded)-2]
 	if _, err := protocol.DecodeBufferDelta(truncated); !errors.Is(err, protocol.ErrPayloadShort) {
 		t.Fatalf("expected ErrPayloadShort on truncated v3, got %v", err)
+	}
+}
+
+func TestDecodeBufferDelta_TruncatedMidDecorRow(t *testing.T) {
+	// Build a payload with one DecorRow that has one span, then truncate
+	// inside the per-row body (after the row+spanCount header but before
+	// the span itself).
+	original := protocol.BufferDelta{
+		PaneID:   [16]byte{0x02},
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "border", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := protocol.EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Chop off the last 6 bytes (the per-span StartCol+TextLen+StyleIdx
+	// header), leaving the row+spanCount header dangling without span data.
+	truncated := encoded[:len(encoded)-len("border")-6]
+	if _, err := protocol.DecodeBufferDelta(truncated); !errors.Is(err, protocol.ErrPayloadShort) {
+		t.Fatalf("expected ErrPayloadShort on mid-row truncation, got %v", err)
+	}
+}
+
+func TestDecodeBufferDelta_RejectsExcessiveRowIdx(t *testing.T) {
+	// Hand-craft a payload with RowIdx > MaxDecorRowIdx (out of sane pane height).
+	original := protocol.BufferDelta{
+		PaneID:   [16]byte{0x03},
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{AttrFlags: 0, FgModel: protocol.ColorModelDefault, BgModel: protocol.ColorModelDefault}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: protocol.MaxDecorRowIdx + 1, Spans: []protocol.CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := protocol.EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, err := protocol.DecodeBufferDelta(encoded); !errors.Is(err, protocol.ErrInvalidSpan) {
+		t.Fatalf("expected ErrInvalidSpan for excessive RowIdx, got %v", err)
 	}
 }
 ```
@@ -224,6 +268,12 @@ In `DecodeBufferDelta`, **replace** the existing `return delta, nil` at the end 
 			rowIdx := binary.LittleEndian.Uint16(b[:2])
 			spanCount := binary.LittleEndian.Uint16(b[2:4])
 			b = b[4:]
+			// Defensive bound: a sane pane is at most a few thousand rows
+			// tall. A RowIdx beyond MaxDecorRowIdx indicates a corrupt or
+			// hostile payload — reject rather than balloon client memory.
+			if rowIdx > MaxDecorRowIdx {
+				return delta, ErrInvalidSpan
+			}
 			spans := make([]CellSpan, spanCount)
 			for s := 0; s < int(spanCount); s++ {
 				if len(b) < 6 {
@@ -250,6 +300,15 @@ In `DecodeBufferDelta`, **replace** the existing `return delta, nil` at the end 
 		return delta, ErrPayloadShort
 	}
 	return delta, nil
+```
+
+Add the constant near the top of `protocol/buffer_delta.go`, alongside `BufferDeltaFlags`:
+
+```go
+// MaxDecorRowIdx caps a decoration row's absolute rowIdx to a sane pane
+// height. Real panes never exceed a few thousand rows; values above this
+// signal a corrupt or hostile payload.
+const MaxDecorRowIdx uint16 = 4096
 ```
 
 Two correctness points:
@@ -605,8 +664,11 @@ In `texel/snapshot.go` near `allMinusOne` (~line 360), add:
 ```go
 // computeContentBounds returns (ContentTopRow, NumContentRows) for the
 // given RowGlobalIdx slice. If no row has gid>=0, returns (0, 0).
-// Assumes contiguity: callers must ensure all gid>=0 rows form a single
-// contiguous block (enforced by capturePaneSnapshot construction).
+// Requires contiguity: every index in [top, last] must have gid >= 0,
+// and every index outside that range must have gid < 0. Logs a warning
+// and returns (0, 0) on violation rather than producing a bogus range —
+// a non-contiguous layout is a bug somewhere up the stack and the
+// renderer falling back to all-decoration is recoverable.
 func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 	top := -1
 	last := -1
@@ -622,7 +684,27 @@ func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 	if top < 0 {
 		return 0, 0
 	}
+	// Verify contiguity: every index in [top, last] must have gid >= 0.
+	for y := top; y <= last; y++ {
+		if rowIdx[y] < 0 {
+			log.Printf("texel: computeContentBounds: non-contiguous content rows at y=%d (top=%d, last=%d); treating pane as all-decoration", y, top, last)
+			return 0, 0
+		}
+	}
 	return uint16(top), uint16(last - top + 1)
+}
+```
+
+Add a test for the contiguity violation:
+
+```go
+func TestComputeContentBounds_NonContiguous(t *testing.T) {
+	// Hole in the middle of the content range.
+	rowIdx := []int64{-1, 100, -1, 102, -1}
+	top, num := computeContentBounds(rowIdx)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected (0, 0) on non-contiguous layout, got (%d, %d)", top, num)
+	}
 }
 ```
 
@@ -957,6 +1039,31 @@ func TestBufferToDelta_AltScreenLeavesDecorRowsEmpty(t *testing.T) {
 		t.Fatalf("alt-screen must not emit DecorRows, got %d", len(delta.DecorRows))
 	}
 }
+
+func TestBufferToDelta_ZeroContentSnapshot(t *testing.T) {
+	// Status pane shape: every row is decoration (no content gids).
+	// Server must emit all rows in DecorRows and zero content rows.
+	rows := [][]texel.Cell{
+		{{Ch: 'a'}},
+		{{Ch: 'b'}},
+		{{Ch: 'c'}},
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, -1, -1},
+		ContentTopRow:  0,
+		NumContentRows: 0,
+	}
+	vp := ClientViewport{Rows: 0, AutoFollow: false}
+	delta := bufferToDelta(snap, vp, nil, 1)
+	if len(delta.Rows) != 0 {
+		t.Fatalf("expected 0 content Rows for zero-content pane, got %d", len(delta.Rows))
+	}
+	if len(delta.DecorRows) != 3 {
+		t.Fatalf("expected 3 DecorRows for zero-content pane, got %d", len(delta.DecorRows))
+	}
+}
 ```
 
 (The exact `ClientViewport` field names and `bufferToDelta` signature must match existing code — read the function signature at `internal/runtime/server/desktop_publisher.go:206` (or near there) and adapt the test calls. The test author should preserve the public-API arguments the function actually takes.)
@@ -1156,18 +1263,25 @@ type PaneState struct {
 	HasAnimated bool
 }
 
-// DecorRowAt returns the cells for an absolute decoration rowIdx, or
-// (nil, false) if no decoration has been applied to that row. Read under
-// rowsMu.RLock(). The returned slice is a direct reference to internal
-// state; callers must not retain or modify it across frame boundaries.
+// DecorRowAt returns a *copy* of the cells for an absolute decoration
+// rowIdx, or (nil, false) if no decoration has been applied to that row.
+// Returning a copy (rather than the internal slice) means the renderer can
+// hold the result across the frame without racing concurrent ApplyDelta
+// writes to the same rowIdx. Allocation is bounded — at most ~4 decoration
+// rows × pane width per render frame.
 func (p *PaneState) DecorRowAt(rowIdx uint16) ([]Cell, bool) {
 	if p == nil {
 		return nil, false
 	}
 	p.rowsMu.RLock()
 	defer p.rowsMu.RUnlock()
-	cells, ok := p.decorRows[rowIdx]
-	return cells, ok
+	src, ok := p.decorRows[rowIdx]
+	if !ok {
+		return nil, false
+	}
+	out := make([]Cell, len(src))
+	copy(out, src)
+	return out, true
 }
 ```
 
@@ -1295,18 +1409,36 @@ In `client/buffercache.go` `ApplyDelta` (~line 149), the existing code acquires 
 	}
 ```
 
-After `pane.rowsMu.Unlock()`, in the dirty-flag block, add:
+After `pane.rowsMu.Unlock()`, replace the existing dirty-row tracking block with:
 
 ```go
-	if len(delta.DecorRows) > 0 {
-		pane.Dirty = true
-		// Decoration changes invalidate row-level dirty tracking; force a
-		// full re-render of this pane.
-		pane.DirtyRows = nil
+	pane.Dirty = true
+	// Force full re-render whenever a delta touches this pane. The pre-
+	// existing per-row dirty map (DirtyRows) was keyed inconsistently:
+	// content rows used (gid - RowBase), decoration rows would be keyed by
+	// absolute rowIdx — mixing the two key spaces silently produced wrong
+	// re-renders. Setting DirtyRows = nil unconditionally tells the
+	// renderer "the whole pane needs paint," which is correct and avoids
+	// the mixed-key bug. The perf cost is small (decoration row writes
+	// are rare; content-row writes already invalidate via the gid-keyed
+	// PaneCache, not DirtyRows).
+	pane.DirtyRows = nil
+```
+
+This replaces the existing block:
+
+```go
+	if pane.DirtyRows == nil && len(delta.Rows) < int(pane.Rect.Height) {
+		pane.DirtyRows = make(map[int]bool, len(delta.Rows))
+	}
+	if pane.DirtyRows != nil {
+		for _, rowDelta := range delta.Rows {
+			pane.DirtyRows[int(rowDelta.Row)] = true
+		}
 	}
 ```
 
-**Lock discipline:** all writes to `pane.decorRows` happen under `pane.rowsMu.Lock()`; all reads go through `DecorRowAt` which takes `pane.rowsMu.RLock()`. The renderer (Task 11) must not access `pane.decorRows` directly.
+**Lock discipline:** all writes to `pane.decorRows` happen under `pane.rowsMu.Lock()`; all reads go through `DecorRowAt` which takes `pane.rowsMu.RLock()` and returns a *copy* (so the renderer can safely retain the slice across the frame). The renderer (Task 11) must not access `pane.decorRows` directly.
 
 - [ ] **Step 4: Run — verify pass.**
 
@@ -1354,6 +1486,60 @@ EOF
 Append to `client/buffercache_test.go`:
 
 ```go
+func TestApplyDelta_ConcurrentDecorRowsReadWrite(t *testing.T) {
+	// Race-detector regression test: concurrently apply decoration deltas
+	// while a renderer-shaped goroutine reads via DecorRowAt. Without the
+	// rowsMu coverage on decorRows, this would flag under -race.
+	cache := client.NewBufferCache()
+	id := [16]byte{0xab}
+
+	// Seed the pane so DecorRowAt has a target.
+	cache.ApplyDelta(protocol.BufferDelta{
+		PaneID:   id,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+		},
+	})
+	pane := cache.Pane(id)
+	if pane == nil {
+		t.Fatal("pane not registered")
+	}
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer goroutine: repeated ApplyDelta with new decoration cells.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			cache.ApplyDelta(protocol.BufferDelta{
+				PaneID:   id,
+				Revision: uint32(i + 2),
+				Styles:   []protocol.StyleEntry{{}},
+				DecorRows: []protocol.DecorRowDelta{
+					{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: fmt.Sprintf("%c", 'a'+i%26), StyleIndex: 0}}},
+				},
+			})
+		}
+	}()
+
+	// Reader goroutine: continuously fetch DecorRowAt(0).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			row, ok := pane.DecorRowAt(0)
+			if ok && len(row) > 0 {
+				_ = row[0].Ch // touch the cell so the race detector sees the read
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestResetRevisions_ClearsDecorRows(t *testing.T) {
 	cache := client.NewBufferCache()
 	id := [16]byte{0xab}
@@ -1412,6 +1598,43 @@ func (c *BufferCache) ResetRevisions() {
 ```
 
 The per-pane `rowsMu.Lock()` ensures the renderer doesn't observe a torn map mid-clear. Holding both `c.mu` and `pane.rowsMu` is safe — `c.mu` is always acquired first throughout the package.
+
+- [ ] **Step 4: Clear `clientState.decorMissSeen` in the same path that calls `ResetRevisions`.**
+
+Decoration miss dedup state must also reset on session reuse so a fresh session can re-log misses. In `internal/runtime/client/post_resume_reset.go` (the one place that calls `state.cache.ResetRevisions()`, currently at line 26), add immediately after:
+
+```go
+state.cache.ResetRevisions()
+state.resetDecorationMissTracker()
+```
+
+Add the method to `clientState`:
+
+```go
+func (s *clientState) resetDecorationMissTracker() {
+	s.decorMissMu.Lock()
+	defer s.decorMissMu.Unlock()
+	s.decorMissSeen = nil
+}
+```
+
+Add a unit test:
+
+```go
+func TestPostResumeReset_ClearsDecorationMissTracker(t *testing.T) {
+	state := newClientStateForTest(t)
+	state.logDecorationMissOnce([16]byte{0xab}, 5)
+	if len(state.decorMissSeen) != 1 {
+		t.Fatalf("expected 1 entry pre-reset, got %d", len(state.decorMissSeen))
+	}
+	applyPostResumeReset(state) // or whatever the existing reset entry point is
+	if len(state.decorMissSeen) != 0 {
+		t.Fatalf("expected decorMissSeen cleared, got %d entries", len(state.decorMissSeen))
+	}
+}
+```
+
+If `applyPostResumeReset` has a different name, use it. Inspect `internal/runtime/client/post_resume_reset.go` for the actual function name.
 
 - [ ] **Step 4: Run — verify pass.**
 
@@ -1594,8 +1817,9 @@ client: onBufferDelta computes top from numContentRows, not vp.Rows
 
 vp.Rows includes border/decoration rows; numContentRows excludes them.
 This stops the viewport top from being offset by the count of non-
-content rows. Falls back to vp.Rows if the pane has no ContentBottom/
-Top yet (pre-snapshot delta — should not happen in production).
+content rows. Logs and skips when pane is absent from the cache
+(pre-snapshot delta — should not happen in production); returns
+early when NumContentRows == 0 (legitimate state for status panes).
 
 Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
 EOF
@@ -1667,9 +1891,13 @@ func TestRowSourceForPane_DecorationLayer(t *testing.T) {
 	if src := rowSourceForPane(state, pane, 4); len(src) == 0 || src[0].Ch != 'B' {
 		t.Fatalf("rowIdx 4 expected decoration 'B', got %+v", src)
 	}
-	// rowIdx 1 → content row (gid = ViewTopIdx + (rowIdx - ContentTopRow) = 8 + 0 = 8)
-	// PaneCache should have gid 10 from the delta; gid 8 is a miss → nil.
-	// To exercise the content-layer path with a hit, also test rowIdx 3 → gid 10:
+	// rowIdx 1 → content row (gid = ViewTopIdx + (rowIdx - ContentTopRow) = 8 + 0 = 8).
+	// PaneCache only has gid 10 from the delta; gid 8 is a miss → nil
+	// (preserves Plan A's no-stale-content guarantee).
+	if src := rowSourceForPane(state, pane, 1); src != nil {
+		t.Fatalf("rowIdx 1 expected nil (content-layer miss for gid 8), got %+v", src)
+	}
+	// rowIdx 3 → gid 10, present in PaneCache → "C".
 	if src := rowSourceForPane(state, pane, 3); len(src) == 0 || src[0].Ch != 'C' {
 		t.Fatalf("rowIdx 3 expected content 'C' (gid 10), got %+v", src)
 	}
@@ -1857,60 +2085,249 @@ func (h *memHarness) ClientPane(id [16]byte) *client.PaneState {
 }
 ```
 
-- [ ] **Step 2: Add `LatestDeltaForPane` / `WaitForDelta` helpers.**
+- [ ] **Step 2: Add `WaitForDelta` and `ResetDeltaTracker` helpers.**
 
 The existing `AwaitRow` waits for a specific gid. For decoration assertions we need the most-recent full delta (so we can iterate `DecorRows`). Add:
 
 ```go
 type lastDeltaTracker struct {
-	mu       sync.Mutex
-	byPane   map[[16]byte]protocol.BufferDelta
-	cond     *sync.Cond
+	mu     sync.Mutex
+	cond   *sync.Cond
+	byPane map[[16]byte]protocol.BufferDelta
 }
 
-// (initialize in newMemHarness; populate in clientReadLoop's MsgBufferDelta
-// case after the cache.ApplyDelta call.)
+func newLastDeltaTracker() *lastDeltaTracker {
+	t := &lastDeltaTracker{byPane: make(map[[16]byte]protocol.BufferDelta)}
+	t.cond = sync.NewCond(&t.mu)
+	return t
+}
 
-func (h *memHarness) WaitForDelta(t *testing.T, paneID [16]byte, timeout time.Duration) protocol.BufferDelta {
-	t.Helper()
+func (t *lastDeltaTracker) put(paneID [16]byte, d protocol.BufferDelta) {
+	t.mu.Lock()
+	t.byPane[paneID] = d
+	t.cond.Broadcast()
+	t.mu.Unlock()
+}
+
+func (t *lastDeltaTracker) wait(paneID [16]byte, timeout time.Duration) (protocol.BufferDelta, bool) {
 	deadline := time.Now().Add(timeout)
-	h.lastDelta.mu.Lock()
-	defer h.lastDelta.mu.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	for {
-		if d, ok := h.lastDelta.byPane[paneID]; ok {
-			return d
+		if d, ok := t.byPane[paneID]; ok {
+			return d, true
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			t.Fatalf("WaitForDelta: timeout waiting for pane %x", paneID)
+			return protocol.BufferDelta{}, false
 		}
-		// Cond.Wait drops the mutex; reacquires before returning.
-		// Use a Cond bound to h.lastDelta.mu.
-		// (If sync.Cond seems heavy here, a simple per-pane channel works too.)
+		// Cond.Wait without timeout — broadcast-on-deadline goroutine
+		// keeps us honest. Spin a one-shot timer that broadcasts when the
+		// deadline passes so the cond wakes up.
+		timer := time.AfterFunc(remaining, func() {
+			t.mu.Lock()
+			t.cond.Broadcast()
+			t.mu.Unlock()
+		})
+		t.cond.Wait()
+		timer.Stop()
 	}
+}
+
+func (t *lastDeltaTracker) reset(paneID [16]byte) {
+	t.mu.Lock()
+	delete(t.byPane, paneID)
+	t.mu.Unlock()
 }
 ```
 
-Pick whichever shape (Cond, channel, polling with `time.Sleep`) fits the existing patterns in the file.
+Add `lastDelta *lastDeltaTracker` to the `memHarness` struct, initialise in `newMemHarness` via `newLastDeltaTracker()`, populate in `clientReadLoop`'s `MsgBufferDelta` case via `h.lastDelta.put(delta.PaneID, delta)`.
+
+Methods on the harness for tests to use:
+
+```go
+func (h *memHarness) WaitForDelta(t *testing.T, paneID [16]byte, timeout time.Duration) protocol.BufferDelta {
+	t.Helper()
+	d, ok := h.lastDelta.wait(paneID, timeout)
+	if !ok {
+		t.Fatalf("WaitForDelta: timeout waiting for pane %x", paneID)
+	}
+	return d
+}
+
+// ResetDeltaTracker clears any cached delta for paneID so the next
+// WaitForDelta blocks until a fresh delta arrives. Use before driving an
+// action whose effect must be observed in a NEW delta (focus change,
+// content append, viewport scroll).
+func (h *memHarness) ResetDeltaTracker(paneID [16]byte) {
+	h.lastDelta.reset(paneID)
+}
+```
 
 - [ ] **Step 3: Add daemon-restart helper.**
 
-Look at `TestD2_FullCrossRestartCycle` in `internal/runtime/server/d2_cross_restart_integration_test.go` for the existing pattern. Extract the common boot sequence into a helper on the harness:
+The existing `TestD2_FullCrossRestartCycle` (in `internal/runtime/server/d2_cross_restart_integration_test.go`) exercises rehydrate at the manager level only — it doesn't drive a full memconn handshake. For Tasks 13 and 15 we need both: persistence-backed manager AND fresh memconn-based handshake.
+
+First, modify `newMemHarness` to enable persistence on the Manager from the start. Add an option:
 
 ```go
-// Restart shuts the in-process server down, recreates the Manager+Server
-// pointing at the same persistence dir, and reconnects the client.
-func (h *memHarness) Restart(t *testing.T) {
+type memHarnessOpts struct {
+	cols, rows  int
+	twoPanes    bool
+	persistDir  string // if non-empty, mgr.EnablePersistence is called with this
+}
+
+func newMemHarnessOpts(t *testing.T, opts memHarnessOpts) *memHarness {
 	t.Helper()
-	// 1. Close existing serverConn / readerDone.
-	// 2. Construct a new Manager with the same persistBasedir.
-	// 3. Wire a new DesktopPublisher + Server.
-	// 4. Open a new memconn pair and rebind h.serverConn / h.clientConn.
-	// 5. Replay handshake (MsgHello / MsgWelcome / MsgResumeRequest with persisted sessionID).
+	h := /* ... existing setup, with cols/rows from opts ... */
+	if opts.persistDir != "" {
+		if err := h.mgr.EnablePersistence(opts.persistDir, 10*time.Millisecond); err != nil {
+			t.Fatalf("EnablePersistence: %v", err)
+		}
+		h.persistDir = opts.persistDir
+	}
+	// ... rest of existing handshake wiring ...
+	return h
 }
 ```
 
-Implementation lives next to `newMemHarness`; reuse the bits from `TestD2_FullCrossRestartCycle`.
+Add `persistDir string` to the `memHarness` struct.
+
+The `Restart` helper:
+
+```go
+// Restart shuts the in-process server down, recreates the Manager + Server
+// pointing at the same persistence dir, opens a fresh memconn pair, and
+// replays the handshake using MsgResumeRequest with the persisted sessionID.
+// Caller must have constructed h with a non-empty persistDir.
+func (h *memHarness) Restart(t *testing.T) {
+	t.Helper()
+	if h.persistDir == "" {
+		t.Fatalf("Restart requires the harness to have been built with persistDir set")
+	}
+
+	// Capture state we need to replay before tearing down.
+	sessionID := h.sessionID()
+	cols := h.fakeApp.cols // adjust to whatever the fake exposes
+	rows := h.fakeApp.rows
+	persistDir := h.persistDir
+
+	// Close client side first; the server's serve goroutine will exit on
+	// EOF and close its end. Drain readerDone so we don't leak.
+	if err := h.clientConn.Close(); err != nil {
+		t.Logf("Restart: close clientConn: %v", err)
+	}
+	<-h.readerDone
+
+	// New Manager + Server bound to the same persistence dir.
+	mgr := NewManager()
+	if err := mgr.EnablePersistence(persistDir, 10*time.Millisecond); err != nil {
+		t.Fatalf("Restart: EnablePersistence: %v", err)
+	}
+
+	// Reuse desktop, fakeApp, sink — they survive across server restarts.
+	srv := &Server{manager: mgr, sink: h.sink, desktopSink: h.sink}
+	h.mgr = mgr
+	h.srv = srv
+
+	// Reset accumulated client-side state so post-restart deltas don't mix
+	// with pre-restart entries.
+	h.mu.Lock()
+	h.rowsByGID = make(map[int64]protocol.RowDelta)
+	h.altRowsByIdx = make(map[uint16][]protocol.CellSpan)
+	h.fetchByReqID = make(map[uint32]protocol.FetchRangeResponse)
+	h.rowBasesByPane = make(map[[16]byte][]int64)
+	h.lastDelta.byPane = make(map[[16]byte]protocol.BufferDelta) // see Step 2
+	h.mu.Unlock()
+	// Fresh client BufferCache too — mirrors what a real client process does.
+	h.clientCache = client.NewBufferCache()
+	h.readerDone = make(chan struct{})
+
+	// New memconn pair.
+	h.serverConn, h.clientConn = testutil.NewMemPipe(64)
+	t.Cleanup(func() {
+		_ = h.serverConn.Close()
+		_ = h.clientConn.Close()
+	})
+
+	// Re-spawn the server-side handshake goroutine (mirrors newMemHarness).
+	serveErrCh := make(chan error, 1)
+	sessCh := make(chan *Session, 1)
+	go func() {
+		defer h.serverConn.Close()
+		sess, resuming, _, err := handleHandshake(h.serverConn, mgr)
+		if err != nil {
+			serveErrCh <- err
+			return
+		}
+		pub := NewDesktopPublisher(h.desktop, sess)
+		h.sink.SetPublisher(pub)
+		conn := newConnection(h.serverConn, sess, h.sink, resuming, true /*rehydrated*/)
+		pub.SetNotifier(conn.nudge)
+		h.mu.Lock()
+		h.session = sess
+		h.pub = pub
+		h.mu.Unlock()
+		sessCh <- sess
+		serveErrCh <- conn.serve()
+	}()
+
+	// Client side: Hello → Welcome → ResumeRequest with persisted sessionID.
+	helloPayload, _ := protocol.EncodeHello(protocol.Hello{ClientName: "intg-client"})
+	h.writeFrame(protocol.MsgHello, helloPayload, [16]byte{})
+	if _, _, err := protocol.ReadMessage(h.clientConn); err != nil {
+		t.Fatalf("Restart: read welcome: %v", err)
+	}
+	resumeReq, _ := protocol.EncodeResumeRequest(protocol.ResumeRequest{
+		SessionID:    sessionID,
+		LastSequence: 0,
+	})
+	h.writeFrame(protocol.MsgResumeRequest, resumeReq, sessionID)
+	// Read MsgConnectAccept (skip non-target frames).
+	for {
+		hdr, payload, err := protocol.ReadMessage(h.clientConn)
+		if err != nil {
+			t.Fatalf("Restart: read connect accept: %v", err)
+		}
+		if hdr.Type == protocol.MsgConnectAccept {
+			if _, err := protocol.DecodeConnectAccept(payload); err != nil {
+				t.Fatalf("Restart: decode connect accept: %v", err)
+			}
+			break
+		}
+	}
+	select {
+	case <-sessCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Restart: session did not materialize")
+	}
+
+	// Spin client read loop back up.
+	go h.clientReadLoop()
+
+	// Catch teardown errors at test cleanup.
+	t.Cleanup(func() {
+		_ = h.clientConn.Close()
+		select {
+		case err := <-serveErrCh:
+			if err != nil && err != io.EOF {
+				t.Logf("Restart: server serve exit: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Log("Restart: server serve goroutine did not exit cleanly")
+		}
+		<-h.readerDone
+	})
+
+	// Note: cols/rows captured above are for documentation; the new server
+	// inherits the existing desktop's geometry. If the test changes pane
+	// dimensions across restart, set them on the new desktop here.
+	_ = cols
+	_ = rows
+}
+```
+
+The exact field names (`h.fakeApp.cols`, `EncodeResumeRequest`, etc.) must match what's in the existing code — search for them and adjust if they've drifted.
 
 - [ ] **Step 4: Add two-pane variant.**
 
@@ -2079,6 +2496,10 @@ func TestPaneRenders_AllFourBorders_AfterRehydrate(t *testing.T) {
 	if pane == nil {
 		t.Fatalf("client cache missing pane after rehydrate")
 	}
+	// Content bounds must survive the rehydrate.
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("client content bounds wrong after rehydrate: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
 	if _, ok := pane.DecorRowAt(0); !ok {
 		t.Fatalf("client decoration cache missing rowIdx 0 after rehydrate")
 	}
@@ -2134,10 +2555,19 @@ func TestPaneRenders_AllFourBorders_ScrolledMidHistory(t *testing.T) {
 	}
 	h.WaitForDelta(t, h.paneID, 2*time.Second)
 
+	// Reset the delta tracker so the next WaitForDelta blocks for a NEW delta
+	// triggered by the viewport change. Without this, a stale delta from the
+	// append loop above could be returned and the test would race past the
+	// scroll without observing it.
+	h.ResetDeltaTracker(h.paneID)
+
 	// Scroll off the live edge: autoFollow=false, viewBottom mid-history.
 	h.ApplyViewport(h.paneID, 10, 15, false, false)
 	h.Publish()
-	// Optionally wait for a fetch-range round-trip if the harness has one.
+	// Wait for the post-scroll delta to land — this is when the publisher
+	// re-emits content for the new viewport AND re-emits decoration rows
+	// (since prev[] is reset on viewport change).
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
 
 	pane := h.ClientPane(h.paneID)
 	if pane == nil {
@@ -2182,8 +2612,12 @@ func TestPaneRenders_FocusChangeRepaintsBorders(t *testing.T) {
 	h := newMemHarnessOpts(t, memHarnessOpts{cols: 10, rows: 6, twoPanes: true})
 	defer h.serverConn.Close()
 	h.Publish()
-	h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
-	h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
+	deltaA0 := h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
+	deltaB0 := h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
+
+	// Capture the initial border style of each pane before focus change.
+	prevBorderA := decorRowsByIdx(deltaA0)
+	prevBorderB := decorRowsByIdx(deltaB0)
 
 	// Snapshot what we've seen so subsequent WaitForDelta returns only NEW deltas.
 	h.ResetDeltaTracker(h.paneIDs[0])
@@ -2200,10 +2634,30 @@ func TestPaneRenders_FocusChangeRepaintsBorders(t *testing.T) {
 	if len(deltaB.DecorRows) == 0 {
 		t.Fatalf("pane B focus gain did not emit DecorRows")
 	}
+
+	// Critical assertion: the new border cells must differ from the old —
+	// otherwise the test passes vacuously when both panes paint identical
+	// chrome regardless of focus state.
+	newBorderA := decorRowsByIdx(deltaA)
+	newBorderB := decorRowsByIdx(deltaB)
+	if reflect.DeepEqual(prevBorderA[0], newBorderA[0]) {
+		t.Fatalf("pane A border at rowIdx 0 did not change on focus loss; theme may be missing an active/inactive distinction")
+	}
+	if reflect.DeepEqual(prevBorderB[0], newBorderB[0]) {
+		t.Fatalf("pane B border at rowIdx 0 did not change on focus gain; theme may be missing an active/inactive distinction")
+	}
+}
+
+// decorRowsByIdx flattens DecorRows into a map keyed by rowIdx for easy
+// per-row comparison. Tiny helper used by focus-change tests.
+func decorRowsByIdx(d protocol.BufferDelta) map[uint16][]protocol.CellSpan {
+	out := make(map[uint16][]protocol.CellSpan, len(d.DecorRows))
+	for _, r := range d.DecorRows {
+		out[r.RowIdx] = r.Spans
+	}
+	return out
 }
 ```
-
-`ResetDeltaTracker` is a small helper on the harness that clears the entry for a pane in the `lastDelta` map so the next `WaitForDelta` blocks until a fresh delta arrives. Add it as part of the Task 11.5 helpers or here, whichever lands first.
 
 - [ ] **Step 2-5: Red, green, run, commit.**
 
@@ -2293,7 +2747,12 @@ No commit for this task — verification only.
 - [ ] **Decoration contiguity invariant** is documented in spec; tests rely on it.
 - [ ] **Zero-content state** is consistently treated: server emits `NumContentRows == 0`; client `onBufferDelta` returns early; client `rowSourceForPane` reads decoration for every rowIdx; no overloaded sentinel.
 - [ ] **`decorRows` lock discipline:** all writes under `pane.rowsMu.Lock()`; all reads via `DecorRowAt` (which takes `pane.rowsMu.RLock()`); `ResetRevisions` takes per-pane `rowsMu.Lock()` before nilling; renderer never touches `pane.decorRows` directly.
-- [ ] **Decoder rejects truncated v3:** `len(b) < 2` for the `DecorRows` count returns `ErrPayloadShort`; no v2 silent-accept fallback (project policy: no backward compat).
+- [ ] **Decoder rejects truncated v3:** `len(b) < 2` for the `DecorRows` count returns `ErrPayloadShort`; mid-row truncation also returns `ErrPayloadShort`; `RowIdx > MaxDecorRowIdx` returns `ErrInvalidSpan`. No v2 silent-accept fallback (project policy: no backward compat).
+- [ ] **`DecorRowAt` returns a copy:** the slice returned to the renderer is independent of the internal cache; concurrent `ApplyDelta` mutations cannot tear it. Test: `TestApplyDelta_ConcurrentDecorRowsReadWrite` exercises read+write under `-race`.
+- [ ] **`DirtyRows` is always nil after `ApplyDelta`:** prevents the pre-existing key-space mix between gid-relative content rows and absolute-rowIdx decoration rows.
+- [ ] **`computeContentBounds` rejects non-contiguous content:** logs and returns `(0, 0)` rather than producing a bogus range.
+- [ ] **`decorMissSeen` is cleared on session reuse:** Plan D2's `applyPostResumeReset` calls `state.resetDecorationMissTracker()`. Test: `TestPostResumeReset_ClearsDecorationMissTracker`.
+- [ ] **Focus-change test asserts active vs inactive cells differ** (Task 15): without this, the test passes vacuously when both panes paint identical chrome.
 - [ ] **Alt-screen path** is unchanged for non-decoration cells; `bufferToDelta` short-circuits decoration emission for `snap.AltScreen=true`.
 - [ ] **Race-detector run** before opening PR: `go test -race -count=1 ./protocol/ ./client/ ./internal/runtime/...`. Address any new races.
 - [ ] **Manual e2e Task 16** completed; observations noted in PR description.

--- a/docs/superpowers/specs/2026-04-27-issue-199-pane-decoration-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-27-issue-199-pane-decoration-rendering-design.md
@@ -1,0 +1,324 @@
+# Issue #199 — Pane Border / Decoration Row Rendering
+
+**Date:** 2026-04-27
+**Branch:** `feature/issue-199-pane-decoration-rendering`
+**Status:** Design — ready for plan
+**Depends on:** Plan A (PR #202), Plan B (PR #203), Plan D (PR #204), Plan D2 (PR #205)
+**Unblocks:** none directly; cleans up a precondition for Plan C selection rendering
+
+## Context
+
+Plan D2's manual e2e (2026-04-26) surfaced a visual bug: after daemon-restart rehydrate, the texelterm pane renders three blank "lighter gray" rows at the top, no top/bottom borders, and content shifted ~3 rows down. Investigation showed the bug is **pre-existing**, not D2-specific — it's been latent since Plan A. D2's rehydrate path made it user-visible by exercising a code path where `maxGid` is large; on clean start, content overwrites the same rows because `maxGid` clamps to zero.
+
+Three classes of row are affected. All have `RowGlobalIdx[y] = -1` in the pane snapshot, and all are dropped by `bufferToDelta`'s `gid < 0` filter so they never reach the client:
+
+1. **Pane top border** at rowIdx 0
+2. **Pane bottom border** at rowIdx H-1
+3. **App-internal decorations** like texelterm's internal statusbar at rowIdx H-2
+
+Today the client treats every one of `vp.Rows` rows as a content row, computes `top := maxGid - (vp.Rows - 1)`, and queries `PaneCache.RowAt(gid)` for each rowIdx. The 3 lowest gids in the projected window are not in `PaneCache` (they don't correspond to content), so they render blank — and they land at the top of the pane.
+
+Full root-cause analysis lives in Task 16 of the Plan D2 plan and in `~/.claude/projects/.../memory/project_issue199_pane_border_render_bug.md`.
+
+## Goals
+
+1. After daemon-restart rehydrate, pane top + bottom borders are visible and content sits inside them.
+2. App-internal decoration rows (texelterm's statusbar) render their actual content, not blank.
+3. Same fix applies to clean start, scrolled-mid-history, focus changes, and resize — not just the rehydrate path that surfaced the bug.
+4. Rendering remains server-authoritative. Client gains no new rendering knowledge about borders, themes, or app internals.
+5. Protocol bump from v2 → v3. No backward-compat shims (per project policy).
+
+## Non-goals
+
+- Per-client themes (no current goal; would require client-side theme state).
+- Animating border color transitions (already handled by the effects pipeline; orthogonal).
+- Selection-aware decoration filtering. Plan C will read the new `ContentTopRow` / `ContentBottomRow` fields when it lands; this spec just provides them.
+- Reworking the alt-screen render path. Alt-screen panes already use a positional encoding and are unaffected.
+- Bundling Task 17's deferred mediums. None of 17.A–F touch the same files.
+
+## Architecture
+
+### One render path, two layers
+
+Server stays the source of truth for every visible cell. The client renders each non-altScreen pane by composing two layers:
+
+- **Content layer** — gid-keyed `PaneCache` rows (existing, viewport-clipped). Holds rows where `RowGlobalIdx[y] >= 0`.
+- **Decoration layer** — rowIdx-keyed positional cache (new). Holds rows where `RowGlobalIdx[y] < 0`: pane chrome (top/bottom borders) and app decorations (texterm's statusbar).
+
+`PaneSnapshot` gains `ContentTopRow` / `ContentBottomRow` so the client knows which rowIdx range maps to gids and which falls back to the decoration layer.
+
+### Why not client-side chrome rendering (rejected Approach A)
+
+The original Plan D2 Task 16 entry suggested Option 4 + Option 2 (client renders pane chrome itself from `pane.Rect` + theme; server tells client where content sits). Rejected because:
+
+- App-specific decorations (texterm internal statusbar at H-2) **cannot** be moved client-side — only the server-side app knows what's in that row. So the server must keep a positional decoration path regardless of where chrome is drawn.
+- Once the server has a positional decoration path for app decor, also using it for borders avoids splitting render responsibility across two locations and duplicating border-drawing + theme logic on the client.
+- Bandwidth win is small. Borders re-ship only on focus / title / resize events; steady-state deltas carry zero decoration rows because the existing positional `prev[y]` diff already filters unchanged rows.
+- Server-authoritative chrome plays better with future Plan C (server-side selection): selection operates on gid-keyed rows; decoration rows are excluded by construction.
+
+### Why not "ship every row including borders, drop ContentTopRow/Bottom" (rejected Approach C)
+
+The viewport math fundamentally needs to know how many of the pane's `H` rows are content. Without that, `top := maxGid - (numContentRows - 1)` cannot be computed and the rowIdx-to-gid mapping stays broken. The client cannot derive `numContentRows` from the delta itself because incremental deltas don't carry every row. So `ContentTopRow` / `ContentBottomRow` are required regardless of how decoration rows are encoded.
+
+## Protocol changes (v2 → v3)
+
+### `protocol.PaneSnapshot` gains two fields
+
+```go
+type PaneSnapshot struct {
+    // ... existing fields ...
+    ContentTopRow    uint16 // first content rowIdx; 0 if no top decoration
+    ContentBottomRow uint16 // last content rowIdx; H-1 if no bottom decoration
+}
+```
+
+Semantics:
+
+- `ContentBottomRow >= ContentTopRow`: pane has at least one content row.
+- `ContentBottomRow < ContentTopRow`: pane has zero content rows (all-decoration apps; e.g., a static dialog). Client renders the entire pane from the decoration layer.
+- `ContentTopRow == 0 && ContentBottomRow == H-1`: pane has no decoration rows (alt-screen panes hit this implicitly; main-screen panes without borders would too, though all current panes have borders).
+
+For alt-screen panes the fields are populated but ignored — the existing alt-screen render path handles everything positionally via `PaneCache.AltRowAt`.
+
+### `protocol.BufferDelta` gains one field
+
+```go
+type BufferDelta struct {
+    // ... existing fields ...
+    DecorRows []RowDelta // rows keyed by absolute rowIdx (not gid - RowBase)
+}
+```
+
+`RowDelta` shape is unchanged. For `DecorRows`, `RowDelta.Row` is interpreted as the absolute rowIdx in the pane buffer. For the existing `Rows`, it remains `gid - RowBase`.
+
+Separate slice rather than a flag on `RowDelta` keeps the two semantically-distinct row types unambiguous at decode time and means existing code paths don't have to branch on every row.
+
+### Wire-format encoding
+
+Append `ContentTopRow` (2 bytes) and `ContentBottomRow` (2 bytes) at the tail of the existing `PaneSnapshot` encoder. Append `DecorRows` (count-prefixed, same per-row encoding as `Rows`) at the tail of `BufferDelta`. No reordering of existing fields. Increment `protocol.Version` from 2 to 3.
+
+### Backward compatibility
+
+None. Per project policy, stale on-disk state should fail-and-overwrite, not auto-migrate. Bumping the protocol version causes pre-v3 clients to fail handshake; users restart their client.
+
+## Server changes
+
+### `texel/snapshot.go` — `capturePaneSnapshot`
+
+Already populates `RowGlobalIdx[i] = -1` for non-content rows. Add: after building `RowGlobalIdx`, compute `ContentTopRow` (first index with `gid >= 0`) and `ContentBottomRow` (last index with `gid >= 0`). If no row has `gid >= 0`, set `ContentTopRow = 1` and `ContentBottomRow = 0` (the "zero content rows" sentinel — `Bottom < Top`). Store on `PaneSnapshot`.
+
+### `internal/runtime/server/tree_convert.go` — `treeCaptureToProtocol`
+
+Currently sets `Rows: nil` on protocol PaneSnapshot. Pass through the new `ContentTopRow` / `ContentBottomRow` fields. `Rows` stays nil — borders and decorations ride deltas, not snapshots.
+
+### `internal/runtime/server/desktop_publisher.go` — `bufferToDelta`
+
+For non-altScreen panes, drop the `gid < 0` skip. Instead route those rows into `DecorRows` keyed by absolute `y`:
+
+```go
+for y, row := range snap.Buffer {
+    if len(row) == 0 {
+        continue
+    }
+    if y >= len(snap.RowGlobalIdx) {
+        continue
+    }
+    if y < len(prev) && rowsEqual(row, prev[y]) {
+        continue
+    }
+    gid := snap.RowGlobalIdx[y]
+    if gid < 0 {
+        decorRows = append(decorRows, protocol.RowDelta{
+            Row:   uint16(y),
+            Spans: encodeRow(row),
+        })
+        continue
+    }
+    if gid < lo || gid > hi {
+        continue
+    }
+    rows = append(rows, protocol.RowDelta{
+        Row:   uint16(gid - lo),
+        Spans: encodeRow(row),
+    })
+}
+delta.DecorRows = decorRows
+```
+
+The existing positional `prev[y]` diff continues to filter unchanged rows for both layers — only changed decoration rows ship.
+
+For alt-screen panes the path is unchanged; `DecorRows` stays empty.
+
+## Client changes
+
+### `client/buffercache.go` — decoration cache
+
+Add a per-pane decoration cache as a field on `PaneState`:
+
+```go
+type PaneState struct {
+    // ... existing fields ...
+    ContentTopRow    uint16
+    ContentBottomRow uint16
+    DecorRows        map[uint16][]Cell // rowIdx -> cells; populated from BufferDelta.DecorRows
+}
+```
+
+Apply `DecorRows` from each incoming `BufferDelta` into this map. Mark the pane dirty whenever a decoration row changes. `BufferCache.ResetRevisions` (used on session-reuse / new publisher) must also clear `DecorRows` per pane so a fresh publisher republishes everything.
+
+### `internal/runtime/client/viewport_tracker.go` — `onBufferDelta`
+
+Replace:
+
+```go
+top := maxGid - int64(vp.Rows-1)
+```
+
+with:
+
+```go
+numContentRows := int(pane.ContentBottomRow) - int(pane.ContentTopRow) + 1
+if numContentRows <= 0 {
+    return // pane has no content rows; nothing to anchor
+}
+top := maxGid - int64(numContentRows-1)
+```
+
+`pane.ContentTopRow` / `ContentBottomRow` are read from the `BufferCache.Pane` populated from the latest `PaneSnapshot`.
+
+### `internal/runtime/client/renderer.go` — `rowSourceForPane`
+
+Two-path lookup for non-altScreen panes:
+
+```go
+if vc.AltScreen {
+    // unchanged: PaneCache.AltRowAt + RowCellsDirect fallback
+}
+
+// Decoration layer
+if rowIdx < int(pane.ContentTopRow) || rowIdx > int(pane.ContentBottomRow) {
+    if row, ok := pane.DecorRows[uint16(rowIdx)]; ok {
+        return row
+    }
+    return nil
+}
+
+// Content layer
+contentRowIdx := rowIdx - int(pane.ContentTopRow)
+gid := vc.ViewTopIdx + int64(contentRowIdx)
+row, found := pc.RowAt(gid)
+if !found {
+    return nil
+}
+return row
+```
+
+A miss on either layer returns nil (renders blank). The decoration layer should hit after the first delta following the snapshot; the content layer can legitimately miss while a `MsgFetchRange` is in flight (existing Plan A behavior — preserved).
+
+## Data flow
+
+### Initial connect / resume
+
+1. Server captures snapshot → `ContentTopRow` / `ContentBottomRow` computed.
+2. Server emits `MsgTreeSnapshot` with the new fields.
+3. Server's first `BufferDelta` after the snapshot ships every changed row; on a fresh publisher (`prev` is empty), every row counts as changed, so all decoration rows ride along.
+4. Client populates `BufferCache.Pane.ContentTopRow/Bottom` from the snapshot, then `DecorRows` from the delta.
+5. Renderer composites both layers.
+
+### Focus change
+
+1. Server's `pane.border.Draw` repaints rows 0 and H-1 in the pane buffer with the new active/inactive style.
+2. `bufferToDelta`'s positional diff detects rows 0 and H-1 changed → emits 2 entries in `DecorRows`. Content rows unchanged → empty `Rows`.
+3. Client applies → decoration cache updates → pane re-renders with new border style.
+
+### Resize
+
+1. Pane geometry changes → `ContentTopRow` / `ContentBottomRow` recomputed in next snapshot.
+2. Server emits fresh snapshot + delta.
+3. Client updates and re-renders.
+
+### Daemon-restart rehydrate (Plan D2 path)
+
+Identical to "initial connect / resume" above. The publisher on the rehydrated session has empty `prev`, so the first post-resume delta carries all decoration rows. Borders + decorations render correctly from the first frame.
+
+## Error handling
+
+- **Decoration cache miss after first delta** — render blank. Mirrors content-row miss behavior. Preserves the "no stale chrome" guarantee.
+- **`ContentTopRow > ContentBottomRow + 1`** with non-zero buffer height — server-side bug. Log via the existing publisher logger; treat pane as zero content rows on the wire (only sentinel `Bottom < Top` should be emitted; any other inversion is a bug).
+- **Client receives `DecorRows` before its first `PaneSnapshot`** — should not happen (snapshot precedes deltas in the protocol). If it does, drop those `DecorRows` and rely on the next delta after `prev` resync. No explicit buffering needed.
+- **Stale decoration cache on session reuse** — `BufferCache.ResetRevisions` (Plan D's revision-monotonicity fix) is the natural pivot point. Extend it to also clear `DecorRows` per pane. The new publisher's empty `prev` then republishes everything.
+
+## Testing
+
+### Unit (server)
+
+- `TestBufferToDelta_DecorationRowsIncluded` — pane with top/bottom borders ships exactly 2 entries in `DecorRows` (rowIdx 0 and H-1) on first publish.
+- `TestBufferToDelta_DecorationRowsDiffed` — second publish with unchanged borders ships zero `DecorRows`.
+- `TestBufferToDelta_DecorationRowsDiffPartial` — repaint of just rowIdx 0 (e.g., title change) ships exactly one `DecorRows` entry.
+- `TestBufferToDelta_TexelTermInternalStatusbar` — pane backed by texterm with internal statusbar at H-2 ships that row in `DecorRows`.
+- `TestCapturePaneSnapshot_ContentBoundsComputed` — `RowGlobalIdx = [-1, 0, 1, 2, -1, -1]` produces `ContentTopRow=1, ContentBottomRow=3`.
+- `TestCapturePaneSnapshot_ContentBoundsAllDecoration` — all rows have `gid<0` (no content) produces `ContentTopRow=1, ContentBottomRow=0` sentinel.
+- `TestBufferToDelta_AltScreenLeavesDecorRowsEmpty` — alt-screen pane never emits `DecorRows`.
+
+### Unit (client)
+
+- `TestRowSourceForPane_DecorationLayer` — rowIdx 0 reads from `DecorRows`; rowIdx between bounds reads via gid; rowIdx H-1 reads from `DecorRows`.
+- `TestOnBufferDelta_TopUsesContentRowCount` — pane with `ContentTopRow=1, ContentBottomRow=H-3` (texterm shape) computes `top = maxGid - (H-3)` not `maxGid - (H-1)`.
+- `TestRowSourceForPane_DecorationCacheMissReturnsNil` — pane without populated `DecorRows` returns nil for decoration rowIdx, renders blank.
+- `TestBufferCache_ResetRevisionsClearsDecorRows` — `ResetRevisions` empties the per-pane decoration map.
+
+### Unit (protocol)
+
+- `TestEncodeDecodePaneSnapshot_ContentBounds` — round-trip preserves new fields.
+- `TestEncodeDecodeBufferDelta_DecorRows` — round-trip preserves DecorRows; empty slice round-trips as zero-length.
+- `TestVersion3` — `protocol.Version == 3`; `MsgWelcome` reflects the bump.
+
+### Integration (memconn)
+
+- `TestPaneRenders_AllFourBorders_CleanStart` — fresh session, single pane, snapshot + first delta arrive → renderer composite has top/bottom border characters at rowIdx 0/H-1, left/right border chars at col 0/W-1, content in between.
+- `TestPaneRenders_AllFourBorders_AfterRehydrate` — extends the Plan D2 cross-restart harness. After daemon restart + reconnect, the rendered pane has all four borders + texterm internal statusbar at H-2.
+- `TestPaneRenders_AllFourBorders_ScrolledMidHistory` — scrolled away from live edge (autoFollow=false), borders + decorations remain rendered.
+- `TestPaneRenders_FocusChangeRepaintsBorders` — pane focus toggles → BufferDelta carries 2 DecorRows → composite reflects new active-style borders.
+
+### Manual e2e
+
+Repeat Plan D2 Step 6: daemon AND client both restart with a long-running texelterm session.
+
+Pass criteria:
+
+1. All 4 pane borders visible from first paint.
+2. Texterm internal statusbar at H-2 shows actual content (not blank).
+3. Content occupies rows 1..H-3 and is not offset.
+4. Focus toggle (Ctrl-A pane switch) repaints borders without flicker.
+5. Window resize triggers correct `ContentTopRow` / `ContentBottomRow` recompute and re-render.
+
+## Touchpoints summary
+
+| File | Change |
+|------|--------|
+| `protocol/messages.go` | `PaneSnapshot.ContentTopRow/Bottom`, `BufferDelta.DecorRows`, `Version=3` |
+| `protocol/encode.go` | Encode new fields |
+| `protocol/decode.go` | Decode new fields |
+| `texel/snapshot.go` | `capturePaneSnapshot` computes Content bounds |
+| `internal/runtime/server/tree_convert.go` | `treeCaptureToProtocol` passes through |
+| `internal/runtime/server/desktop_publisher.go` | `bufferToDelta` emits `DecorRows` |
+| `client/buffercache.go` | `PaneState.{ContentTopRow,ContentBottomRow,DecorRows}` fields; `ResetRevisions` clears `DecorRows` |
+| `internal/runtime/client/viewport_tracker.go` | `onBufferDelta` `top` uses content row count |
+| `internal/runtime/client/renderer.go` | `rowSourceForPane` two-layer lookup |
+
+## Invariants
+
+- **Decoration contiguity** — decoration rows (`RowGlobalIdx[y] < 0`) must be contiguous at the top and/or bottom of the pane buffer. Concretely: `ContentTopRow` is the smallest `y` with `RowGlobalIdx[y] >= 0`, `ContentBottomRow` is the largest, and every `y` outside `[ContentTopRow, ContentBottomRow]` has `RowGlobalIdx[y] < 0` while every `y` inside has `RowGlobalIdx[y] >= 0`. This holds today by construction in `capturePaneSnapshot` (top border at 0, content via `RowGlobalIdxProvider` in [1..H-2], app statusbar / bottom border in the trailing slots). If a future app interleaves decoration mid-pane, this design must be revisited.
+- **Decoration positional vs content gid-keyed** — `BufferDelta.DecorRows[*].Row` is always an absolute rowIdx; `BufferDelta.Rows[*].Row` is always `gid - RowBase`. These two encodings never collide because they live in different slices.
+- **First-delta decoration completeness** — when the publisher sees an empty `prev` (fresh session, post-reset, post-resume), every changed row is shipped, including all decoration rows. This is what makes the rehydrate path render correctly from frame 1.
+
+## Open questions
+
+None. The exact wire byte layout for the new fields is mechanical and the plan will pin it.
+
+## Self-review
+
+- Placeholders: none.
+- Internal consistency: the two new `PaneSnapshot` fields and the new `BufferDelta` field are referenced consistently across server, client, and tests.
+- Scope: bounded — single-pass change covering one bug class. No bundled refactors.
+- Ambiguity: `ContentTopRow`/`ContentBottomRow` semantics include the `Bottom < Top` zero-content sentinel. `DecorRows.Row` semantics (absolute rowIdx vs `gid - RowBase`) are explicit.

--- a/docs/superpowers/specs/2026-04-27-issue-199-pane-decoration-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-27-issue-199-pane-decoration-rendering-design.md
@@ -32,7 +32,7 @@ Full root-cause analysis lives in Task 16 of the Plan D2 plan and in `~/.claude/
 
 - Per-client themes (no current goal; would require client-side theme state).
 - Animating border color transitions (already handled by the effects pipeline; orthogonal).
-- Selection-aware decoration filtering. Plan C will read the new `ContentTopRow` / `ContentBottomRow` fields when it lands; this spec just provides them.
+- Selection-aware decoration filtering. Plan C will read the new `ContentTopRow` / `NumContentRows` fields when it lands; this spec just provides them.
 - Reworking the alt-screen render path. Alt-screen panes already use a positional encoding and are unaffected.
 - Bundling Task 17's deferred mediums. None of 17.A–F touch the same files.
 
@@ -45,7 +45,7 @@ Server stays the source of truth for every visible cell. The client renders each
 - **Content layer** — gid-keyed `PaneCache` rows (existing, viewport-clipped). Holds rows where `RowGlobalIdx[y] >= 0`.
 - **Decoration layer** — rowIdx-keyed positional cache (new). Holds rows where `RowGlobalIdx[y] < 0`: pane chrome (top/bottom borders) and app decorations (texterm's statusbar).
 
-`PaneSnapshot` gains `ContentTopRow` / `ContentBottomRow` so the client knows which rowIdx range maps to gids and which falls back to the decoration layer.
+`PaneSnapshot` gains `ContentTopRow` / `NumContentRows` so the client knows which rowIdx range maps to gids and which falls back to the decoration layer.
 
 ### Why not client-side chrome rendering (rejected Approach A)
 
@@ -58,7 +58,7 @@ The original Plan D2 Task 16 entry suggested Option 4 + Option 2 (client renders
 
 ### Why not "ship every row including borders, drop ContentTopRow/Bottom" (rejected Approach C)
 
-The viewport math fundamentally needs to know how many of the pane's `H` rows are content. Without that, `top := maxGid - (numContentRows - 1)` cannot be computed and the rowIdx-to-gid mapping stays broken. The client cannot derive `numContentRows` from the delta itself because incremental deltas don't carry every row. So `ContentTopRow` / `ContentBottomRow` are required regardless of how decoration rows are encoded.
+The viewport math fundamentally needs to know how many of the pane's `H` rows are content. Without that, `top := maxGid - (numContentRows - 1)` cannot be computed and the rowIdx-to-gid mapping stays broken. The client cannot derive `numContentRows` from the delta itself because incremental deltas don't carry every row. So `ContentTopRow` / `NumContentRows` are required regardless of how decoration rows are encoded.
 
 ## Protocol changes (v2 → v3)
 
@@ -67,49 +67,56 @@ The viewport math fundamentally needs to know how many of the pane's `H` rows ar
 ```go
 type PaneSnapshot struct {
     // ... existing fields ...
-    ContentTopRow    uint16 // first content rowIdx; 0 if no top decoration
-    ContentBottomRow uint16 // last content rowIdx; H-1 if no bottom decoration
+    ContentTopRow   uint16 // first content rowIdx (0 if no top decoration)
+    NumContentRows  uint16 // number of content rows; 0 means the pane has zero content rows
 }
 ```
 
 Semantics:
 
-- `ContentBottomRow >= ContentTopRow`: pane has at least one content row.
-- `ContentBottomRow < ContentTopRow`: pane has zero content rows (all-decoration apps; e.g., a static dialog). Client renders the entire pane from the decoration layer.
-- `ContentTopRow == 0 && ContentBottomRow == H-1`: pane has no decoration rows (alt-screen panes hit this implicitly; main-screen panes without borders would too, though all current panes have borders).
+- `NumContentRows > 0`: pane has content rows in `[ContentTopRow, ContentTopRow + NumContentRows - 1]`. All rowIdx outside that range are decoration.
+- `NumContentRows == 0`: pane has zero content rows (all-decoration apps; e.g., a static dialog or a status pane). The client renders the entire pane from the decoration layer. `ContentTopRow` is meaningless and should be ignored.
+
+This shape (rather than a `(ContentTopRow, ContentBottomRow)` pair with a `Bottom < Top` sentinel) makes the renderer math read directly off the type — `top := maxGid - int64(NumContentRows) + 1` — and removes the ambiguity between a sentinel and a malformed value.
 
 For alt-screen panes the fields are populated but ignored — the existing alt-screen render path handles everything positionally via `PaneCache.AltRowAt`.
 
-### `protocol.BufferDelta` gains one field
+### `protocol.BufferDelta` gains one field with a distinct row-delta type
 
 ```go
+// DecorRowDelta has the same byte layout as RowDelta on the wire, but its
+// Row field carries the absolute rowIdx in the pane buffer, NOT (gid - RowBase).
+// The distinct type prevents accidentally mixing content and decoration rows.
+type DecorRowDelta struct {
+    RowIdx uint16
+    Spans  []CellSpan
+}
+
 type BufferDelta struct {
     // ... existing fields ...
-    DecorRows []RowDelta // rows keyed by absolute rowIdx (not gid - RowBase)
+    DecorRows []DecorRowDelta // rows keyed by absolute rowIdx
 }
 ```
 
-`RowDelta` shape is unchanged. For `DecorRows`, `RowDelta.Row` is interpreted as the absolute rowIdx in the pane buffer. For the existing `Rows`, it remains `gid - RowBase`.
-
-Separate slice rather than a flag on `RowDelta` keeps the two semantically-distinct row types unambiguous at decode time and means existing code paths don't have to branch on every row.
+`RowDelta` is unchanged: `Rows[*].Row` continues to mean `gid - RowBase`. `DecorRowDelta.RowIdx` is the absolute rowIdx — a distinct named field so misuse fails at compile time, not at render time. Wire format byte layout matches `RowDelta` so the encoder/decoder bodies are nearly identical.
 
 ### Wire-format encoding
 
-Append `ContentTopRow` (2 bytes) and `ContentBottomRow` (2 bytes) at the tail of the existing `PaneSnapshot` encoder. Append `DecorRows` (count-prefixed, same per-row encoding as `Rows`) at the tail of `BufferDelta`. No reordering of existing fields. Increment `protocol.Version` from 2 to 3.
+Append `ContentTopRow` (2 bytes) and `NumContentRows` (2 bytes) at the tail of the existing `PaneSnapshot` encoder. Append `DecorRows` (count-prefixed, same per-row byte layout as `Rows`) at the tail of `BufferDelta`. No reordering of existing fields. Increment `protocol.Version` from 2 to 3.
 
 ### Backward compatibility
 
-None. Per project policy, stale on-disk state should fail-and-overwrite, not auto-migrate. Bumping the protocol version causes pre-v3 clients to fail handshake; users restart their client.
+None. Per project policy, stale on-disk state should fail-and-overwrite, not auto-migrate. Bumping the protocol version causes pre-v3 clients to fail handshake; users restart their client. The decoder rejects truncated payloads with `ErrPayloadShort` rather than silently treating them as v2 — there is no v2 wire to fall back to.
 
 ## Server changes
 
 ### `texel/snapshot.go` — `capturePaneSnapshot`
 
-Already populates `RowGlobalIdx[i] = -1` for non-content rows. Add: after building `RowGlobalIdx`, compute `ContentTopRow` (first index with `gid >= 0`) and `ContentBottomRow` (last index with `gid >= 0`). If no row has `gid >= 0`, set `ContentTopRow = 1` and `ContentBottomRow = 0` (the "zero content rows" sentinel — `Bottom < Top`). Store on `PaneSnapshot`.
+Already populates `RowGlobalIdx[i] = -1` for non-content rows. Add: after building `RowGlobalIdx`, compute `ContentTopRow` (first index with `gid >= 0`) and `NumContentRows` (count of indices with `gid >= 0`). If no row has `gid >= 0`, set `ContentTopRow = 0` and `NumContentRows = 0` — unambiguous "zero content rows" state. Store on `PaneSnapshot`.
 
 ### `internal/runtime/server/tree_convert.go` — `treeCaptureToProtocol`
 
-Currently sets `Rows: nil` on protocol PaneSnapshot. Pass through the new `ContentTopRow` / `ContentBottomRow` fields. `Rows` stays nil — borders and decorations ride deltas, not snapshots.
+Currently sets `Rows: nil` on protocol PaneSnapshot. Pass through the new `ContentTopRow` / `NumContentRows` fields. `Rows` stays nil — borders and decorations ride deltas, not snapshots.
 
 ### `internal/runtime/server/desktop_publisher.go` — `bufferToDelta`
 
@@ -123,14 +130,19 @@ for y, row := range snap.Buffer {
     if y >= len(snap.RowGlobalIdx) {
         continue
     }
+    gid := snap.RowGlobalIdx[y]
+    // Alt-screen panes have RowGlobalIdx all -1; the existing alt-screen
+    // positional path handles them, so skip emitting decoration here.
+    if snap.AltScreen && gid < 0 {
+        continue
+    }
     if y < len(prev) && rowsEqual(row, prev[y]) {
         continue
     }
-    gid := snap.RowGlobalIdx[y]
     if gid < 0 {
-        decorRows = append(decorRows, protocol.RowDelta{
-            Row:   uint16(y),
-            Spans: encodeRow(row),
+        decorRows = append(decorRows, protocol.DecorRowDelta{
+            RowIdx: uint16(y),
+            Spans:  encodeRow(row),
         })
         continue
     }
@@ -145,26 +157,33 @@ for y, row := range snap.Buffer {
 delta.DecorRows = decorRows
 ```
 
+Two ordering notes:
+
+1. The alt-screen+gid<0 short-circuit fires *before* `rowsEqual` — alt-screen panes never pay the diff comparison for decoration emission.
+2. For non-altScreen panes, the `rowsEqual` diff fires for both content and decoration paths (they share positional `prev[y]` storage), so unchanged decoration rows don't re-ship.
+
 The existing positional `prev[y]` diff continues to filter unchanged rows for both layers — only changed decoration rows ship.
 
-For alt-screen panes the path is unchanged; `DecorRows` stays empty.
+For alt-screen panes `DecorRows` stays empty.
 
 ## Client changes
 
 ### `client/buffercache.go` — decoration cache
 
-Add a per-pane decoration cache as a field on `PaneState`:
+Add per-pane decoration cache fields on `PaneState`:
 
 ```go
 type PaneState struct {
     // ... existing fields ...
-    ContentTopRow    uint16
-    ContentBottomRow uint16
-    DecorRows        map[uint16][]Cell // rowIdx -> cells; populated from BufferDelta.DecorRows
+    ContentTopRow  uint16
+    NumContentRows uint16
+    decorRows      map[uint16][]Cell // unexported; rowIdx -> cells; guarded by rowsMu
 }
 ```
 
-Apply `DecorRows` from each incoming `BufferDelta` into this map. Mark the pane dirty whenever a decoration row changes. `BufferCache.ResetRevisions` (used on session-reuse / new publisher) must also clear `DecorRows` per pane so a fresh publisher republishes everything.
+The decoration map is **unexported** and guarded by the existing `rowsMu sync.RWMutex` (same as `pane.rows`). All access — `ApplyDelta` writes, `rowSourceForPane` reads, `ResetRevisions` clears — must take the lock. A `DecorRowAt(rowIdx uint16) ([]Cell, bool)` accessor on `PaneState` reads under `rowsMu.RLock()` and returns a slice that the caller must not retain across frames (same contract as `RowCellsDirect`).
+
+`BufferCache.ResetRevisions` clears `decorRows` per pane (under `rowsMu.Lock()`) so a fresh publisher republishes everything.
 
 ### `internal/runtime/client/viewport_tracker.go` — `onBufferDelta`
 
@@ -177,14 +196,20 @@ top := maxGid - int64(vp.Rows-1)
 with:
 
 ```go
-numContentRows := int(pane.ContentBottomRow) - int(pane.ContentTopRow) + 1
-if numContentRows <= 0 {
-    return // pane has no content rows; nothing to anchor
+pane := s.cache.Pane(delta.PaneID)
+if pane == nil {
+    // Delta arrived before the snapshot populated the cache. This shouldn't
+    // happen in production; if it does, log loudly and skip.
+    log.Printf("client: onBufferDelta received delta for pane %x with no cached PaneState; skipping viewport update", delta.PaneID)
+    return
 }
-top := maxGid - int64(numContentRows-1)
+if pane.NumContentRows == 0 {
+    return // zero-content pane (status panes, all-decoration apps) — no viewport to advance
+}
+top := maxGid - int64(pane.NumContentRows) + 1
 ```
 
-`pane.ContentTopRow` / `ContentBottomRow` are read from the `BufferCache.Pane` populated from the latest `PaneSnapshot`.
+`pane.NumContentRows` is read from the `BufferCache.Pane` populated from the latest `PaneSnapshot`. The `pane == nil` branch is treated as a hard error (logged) rather than a silent fallback to `vp.Rows`, because the silent fallback is what reintroduces the original Issue #199 misalignment.
 
 ### `internal/runtime/client/renderer.go` — `rowSourceForPane`
 
@@ -195,11 +220,14 @@ if vc.AltScreen {
     // unchanged: PaneCache.AltRowAt + RowCellsDirect fallback
 }
 
-// Decoration layer
-if rowIdx < int(pane.ContentTopRow) || rowIdx > int(pane.ContentBottomRow) {
-    if row, ok := pane.DecorRows[uint16(rowIdx)]; ok {
+// Decoration layer (rowIdx outside the content range)
+if pane.NumContentRows == 0 ||
+   rowIdx < int(pane.ContentTopRow) ||
+   rowIdx >= int(pane.ContentTopRow) + int(pane.NumContentRows) {
+    if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
         return row
     }
+    state.logDecorationMissOnce(pane.ID, uint16(rowIdx))
     return nil
 }
 
@@ -213,13 +241,13 @@ if !found {
 return row
 ```
 
-A miss on either layer returns nil (renders blank). The decoration layer should hit after the first delta following the snapshot; the content layer can legitimately miss while a `MsgFetchRange` is in flight (existing Plan A behavior — preserved).
+A miss on either layer returns nil (renders blank). The decoration miss is logged **once per (paneID, rowIdx) pair** — the user's symptom of "blank border row" should never be silent. The content layer can legitimately miss while a `MsgFetchRange` is in flight (existing Plan A behavior — not logged, since it's expected).
 
 ## Data flow
 
 ### Initial connect / resume
 
-1. Server captures snapshot → `ContentTopRow` / `ContentBottomRow` computed.
+1. Server captures snapshot → `ContentTopRow` / `NumContentRows` computed.
 2. Server emits `MsgTreeSnapshot` with the new fields.
 3. Server's first `BufferDelta` after the snapshot ships every changed row; on a fresh publisher (`prev` is empty), every row counts as changed, so all decoration rows ride along.
 4. Client populates `BufferCache.Pane.ContentTopRow/Bottom` from the snapshot, then `DecorRows` from the delta.
@@ -233,7 +261,7 @@ A miss on either layer returns nil (renders blank). The decoration layer should 
 
 ### Resize
 
-1. Pane geometry changes → `ContentTopRow` / `ContentBottomRow` recomputed in next snapshot.
+1. Pane geometry changes → `ContentTopRow` / `NumContentRows` recomputed in next snapshot.
 2. Server emits fresh snapshot + delta.
 3. Client updates and re-renders.
 
@@ -244,7 +272,7 @@ Identical to "initial connect / resume" above. The publisher on the rehydrated s
 ## Error handling
 
 - **Decoration cache miss after first delta** — render blank. Mirrors content-row miss behavior. Preserves the "no stale chrome" guarantee.
-- **`ContentTopRow > ContentBottomRow + 1`** with non-zero buffer height — server-side bug. Log via the existing publisher logger; treat pane as zero content rows on the wire (only sentinel `Bottom < Top` should be emitted; any other inversion is a bug).
+- **`ContentTopRow + NumContentRows > buffer height`** — server-side bug (content range exceeds the pane buffer). Log via the existing publisher logger; emit `NumContentRows = 0` on the wire to force the client into all-decoration rendering until the next snapshot rebuilds the bounds correctly.
 - **Client receives `DecorRows` before its first `PaneSnapshot`** — should not happen (snapshot precedes deltas in the protocol). If it does, drop those `DecorRows` and rely on the next delta after `prev` resync. No explicit buffering needed.
 - **Stale decoration cache on session reuse** — `BufferCache.ResetRevisions` (Plan D's revision-monotonicity fix) is the natural pivot point. Extend it to also clear `DecorRows` per pane. The new publisher's empty `prev` then republishes everything.
 
@@ -256,14 +284,14 @@ Identical to "initial connect / resume" above. The publisher on the rehydrated s
 - `TestBufferToDelta_DecorationRowsDiffed` — second publish with unchanged borders ships zero `DecorRows`.
 - `TestBufferToDelta_DecorationRowsDiffPartial` — repaint of just rowIdx 0 (e.g., title change) ships exactly one `DecorRows` entry.
 - `TestBufferToDelta_TexelTermInternalStatusbar` — pane backed by texterm with internal statusbar at H-2 ships that row in `DecorRows`.
-- `TestCapturePaneSnapshot_ContentBoundsComputed` — `RowGlobalIdx = [-1, 0, 1, 2, -1, -1]` produces `ContentTopRow=1, ContentBottomRow=3`.
-- `TestCapturePaneSnapshot_ContentBoundsAllDecoration` — all rows have `gid<0` (no content) produces `ContentTopRow=1, ContentBottomRow=0` sentinel.
+- `TestCapturePaneSnapshot_ContentBoundsComputed` — `RowGlobalIdx = [-1, 0, 1, 2, -1, -1]` produces `ContentTopRow=1, NumContentRows=3`.
+- `TestCapturePaneSnapshot_ContentBoundsAllDecoration` — all rows have `gid<0` (no content) produces `ContentTopRow=0, NumContentRows=0`.
 - `TestBufferToDelta_AltScreenLeavesDecorRowsEmpty` — alt-screen pane never emits `DecorRows`.
 
 ### Unit (client)
 
 - `TestRowSourceForPane_DecorationLayer` — rowIdx 0 reads from `DecorRows`; rowIdx between bounds reads via gid; rowIdx H-1 reads from `DecorRows`.
-- `TestOnBufferDelta_TopUsesContentRowCount` — pane with `ContentTopRow=1, ContentBottomRow=H-3` (texterm shape) computes `top = maxGid - (H-3)` not `maxGid - (H-1)`.
+- `TestOnBufferDelta_TopUsesContentRowCount` — pane with `ContentTopRow=1, NumContentRows=H-3` (texterm shape) computes `top = maxGid - (H-3)` not `maxGid - (H-1)`.
 - `TestRowSourceForPane_DecorationCacheMissReturnsNil` — pane without populated `DecorRows` returns nil for decoration rowIdx, renders blank.
 - `TestBufferCache_ResetRevisionsClearsDecorRows` — `ResetRevisions` empties the per-pane decoration map.
 
@@ -290,7 +318,7 @@ Pass criteria:
 2. Texterm internal statusbar at H-2 shows actual content (not blank).
 3. Content occupies rows 1..H-3 and is not offset.
 4. Focus toggle (Ctrl-A pane switch) repaints borders without flicker.
-5. Window resize triggers correct `ContentTopRow` / `ContentBottomRow` recompute and re-render.
+5. Window resize triggers correct `ContentTopRow` / `NumContentRows` recompute and re-render.
 
 ## Touchpoints summary
 
@@ -302,15 +330,16 @@ Pass criteria:
 | `texel/snapshot.go` | `capturePaneSnapshot` computes Content bounds |
 | `internal/runtime/server/tree_convert.go` | `treeCaptureToProtocol` passes through |
 | `internal/runtime/server/desktop_publisher.go` | `bufferToDelta` emits `DecorRows` |
-| `client/buffercache.go` | `PaneState.{ContentTopRow,ContentBottomRow,DecorRows}` fields; `ResetRevisions` clears `DecorRows` |
+| `client/buffercache.go` | `PaneState.{ContentTopRow,NumContentRows,DecorRows}` fields; `ResetRevisions` clears `DecorRows` |
 | `internal/runtime/client/viewport_tracker.go` | `onBufferDelta` `top` uses content row count |
 | `internal/runtime/client/renderer.go` | `rowSourceForPane` two-layer lookup |
 
 ## Invariants
 
-- **Decoration contiguity** — decoration rows (`RowGlobalIdx[y] < 0`) must be contiguous at the top and/or bottom of the pane buffer. Concretely: `ContentTopRow` is the smallest `y` with `RowGlobalIdx[y] >= 0`, `ContentBottomRow` is the largest, and every `y` outside `[ContentTopRow, ContentBottomRow]` has `RowGlobalIdx[y] < 0` while every `y` inside has `RowGlobalIdx[y] >= 0`. This holds today by construction in `capturePaneSnapshot` (top border at 0, content via `RowGlobalIdxProvider` in [1..H-2], app statusbar / bottom border in the trailing slots). If a future app interleaves decoration mid-pane, this design must be revisited.
-- **Decoration positional vs content gid-keyed** — `BufferDelta.DecorRows[*].Row` is always an absolute rowIdx; `BufferDelta.Rows[*].Row` is always `gid - RowBase`. These two encodings never collide because they live in different slices.
+- **Decoration contiguity** — decoration rows (`RowGlobalIdx[y] < 0`) must be contiguous at the top and/or bottom of the pane buffer. Concretely: `ContentTopRow` is the smallest `y` with `RowGlobalIdx[y] >= 0`, the content range is `[ContentTopRow, ContentTopRow + NumContentRows - 1]`, and every `y` outside that range has `RowGlobalIdx[y] < 0` while every `y` inside has `RowGlobalIdx[y] >= 0`. This holds today by construction in `capturePaneSnapshot` (top border at 0, content via `RowGlobalIdxProvider` in [1..H-2], app statusbar / bottom border in the trailing slots). If a future app interleaves decoration mid-pane, this design must be revisited.
+- **Type-level decoration vs content distinction** — `BufferDelta.DecorRows` is `[]DecorRowDelta` (with a `RowIdx` field carrying absolute rowIdx); `BufferDelta.Rows` is `[]RowDelta` (with a `Row` field carrying `gid - RowBase`). The compiler refuses to mix the two.
 - **First-delta decoration completeness** — when the publisher sees an empty `prev` (fresh session, post-reset, post-resume), every changed row is shipped, including all decoration rows. This is what makes the rehydrate path render correctly from frame 1.
+- **`decorRows` lock discipline** — all access to `PaneState.decorRows` (write in `ApplyDelta`, read via `DecorRowAt`, clear in `ResetRevisions`) goes through `pane.rowsMu`. The map is unexported to prevent direct access bypassing the lock.
 
 ## Open questions
 
@@ -321,4 +350,4 @@ None. The exact wire byte layout for the new fields is mechanical and the plan w
 - Placeholders: none.
 - Internal consistency: the two new `PaneSnapshot` fields and the new `BufferDelta` field are referenced consistently across server, client, and tests.
 - Scope: bounded — single-pass change covering one bug class. No bundled refactors.
-- Ambiguity: `ContentTopRow`/`ContentBottomRow` semantics include the `Bottom < Top` zero-content sentinel. `DecorRows.Row` semantics (absolute rowIdx vs `gid - RowBase`) are explicit.
+- Ambiguity: `NumContentRows == 0` is the unambiguous zero-content state (no overloaded sentinel). `DecorRows` use a distinct `DecorRowDelta` type with a `RowIdx` field, so the absolute-rowIdx semantic is enforced at compile time, not by convention.

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -133,6 +133,46 @@ type clientState struct {
 	// the resume error path — see app.go — so a failed-then-retried resume
 	// against a different sessionID does not consume a stale flag.
 	resetOnNextSnapshot atomic.Bool
+
+	// decorMissMu / decorMissSeen dedup decoration-cache miss log lines
+	// emitted by rowSourceForPane. We log once per (paneID, rowIdx) pair
+	// to avoid drowning the log when a decoration cache miss persists for
+	// multiple frames. resetDecorationMissTracker clears this on
+	// post-resume reset so a fresh session can re-log misses. Issue #199.
+	decorMissMu   sync.Mutex
+	decorMissSeen map[decorationMissKey]struct{}
+}
+
+// decorationMissKey is the dedup key for once-per-pane-row decoration miss logging.
+type decorationMissKey struct {
+	paneID [16]byte
+	rowIdx uint16
+}
+
+// logDecorationMissOnce emits a log line the first time the renderer
+// observes a decoration cache miss for a given (paneID, rowIdx). Subsequent
+// misses for the same key are silent.
+func (s *clientState) logDecorationMissOnce(paneID [16]byte, rowIdx uint16) {
+	s.decorMissMu.Lock()
+	defer s.decorMissMu.Unlock()
+	if s.decorMissSeen == nil {
+		s.decorMissSeen = make(map[decorationMissKey]struct{})
+	}
+	key := decorationMissKey{paneID: paneID, rowIdx: rowIdx}
+	if _, seen := s.decorMissSeen[key]; seen {
+		return
+	}
+	s.decorMissSeen[key] = struct{}{}
+	log.Printf("client: decoration cache miss for pane %x rowIdx %d (rendering blank); subsequent misses suppressed", paneID, rowIdx)
+}
+
+// resetDecorationMissTracker clears the dedup state used by
+// logDecorationMissOnce. Called from the post-resume reset path so a
+// fresh session can re-log misses.
+func (s *clientState) resetDecorationMissTracker() {
+	s.decorMissMu.Lock()
+	defer s.decorMissMu.Unlock()
+	s.decorMissSeen = nil
 }
 
 func (s *clientState) setRenderChannel(ch chan<- struct{}) {

--- a/internal/runtime/client/post_resume_reset.go
+++ b/internal/runtime/client/post_resume_reset.go
@@ -24,6 +24,7 @@ func applyPostResumeReset(state *clientState, lastSequence *atomic.Uint64) {
 		return
 	}
 	state.cache.ResetRevisions()
+	state.resetDecorationMissTracker()
 	if lastSequence != nil {
 		lastSequence.Store(0)
 	}

--- a/internal/runtime/client/post_resume_reset_test.go
+++ b/internal/runtime/client/post_resume_reset_test.go
@@ -109,3 +109,20 @@ func TestApplyPostResumeReset_NilSequenceIsNotADereference(t *testing.T) {
 		t.Fatalf("nil lastSeq should still reset cache: got %d", got)
 	}
 }
+
+// TestPostResumeReset_ClearsDecorationMissTracker verifies the
+// decoration-miss dedup tracker is cleared when the post-resume reset
+// fires. Issue #199 Task 11 / Task 9 Step 4.
+func TestPostResumeReset_ClearsDecorationMissTracker(t *testing.T) {
+	cache := client.NewBufferCache()
+	state := newStateWithCache(cache)
+	state.logDecorationMissOnce([16]byte{0xab}, 5)
+	if len(state.decorMissSeen) != 1 {
+		t.Fatalf("expected 1 entry pre-reset, got %d", len(state.decorMissSeen))
+	}
+	state.resetOnNextSnapshot.Store(true)
+	applyPostResumeReset(state, nil)
+	if len(state.decorMissSeen) != 0 {
+		t.Fatalf("expected decorMissSeen cleared, got %d entries", len(state.decorMissSeen))
+	}
+}

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -100,6 +100,52 @@ func debugLogRender(msg string) {
 	}
 }
 
+// rendererDebug is gated by env var TEXELATION_DEBUG=1. When enabled, the
+// renderer logs the source row resolved by rowSourceForPane for the first
+// content rowIdx of each pane. Use to confirm whether the client-side
+// composite is reading the correct cells (col 0 = '│', col W-1 = '│' for
+// terminal panes). Logs to stderr, which texelation redirects to
+// ~/.texelation/server.log only for server output — the client side's
+// stderr typically goes to the controlling terminal. When debugging,
+// redirect stderr or run with `2>/tmp/client.log`.
+var rendererDebug = os.Getenv("TEXELATION_DEBUG") == "1"
+
+// logRowSourceDebug emits one line per (pane, rowIdx) describing the source
+// row resolved by rowSourceForPane. Caller passes rowIdx and the resolved
+// source slice. Cheap when rendererDebug is off (one bool check).
+func logRowSourceDebug(path string, paneID [16]byte, rowIdx int, w int, source []client.Cell, vc paneViewportCopy, pane *client.PaneState) {
+	if !rendererDebug {
+		return
+	}
+	contentEnd := int(pane.ContentTopRow) + int(pane.NumContentRows)
+	zoneTag := "decor"
+	if int(pane.NumContentRows) > 0 && rowIdx >= int(pane.ContentTopRow) && rowIdx < contentEnd {
+		zoneTag = "content"
+	}
+	if source == nil {
+		log.Printf("clientRenderDebug %s pane=%x rowIdx=%d zone=%s w=%d source=nil viewTop=%d ctTop=%d numCt=%d alt=%v",
+			path, paneID[:4], rowIdx, zoneTag, w,
+			vc.ViewTopIdx, pane.ContentTopRow, pane.NumContentRows, vc.AltScreen)
+		return
+	}
+	c0 := ' '
+	c1 := ' '
+	cw := ' '
+	if len(source) > 0 {
+		c0 = source[0].Ch
+	}
+	if len(source) > 1 {
+		c1 = source[1].Ch
+	}
+	if len(source) > 0 {
+		cw = source[len(source)-1].Ch
+	}
+	log.Printf("clientRenderDebug %s pane=%x rowIdx=%d zone=%s w=%d srcLen=%d src[0]=%q src[1]=%q src[len-1]=%q viewTop=%d ctTop=%d numCt=%d alt=%v",
+		path, paneID[:4], rowIdx, zoneTag, w, len(source),
+		c0, c1, cw,
+		vc.ViewTopIdx, pane.ContentTopRow, pane.NumContentRows, vc.AltScreen)
+}
+
 // ensureBuffers allocates or resizes both prevBuffer and renderBuffer.
 // Returns true if the buffers were (re)allocated (size changed).
 func ensureBuffers(state *clientState, width, height int) bool {
@@ -190,21 +236,22 @@ func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []
 		return nil
 	}
 
-	// Content layer: rowIdx mapped via gid lookup.
+	// Content layer: prefer the positional decoration cache. The server
+	// emits every changed content row positionally (via DecorRowDelta)
+	// IN ADDITION to keying it by gid (RowDelta) for scrollback. The
+	// positional path is correct under wrapped chains (multiple rowIdxs
+	// sharing one head gid) and erased-row gaps, where the gid-derived
+	// formula `ViewTopIdx + (rowIdx - ContentTopRow)` mismatches the
+	// actual rowIdx → gid map. Falling back to PaneCache.RowAt only when
+	// the decor cache hasn't seen this rowIdx (early frames, or after a
+	// snapshot reset that cleared decor) preserves the existing fast
+	// path while fixing the wrapped-chain bug.
+	if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
+		return row
+	}
 	contentRowIdx := rowIdx - int(pane.ContentTopRow)
 	gid := vc.ViewTopIdx + int64(contentRowIdx)
 	if row, found := pc.RowAt(gid); found {
-		return row
-	}
-	// PaneCache miss inside the structural content range. The publisher
-	// emits rows whose RowGlobalIdx[y] < 0 (e.g., unwritten interior rows
-	// of a fresh terminal — only the prompt row has a gid yet) as
-	// positional DecorRowDeltas. Honor that channel before giving up: the
-	// row may already be in the decoration cache. Without this fallback,
-	// the renderer paints blank for every interior row whose gid wasn't
-	// shipped, which hides side borders and any cells the server painted
-	// into "unwritten" rows.
-	if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
 		return row
 	}
 	// Row not yet in either cache (fetch is en route, or the row really
@@ -245,9 +292,18 @@ func incrementalComposite(state *clientState, screenW, screenH int) bool {
 		// when PaneCache has no entry yet.
 		paneBuffer := ensurePaneBuffer(state, w, h)
 		defaultCell := client.Cell{Ch: ' ', Style: state.defaultStyle}
+		var dbgVC paneViewportCopy
+		if rendererDebug {
+			if vc, ok := state.paneViewportFor(pane.ID); ok {
+				dbgVC = vc
+			}
+		}
 		for rowIdx := 0; rowIdx < h; rowIdx++ {
 			row := paneBuffer[rowIdx]
 			source := rowSourceForPane(state, pane, rowIdx)
+			if rendererDebug && rowIdx == int(pane.ContentTopRow) {
+				logRowSourceDebug("incremental", pane.ID, rowIdx, w, source, dbgVC, pane)
+			}
 			for col := 0; col < w; col++ {
 				if col < len(source) {
 					cell := source[col]
@@ -492,9 +548,18 @@ func compositeInto(workspaceBuffer [][]client.Cell, panes []*client.PaneState, s
 
 		paneBuffer := ensurePaneBuffer(state, w, h)
 		defaultCell := client.Cell{Ch: ' ', Style: state.defaultStyle}
+		var dbgVC paneViewportCopy
+		if rendererDebug {
+			if vc, ok := state.paneViewportFor(pane.ID); ok {
+				dbgVC = vc
+			}
+		}
 		for rowIdx := 0; rowIdx < h; rowIdx++ {
 			row := paneBuffer[rowIdx]
 			source := rowSourceForPane(state, pane, rowIdx)
+			if rendererDebug && rowIdx == int(pane.ContentTopRow) {
+				logRowSourceDebug("full", pane.ID, rowIdx, w, source, dbgVC, pane)
+			}
 			for col := 0; col < w; col++ {
 				if col < len(source) {
 					cell := source[col]

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -178,11 +178,26 @@ func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []
 		}
 		return row
 	}
-	gid := vc.ViewTopIdx + int64(rowIdx)
+
+	// Decoration layer: rowIdx outside the content range reads from the
+	// pane's decoration cache (positional).
+	contentEnd := int(pane.ContentTopRow) + int(pane.NumContentRows) // exclusive
+	if pane.NumContentRows == 0 || rowIdx < int(pane.ContentTopRow) || rowIdx >= contentEnd {
+		if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
+			return row
+		}
+		state.logDecorationMissOnce(pane.ID, uint16(rowIdx))
+		return nil
+	}
+
+	// Content layer: rowIdx mapped via gid lookup.
+	contentRowIdx := rowIdx - int(pane.ContentTopRow)
+	gid := vc.ViewTopIdx + int64(contentRowIdx)
 	row, found := pc.RowAt(gid)
 	if !found {
 		// Row not yet in cache (fetch is en route). Render blank rather than
 		// showing stale BufferCache content at a mismatched globalIdx.
+		// No log here — content-layer misses are normal during FetchRange.
 		return nil
 	}
 	return row

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -193,14 +193,24 @@ func rowSourceForPane(state *clientState, pane *client.PaneState, rowIdx int) []
 	// Content layer: rowIdx mapped via gid lookup.
 	contentRowIdx := rowIdx - int(pane.ContentTopRow)
 	gid := vc.ViewTopIdx + int64(contentRowIdx)
-	row, found := pc.RowAt(gid)
-	if !found {
-		// Row not yet in cache (fetch is en route). Render blank rather than
-		// showing stale BufferCache content at a mismatched globalIdx.
-		// No log here — content-layer misses are normal during FetchRange.
-		return nil
+	if row, found := pc.RowAt(gid); found {
+		return row
 	}
-	return row
+	// PaneCache miss inside the structural content range. The publisher
+	// emits rows whose RowGlobalIdx[y] < 0 (e.g., unwritten interior rows
+	// of a fresh terminal — only the prompt row has a gid yet) as
+	// positional DecorRowDeltas. Honor that channel before giving up: the
+	// row may already be in the decoration cache. Without this fallback,
+	// the renderer paints blank for every interior row whose gid wasn't
+	// shipped, which hides side borders and any cells the server painted
+	// into "unwritten" rows.
+	if row, ok := pane.DecorRowAt(uint16(rowIdx)); ok {
+		return row
+	}
+	// Row not yet in either cache (fetch is en route, or the row really
+	// is empty). Render blank rather than showing stale BufferCache
+	// content at a mismatched globalIdx.
+	return nil
 }
 
 // incrementalComposite updates only dirty panes/rows into state.prevBuffer.

--- a/internal/runtime/client/renderer_test.go
+++ b/internal/runtime/client/renderer_test.go
@@ -752,6 +752,223 @@ func TestRowSourceForPane_GeometrySnapshotPreservesContentBounds(t *testing.T) {
 	}
 }
 
+// TestIncrementalComposite_ContentRowBordersSurvive exercises the full
+// incremental render path for a content row with `│` borders at col 0
+// and col W-1. Reproduces the 1-column shift bug at the renderer level:
+//
+//   - Snapshot establishes geometry with ContentTopRow / NumContentRows.
+//   - BufferDelta carries a content row with borders + content.
+//   - Pane is marked Dirty by ApplyDelta.
+//   - incrementalComposite reads via rowSourceForPane and writes to prevBuffer.
+//
+// Asserts state.prevBuffer at the pane's content row has `│` at col 0
+// and col W-1. If this fails, the bug is in incrementalComposite or
+// downstream of rowSourceForPane.
+func TestIncrementalComposite_ContentRowBordersSurvive(t *testing.T) {
+	state := makeStateWithViewports()
+	state.defaultStyle = tcell.StyleDefault
+	id := paneID(0xb1)
+
+	const h, w = int32(5), int32(10)
+	const contentTop, numContent uint16 = 1, 3
+
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+
+	// Build the content row: '│' + "hello" + spaces + '│'.
+	full := make([]rune, w)
+	for i := range full {
+		full[i] = ' '
+	}
+	full[0] = '│'
+	full[w-1] = '│'
+	greeting := []rune("hello")
+	for i, r := range greeting {
+		full[1+i] = r
+	}
+
+	const promptGid int64 = 100
+	const rowBase int64 = 80
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{{
+			Row: uint16(promptGid - rowBase),
+			Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: string(full), StyleIndex: 0},
+			},
+		}},
+		// Ship the top + bottom borders as decoration so the renderer can
+		// resolve rowIdx 0 and rowIdx h-1 without falling through to nil.
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: "╭────────╮", StyleIndex: 0},
+			}},
+			{RowIdx: uint16(h) - 1, Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: "╰────────╯", StyleIndex: 0},
+			}},
+		},
+	}
+
+	state.cache.ApplyDelta(delta)
+	state.paneCacheFor(id).ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	// Allocate prev/render buffers and run incremental composite.
+	ensureBuffers(state, int(w), int(h))
+	hasDyn := incrementalComposite(state, int(w), int(h))
+	_ = hasDyn
+
+	// The content row sits at lastContent = ContentTopRow + NumContentRows - 1.
+	lastContent := int(contentTop) + int(numContent) - 1
+	r := state.prevBuffer[lastContent]
+	if r[0].Ch != '│' {
+		t.Fatalf("incrementalComposite col 0 = %q, want '│' (1-col shift bug — content overran left border)", r[0].Ch)
+	}
+	if r[int(w)-1].Ch != '│' {
+		t.Fatalf("incrementalComposite col W-1 = %q, want '│' (right border missing)", r[int(w)-1].Ch)
+	}
+	for i, want := range greeting {
+		if r[1+i].Ch != want {
+			t.Fatalf("incrementalComposite col %d = %q, want %q", 1+i, r[1+i].Ch, want)
+		}
+	}
+}
+
+// TestRowSourceForPane_ContentRowBordersSurviveDelta is the renderer-side
+// regression for the 1-column horizontal shift bug (issue #199 follow-up).
+//
+// Symptom: After a clean ./bin/texelation start, the user types any
+// command and presses enter. The pane content shifts one column LEFT —
+// content overwrites col 0 (where the left border `│` was) and col W-1
+// goes blank. Pressing Ctrl-A (control-mode toggle, which forces a
+// full-render path via workspace effect activation) snaps everything
+// back. Typing again reproduces the shift.
+//
+// The shift is invisible on rows with no content (e.g., blank scrollback
+// lines): those flow through the DecorRowDelta channel and stay
+// positional, so their borders remain. Only rows whose `gid >= 0` (i.e.,
+// rows the renderer reads via `PaneCache.RowAt(gid)`) lose their border.
+//
+// This test exercises the full content-row path:
+//
+//  1. Server-style snapshot with a content row whose col 0 / col W-1 are
+//     `│` (matching what `pane.renderBuffer` produces — the texterm child
+//     draws inside the border, the border widget paints `│` at the edges).
+//  2. bufferToDelta encodes; protocol round-trips; PaneCache stores.
+//  3. rowSourceForPane resolves the content rowIdx via gid lookup.
+//  4. Asserts the returned row has `│` at col 0 and col W-1.
+//
+// If this fails, the bug is somewhere in the encode → decode → PaneCache
+// → rowSourceForPane content-row path. If it passes, the bug is in the
+// composite/render layer (incrementalComposite vs compositeInto).
+func TestRowSourceForPane_ContentRowBordersSurviveDelta(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xb0)
+
+	const h, w = int32(5), int32(10)
+	const contentTop, numContent uint16 = 1, 3
+
+	// 1. TreeSnapshot establishes geometry + structural bounds.
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+
+	// 2. Build a content row matching what `pane.renderBuffer` produces:
+	//    col 0      = '│' (left border drawn by Border widget)
+	//    col 1..W-2 = "hello   " (texterm content, padded with spaces)
+	//    col W-1    = '│' (right border)
+	const promptGid int64 = 100
+	rowFull := make([]client.Cell, w)
+	for i := range rowFull {
+		rowFull[i] = client.Cell{Ch: ' ', Style: tcell.StyleDefault}
+	}
+	rowFull[0] = client.Cell{Ch: '│', Style: tcell.StyleDefault}
+	rowFull[w-1] = client.Cell{Ch: '│', Style: tcell.StyleDefault}
+	greeting := []rune("hello")
+	for i, r := range greeting {
+		rowFull[1+i] = client.Cell{Ch: r, Style: tcell.StyleDefault}
+	}
+
+	// Encode the row exactly the way bufferToDelta would: one span per
+	// column for distinct chars, grouped by style. Because all cells share
+	// StyleDefault here, encodeRow produces one span starting at col 0
+	// covering the entire row.
+	flatText := make([]rune, w)
+	for i, c := range rowFull {
+		flatText[i] = c.Ch
+	}
+	const rowBase int64 = 80
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{{
+			Row: uint16(promptGid - rowBase),
+			Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: string(flatText), StyleIndex: 0},
+			},
+		}},
+	}
+
+	// 3. Wire round-trip + dispatch.
+	encoded, err := protocol.EncodeBufferDelta(delta)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	state.cache.ApplyDelta(decoded)
+	state.paneCacheFor(id).ApplyDelta(decoded)
+	state.onBufferDelta(decoded)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after delta")
+	}
+
+	// 4. The content row sits at the LAST content rowIdx (autoFollow places
+	//    promptGid at the live edge). Verify rowSourceForPane returns the
+	//    full W-wide row including borders at col 0 and col W-1.
+	lastContent := int(contentTop) + int(numContent) - 1
+	src := rowSourceForPane(state, pane, lastContent)
+	if src == nil {
+		t.Fatalf("rowSourceForPane returned nil for content rowIdx=%d", lastContent)
+	}
+	if len(src) != int(w) {
+		t.Fatalf("rowSourceForPane row length = %d, want %d (full pane width)", len(src), w)
+	}
+	if src[0].Ch != '│' {
+		t.Fatalf("rowSourceForPane col 0 = %q, want '│' (left border lost — 1-col shift bug)", src[0].Ch)
+	}
+	if src[int(w)-1].Ch != '│' {
+		t.Fatalf("rowSourceForPane col W-1 = %q, want '│' (right border lost)", src[int(w)-1].Ch)
+	}
+	for i, want := range greeting {
+		if src[1+i].Ch != want {
+			t.Fatalf("rowSourceForPane col %d = %q, want %q", 1+i, src[1+i].Ch, want)
+		}
+	}
+}
+
 // TestRowSourceForPane_DecorationCacheMiss verifies that an empty
 // decoration cache returns nil for a decoration-row lookup.
 func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {

--- a/internal/runtime/client/renderer_test.go
+++ b/internal/runtime/client/renderer_test.go
@@ -492,6 +492,173 @@ func TestRowSourceForPane_DecorationLayer(t *testing.T) {
 	}
 }
 
+// TestRowSourceForPane_DeltaBeforeSnapshot reproduces the runtime bug
+// reported in issue #199 follow-up:
+//
+//   - User runs `./bin/texelation --reset-state`.
+//   - Server publishes `MsgBufferDelta` with the prompt row before the client
+//     has any viewport tracker initialised. The delta carries
+//     `RowBase = ViewTopIdx - Rows` (server's view of clip-offset; e.g. 100
+//     because the server's saved ViewTopIdx is non-zero and overscan is
+//     subtracted), and the prompt is encoded with `Row` such that
+//     `gid = RowBase + Row` matches the actual write.
+//   - On the client, the dispatch order is:
+//     1. `cache.ApplyDelta(delta)`           — populates BufferCache.
+//     2. `paneCacheFor(id).ApplyDelta(delta)` — populates PaneCache at gid.
+//     3. `state.onBufferDelta(delta)`         — early-exits because
+//     `vp.AutoFollow == false` (still default-zero state — viewport
+//     tracker has not been initialised yet). `vp.knownBottomGid` and
+//     `vp.ViewTopIdx` stay at zero.
+//   - Then `MsgTreeSnapshot` arrives:
+//     4. `cache.ApplySnapshot(snap)`          — sets pane.Rect /
+//     ContentTopRow / NumContentRows.
+//     5. `state.onTreeSnapshot(snap)`         — sees `vp.Rows == 0`,
+//     initialises tracker with `AutoFollow=true`, `ViewTopIdx=0`,
+//     `ViewBottomIdx=Rows-1`, `knownBottomGid=-1`.
+//
+// At this point the renderer asks `rowSourceForPane(state, pane, contentRow)`.
+// The tracker's `ViewTopIdx` is 0, so the renderer looks up `gid = 0` in
+// PaneCache. But PaneCache stored the prompt at `gid = RowBase + 0 = 100`
+// (or whatever the server's pre-existing viewport hint produced). The
+// content lookup misses, the decoration fallback also misses, and
+// `rowSourceForPane` returns nil — the user sees a blank pane.
+//
+// The fix is to re-run the AutoFollow-advance logic of `onBufferDelta`
+// after `onTreeSnapshot` initialises the tracker, so the tracker can
+// catch up to the rows already sitting in the PaneCache.
+func TestRowSourceForPane_DeltaBeforeSnapshot(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xc0)
+	// h=10, w=20. Texterm-style pane: ContentTopRow=1, NumContentRows=7
+	// (one bottom-border row at h-1 plus an internal statusbar row, both
+	// shipped via the decoration channel).
+	const h, w = int32(10), int32(20)
+	const contentTop, numContent uint16 = 1, 7
+
+	// The server's saved ClientViewport happens to be non-zero. Pretend the
+	// server thinks the client is following the live edge at gid=100 with
+	// rows=numContent=7 and overscan=Rows; clip-offset:
+	//   lo = ViewTopIdx - overscan = (100 - 6) - 7 = 87
+	// The publisher sets RowBase=87 and encodes the prompt at gid=100 as
+	// Row = gid - RowBase = 13. This is the exact scenario where, if the
+	// client's tracker is still at default zeros, looking up "gid 0"
+	// misses every cell that was actually delivered.
+	const rowBase int64 = 87
+	const promptGid int64 = 100
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: uint16(promptGid - rowBase), Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: "PROMPT $", StyleIndex: 0},
+			}},
+		},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "T", StyleIndex: 0}}},
+			{RowIdx: 8, Spans: []protocol.CellSpan{{StartCol: 0, Text: "S", StyleIndex: 0}}},
+			{RowIdx: 9, Spans: []protocol.CellSpan{{StartCol: 0, Text: "B", StyleIndex: 0}}},
+		},
+	}
+
+	// Step 1+2+3: BufferDelta arrives FIRST, before any snapshot.
+	state.cache.ApplyDelta(delta)
+	state.paneCacheFor(id).ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	// Sanity: PaneCache holds the prompt at the server-encoded gid.
+	if row, ok := state.paneCacheFor(id).RowAt(promptGid); !ok || len(row) == 0 || row[0].Ch != 'P' {
+		t.Fatalf("PaneCache should hold prompt at gid=%d (got ok=%v row=%+v)", promptGid, ok, row)
+	}
+
+	// Step 4+5: TreeSnapshot arrives AFTER the delta.
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after snapshot")
+	}
+
+	// AutoFollow places the prompt (gid=100) at the LAST content row.
+	// rowIdx = ContentTopRow + NumContentRows - 1 = 1 + 7 - 1 = 7.
+	// Without the fix, tracker ViewTopIdx=0 → gid=0, PaneCache miss → nil
+	// → blank render at every content row.
+	lastContent := int(contentTop) + int(numContent) - 1
+	src := rowSourceForPane(state, pane, lastContent)
+	if src == nil {
+		t.Fatalf("BUG: content rowIdx=%d returned nil — bare delta-before-snapshot lost the prompt (PaneCache has gid=%d but tracker ViewTopIdx is not aligned)", lastContent, promptGid)
+	}
+	if src[0].Ch != 'P' {
+		t.Fatalf("expected prompt 'P' at content rowIdx=%d, got %+v", lastContent, src)
+	}
+}
+
+// TestRowSourceForPane_SnapshotBeforeDelta is the reverse-order control:
+// when the snapshot arrives first (so the viewport tracker is fully
+// initialised before any delta), the AutoFollow advance in onBufferDelta
+// runs normally and the prompt is visible. This must pass both before and
+// after the fix; it confirms the bug is order-dependent.
+func TestRowSourceForPane_SnapshotBeforeDelta(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xc1)
+	const h, w = int32(10), int32(20)
+	const contentTop, numContent uint16 = 1, 7
+
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+
+	const rowBase int64 = 87
+	const promptGid int64 = 100
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: uint16(promptGid - rowBase), Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: "PROMPT $", StyleIndex: 0},
+			}},
+		},
+	}
+	state.cache.ApplyDelta(delta)
+	state.paneCacheFor(id).ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after snapshot")
+	}
+
+	// AutoFollow advance should have set ViewTopIdx so that the LAST
+	// content row holds promptGid. So the LAST content rowIdx
+	// (contentTop+numContent-1 = 7) should map to promptGid and resolve
+	// to the 'P' cell.
+	lastContent := int(contentTop) + int(numContent) - 1
+	src := rowSourceForPane(state, pane, lastContent)
+	if src == nil {
+		t.Fatalf("snapshot-before-delta: last content rowIdx=%d returned nil", lastContent)
+	}
+	if src[0].Ch != 'P' {
+		t.Fatalf("snapshot-before-delta: expected 'P' at last content rowIdx=%d, got %+v", lastContent, src)
+	}
+}
+
 // TestRowSourceForPane_DecorationCacheMiss verifies that an empty
 // decoration cache returns nil for a decoration-row lookup.
 func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {

--- a/internal/runtime/client/renderer_test.go
+++ b/internal/runtime/client/renderer_test.go
@@ -265,7 +265,7 @@ func TestDynamicColorFullPipeline(t *testing.T) {
 		defaultStyle: tcell.StyleDefault.Foreground(tcell.ColorWhite).Background(tcell.ColorBlack),
 		defaultFg:    tcell.ColorWhite,
 		defaultBg:    tcell.ColorBlack,
-		tickAccum: 0.5, // pretend 500ms has passed
+		tickAccum:    0.5, // pretend 500ms has passed
 	}
 
 	workspaceBuf := make([][]client.Cell, 1)
@@ -422,5 +422,96 @@ func TestBlendColorSymmetry(t *testing.T) {
 	if r1 != r2 || g1 != g2 || b1 != b2 {
 		t.Errorf("Blending should be symmetric: (%d,%d,%d) != (%d,%d,%d)",
 			r1, g1, b1, r2, g2, b2)
+	}
+}
+
+// TestRowSourceForPane_DecorationLayer verifies the two-layer lookup:
+// rowIdx outside [ContentTopRow, ContentTopRow+NumContentRows) reads
+// from the decoration cache; rowIdx inside reads via gid from PaneCache.
+// Issue #199 Task 11.
+func TestRowSourceForPane_DecorationLayer(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xab)
+	// Pane H=5, ContentTopRow=1, NumContentRows=3 (rowIdx 1..3 are content).
+	state.cache.ApplySnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 4, Height: 5,
+			ContentTopRow: 1, NumContentRows: 3,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+	// Initialise viewport tracker from the snapshot so paneViewportFor returns ok.
+	state.onTreeSnapshot(protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 4, Height: 5,
+			ContentTopRow: 1, NumContentRows: 3,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	})
+
+	// Apply a delta with one content row (gid 10) and two decoration rows.
+	// onBufferDelta will set ViewTopIdx = 10 - (NumContentRows-1) = 10 - 2 = 8.
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 10,
+		Styles:  []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "C", StyleIndex: 0}}},
+		},
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "T", StyleIndex: 0}}},
+			{RowIdx: 4, Spans: []protocol.CellSpan{{StartCol: 0, Text: "B", StyleIndex: 0}}},
+		},
+	}
+	state.cache.ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	// Also feed the row into the PaneCache so the content lookup at gid 10 hits.
+	state.paneCacheFor(id).ApplyDelta(delta)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing")
+	}
+
+	// rowIdx 0 → decoration "T"
+	if src := rowSourceForPane(state, pane, 0); len(src) == 0 || src[0].Ch != 'T' {
+		t.Fatalf("rowIdx 0 expected decoration 'T', got %+v", src)
+	}
+	// rowIdx 4 → decoration "B"
+	if src := rowSourceForPane(state, pane, 4); len(src) == 0 || src[0].Ch != 'B' {
+		t.Fatalf("rowIdx 4 expected decoration 'B', got %+v", src)
+	}
+	// rowIdx 1 → gid = 8 + 0 = 8; PaneCache only has gid 10 → miss → nil
+	if src := rowSourceForPane(state, pane, 1); src != nil {
+		t.Fatalf("rowIdx 1 expected nil (content-layer miss for gid 8), got %+v", src)
+	}
+	// rowIdx 3 → gid = 8 + 2 = 10, present in PaneCache → "C"
+	if src := rowSourceForPane(state, pane, 3); len(src) == 0 || src[0].Ch != 'C' {
+		t.Fatalf("rowIdx 3 expected content 'C' (gid 10), got %+v", src)
+	}
+}
+
+// TestRowSourceForPane_DecorationCacheMiss verifies that an empty
+// decoration cache returns nil for a decoration-row lookup.
+func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xab)
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, Width: 4, Height: 5,
+			ContentTopRow: 1, NumContentRows: 3,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing")
+	}
+	src := rowSourceForPane(state, pane, 0)
+	if src != nil {
+		t.Fatalf("expected nil for decoration miss, got %+v", src)
 	}
 }

--- a/internal/runtime/client/renderer_test.go
+++ b/internal/runtime/client/renderer_test.go
@@ -992,3 +992,130 @@ func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {
 		t.Fatalf("expected nil for decoration miss, got %+v", src)
 	}
 }
+
+// TestRowSourceForPane_WrappedChainGidGap reproduces the issue #199 follow-up
+// bug where a wrapped chain (multiple visible rowIdxs sharing one head gid)
+// breaks the client formula `gid = ViewTopIdx + (rowIdx - ContentTopRow)`.
+//
+// When the server's view.Render emits a wrapped chain, all sub-rows share the
+// chain head gid and `gi` advances by the chain length, so subsequent rowIdxs
+// have non-contiguous gids:
+//
+//	rowIdx=1 → gid=A      (chain head)
+//	rowIdx=2 → gid=A      (wrapped sub-row of same chain)
+//	rowIdx=3 → gid=A+3    (next chain after gi advanced past wrap)
+//
+// The client formula assumes contiguous gids: ViewTopIdx + 0 = A, ViewTopIdx
+// + 1 = A+1, ViewTopIdx + 2 = A+2, etc. With ViewTopIdx = maxGid - 38 the
+// formula MISMATCHES the actual rowIdx → gid map for every row before the
+// wrap. The pre-fix renderer painted those rows blank (no border, no
+// content) because both gid lookup and decor lookup missed.
+//
+// Fix: server emits every changed content row positionally (DecorRowDelta
+// keyed by rowIdx) IN ADDITION to keying by gid. The renderer prefers the
+// positional path for content rows. This test confirms the renderer reads
+// the positional row even when the gid computed by the formula doesn't
+// exist in PaneCache.
+func TestRowSourceForPane_WrappedChainGidGap(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xc7)
+	const h, w = int32(5), int32(10)
+	const contentTop, numContent uint16 = 1, 3
+
+	// 1. Snapshot establishes geometry + structural bounds.
+	snap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(snap)
+	state.onTreeSnapshot(snap)
+
+	// 2. Build a content row with side borders (`│` at col 0 / col W-1).
+	full := make([]rune, w)
+	for i := range full {
+		full[i] = ' '
+	}
+	full[0] = '│'
+	full[w-1] = '│'
+	greeting := []rune("hi")
+	for i, r := range greeting {
+		full[1+i] = r
+	}
+	flatText := string(full)
+
+	// 3. Simulate a wrapped chain: rowIdx=1 and rowIdx=2 share head gid=100,
+	//    rowIdx=3 has gid=103 (gi advanced past wrap). PaneCache will only
+	//    hold gids 100 and 103; the client formula's gid=ViewTopIdx+1 = 101
+	//    misses both PaneCache and the gid space entirely.
+	const headGid, postWrapGid int64 = 100, 103
+	const rowBase int64 = 80
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			// gid=100 emitted twice (once per wrapped sub-row); the second
+			// write into PaneCache.main[100] overwrites the first. This is
+			// the existing behaviour — the test just confirms the renderer
+			// does not depend on gid-keyed lookup for rendering content.
+			{Row: uint16(headGid - rowBase), Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: flatText, StyleIndex: 0},
+			}},
+			{Row: uint16(postWrapGid - rowBase), Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: flatText, StyleIndex: 0},
+			}},
+		},
+		// Server-side fix: each content row is also emitted positionally
+		// so the renderer can resolve rowIdx → cells without going through
+		// gid arithmetic.
+		DecorRows: []protocol.DecorRowDelta{
+			{RowIdx: 1, Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: flatText, StyleIndex: 0},
+			}},
+			{RowIdx: 2, Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: flatText, StyleIndex: 0},
+			}},
+			{RowIdx: 3, Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: flatText, StyleIndex: 0},
+			}},
+		},
+	}
+
+	state.cache.ApplyDelta(delta)
+	state.paneCacheFor(id).ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after delta")
+	}
+
+	// 4. Verify each content rowIdx resolves with full borders. Pre-fix,
+	//    rowIdx=2 (the wrapped sub-row) would compute gid=ViewTopIdx+1
+	//    which doesn't exist in PaneCache, the decor cache had no entry,
+	//    and the renderer returned nil — leaving the row blank.
+	for _, rowIdx := range []int{1, 2, 3} {
+		src := rowSourceForPane(state, pane, rowIdx)
+		if src == nil {
+			t.Fatalf("rowSourceForPane(rowIdx=%d) returned nil — wrapped-chain gid gap regression", rowIdx)
+		}
+		if len(src) != int(w) {
+			t.Fatalf("rowSourceForPane(rowIdx=%d) length=%d, want %d", rowIdx, len(src), w)
+		}
+		if src[0].Ch != '│' {
+			t.Fatalf("rowSourceForPane(rowIdx=%d) col 0 = %q, want '│' (left border)", rowIdx, src[0].Ch)
+		}
+		if src[int(w)-1].Ch != '│' {
+			t.Fatalf("rowSourceForPane(rowIdx=%d) col W-1 = %q, want '│' (right border)", rowIdx, src[int(w)-1].Ch)
+		}
+		for i, want := range greeting {
+			if src[1+i].Ch != want {
+				t.Fatalf("rowSourceForPane(rowIdx=%d) col %d = %q, want %q", rowIdx, 1+i, src[1+i].Ch, want)
+			}
+		}
+	}
+}

--- a/internal/runtime/client/renderer_test.go
+++ b/internal/runtime/client/renderer_test.go
@@ -659,6 +659,99 @@ func TestRowSourceForPane_SnapshotBeforeDelta(t *testing.T) {
 	}
 }
 
+// TestRowSourceForPane_GeometrySnapshotPreservesContentBounds covers the
+// resize-blanks-content regression (issue #199 follow-up). On resize the
+// server emits a geometry-only TreeSnapshot via GeometryForClient(); if
+// that snapshot reaches the client with ContentTopRow / NumContentRows
+// zeroed, ApplySnapshot overwrites the pane's previously-correct bounds,
+// rowSourceForPane falls into the decoration-only branch for every interior
+// rowIdx, and content rows paint blank even though the prompt is still in
+// the PaneCache at its real gid.
+//
+// The fix lives server-side: GeometryForClient now populates structural
+// content bounds via applyStructuralBounds, mirroring capturePaneSnapshot.
+// This client-side test covers the matching post-fix invariant: when the
+// server emits a geometry snapshot WITH the structural bounds populated,
+// the client renders the prompt at the correct rowIdx after the resize.
+func TestRowSourceForPane_GeometrySnapshotPreservesContentBounds(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xd0)
+	const h, w = int32(10), int32(20)
+	const contentTop, numContent uint16 = 1, 8
+
+	// Step 1: full snapshot with content bounds populated.
+	fullSnap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(fullSnap)
+	state.onTreeSnapshot(fullSnap)
+
+	const rowBase int64 = 87
+	const promptGid int64 = 100
+	delta := protocol.BufferDelta{
+		PaneID:   id,
+		RowBase:  rowBase,
+		Revision: 1,
+		Styles:   []protocol.StyleEntry{{}},
+		Rows: []protocol.RowDelta{
+			{Row: uint16(promptGid - rowBase), Spans: []protocol.CellSpan{
+				{StartCol: 0, Text: "PROMPT $", StyleIndex: 0},
+			}},
+		},
+	}
+	state.cache.ApplyDelta(delta)
+	state.paneCacheFor(id).ApplyDelta(delta)
+	state.onBufferDelta(delta)
+
+	pane := state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after initial snapshot+delta")
+	}
+	lastContent := int(contentTop) + int(numContent) - 1
+	if src := rowSourceForPane(state, pane, lastContent); src == nil || src[0].Ch != 'P' {
+		t.Fatalf("baseline failed: expected prompt 'P' at rowIdx=%d before resize, got %+v",
+			lastContent, src)
+	}
+
+	// Step 2: simulate the post-fix resize path. The server emits a
+	// geometry-only snapshot — same pane, same dimensions, AND the
+	// structural ContentTopRow / NumContentRows fields are populated
+	// (the fix). With these in place the client must continue to resolve
+	// the prompt row correctly.
+	geomSnap := protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id, X: 0, Y: 0, Width: w, Height: h,
+			// Bounds preserved by the server-side GeometryForClient fix.
+			ContentTopRow: contentTop, NumContentRows: numContent,
+		}},
+		Root: protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone},
+	}
+	state.cache.ApplySnapshot(geomSnap)
+	state.onTreeSnapshot(geomSnap)
+
+	pane = state.cache.PaneByID(id)
+	if pane == nil {
+		t.Fatalf("pane missing after geometry snapshot")
+	}
+	if pane.ContentTopRow != contentTop || pane.NumContentRows != numContent {
+		t.Fatalf("client lost content bounds after geometry snapshot: top=%d num=%d (want top=%d num=%d)",
+			pane.ContentTopRow, pane.NumContentRows, contentTop, numContent)
+	}
+
+	src := rowSourceForPane(state, pane, lastContent)
+	if src == nil {
+		t.Fatalf("post-resize content rowIdx=%d returned nil (NumContentRows=%d, ContentTopRow=%d)",
+			lastContent, pane.NumContentRows, pane.ContentTopRow)
+	}
+	if src[0].Ch != 'P' {
+		t.Fatalf("expected prompt 'P' to survive resize at rowIdx=%d, got %+v", lastContent, src)
+	}
+}
+
 // TestRowSourceForPane_DecorationCacheMiss verifies that an empty
 // decoration cache returns nil for a decoration-row lookup.
 func TestRowSourceForPane_DecorationCacheMiss(t *testing.T) {

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -80,7 +80,15 @@ func (t *viewportTrackers) get(id [16]byte) *paneViewport {
 	if vp, ok = t.panes[id]; ok {
 		return vp
 	}
-	vp = &paneViewport{}
+	// knownBottomGid is initialised to -1 so the zero value (0) is not
+	// mistaken for "we have seen gid 0". This lets onBufferDelta record a
+	// preliminary maxGid even when the tracker is otherwise uninitialised
+	// (Rows == 0), so that a TreeSnapshot arriving AFTER the first delta
+	// can still seed ViewTopIdx / ViewBottomIdx around the rows that have
+	// already been delivered into the PaneCache. Without this seed the
+	// renderer maps content rowIdxs to gid=0, misses every row in
+	// PaneCache, and paints a blank pane until the next snapshot.
+	vp = &paneViewport{knownBottomGid: -1}
 	t.panes[id] = vp
 	return vp
 }
@@ -185,13 +193,40 @@ func (s *clientState) onTreeSnapshot(snap protocol.TreeSnapshot) {
 		// Only initialise if this pane is brand-new.
 		if vp.Rows == 0 {
 			vp.AltScreen = false
-			vp.ViewTopIdx = 0
-			vp.ViewBottomIdx = int64(rows) - 1
 			vp.Rows = rows
 			vp.Cols = cols
 			vp.AutoFollow = true
-			vp.knownBottomGid = -1
 			vp.dirty = true
+			// If a BufferDelta arrived before this snapshot,
+			// vp.knownBottomGid will already hold the highest gid
+			// delivered (preliminary seed from onBufferDelta).
+			// Honour it so the viewport aligns with the rows
+			// already sitting in the PaneCache; otherwise the
+			// renderer maps content rowIdxs to gid=0, the
+			// PaneCache misses every row, and the pane paints
+			// blank until something else dirties the tree.
+			//
+			// Use the structural NumContentRows from the snapshot
+			// (not the geometry rows) when computing ViewTopIdx,
+			// because the AutoFollow live-edge calculation in
+			// onBufferDelta uses the same denominator.
+			contentRows := int64(p.NumContentRows)
+			if contentRows <= 0 {
+				contentRows = int64(rows)
+			}
+			if vp.knownBottomGid >= 0 {
+				bottom := vp.knownBottomGid
+				vp.ViewBottomIdx = bottom
+				top := bottom - (contentRows - 1)
+				if top < 0 {
+					top = 0
+				}
+				vp.ViewTopIdx = top
+			} else {
+				vp.ViewTopIdx = 0
+				vp.ViewBottomIdx = int64(rows) - 1
+				vp.knownBottomGid = -1
+			}
 		} else if vp.Rows != rows || vp.Cols != cols {
 			// Geometry changed — update dims and mark dirty. When
 			// AutoFollow is true, ALSO recompute ViewTopIdx /
@@ -243,11 +278,11 @@ func (s *clientState) onBufferDelta(delta protocol.BufferDelta) {
 		return
 	}
 
-	if !vp.AutoFollow || vp.Rows == 0 {
-		return
-	}
-
-	// AutoFollow on main-screen: advance view to track the live bottom.
+	// Compute the highest gid in this delta. We need it for two things:
+	//   (a) advancing the viewport when AutoFollow is on (the normal path);
+	//   (b) seeding knownBottomGid when the tracker hasn't been initialised
+	//       yet (Rows == 0), so a TreeSnapshot arriving AFTER this delta can
+	//       still align ViewTopIdx with the rows already in PaneCache.
 	var maxGid int64 = -1
 	for _, row := range delta.Rows {
 		gid := delta.RowBase + int64(row.Row)
@@ -255,6 +290,21 @@ func (s *clientState) onBufferDelta(delta protocol.BufferDelta) {
 			maxGid = gid
 		}
 	}
+
+	if vp.Rows == 0 {
+		// Tracker not yet initialised by a TreeSnapshot. Record the
+		// highest delivered gid so onTreeSnapshot can seed the viewport
+		// around the live edge instead of around gid=0.
+		if maxGid >= 0 && maxGid > vp.knownBottomGid {
+			vp.knownBottomGid = maxGid
+		}
+		return
+	}
+
+	if !vp.AutoFollow {
+		return
+	}
+
 	if maxGid < 0 || maxGid <= vp.knownBottomGid {
 		return
 	}

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -258,9 +258,18 @@ func (s *clientState) onBufferDelta(delta protocol.BufferDelta) {
 	if maxGid < 0 || maxGid <= vp.knownBottomGid {
 		return
 	}
+	pane := s.cache.PaneByID(delta.PaneID)
+	if pane == nil {
+		log.Printf("client: onBufferDelta: pane %x not in cache; skipping viewport advance", delta.PaneID)
+		return
+	}
+	if pane.NumContentRows == 0 {
+		return
+	}
+	numContentRows := int64(pane.NumContentRows)
 	vp.knownBottomGid = maxGid
 	vp.ViewBottomIdx = maxGid
-	top := maxGid - int64(vp.Rows-1)
+	top := maxGid - (numContentRows - 1)
 	if top < 0 {
 		top = 0
 	}

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -127,6 +127,23 @@ func makeTreeSnapshot(id [16]byte, width, height int32) protocol.TreeSnapshot {
 	}
 }
 
+// makeTreeSnapshotWithContent builds a tree snapshot with content-row metadata
+// populated, matching the production flow where the server publishes
+// ContentTopRow / NumContentRows alongside geometry.
+func makeTreeSnapshotWithContent(id [16]byte, width, height int32, contentTop, numContent uint16) protocol.TreeSnapshot {
+	return protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{
+			{
+				PaneID:         id,
+				Width:          width,
+				Height:         height,
+				ContentTopRow:  contentTop,
+				NumContentRows: numContent,
+			},
+		},
+	}
+}
+
 // --------------------------------------------------------------------------
 // Part 5, item 1: TestViewportTracker_InitializesFromSnapshot
 // --------------------------------------------------------------------------
@@ -179,6 +196,9 @@ func TestViewportTracker_AdvancesOnAutoFollowDelta(t *testing.T) {
 	// Initialise pane with height=24 so rows is set.
 	snap := makeTreeSnapshot(paneID(2), 80, 24)
 	state.onTreeSnapshot(snap)
+	// Seed the cache so onBufferDelta finds NumContentRows. The pre-Task-10
+	// behaviour matched a full-content pane (NumContentRows == Rows).
+	state.cache.ApplySnapshot(makeTreeSnapshotWithContent(paneID(2), 80, 24, 0, 24))
 
 	// Clear dirty so we can detect the advance.
 	vp := state.viewports.get(paneID(2))
@@ -228,6 +248,7 @@ func TestViewportTracker_AutoFollowAdvancesFromGidZero(t *testing.T) {
 	// Initialise a single pane from a tree snapshot (Rows=24).
 	id := paneID(0xA0)
 	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+	state.cache.ApplySnapshot(makeTreeSnapshotWithContent(id, 80, 24, 0, 24))
 
 	// Drain the initial dirty state via flushFrame so subsequent dirty
 	// assertions are clean. Use a testConn so nothing writes to a real socket.
@@ -755,5 +776,115 @@ func TestFlushFrame_ZeroDimSkipped(t *testing.T) {
 	n := conn.countType(protocol.MsgViewportUpdate)
 	if n != 0 {
 		t.Errorf("expected 0 MsgViewportUpdate for zero-dim pane, got %d", n)
+	}
+}
+
+// --------------------------------------------------------------------------
+// Task 10: onBufferDelta uses NumContentRows (Issue #199 misalignment fix).
+//
+// Pre-Task-10 the math was top = maxGid - (Rows-1). With a 1-row decoration
+// header the live edge advances 1 row "into" the decoration band, leaving
+// blank rows at the top of the pane on rehydrate. The new math
+// top = maxGid - (NumContentRows-1) keeps the live edge anchored to the
+// last content row regardless of decoration borders.
+// --------------------------------------------------------------------------
+
+func TestOnBufferDelta_TopUsesContentRowCount(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xE0)
+	// Pane geometry: 10 rows total, 1-row top decoration, 8 content rows,
+	// 1-row bottom decoration. ContentTopRow=1, NumContentRows=8.
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 10))
+	state.cache.ApplySnapshot(makeTreeSnapshotWithContent(id, 80, 10, 1, 8))
+
+	// Drive maxGid to 100 via a delta on row 1 (first content row).
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 100,
+		Rows: []protocol.RowDelta{
+			{Row: 0},
+		},
+	}
+	state.onBufferDelta(delta)
+
+	vc, ok := state.paneViewportFor(id)
+	if !ok {
+		t.Fatal("paneViewportFor returned false")
+	}
+	if vc.ViewBottomIdx != 100 {
+		t.Errorf("ViewBottomIdx = %d, want 100", vc.ViewBottomIdx)
+	}
+	// New math: top = 100 - (8-1) = 93. Old math would have given 91.
+	if vc.ViewTopIdx != 93 {
+		t.Errorf("ViewTopIdx = %d, want 93 (maxGid - NumContentRows + 1)", vc.ViewTopIdx)
+	}
+}
+
+func TestOnBufferDelta_PaneNilSkipsAndLogs(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xE1)
+	// Initialise the viewport but DO NOT seed the buffer cache, so PaneByID
+	// returns nil. The viewport must NOT advance (silent fallback would
+	// reintroduce the original bug).
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	beforeBottom := vp.ViewBottomIdx
+	beforeTop := vp.ViewTopIdx
+	beforeKnown := vp.knownBottomGid
+	vp.mu.Unlock()
+
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 500,
+		Rows:    []protocol.RowDelta{{Row: 0}},
+	}
+	state.onBufferDelta(delta)
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.ViewBottomIdx != beforeBottom {
+		t.Errorf("ViewBottomIdx advanced to %d (was %d) despite nil cache pane", vp.ViewBottomIdx, beforeBottom)
+	}
+	if vp.ViewTopIdx != beforeTop {
+		t.Errorf("ViewTopIdx advanced to %d (was %d) despite nil cache pane", vp.ViewTopIdx, beforeTop)
+	}
+	if vp.knownBottomGid != beforeKnown {
+		t.Errorf("knownBottomGid advanced to %d (was %d) despite nil cache pane", vp.knownBottomGid, beforeKnown)
+	}
+}
+
+func TestOnBufferDelta_ZeroContentRowsReturnsEarly(t *testing.T) {
+	state := makeStateWithViewports()
+	id := paneID(0xE2)
+	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
+	// Pane is all-decoration: NumContentRows == 0.
+	state.cache.ApplySnapshot(makeTreeSnapshotWithContent(id, 80, 24, 0, 0))
+
+	vp := state.viewports.get(id)
+	vp.mu.Lock()
+	beforeBottom := vp.ViewBottomIdx
+	beforeTop := vp.ViewTopIdx
+	beforeKnown := vp.knownBottomGid
+	vp.mu.Unlock()
+
+	delta := protocol.BufferDelta{
+		PaneID:  id,
+		RowBase: 700,
+		Rows:    []protocol.RowDelta{{Row: 0}},
+	}
+	state.onBufferDelta(delta)
+
+	vp.mu.Lock()
+	defer vp.mu.Unlock()
+	if vp.ViewBottomIdx != beforeBottom {
+		t.Errorf("ViewBottomIdx advanced to %d (was %d) with NumContentRows=0", vp.ViewBottomIdx, beforeBottom)
+	}
+	if vp.ViewTopIdx != beforeTop {
+		t.Errorf("ViewTopIdx advanced to %d (was %d) with NumContentRows=0", vp.ViewTopIdx, beforeTop)
+	}
+	if vp.knownBottomGid != beforeKnown {
+		t.Errorf("knownBottomGid advanced to %d (was %d) with NumContentRows=0", vp.knownBottomGid, beforeKnown)
 	}
 }

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -288,6 +288,7 @@ func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32
 		// `gid >= 0 && gid in [lo,hi]` gate anyway.
 	}
 
+	var decorRows []protocol.DecorRowDelta
 	for y, row := range snap.Buffer {
 		if len(row) == 0 {
 			continue
@@ -296,19 +297,31 @@ func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32
 			continue
 		}
 		gid := snap.RowGlobalIdx[y]
-		if gid < 0 {
-			continue
-		}
-		if gid < lo || gid > hi {
+		// Alt-screen panes have RowGlobalIdx all -1; skip decoration emission
+		// before the rowsEqual cost. The existing alt-screen positional path
+		// (BufferDeltaAltScreen flag) handles them.
+		if snap.AltScreen && gid < 0 {
 			continue
 		}
 		if y < len(prev) && rowsEqual(row, prev[y]) {
+			continue
+		}
+		if gid < 0 {
+			// Decoration row (border or app statusbar) — positional.
+			decorRows = append(decorRows, protocol.DecorRowDelta{
+				RowIdx: uint16(y),
+				Spans:  encodeRow(row),
+			})
+			continue
+		}
+		if gid < lo || gid > hi {
 			continue
 		}
 		rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: encodeRow(row)})
 	}
 	delta.Styles = styles
 	delta.Rows = rows
+	delta.DecorRows = decorRows
 	return delta
 }
 

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -170,7 +170,10 @@ func (p *DesktopPublisher) publishSnapshotsLocked(buffers []texel.PaneSnapshot) 
 		rev := p.session.NextRevision(snap.ID)
 		prev := p.prevBuffers[snap.ID]
 		delta := bufferToDelta(snap, prev, rev, vp)
-		if len(delta.Rows) == 0 {
+		// Allow decoration-only deltas (e.g. focus change repaints just the
+		// borders): a delta is meaningful if either content rows or
+		// decoration rows changed since the previous frame.
+		if len(delta.Rows) == 0 && len(delta.DecorRows) == 0 {
 			continue
 		}
 		// Only clone when there are actual changes — avoids massive GC

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -9,6 +9,8 @@
 package server
 
 import (
+	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +23,13 @@ import (
 	texelcore "github.com/framegrace/texelui/core"
 	"github.com/framegrace/texelui/theme"
 )
+
+// publisherDebug is gated by env TEXELATION_DEBUG=1. Logs the pane ID,
+// RowBase, content rows shipped (gid + first/last span StartCol+Text len)
+// and decor rows shipped (rowIdx + first span info). This shows whether
+// the publisher is dropping the leading or trailing border cell of a
+// content row before it leaves the server.
+var publisherDebug = os.Getenv("TEXELATION_DEBUG") == "1"
 
 // DesktopPublisher captures desktop pane buffers and enqueues them as buffer
 // deltas on the associated session.
@@ -317,15 +326,119 @@ func bufferToDelta(snap texel.PaneSnapshot, prev [][]texel.Cell, revision uint32
 			})
 			continue
 		}
+		// Content row (gid >= 0). Encode spans once and emit positionally
+		// (DecorRowDelta keyed by rowIdx) IN ADDITION to keying by gid for
+		// scrollback. The positional duplicate is what the renderer reads
+		// for live composition: it remains correct under wrapped chains
+		// (multiple rowIdxs sharing one head gid) and erased-row gaps,
+		// where the gid space is non-contiguous and the client-side
+		// formula `gid = ViewTopIdx + (rowIdx - ContentTopRow)` mismatches
+		// the actual rowIdx → gid map. Without this, the renderer reads
+		// stale or missing rows on wrap and prints blank lines (no side
+		// border, no content). Bandwidth cost: one DecorRowDelta per
+		// changed content row inside the viewport (the rowsEqual filter
+		// above already skipped unchanged rows). The gid-keyed RowDelta
+		// is still emitted so the PaneCache can serve scrollback walks.
+		spans := encodeRow(row)
+		decorRows = append(decorRows, protocol.DecorRowDelta{
+			RowIdx: uint16(y),
+			Spans:  spans,
+		})
 		if gid < lo || gid > hi {
 			continue
 		}
-		rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: encodeRow(row)})
+		rows = append(rows, protocol.RowDelta{Row: uint16(gid - lo), Spans: spans})
 	}
 	delta.Styles = styles
 	delta.Rows = rows
 	delta.DecorRows = decorRows
+	if publisherDebug {
+		// Sample the first and last content rows + first/last decoration rows
+		// so the log line stays bounded while still showing whether borders
+		// went out on the wire.
+		var sampleContent, sampleDecor string
+		if n := len(rows); n > 0 {
+			first := rows[0]
+			sampleContent = formatRowSample("content", int64(first.Row)+delta.RowBase, first.Spans)
+			if n > 1 {
+				last := rows[n-1]
+				sampleContent += "; " + formatRowSample("content", int64(last.Row)+delta.RowBase, last.Spans)
+			}
+		}
+		if n := len(decorRows); n > 0 {
+			first := decorRows[0]
+			sampleDecor = formatDecorSample("decor", int(first.RowIdx), first.Spans)
+			if n > 1 {
+				last := decorRows[n-1]
+				sampleDecor += "; " + formatDecorSample("decor", int(last.RowIdx), last.Spans)
+			}
+		}
+		log.Printf("publishDebug pane=%x rev=%d alt=%v RowBase=%d rows=%d decor=%d styles=%d sample=[%s | %s]",
+			snap.ID[:4], revision, snap.AltScreen, delta.RowBase,
+			len(rows), len(decorRows), len(styles),
+			sampleContent, sampleDecor)
+	}
 	return delta
+}
+
+func formatRowSample(kind string, gid int64, spans []protocol.CellSpan) string {
+	if len(spans) == 0 {
+		return kind + " gid=" + itoa(int(gid)) + " EMPTY"
+	}
+	first := spans[0]
+	last := spans[len(spans)-1]
+	endCol := int(last.StartCol) + len([]rune(last.Text))
+	preview := first.Text
+	if len([]rune(preview)) > 8 {
+		preview = string([]rune(preview)[:8]) + "..."
+	}
+	return kind + " gid=" + itoa(int(gid)) +
+		" spans=" + itoa(len(spans)) +
+		" firstStart=" + itoa(int(first.StartCol)) +
+		" lastEnd=" + itoa(endCol) +
+		" first=\"" + preview + "\""
+}
+
+func formatDecorSample(kind string, rowIdx int, spans []protocol.CellSpan) string {
+	if len(spans) == 0 {
+		return kind + " rowIdx=" + itoa(rowIdx) + " EMPTY"
+	}
+	first := spans[0]
+	last := spans[len(spans)-1]
+	endCol := int(last.StartCol) + len([]rune(last.Text))
+	preview := first.Text
+	if len([]rune(preview)) > 8 {
+		preview = string([]rune(preview)[:8]) + "..."
+	}
+	return kind + " rowIdx=" + itoa(rowIdx) +
+		" spans=" + itoa(len(spans)) +
+		" firstStart=" + itoa(int(first.StartCol)) +
+		" lastEnd=" + itoa(endCol) +
+		" first=\"" + preview + "\""
+}
+
+// itoa is a tiny helper to keep the debug logger free of strconv imports.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
 }
 
 type styleKey struct {

--- a/internal/runtime/server/desktop_publisher_test.go
+++ b/internal/runtime/server/desktop_publisher_test.go
@@ -233,3 +233,159 @@ func TestPublisher_AltScreenSetsFlag(t *testing.T) {
 		t.Fatalf("alt-screen delta: want 24 rows, got %d", len(delta.Rows))
 	}
 }
+
+func TestBufferToDelta_DecorationRowsIncluded(t *testing.T) {
+	// 5-row buffer: rowIdx 0 = top border (-1), rowIdx 1..3 = content gids,
+	// rowIdx 4 = bottom border (-1).
+	rows := [][]texel.Cell{
+		{{Ch: '+'}, {Ch: '-'}, {Ch: '+'}}, // border
+		{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}}, // content
+		{{Ch: 'd'}, {Ch: 'e'}, {Ch: 'f'}}, // content
+		{{Ch: 'g'}, {Ch: 'h'}, {Ch: 'i'}}, // content
+		{{Ch: '+'}, {Ch: '-'}, {Ch: '+'}}, // border
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, 101, 102, -1},
+		ContentTopRow:  1,
+		NumContentRows: 3,
+	}
+	vp := ClientViewport{Rows: 3, AutoFollow: true}
+	prev := [][]texel.Cell(nil)
+
+	delta := bufferToDelta(snap, prev, 1, vp)
+
+	if len(delta.DecorRows) != 2 {
+		t.Fatalf("expected 2 DecorRows, got %d: %+v", len(delta.DecorRows), delta.DecorRows)
+	}
+	gotIdx := map[uint16]bool{delta.DecorRows[0].RowIdx: true, delta.DecorRows[1].RowIdx: true}
+	if !gotIdx[0] || !gotIdx[4] {
+		t.Fatalf("expected decoration rows at rowIdx 0 and 4, got %v", gotIdx)
+	}
+	if len(delta.Rows) != 3 {
+		t.Fatalf("expected 3 content Rows, got %d", len(delta.Rows))
+	}
+}
+
+func TestBufferToDelta_DecorationRowsDiffed(t *testing.T) {
+	rows := [][]texel.Cell{
+		{{Ch: '+'}}, // border
+		{{Ch: 'a'}}, // content
+		{{Ch: '+'}}, // border
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, -1},
+		ContentTopRow:  1,
+		NumContentRows: 1,
+	}
+	vp := ClientViewport{Rows: 1, AutoFollow: true}
+	prev := [][]texel.Cell{
+		{{Ch: '+'}},
+		{{Ch: 'a'}},
+		{{Ch: '+'}},
+	}
+	delta := bufferToDelta(snap, prev, 1, vp)
+	if len(delta.DecorRows) != 0 {
+		t.Fatalf("expected 0 DecorRows when borders unchanged, got %d", len(delta.DecorRows))
+	}
+	if len(delta.Rows) != 0 {
+		t.Fatalf("expected 0 content Rows when content unchanged, got %d", len(delta.Rows))
+	}
+}
+
+func TestBufferToDelta_DecorationRowsDiffPartial(t *testing.T) {
+	rows := [][]texel.Cell{
+		{{Ch: '+'}}, // border (will change)
+		{{Ch: 'a'}}, // content
+		{{Ch: '+'}}, // border (unchanged)
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, -1},
+		ContentTopRow:  1,
+		NumContentRows: 1,
+	}
+	vp := ClientViewport{Rows: 1, AutoFollow: true}
+	prev := [][]texel.Cell{
+		{{Ch: '#'}}, // different
+		{{Ch: 'a'}}, // same
+		{{Ch: '+'}}, // same
+	}
+	delta := bufferToDelta(snap, prev, 1, vp)
+	if len(delta.DecorRows) != 1 || delta.DecorRows[0].RowIdx != 0 {
+		t.Fatalf("expected 1 DecorRows entry at rowIdx 0, got %+v", delta.DecorRows)
+	}
+}
+
+func TestBufferToDelta_TexelTermInternalStatusbar(t *testing.T) {
+	// 6-row layout: rowIdx 0 = top border, [1..3] = content, rowIdx 4 = app
+	// internal statusbar (gid=-1), rowIdx 5 = bottom border.
+	rows := [][]texel.Cell{
+		{{Ch: '+'}},
+		{{Ch: 'a'}},
+		{{Ch: 'b'}},
+		{{Ch: 'c'}},
+		{{Ch: 'S'}},
+		{{Ch: '+'}},
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, 100, 101, 102, -1, -1},
+		ContentTopRow:  1,
+		NumContentRows: 3,
+	}
+	vp := ClientViewport{Rows: 3, AutoFollow: true}
+	delta := bufferToDelta(snap, nil, 1, vp)
+	got := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		got[r.RowIdx] = true
+	}
+	if !got[0] || !got[4] || !got[5] {
+		t.Fatalf("expected DecorRows at rowIdx 0, 4, 5 (top + statusbar + bottom), got %v", got)
+	}
+}
+
+func TestBufferToDelta_AltScreenLeavesDecorRowsEmpty(t *testing.T) {
+	rows := [][]texel.Cell{{{Ch: 'x'}}}
+	snap := texel.PaneSnapshot{
+		ID:           [16]byte{0xab},
+		Buffer:       rows,
+		RowGlobalIdx: []int64{-1},
+		AltScreen:    true,
+	}
+	vp := ClientViewport{Rows: 1, AltScreen: true}
+	delta := bufferToDelta(snap, nil, 1, vp)
+	if len(delta.DecorRows) != 0 {
+		t.Fatalf("alt-screen must not emit DecorRows, got %d", len(delta.DecorRows))
+	}
+}
+
+func TestBufferToDelta_ZeroContentSnapshot(t *testing.T) {
+	// Status pane shape: every row is decoration (no content gids).
+	// Server must emit all rows in DecorRows and zero content rows.
+	rows := [][]texel.Cell{
+		{{Ch: 'a'}},
+		{{Ch: 'b'}},
+		{{Ch: 'c'}},
+	}
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         rows,
+		RowGlobalIdx:   []int64{-1, -1, -1},
+		ContentTopRow:  0,
+		NumContentRows: 0,
+	}
+	vp := ClientViewport{Rows: 0, AutoFollow: false}
+	delta := bufferToDelta(snap, nil, 1, vp)
+	if len(delta.Rows) != 0 {
+		t.Fatalf("expected 0 content Rows for zero-content pane, got %d", len(delta.Rows))
+	}
+	if len(delta.DecorRows) != 3 {
+		t.Fatalf("expected 3 DecorRows for zero-content pane, got %d", len(delta.DecorRows))
+	}
+}

--- a/internal/runtime/server/desktop_publisher_test.go
+++ b/internal/runtime/server/desktop_publisher_test.go
@@ -257,12 +257,22 @@ func TestBufferToDelta_DecorationRowsIncluded(t *testing.T) {
 
 	delta := bufferToDelta(snap, prev, 1, vp)
 
-	if len(delta.DecorRows) != 2 {
-		t.Fatalf("expected 2 DecorRows, got %d: %+v", len(delta.DecorRows), delta.DecorRows)
+	// After the wrapped-chain rendering fix: content rows are emitted
+	// positionally (DecorRowDelta) IN ADDITION to gid-keyed RowDelta. So
+	// DecorRows includes both borders (rowIdx 0, 4) AND each content row
+	// (rowIdx 1, 2, 3) — total 5. The gid-keyed Rows still has the 3
+	// content entries for scrollback.
+	if len(delta.DecorRows) != 5 {
+		t.Fatalf("expected 5 DecorRows (2 borders + 3 content positional), got %d: %+v", len(delta.DecorRows), delta.DecorRows)
 	}
-	gotIdx := map[uint16]bool{delta.DecorRows[0].RowIdx: true, delta.DecorRows[1].RowIdx: true}
-	if !gotIdx[0] || !gotIdx[4] {
-		t.Fatalf("expected decoration rows at rowIdx 0 and 4, got %v", gotIdx)
+	gotIdx := make(map[uint16]bool, 5)
+	for _, dr := range delta.DecorRows {
+		gotIdx[dr.RowIdx] = true
+	}
+	for _, want := range []uint16{0, 1, 2, 3, 4} {
+		if !gotIdx[want] {
+			t.Fatalf("expected decor rowIdx=%d in DecorRows, got %v", want, gotIdx)
+		}
 	}
 	if len(delta.Rows) != 3 {
 		t.Fatalf("expected 3 content Rows, got %d", len(delta.Rows))

--- a/internal/runtime/server/desktop_publisher_test.go
+++ b/internal/runtime/server/desktop_publisher_test.go
@@ -14,6 +14,7 @@ import (
 	texelcore "github.com/framegrace/texelui/core"
 	"github.com/gdamore/tcell/v2"
 
+	"github.com/framegrace/texelation/client"
 	"github.com/framegrace/texelation/protocol"
 	"github.com/framegrace/texelation/texel"
 )
@@ -362,6 +363,115 @@ func TestBufferToDelta_AltScreenLeavesDecorRowsEmpty(t *testing.T) {
 	delta := bufferToDelta(snap, nil, 1, vp)
 	if len(delta.DecorRows) != 0 {
 		t.Fatalf("alt-screen must not emit DecorRows, got %d", len(delta.DecorRows))
+	}
+}
+
+// TestBufferToDelta_ContentRowRoundTripPreservesBorders reproduces the
+// 1-column horizontal shift bug seen in `./bin/texelation` after typing a
+// command: the content shifts left by one column, the left border (col 0)
+// disappears (overwritten by content) and the right border (col W-1) goes
+// blank. Blank-content rows still display borders correctly because they
+// flow through the decoration channel; only PaneCache content rows are
+// affected.
+//
+// The test runs a content row whose first cell is a `│` border at col 0
+// through the FULL pipeline:
+//
+//  1. bufferToDelta encodes the snapshot row → BufferDelta.
+//  2. EncodeBufferDelta + DecodeBufferDelta survive the wire format.
+//  3. PaneCache.ApplyDelta decodes spans into client cells keyed by gid.
+//  4. PaneCache.RowAt(gid) reads the row back.
+//
+// At each stage, col 0 must remain `│` and col W-1 must remain `│`.
+func TestBufferToDelta_ContentRowRoundTripPreservesBorders(t *testing.T) {
+	const W = 8
+	// One content row mimicking a texterm row inside its border:
+	//   col 0      = '│' (left border)
+	//   col 1..W-2 = "hello "
+	//   col W-1    = '│' (right border)
+	row := make([]texel.Cell, W)
+	row[0] = texel.Cell{Ch: '│', Style: tcell.StyleDefault}
+	row[W-1] = texel.Cell{Ch: '│', Style: tcell.StyleDefault}
+	content := []rune("hello ")
+	for i, r := range content {
+		row[1+i] = texel.Cell{Ch: r, Style: tcell.StyleDefault}
+	}
+
+	const gid int64 = 100
+	snap := texel.PaneSnapshot{
+		ID:             [16]byte{0xab},
+		Buffer:         [][]texel.Cell{row},
+		RowGlobalIdx:   []int64{gid},
+		ContentTopRow:  1,
+		NumContentRows: 1,
+	}
+	vp := ClientViewport{Rows: 1, AutoFollow: true}
+
+	delta := bufferToDelta(snap, nil, 1, vp)
+	if len(delta.Rows) != 1 {
+		t.Fatalf("want 1 content row in delta, got %d (DecorRows=%d)",
+			len(delta.Rows), len(delta.DecorRows))
+	}
+
+	// Check the publisher emitted the border cell at col 0 in the spans.
+	rowDelta := delta.Rows[0]
+	if len(rowDelta.Spans) == 0 {
+		t.Fatalf("publisher emitted zero spans for content row")
+	}
+	if rowDelta.Spans[0].StartCol != 0 {
+		t.Fatalf("first span StartCol = %d, want 0 (left border lost)",
+			rowDelta.Spans[0].StartCol)
+	}
+	// Concatenate span text by column to verify col 0 == '│' and col W-1 == '│'.
+	flat := make([]rune, W)
+	for i := range flat {
+		flat[i] = ' '
+	}
+	for _, s := range rowDelta.Spans {
+		for i, r := range []rune(s.Text) {
+			if int(s.StartCol)+i < W {
+				flat[int(s.StartCol)+i] = r
+			}
+		}
+	}
+	if flat[0] != '│' {
+		t.Fatalf("delta col 0 = %q, want '│' (left border encoded wrong)", flat[0])
+	}
+	if flat[W-1] != '│' {
+		t.Fatalf("delta col W-1 = %q, want '│' (right border encoded wrong)", flat[W-1])
+	}
+
+	// Wire round-trip.
+	encoded, err := protocol.EncodeBufferDelta(delta)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := protocol.DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Apply to a fresh PaneCache and read back the row at the original gid.
+	pc := client.NewPaneCache()
+	pc.ApplyDelta(decoded)
+	cells, ok := pc.RowAt(gid)
+	if !ok {
+		t.Fatalf("PaneCache.RowAt(%d): not found after round trip", gid)
+	}
+	if len(cells) < W {
+		t.Fatalf("PaneCache row length = %d, want >= %d", len(cells), W)
+	}
+	if cells[0].Ch != '│' {
+		t.Fatalf("PaneCache row col 0 = %q, want '│' (border lost)", cells[0].Ch)
+	}
+	if cells[W-1].Ch != '│' {
+		t.Fatalf("PaneCache row col W-1 = %q, want '│' (right border lost)", cells[W-1].Ch)
+	}
+	for i, want := range content {
+		got := cells[1+i].Ch
+		if got != want {
+			t.Fatalf("PaneCache row col %d = %q, want %q", 1+i, got, want)
+		}
 	}
 }
 

--- a/internal/runtime/server/tree_convert.go
+++ b/internal/runtime/server/tree_convert.go
@@ -9,27 +9,29 @@
 package server
 
 import (
-	texelcore "github.com/framegrace/texelui/core"
 	"encoding/json"
 
 	"github.com/framegrace/texelation/protocol"
 	"github.com/framegrace/texelation/texel"
+	texelcore "github.com/framegrace/texelui/core"
 )
 
 func treeCaptureToProtocol(capture texel.TreeCapture) protocol.TreeSnapshot {
 	snapshot := protocol.TreeSnapshot{Panes: make([]protocol.PaneSnapshot, len(capture.Panes))}
 	for i, pane := range capture.Panes {
 		snapshot.Panes[i] = protocol.PaneSnapshot{
-			PaneID:    pane.ID,
-			Revision:  0,
-			Title:     pane.Title,
-			Rows:      nil,
-			X:         int32(pane.Rect.X),
-			Y:         int32(pane.Rect.Y),
-			Width:     int32(pane.Rect.Width),
-			Height:    int32(pane.Rect.Height),
-			AppType:   pane.AppType,
-			AppConfig: encodeAppConfig(pane.AppConfig),
+			PaneID:         pane.ID,
+			Revision:       0,
+			Title:          pane.Title,
+			Rows:           nil,
+			X:              int32(pane.Rect.X),
+			Y:              int32(pane.Rect.Y),
+			Width:          int32(pane.Rect.Width),
+			Height:         int32(pane.Rect.Height),
+			AppType:        pane.AppType,
+			AppConfig:      encodeAppConfig(pane.AppConfig),
+			ContentTopRow:  pane.ContentTopRow,
+			NumContentRows: pane.NumContentRows,
 		}
 	}
 	snapshot.Root = buildProtocolTreeNode(capture.Root)
@@ -48,13 +50,15 @@ func protocolToTreeCapture(snapshot protocol.TreeSnapshot) texel.TreeCapture {
 			}
 		}
 		capture.Panes[i] = texel.PaneSnapshot{
-			ID:           pane.PaneID,
-			Title:        pane.Title,
-			Buffer:       buffer,
-			RowGlobalIdx: rowGlobalIdxAllMinusOne(len(buffer)),
-			Rect:         texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
-			AppType:      pane.AppType,
-			AppConfig:    decodeAppConfig(pane.AppConfig),
+			ID:             pane.PaneID,
+			Title:          pane.Title,
+			Buffer:         buffer,
+			RowGlobalIdx:   rowGlobalIdxAllMinusOne(len(buffer)),
+			Rect:           texel.Rectangle{X: int(pane.X), Y: int(pane.Y), Width: int(pane.Width), Height: int(pane.Height)},
+			AppType:        pane.AppType,
+			AppConfig:      decodeAppConfig(pane.AppConfig),
+			ContentTopRow:  pane.ContentTopRow,
+			NumContentRows: pane.NumContentRows,
 		}
 	}
 	capture.Root = protocolNodeToCapture(snapshot.Root)

--- a/internal/runtime/server/tree_convert_test.go
+++ b/internal/runtime/server/tree_convert_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelation/texel"
 )
 
 func TestProtocolToTreeCapturePopulatesRowGlobalIdx(t *testing.T) {
@@ -60,5 +61,33 @@ func TestProtocolToTreeCaptureEmptyRows(t *testing.T) {
 	pane := capture.Panes[0]
 	if len(pane.RowGlobalIdx) != len(pane.Buffer) {
 		t.Fatalf("invariant violated: len(RowGlobalIdx)=%d len(Buffer)=%d", len(pane.RowGlobalIdx), len(pane.Buffer))
+	}
+}
+
+func TestTreeCaptureToProtocol_PassesContentBounds(t *testing.T) {
+	capture := texel.TreeCapture{
+		Panes: []texel.PaneSnapshot{{
+			ID:             [16]byte{0xab},
+			Title:          "t",
+			ContentTopRow:  2,
+			NumContentRows: 16,
+		}},
+	}
+	snap := treeCaptureToProtocol(capture)
+	if len(snap.Panes) != 1 {
+		t.Fatalf("expected 1 pane, got %d", len(snap.Panes))
+	}
+	if snap.Panes[0].ContentTopRow != 2 || snap.Panes[0].NumContentRows != 16 {
+		t.Fatalf("content bounds not passed through forward: top=%d num=%d",
+			snap.Panes[0].ContentTopRow, snap.Panes[0].NumContentRows)
+	}
+
+	roundTrip := protocolToTreeCapture(snap)
+	if len(roundTrip.Panes) != 1 {
+		t.Fatalf("expected 1 pane after reverse, got %d", len(roundTrip.Panes))
+	}
+	if roundTrip.Panes[0].ContentTopRow != 2 || roundTrip.Panes[0].NumContentRows != 16 {
+		t.Fatalf("content bounds not passed through reverse: top=%d num=%d",
+			roundTrip.Panes[0].ContentTopRow, roundTrip.Panes[0].NumContentRows)
 	}
 }

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -1639,6 +1639,74 @@ func TestPaneRenders_ResizePreservesContentBounds(t *testing.T) {
 	}
 }
 
+// TestPaneRenders_ContentRowSideBorders verifies that for a content row
+// (gid >= 0) the publisher emits a span set covering the FULL pane width,
+// including `│` at col 0 (left border) and `│` at col W-1 (right border).
+//
+// This is the integration-level regression for the 1-column horizontal
+// shift bug: the bug manifests visually as content overrunning col 0 and
+// col W-1 going blank after a BufferDelta updates a content row. If the
+// publisher is dropping the leading / trailing border cell from content-
+// row spans, this test fails. If the test passes, the publisher is doing
+// its job and the shift is somewhere else (client-side composite, or
+// the texterm's own buffer is missing the borders before pane.Render
+// composes them in).
+func TestPaneRenders_ContentRowSideBorders(t *testing.T) {
+	const cols, rows = 10, 6
+	feed := make([]string, 4)
+	for i := range feed {
+		feed[i] = "abcdefgh" // exactly 8 chars = drawable interior (cols-2)
+	}
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: cols, rows: rows, seedFeed: feed})
+	defer h.serverConn.Close()
+
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: cols, Rows: rows})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+
+	// Viewport for the 4 content rows (gids 0..3 land in the visible window).
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	// Pick the highest content gid that the publisher shipped. The harness
+	// records main-screen rows keyed by globalIdx in h.rowsByGID.
+	h.mu.Lock()
+	gids := make([]int64, 0, len(h.rowsByGID))
+	for gid := range h.rowsByGID {
+		gids = append(gids, gid)
+	}
+	h.mu.Unlock()
+	if len(gids) == 0 {
+		t.Fatalf("publisher shipped zero content rows")
+	}
+	// Pick any content gid; they should all carry the side borders.
+	rd := h.AwaitRow(h.paneID, gids[0], 2*time.Second)
+
+	// Concatenate the spans by column to inspect col 0 and col W-1.
+	flat := make([]rune, cols)
+	for i := range flat {
+		flat[i] = ' '
+	}
+	for _, sp := range rd.Spans {
+		for i, r := range []rune(sp.Text) {
+			if int(sp.StartCol)+i < cols {
+				flat[int(sp.StartCol)+i] = r
+			}
+		}
+	}
+	if flat[0] != '│' {
+		t.Fatalf("content row gid=%d col 0 = %q (publisher dropped left border — 1-col shift bug); flat=%q",
+			gids[0], flat[0], string(flat))
+	}
+	if flat[cols-1] != '│' {
+		t.Fatalf("content row gid=%d col W-1 = %q (publisher dropped right border); flat=%q",
+			gids[0], flat[cols-1], string(flat))
+	}
+}
+
 // paneBoundsLocked reads ContentTopRow / NumContentRows under h.mu so the
 // race detector sees a happens-before edge against the client read loop.
 // The reader goroutine acquires h.mu inside clientReadLoop when it stores

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -314,6 +314,13 @@ type memHarnessOpts struct {
 	cols, rows int
 	twoPanes   bool
 	persistDir string // if non-empty, mgr.EnablePersistence is called with this
+	// seedFeed is fed into the primary fake app via FeedRows(0, seedFeed)
+	// BEFORE the handshake completes, so the initial TreeSnapshot the server
+	// ships during connect carries non-default ContentTopRow / NumContentRows.
+	// Tests that need the client cache to observe content bounds on a clean
+	// start must use this rather than calling FeedRows post-handshake (where
+	// the snapshot has already been sent with NumContentRows == 0).
+	seedFeed []string
 }
 
 // lastDeltaTracker remembers the most recent BufferDelta per pane and lets
@@ -410,6 +417,9 @@ func newMemHarnessOpts(t *testing.T, opts memHarnessOpts) *memHarness {
 		return a
 	}
 	primary := makeFake()
+	if len(opts.seedFeed) > 0 {
+		primary.FeedRows(0, opts.seedFeed)
+	}
 	driver := vpScreenDriver{cols: cols, rows: rows}
 	lifecycle := texel.NoopAppLifecycle{}
 	// Shell factory: hand out the first fake on the initial call, then
@@ -1161,4 +1171,70 @@ func (h *memHarness) Restart(t *testing.T) {
 		}
 		<-h.readerDone
 	})
+}
+
+// TestPaneRenders_AllFourBorders_CleanStart verifies that on a clean start
+// with no rehydrate, the publisher emits decoration rows for both the top
+// and bottom pane borders, and that the client cache observes the correct
+// content bounds (ContentTopRow / NumContentRows) plus populated decoration
+// rows for both border rowIdxs.
+func TestPaneRenders_AllFourBorders_CleanStart(t *testing.T) {
+	// Seed the primary fake with 6 main-screen rows BEFORE handshake so the
+	// initial TreeSnapshot the server ships during connect carries
+	// ContentTopRow=1 / NumContentRows=4. With h=6, capturePaneSnapshot
+	// writes RowGlobalIdx[1..4] (rowIdx 0 + 5 stay -1 as borders).
+	feed := make([]string, 6)
+	for i := range feed {
+		feed[i] = "row-content"
+	}
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: 10, rows: 6, seedFeed: feed})
+	defer h.serverConn.Close()
+
+	// Send MsgClientReady so the server runs handleClientReady, which calls
+	// sink.Snapshot() and ships an initial MsgTreeSnapshot. Because the fake
+	// is already seeded, that snapshot carries ContentTopRow=1 /
+	// NumContentRows=4 for the primary pane.
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: 10, Rows: 6})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+
+	// Send a viewport so the publisher emits the main-screen pane. Content
+	// gids land in rowGIDs[0..3] (the first 4 of 6 rebuilt entries) once
+	// capturePaneSnapshot drops the border slots, so the visible window is
+	// gids 0..3.
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+
+	// First publish primes the buffer + ships the initial deltas.
+	h.Publish()
+
+	delta := h.WaitForDelta(t, h.paneID, 2*time.Second)
+	if len(delta.DecorRows) == 0 {
+		t.Fatal("expected DecorRows for at least the top + bottom borders")
+	}
+	rowIdxs := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		rowIdxs[r.RowIdx] = true
+	}
+	if !rowIdxs[0] || !rowIdxs[5] {
+		t.Fatalf("expected decoration rows at rowIdx 0 and 5, got %v", rowIdxs)
+	}
+
+	// Verify content bounds reached the client cache.
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane %x", h.paneID)
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("client content bounds wrong: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+
+	// And the cache has decoration rows for both borders.
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 0")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("client decoration cache missing rowIdx 5")
+	}
 }

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
 	"github.com/framegrace/texelation/apps/texelterm/parser/sparse"
+	"github.com/framegrace/texelation/client"
 	"github.com/framegrace/texelation/internal/runtime/server/testutil"
 	"github.com/framegrace/texelation/protocol"
 	"github.com/framegrace/texelation/texel"
@@ -285,8 +286,15 @@ type memHarness struct {
 	srv     *Server
 	session *Session
 	pub     *DesktopPublisher
-	fakeApp *sparseFakeApp
-	paneID  [16]byte
+	fakeApp *sparseFakeApp   // primary fake app (paneIDs[0])
+	fakes   []*sparseFakeApp // all fake apps spawned, parallel to paneIDs
+	paneID  [16]byte         // primary pane ID (paneIDs[0])
+	paneIDs [][16]byte       // [0] = original; [1..] = additional panes when twoPanes=true
+
+	persistDir string // empty unless newMemHarnessOpts was given persistDir
+
+	clientCache *client.BufferCache
+	lastDelta   *lastDeltaTracker
 
 	serverConn *testutil.MemConn
 	clientConn *testutil.MemConn
@@ -299,6 +307,64 @@ type memHarness struct {
 	fetchByReqID   map[uint32]protocol.FetchRangeResponse
 	rowBasesByPane map[[16]byte][]int64 // every RowBase observed per pane, in order
 	writeMu        sync.Mutex           // client-side write serialization
+}
+
+// memHarnessOpts configures newMemHarnessOpts.
+type memHarnessOpts struct {
+	cols, rows int
+	twoPanes   bool
+	persistDir string // if non-empty, mgr.EnablePersistence is called with this
+}
+
+// lastDeltaTracker remembers the most recent BufferDelta per pane and lets
+// callers wait for a fresh one.
+type lastDeltaTracker struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	byPane map[[16]byte]protocol.BufferDelta
+}
+
+func newLastDeltaTracker() *lastDeltaTracker {
+	t := &lastDeltaTracker{byPane: make(map[[16]byte]protocol.BufferDelta)}
+	t.cond = sync.NewCond(&t.mu)
+	return t
+}
+
+func (t *lastDeltaTracker) put(paneID [16]byte, d protocol.BufferDelta) {
+	t.mu.Lock()
+	t.byPane[paneID] = d
+	t.cond.Broadcast()
+	t.mu.Unlock()
+}
+
+func (t *lastDeltaTracker) wait(paneID [16]byte, timeout time.Duration) (protocol.BufferDelta, bool) {
+	deadline := time.Now().Add(timeout)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for {
+		if d, ok := t.byPane[paneID]; ok {
+			return d, true
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return protocol.BufferDelta{}, false
+		}
+		// Cond.Wait has no timeout. Spin a one-shot timer that broadcasts
+		// when the deadline passes so the cond wakes up.
+		timer := time.AfterFunc(remaining, func() {
+			t.mu.Lock()
+			t.cond.Broadcast()
+			t.mu.Unlock()
+		})
+		t.cond.Wait()
+		timer.Stop()
+	}
+}
+
+func (t *lastDeltaTracker) reset(paneID [16]byte) {
+	t.mu.Lock()
+	delete(t.byPane, paneID)
+	t.mu.Unlock()
 }
 
 type vpScreenDriver struct {
@@ -319,12 +385,45 @@ func (d vpScreenDriver) GetContent(int, int) (rune, []rune, tcell.Style, int) {
 
 // newMemHarness wires everything up and performs the initial handshake so
 // the test can immediately push viewports / feed rows / call FetchRange.
+// Existing callers rely on this signature; new callers needing persistence
+// or two-pane setups should use newMemHarnessOpts.
 func newMemHarness(t *testing.T, cols, rows int) *memHarness {
 	t.Helper()
-	fakeApp := newSparseFakeApp(cols, rows)
+	return newMemHarnessOpts(t, memHarnessOpts{cols: cols, rows: rows})
+}
+
+// newMemHarnessOpts is the configurable variant. cols and rows are required;
+// other fields are optional. When twoPanes is true, the active workspace is
+// horizontally split and a second sparseFakeApp is attached so paneIDs has
+// two entries. When persistDir is set, the manager is bound to that
+// directory via EnablePersistence (required for Restart).
+func newMemHarnessOpts(t *testing.T, opts memHarnessOpts) *memHarness {
+	t.Helper()
+	cols, rows := opts.cols, opts.rows
+	// Build a shell factory that hands out fresh sparseFakeApp instances
+	// in order. The first call (during desktop init) yields fakes[0], which
+	// we also expose as h.fakeApp for back-compat with single-pane tests.
+	var fakes []*sparseFakeApp
+	makeFake := func() *sparseFakeApp {
+		a := newSparseFakeApp(cols, rows)
+		fakes = append(fakes, a)
+		return a
+	}
+	primary := makeFake()
 	driver := vpScreenDriver{cols: cols, rows: rows}
 	lifecycle := texel.NoopAppLifecycle{}
-	shellFactory := func() texelcore.App { return fakeApp }
+	// Shell factory: hand out the first fake on the initial call, then
+	// allocate fresh fakes for subsequent splits.
+	first := true
+	shellFactory := func() texelcore.App {
+		if first {
+			first = false
+			return primary
+		}
+		return makeFake()
+	}
+	// Keep the legacy local for the existing body below.
+	fakeApp := primary
 	desktop, err := texel.NewDesktopEngineWithDriver(driver, shellFactory, "texelterm", &lifecycle)
 	if err != nil {
 		t.Fatalf("NewDesktopEngineWithDriver: %v", err)
@@ -338,8 +437,23 @@ func newMemHarness(t *testing.T, cols, rows int) *memHarness {
 	desktop.SetViewportSize(cols, rows)
 
 	mgr := NewManager()
+	if opts.persistDir != "" {
+		if err := mgr.EnablePersistence(opts.persistDir, 10*time.Millisecond); err != nil {
+			t.Fatalf("EnablePersistence: %v", err)
+		}
+	}
 	sink := NewDesktopSink(desktop)
 	srv := &Server{manager: mgr, sink: sink, desktopSink: sink}
+
+	// Optional second pane: split the active workspace horizontally so the
+	// shell factory is invoked again, attaching fakes[1] to the new leaf.
+	if opts.twoPanes {
+		ws := desktop.ActiveWorkspace()
+		if ws == nil {
+			t.Fatalf("twoPanes: no active workspace to split")
+		}
+		ws.PerformSplit(texel.Vertical)
+	}
 
 	h := &memHarness{
 		t:              t,
@@ -348,6 +462,10 @@ func newMemHarness(t *testing.T, cols, rows int) *memHarness {
 		mgr:            mgr,
 		srv:            srv,
 		fakeApp:        fakeApp,
+		fakes:          fakes,
+		persistDir:     opts.persistDir,
+		clientCache:    client.NewBufferCache(),
+		lastDelta:      newLastDeltaTracker(),
 		rowsByGID:      make(map[int64]protocol.RowDelta),
 		altRowsByIdx:   make(map[uint16][]protocol.CellSpan),
 		fetchByReqID:   make(map[uint32]protocol.FetchRangeResponse),
@@ -355,18 +473,36 @@ func newMemHarness(t *testing.T, cols, rows int) *memHarness {
 		readerDone:     make(chan struct{}),
 	}
 
-	// Find the pane ID assigned to the shell app by the desktop.
-	var foundID [16]byte
-	for _, snap := range desktop.SnapshotBuffers() {
-		if snap.Title == fakeApp.GetTitle() {
-			foundID = snap.ID
-			break
+	// Resolve pane IDs in the order the fakes were created. SnapshotBuffers
+	// returns one entry per pane; for each fake (in factory-call order) we
+	// pick the matching ID by app pointer identity, falling back to title.
+	snaps := desktop.SnapshotBuffers()
+	for i, fa := range fakes {
+		var id [16]byte
+		// Prefer pointer-equality-by-title-position: if every fake reports
+		// the same title, we have to disambiguate by which buffer index in
+		// the snapshot list this fake corresponds to. Since the factory
+		// hands them out in split order, we map fakes[i] -> the i-th
+		// matching snapshot title.
+		matches := 0
+		for _, snap := range snaps {
+			if snap.Title == fa.GetTitle() {
+				if matches == i {
+					id = snap.ID
+					break
+				}
+				matches++
+			}
 		}
+		if id == ([16]byte{}) {
+			t.Fatalf("could not locate pane %d hosting sparseFakeApp", i)
+		}
+		h.paneIDs = append(h.paneIDs, id)
 	}
-	if foundID == ([16]byte{}) {
-		t.Fatalf("could not locate pane hosting sparseFakeApp")
+	if len(h.paneIDs) == 0 {
+		t.Fatalf("no panes located")
 	}
-	h.paneID = foundID
+	h.paneID = h.paneIDs[0]
 
 	h.serverConn, h.clientConn = testutil.NewMemPipe(64)
 	t.Cleanup(func() {
@@ -489,7 +625,16 @@ func (h *memHarness) clientReadLoop() {
 				h.t.Logf("client decode buffer delta: %v", derr)
 				continue
 			}
+			// Always feed the client-side BufferCache so tests can inspect
+			// PaneState (ContentTopRow / NumContentRows / DecorRows) for any
+			// pane, not just the primary.
+			h.clientCache.ApplyDelta(delta)
+			h.lastDelta.put(delta.PaneID, delta)
 			if delta.PaneID != h.paneID {
+				// Other panes still get cached + tracked above; only the
+				// primary pane's rows are recorded in rowsByGID.
+				ackPayload, _ := protocol.EncodeBufferAck(protocol.BufferAck{Sequence: hdr.Sequence})
+				h.writeFrame(protocol.MsgBufferAck, ackPayload, h.sessionID())
 				continue
 			}
 			h.mu.Lock()
@@ -514,6 +659,13 @@ func (h *memHarness) clientReadLoop() {
 			// Ack the delta so the session queue stays bounded.
 			ackPayload, _ := protocol.EncodeBufferAck(protocol.BufferAck{Sequence: hdr.Sequence})
 			h.writeFrame(protocol.MsgBufferAck, ackPayload, h.sessionID())
+		case protocol.MsgTreeSnapshot:
+			snap, derr := protocol.DecodeTreeSnapshot(payload)
+			if derr != nil {
+				h.t.Logf("client decode tree snapshot: %v", derr)
+				continue
+			}
+			h.clientCache.ApplySnapshot(snap)
 		case protocol.MsgFetchRangeResponse:
 			resp, derr := protocol.DecodeFetchRangeResponse(payload)
 			if derr != nil {
@@ -845,4 +997,168 @@ func gidList(rows []protocol.LogicalRow) []int64 {
 		out[i] = r.GlobalIdx
 	}
 	return out
+}
+
+// ClientPane returns the client-side BufferCache PaneState for paneID, or
+// nil if the cache hasn't seen that pane yet.
+func (h *memHarness) ClientPane(id [16]byte) *client.PaneState {
+	return h.clientCache.PaneByID(id)
+}
+
+// WaitForDelta blocks until a BufferDelta for paneID has been observed by
+// the client read loop. Returns the most-recent delta seen for that pane.
+// Use ResetDeltaTracker before driving a new action so the next call here
+// is guaranteed to wait for a fresh delta rather than returning a stale one.
+func (h *memHarness) WaitForDelta(t *testing.T, paneID [16]byte, timeout time.Duration) protocol.BufferDelta {
+	t.Helper()
+	d, ok := h.lastDelta.wait(paneID, timeout)
+	if !ok {
+		t.Fatalf("WaitForDelta: timeout waiting for pane %x", paneID)
+	}
+	return d
+}
+
+// ResetDeltaTracker clears the cached last-delta for paneID. Call before
+// triggering an action whose effect must be observed in a NEW delta (focus
+// change, content append, viewport scroll).
+func (h *memHarness) ResetDeltaTracker(paneID [16]byte) {
+	h.lastDelta.reset(paneID)
+}
+
+// FocusPane drives a focus change to the given pane ID. The workspace's
+// internal tree state is unexported and there is no public, non-destructive
+// "focus pane by ID" API on Workspace or DesktopEngine today. For now this
+// helper is a no-op when paneID already matches ActivePane().ID(), and
+// otherwise fatals with a TODO. Task 15 is expected to either inline a
+// keyboard-event-based focus drive or add a public Workspace.FocusByID
+// API in the texel package.
+func (h *memHarness) FocusPane(paneID [16]byte) {
+	h.t.Helper()
+	ws := h.desktop.ActiveWorkspace()
+	if ws == nil {
+		h.t.Fatalf("FocusPane: no active workspace")
+	}
+	if cur := ws.ActivePane(); cur != nil && cur.ID() == paneID {
+		return
+	}
+	h.t.Fatalf("FocusPane: target %x is not currently active and no public focus-by-ID API exists; Task 15 must add one (or inline a keyboard event)", paneID)
+}
+
+// Restart shuts the in-process server down, recreates the Manager + Server
+// pointing at the same persistence dir, opens a fresh memconn pair, and
+// replays the handshake using MsgResumeRequest with the persisted sessionID.
+// Caller must have constructed h with a non-empty persistDir (via
+// newMemHarnessOpts).
+func (h *memHarness) Restart(t *testing.T) {
+	t.Helper()
+	if h.persistDir == "" {
+		t.Fatalf("Restart requires the harness to have been built with persistDir set")
+	}
+
+	sessionID := h.sessionID()
+	persistDir := h.persistDir
+
+	// Close client side first; the server's serve goroutine exits on EOF
+	// and closes its end. Drain readerDone so we don't leak.
+	if err := h.clientConn.Close(); err != nil {
+		t.Logf("Restart: close clientConn: %v", err)
+	}
+	<-h.readerDone
+
+	// New Manager bound to the same persistence dir. The desktop, sink,
+	// and fakes survive across the restart — only the manager / connection
+	// is rebuilt.
+	mgr := NewManager()
+	if err := mgr.EnablePersistence(persistDir, 10*time.Millisecond); err != nil {
+		t.Fatalf("Restart: EnablePersistence: %v", err)
+	}
+	srv := &Server{manager: mgr, sink: h.sink, desktopSink: h.sink}
+	h.mgr = mgr
+	h.srv = srv
+
+	// Reset client-side accumulated state so post-restart deltas don't mix
+	// with pre-restart entries.
+	h.mu.Lock()
+	h.rowsByGID = make(map[int64]protocol.RowDelta)
+	h.altRowsByIdx = make(map[uint16][]protocol.CellSpan)
+	h.fetchByReqID = make(map[uint32]protocol.FetchRangeResponse)
+	h.rowBasesByPane = make(map[[16]byte][]int64)
+	h.mu.Unlock()
+	h.lastDelta = newLastDeltaTracker()
+	h.clientCache = client.NewBufferCache()
+	h.readerDone = make(chan struct{})
+
+	// New memconn pair.
+	h.serverConn, h.clientConn = testutil.NewMemPipe(64)
+	t.Cleanup(func() {
+		_ = h.serverConn.Close()
+		_ = h.clientConn.Close()
+	})
+
+	// Re-spawn the server-side handshake goroutine.
+	serveErrCh := make(chan error, 1)
+	sessCh := make(chan *Session, 1)
+	go func() {
+		defer h.serverConn.Close()
+		sess, resuming, _, err := handleHandshake(h.serverConn, mgr)
+		if err != nil {
+			serveErrCh <- err
+			return
+		}
+		pub := NewDesktopPublisher(h.desktop, sess)
+		h.sink.SetPublisher(pub)
+		conn := newConnection(h.serverConn, sess, h.sink, resuming, true /*rehydrated*/)
+		pub.SetNotifier(conn.nudge)
+		h.mu.Lock()
+		h.session = sess
+		h.pub = pub
+		h.mu.Unlock()
+		sessCh <- sess
+		serveErrCh <- conn.serve()
+	}()
+
+	// Client side: Hello -> Welcome -> ResumeRequest with persisted sessionID.
+	helloPayload, _ := protocol.EncodeHello(protocol.Hello{ClientName: "intg-client"})
+	h.writeFrame(protocol.MsgHello, helloPayload, [16]byte{})
+	if _, _, err := protocol.ReadMessage(h.clientConn); err != nil {
+		t.Fatalf("Restart: read welcome: %v", err)
+	}
+	resumeReq, _ := protocol.EncodeResumeRequest(protocol.ResumeRequest{
+		SessionID:    sessionID,
+		LastSequence: 0,
+	})
+	h.writeFrame(protocol.MsgResumeRequest, resumeReq, sessionID)
+	for {
+		hdr, payload, err := protocol.ReadMessage(h.clientConn)
+		if err != nil {
+			t.Fatalf("Restart: read connect accept: %v", err)
+		}
+		if hdr.Type == protocol.MsgConnectAccept {
+			if _, err := protocol.DecodeConnectAccept(payload); err != nil {
+				t.Fatalf("Restart: decode connect accept: %v", err)
+			}
+			break
+		}
+	}
+	select {
+	case <-sessCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Restart: session did not materialize")
+	}
+
+	// Spin client read loop back up.
+	go h.clientReadLoop()
+
+	t.Cleanup(func() {
+		_ = h.clientConn.Close()
+		select {
+		case err := <-serveErrCh:
+			if err != nil && err != io.EOF {
+				t.Logf("Restart: server serve exit: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Log("Restart: server serve goroutine did not exit cleanly")
+		}
+		<-h.readerDone
+	})
 }

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -1562,3 +1562,91 @@ func TestPaneRenders_FocusChangeRepaintsBorders(t *testing.T) {
 		t.Fatalf("pane B border at rowIdx 0 did not change on focus toggle; theme may be missing an active/inactive distinction\nprev=%+v\nnew=%+v", prevBorderB, newBorderB)
 	}
 }
+
+// TestPaneRenders_ResizePreservesContentBounds verifies that the
+// geometry-only TreeSnapshot the server emits during a resize carries the
+// pane's structural ContentTopRow / NumContentRows. Without this the
+// client's BufferCache.ApplySnapshot overwrites the previously-correct
+// bounds with zeros, the renderer's rowSourceForPane routes every interior
+// rowIdx through the decoration-only branch, and content rows paint blank
+// until the next full snapshot. See issue #199 follow-up: resize-blanks-
+// content. The fix lives in texel/snapshot.go GeometryForClient — it now
+// calls applyStructuralBounds for each leaf pane, mirroring
+// capturePaneSnapshot's structural calculation without rendering the pane
+// buffer.
+func TestPaneRenders_ResizePreservesContentBounds(t *testing.T) {
+	feed := make([]string, 6)
+	for i := range feed {
+		feed[i] = "row-content"
+	}
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: 10, rows: 6, seedFeed: feed})
+	defer h.serverConn.Close()
+
+	// Drive the initial snapshot+delta cycle (mirrors the clean-start test).
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: 10, Rows: 6})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	// Sanity: client sees correct content bounds before resize.
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane before resize")
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("pre-resize bounds wrong: top=%d num=%d (want top=1 num=4)",
+			pane.ContentTopRow, pane.NumContentRows)
+	}
+
+	// Drive a resize to NEW dimensions so the server-side handleResize
+	// path actually rebuilds geometry instead of short-circuiting on
+	// "no change". Pre-fix, the geometry-only TreeSnapshot has
+	// ContentTopRow=0, NumContentRows=0 — overwriting the client's
+	// previously-correct bounds. Post-fix, the snapshot carries the
+	// structural bounds.
+	h.ResetDeltaTracker(h.paneID)
+	resizePayload, err := protocol.EncodeResize(protocol.Resize{Cols: 12, Rows: 7})
+	if err != nil {
+		t.Fatalf("encode resize: %v", err)
+	}
+	h.writeFrame(protocol.MsgResize, resizePayload, h.sessionID())
+
+	// handleResize ships a TreeSnapshot then publishes deltas. Wait for
+	// the post-resize delta — both messages are processed by the same
+	// reader goroutine in serial order, so by the time the delta is
+	// observed the snapshot's ApplySnapshot() write has already returned.
+	// This synchronises the test goroutine's subsequent pane field reads
+	// against the reader's writes via the shared harness lock that
+	// WaitForDelta acquires.
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	// After resize the pane is 7 rows tall (was 6), so the structural
+	// bounds are ContentTopRow=1, NumContentRows=h-2=5. (sparseFakeApp
+	// does not emit a trailing statusbar row.) Read fields under the
+	// harness lock for race-detector cleanliness.
+	pane = h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane after resize")
+	}
+	gotTop, gotNum := paneBoundsLocked(h, pane)
+	if gotTop != 1 || gotNum != 5 {
+		t.Fatalf("post-resize content bounds wrong: top=%d num=%d (want top=1 num=5) — geometry snapshot blanked the bounds, the resize-blanks-content regression has returned",
+			gotTop, gotNum)
+	}
+}
+
+// paneBoundsLocked reads ContentTopRow / NumContentRows under h.mu so the
+// race detector sees a happens-before edge against the client read loop.
+// The reader goroutine acquires h.mu inside clientReadLoop when it stores
+// per-row state; serialising bounds reads through the same lock pins the
+// happens-before edge. Sufficient for the bounds-invariant assertions this
+// suite makes.
+func paneBoundsLocked(h *memHarness, pane *client.PaneState) (uint16, uint16) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return pane.ContentTopRow, pane.NumContentRows
+}

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -16,6 +16,7 @@
 package server
 
 import (
+	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -97,6 +98,16 @@ func (a *sparseFakeApp) FeedRows(startGID int64, rows []string) {
 	a.rebuildRenderFromStoreLocked(maxGID)
 	a.mu.Unlock()
 	a.markDirty()
+}
+
+// AppendLine appends a single main-screen row at the next free globalIdx
+// (one past the current Max). Thin wrapper over FeedRows kept for tests
+// that want a "stream a line at a time" feel without computing gids.
+func (a *sparseFakeApp) AppendLine(s string) {
+	a.mu.Lock()
+	next := a.store.Max() + 1
+	a.mu.Unlock()
+	a.FeedRows(next, []string{s})
 }
 
 // ScrollTo sets the render buffer to show the <height> rows ending at
@@ -1366,5 +1377,66 @@ func TestPaneRenders_AllFourBorders_AfterRehydrate(t *testing.T) {
 	}
 	if _, ok := pane.DecorRowAt(5); !ok {
 		t.Fatalf("decoration cache missing rowIdx 5 after rehydrate")
+	}
+}
+
+// TestPaneRenders_AllFourBorders_ScrolledMidHistory verifies that when the
+// client scrolls off the live edge (autoFollow=false, viewBottom mid-history)
+// the publisher re-emits decoration rows for both pane borders and the
+// client cache still observes correct content bounds. This protects the
+// invariant that border decorations and ContentTopRow / NumContentRows
+// survive a viewport change that resets prev[] inside the publisher.
+func TestPaneRenders_AllFourBorders_ScrolledMidHistory(t *testing.T) {
+	feed := make([]string, 6)
+	for i := range feed {
+		feed[i] = "row-content"
+	}
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: 10, rows: 6, seedFeed: feed})
+	defer h.serverConn.Close()
+
+	// Drive an initial snapshot+delta cycle so the client cache observes
+	// the pane (mirrors Tasks 12 / 13).
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: 10, Rows: 6})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	// Append several screens of content via the fake app's writer.
+	for i := 0; i < 50; i++ {
+		h.fakeApp.AppendLine(fmt.Sprintf("line-%d", i))
+		h.Publish()
+	}
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	// Reset the delta tracker so the next WaitForDelta blocks for a NEW
+	// delta triggered by the viewport change. Without this, a stale delta
+	// from the append loop above could be returned and the test would race
+	// past the scroll without observing it.
+	h.ResetDeltaTracker(h.paneID)
+
+	// Scroll off the live edge: autoFollow=false, viewBottom mid-history.
+	h.ApplyViewport(h.paneID, 10, 15, false, false)
+	h.Publish()
+	// Wait for the post-scroll delta to land — this is when the publisher
+	// re-emits content for the new viewport AND re-emits decoration rows
+	// (since prev[] is reset on viewport change).
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	pane := h.ClientPane(h.paneID)
+	if pane == nil {
+		t.Fatalf("client cache missing pane")
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("scrolled state lost content bounds: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("scrolled state lost top border decoration")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("scrolled state lost bottom border decoration")
 	}
 }

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -610,6 +610,22 @@ func (h *memHarness) writeFrame(msgType protocol.MessageType, payload []byte, se
 	}
 }
 
+// tryWriteFrame is the non-fatal variant used by the client read loop. The
+// reader runs as a background goroutine and may race a Restart() that
+// closes clientConn while a delta ack is in flight; treating that EOF as
+// fatal would mark the test failed despite being a benign teardown race.
+func (h *memHarness) tryWriteFrame(msgType protocol.MessageType, payload []byte, sessionID [16]byte) error {
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      msgType,
+		Flags:     protocol.FlagChecksum,
+		SessionID: sessionID,
+	}
+	return protocol.WriteMessage(h.clientConn, hdr, payload)
+}
+
 func (h *memHarness) sessionID() [16]byte {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -644,7 +660,9 @@ func (h *memHarness) clientReadLoop() {
 				// Other panes still get cached + tracked above; only the
 				// primary pane's rows are recorded in rowsByGID.
 				ackPayload, _ := protocol.EncodeBufferAck(protocol.BufferAck{Sequence: hdr.Sequence})
-				h.writeFrame(protocol.MsgBufferAck, ackPayload, h.sessionID())
+				if err := h.tryWriteFrame(protocol.MsgBufferAck, ackPayload, h.sessionID()); err != nil {
+					return
+				}
 				continue
 			}
 			h.mu.Lock()
@@ -668,7 +686,9 @@ func (h *memHarness) clientReadLoop() {
 			h.mu.Unlock()
 			// Ack the delta so the session queue stays bounded.
 			ackPayload, _ := protocol.EncodeBufferAck(protocol.BufferAck{Sequence: hdr.Sequence})
-			h.writeFrame(protocol.MsgBufferAck, ackPayload, h.sessionID())
+			if err := h.tryWriteFrame(protocol.MsgBufferAck, ackPayload, h.sessionID()); err != nil {
+				return
+			}
 		case protocol.MsgTreeSnapshot:
 			snap, derr := protocol.DecodeTreeSnapshot(payload)
 			if derr != nil {
@@ -1068,6 +1088,17 @@ func (h *memHarness) Restart(t *testing.T) {
 	sessionID := h.sessionID()
 	persistDir := h.persistDir
 
+	// Flush any pending debounced persistence write so the post-restart
+	// EnablePersistence boot scan sees this session on disk. Without this
+	// the 10ms debounce window can race the close + rebuild and the new
+	// Manager's LookupOrRehydrate would return ErrSessionNotFound.
+	h.mu.Lock()
+	sess := h.session
+	h.mu.Unlock()
+	if sess != nil {
+		sess.FlushPersistForTest()
+	}
+
 	// Close client side first; the server's serve goroutine exits on EOF
 	// and closes its end. Drain readerDone so we don't leak.
 	if err := h.clientConn.Close(); err != nil {
@@ -1127,17 +1158,19 @@ func (h *memHarness) Restart(t *testing.T) {
 		serveErrCh <- conn.serve()
 	}()
 
-	// Client side: Hello -> Welcome -> ResumeRequest with persisted sessionID.
+	// Client side: Hello -> Welcome -> ConnectRequest carrying the persisted
+	// sessionID. handleHandshake routes a non-zero SessionID through
+	// mgr.LookupOrRehydrate and replies with ConnectAccept. We then send
+	// MsgResumeRequest (with empty PaneViewports — Plan B's payload is
+	// optional here) to flip the connection out of awaitResume mode so
+	// sendPending will start writing diffs to the wire.
 	helloPayload, _ := protocol.EncodeHello(protocol.Hello{ClientName: "intg-client"})
 	h.writeFrame(protocol.MsgHello, helloPayload, [16]byte{})
 	if _, _, err := protocol.ReadMessage(h.clientConn); err != nil {
 		t.Fatalf("Restart: read welcome: %v", err)
 	}
-	resumeReq, _ := protocol.EncodeResumeRequest(protocol.ResumeRequest{
-		SessionID:    sessionID,
-		LastSequence: 0,
-	})
-	h.writeFrame(protocol.MsgResumeRequest, resumeReq, sessionID)
+	connectReq, _ := protocol.EncodeConnectRequest(protocol.ConnectRequest{SessionID: sessionID})
+	h.writeFrame(protocol.MsgConnectRequest, connectReq, sessionID)
 	for {
 		hdr, payload, err := protocol.ReadMessage(h.clientConn)
 		if err != nil {
@@ -1155,6 +1188,14 @@ func (h *memHarness) Restart(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Restart: session did not materialize")
 	}
+
+	// Send MsgResumeRequest to flip awaitResume off. Without this,
+	// sendPending early-returns and no diffs reach the client.
+	resumeReq, _ := protocol.EncodeResumeRequest(protocol.ResumeRequest{
+		SessionID:    sessionID,
+		LastSequence: 0,
+	})
+	h.writeFrame(protocol.MsgResumeRequest, resumeReq, sessionID)
 
 	// Spin client read loop back up.
 	go h.clientReadLoop()
@@ -1236,5 +1277,94 @@ func TestPaneRenders_AllFourBorders_CleanStart(t *testing.T) {
 	}
 	if _, ok := pane.DecorRowAt(5); !ok {
 		t.Fatalf("client decoration cache missing rowIdx 5")
+	}
+}
+
+// TestPaneRenders_AllFourBorders_AfterRehydrate verifies that after a daemon
+// restart (manager + connection rebuilt against the same persistence dir),
+// the publisher still emits border decoration rows and the client cache
+// still observes the correct content bounds + populated border decoration
+// entries. Mirrors TestPaneRenders_AllFourBorders_CleanStart but adds a
+// Restart() in the middle.
+//
+// Note: the plan also asserts a statusbar decoration row at rowIdx 4 (H-2),
+// but sparseFakeApp does not mimic texelterm's internal statusbar — its
+// rowGIDs are 1:1 with content rows. So that assertion is intentionally
+// dropped here; the test still validates the Plan B / Plan D2 invariant
+// that border decorations and content bounds round-trip across rehydrate.
+func TestPaneRenders_AllFourBorders_AfterRehydrate(t *testing.T) {
+	dir := t.TempDir()
+	feed := make([]string, 6)
+	for i := range feed {
+		feed[i] = "row-content"
+	}
+	h := newMemHarnessOpts(t, memHarnessOpts{
+		cols:       10,
+		rows:       6,
+		persistDir: dir,
+		seedFeed:   feed,
+	})
+	defer h.serverConn.Close()
+
+	// Drive the initial snapshot+delta cycle (mirrors Task 12).
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: 10, Rows: 6})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+	h.Publish()
+	h.WaitForDelta(t, h.paneID, 2*time.Second)
+
+	sessionID := h.sessionID()
+
+	// Daemon restart: rebuild manager + connection against the same persist
+	// dir, replay Hello + ResumeRequest with sessionID.
+	h.Restart(t)
+	_ = sessionID
+
+	// Re-trigger the initial publishing path post-rehydrate. Like clean
+	// start, the new connection needs MsgClientReady to call
+	// sink.Snapshot(), and a viewport so the publisher emits a delta.
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+	h.ApplyViewport(h.paneID, 0, 3, true, false)
+	h.Publish()
+
+	delta := h.WaitForDelta(t, h.paneID, 2*time.Second)
+	rowIdxs := map[uint16]bool{}
+	for _, r := range delta.DecorRows {
+		rowIdxs[r.RowIdx] = true
+	}
+	if !rowIdxs[0] || !rowIdxs[5] {
+		t.Fatalf("post-rehydrate delta missing border DecorRows, got %v", rowIdxs)
+	}
+
+	// On a rehydrated session the first post-handshake sink.Publish() (run
+	// inside handleClientReady BEFORE the TreeSnapshot is written) can race
+	// the TreeSnapshot onto the wire because viewport pre-seed from disk
+	// makes the publisher emit immediately. As a result the BufferDelta
+	// that wakes WaitForDelta may be processed by the reader before the
+	// TreeSnapshot. Poll briefly so the test does not depend on which
+	// message the reader handled first.
+	deadline := time.Now().Add(2 * time.Second)
+	var pane *client.PaneState
+	for time.Now().Before(deadline) {
+		pane = h.ClientPane(h.paneID)
+		if pane != nil && pane.ContentTopRow == 1 && pane.NumContentRows == 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if pane == nil {
+		t.Fatalf("client cache missing pane after rehydrate")
+	}
+	if pane.ContentTopRow != 1 || pane.NumContentRows != 4 {
+		t.Fatalf("client content bounds wrong after rehydrate: top=%d num=%d", pane.ContentTopRow, pane.NumContentRows)
+	}
+	if _, ok := pane.DecorRowAt(0); !ok {
+		t.Fatalf("decoration cache missing rowIdx 0 after rehydrate")
+	}
+	if _, ok := pane.DecorRowAt(5); !ok {
+		t.Fatalf("decoration cache missing rowIdx 5 after rehydrate")
 	}
 }

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -18,6 +18,7 @@ package server
 import (
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -1066,13 +1067,9 @@ func (h *memHarness) ResetDeltaTracker(paneID [16]byte) {
 	h.lastDelta.reset(paneID)
 }
 
-// FocusPane drives a focus change to the given pane ID. The workspace's
-// internal tree state is unexported and there is no public, non-destructive
-// "focus pane by ID" API on Workspace or DesktopEngine today. For now this
-// helper is a no-op when paneID already matches ActivePane().ID(), and
-// otherwise fatals with a TODO. Task 15 is expected to either inline a
-// keyboard-event-based focus drive or add a public Workspace.FocusByID
-// API in the texel package.
+// FocusPane drives a focus change to the given pane ID via the public
+// Workspace.FocusByID API added for Task 15. No-op when the target is
+// already active.
 func (h *memHarness) FocusPane(paneID [16]byte) {
 	h.t.Helper()
 	ws := h.desktop.ActiveWorkspace()
@@ -1082,7 +1079,9 @@ func (h *memHarness) FocusPane(paneID [16]byte) {
 	if cur := ws.ActivePane(); cur != nil && cur.ID() == paneID {
 		return
 	}
-	h.t.Fatalf("FocusPane: target %x is not currently active and no public focus-by-ID API exists; Task 15 must add one (or inline a keyboard event)", paneID)
+	if !ws.FocusByID(paneID) {
+		h.t.Fatalf("FocusPane: FocusByID(%x) returned false (pane not found in active workspace)", paneID)
+	}
 }
 
 // Restart shuts the in-process server down, recreates the Manager + Server
@@ -1438,5 +1437,128 @@ func TestPaneRenders_AllFourBorders_ScrolledMidHistory(t *testing.T) {
 	}
 	if _, ok := pane.DecorRowAt(5); !ok {
 		t.Fatalf("scrolled state lost bottom border decoration")
+	}
+}
+
+// decorRowResolvedAt returns the (text, style-entry) pairs of a decoration
+// row at rowIdx in d, with span StyleIndex resolved against d.Styles. This
+// makes equality comparisons across two deltas meaningful: the per-delta
+// StyleIndex values are not stable, but the underlying StyleEntry values
+// are. Returns nil if the row is not present.
+type resolvedSpan struct {
+	Text  string
+	Style protocol.StyleEntry
+}
+
+func decorRowResolved(d protocol.BufferDelta, rowIdx uint16) []resolvedSpan {
+	for _, r := range d.DecorRows {
+		if r.RowIdx != rowIdx {
+			continue
+		}
+		out := make([]resolvedSpan, len(r.Spans))
+		for i, sp := range r.Spans {
+			var style protocol.StyleEntry
+			if int(sp.StyleIndex) < len(d.Styles) {
+				style = d.Styles[sp.StyleIndex]
+			}
+			out[i] = resolvedSpan{Text: sp.Text, Style: style}
+		}
+		return out
+	}
+	return nil
+}
+
+// TestPaneRenders_FocusChangeRepaintsBorders verifies that a focus change
+// in a two-pane workspace causes BOTH panes to ship fresh decoration rows
+// AND that the new border cells differ from the old (i.e. the active vs
+// inactive theme distinction round-trips through bufferToDelta and the
+// client-side ApplyDelta paths exercised by Tasks 7-14).
+func TestPaneRenders_FocusChangeRepaintsBorders(t *testing.T) {
+	// Workspace.PerformSplit enforces MinPaneWidth=20 / MinPaneHeight=8;
+	// twoPanes splits Vertical so cols must be >= 40.
+	const cols, rows = 40, 8
+	h := newMemHarnessOpts(t, memHarnessOpts{cols: cols, rows: rows, twoPanes: true})
+	defer h.serverConn.Close()
+
+	// Drive the initial snapshot+delta cycle so both panes have shipped at
+	// least one BufferDelta and we have a baseline to compare against.
+	readyPayload, err := protocol.EncodeClientReady(protocol.ClientReady{Cols: cols, Rows: rows})
+	if err != nil {
+		t.Fatalf("encode client ready: %v", err)
+	}
+	h.writeFrame(protocol.MsgClientReady, readyPayload, h.sessionID())
+	h.ApplyViewport(h.paneIDs[0], 0, 3, true, false)
+	h.ApplyViewport(h.paneIDs[1], 0, 3, true, false)
+	h.Publish()
+
+	deltaA0 := h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
+	deltaB0 := h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
+	if len(deltaA0.DecorRows) == 0 {
+		t.Fatalf("pane A initial delta missing DecorRows")
+	}
+	if len(deltaB0.DecorRows) == 0 {
+		t.Fatalf("pane B initial delta missing DecorRows")
+	}
+
+	// Capture the initial border style of each pane before focus change.
+	// Resolve StyleIndex against the per-delta Styles table so the
+	// post-focus comparison is style-content-aware (per-delta StyleIndex
+	// values themselves are not stable across deltas).
+	prevBorderA := decorRowResolved(deltaA0, 0)
+	prevBorderB := decorRowResolved(deltaB0, 0)
+
+	// Snapshot what we've seen so subsequent WaitForDelta returns only NEW
+	// deltas triggered by the focus change.
+	h.ResetDeltaTracker(h.paneIDs[0])
+	h.ResetDeltaTracker(h.paneIDs[1])
+
+	// Confirm the workspace's notion of "active" matches paneIDs[0] before
+	// we drive the change, so the post-focus deltas really do represent a
+	// transition. (twoPanes=true splits via PerformSplit which leaves the
+	// new leaf active per Tree.SplitActive semantics, so paneIDs[1] is
+	// actually the active one at this point — driving FocusPane back to
+	// paneIDs[1] after toggling away tests the same invariant either way.)
+	ws := h.desktop.ActiveWorkspace()
+	if ws == nil || ws.ActivePane() == nil {
+		t.Fatalf("no active pane in workspace before focus drive")
+	}
+	curID := ws.ActivePane().ID()
+	var targetID [16]byte
+	if curID == h.paneIDs[0] {
+		targetID = h.paneIDs[1]
+	} else {
+		targetID = h.paneIDs[0]
+	}
+
+	h.FocusPane(targetID)
+	h.Publish()
+
+	deltaA := h.WaitForDelta(t, h.paneIDs[0], 2*time.Second)
+	deltaB := h.WaitForDelta(t, h.paneIDs[1], 2*time.Second)
+	if len(deltaA.DecorRows) == 0 {
+		t.Fatalf("pane A focus toggle did not emit DecorRows")
+	}
+	if len(deltaB.DecorRows) == 0 {
+		t.Fatalf("pane B focus toggle did not emit DecorRows")
+	}
+
+	// Critical assertion: the new border cells must differ from the old —
+	// otherwise the test passes vacuously when both panes paint identical
+	// chrome regardless of focus state. Comparing resolved styles (text +
+	// fully-decoded StyleEntry) catches the active/inactive theme color
+	// difference even when per-delta StyleIndex numbering shifts.
+	newBorderA := decorRowResolved(deltaA, 0)
+	newBorderB := decorRowResolved(deltaB, 0)
+	if prevBorderA == nil || newBorderA == nil {
+		t.Fatalf("pane A missing rowIdx 0 decoration row (prev=%v new=%v)", prevBorderA, newBorderA)
+	}
+	if prevBorderB == nil || newBorderB == nil {
+		t.Fatalf("pane B missing rowIdx 0 decoration row (prev=%v new=%v)", prevBorderB, newBorderB)
+	}
+	if reflect.DeepEqual(prevBorderA, newBorderA) {
+		t.Fatalf("pane A border at rowIdx 0 did not change on focus toggle; theme may be missing an active/inactive distinction\nprev=%+v\nnew=%+v", prevBorderA, newBorderA)
+	}
+	if reflect.DeepEqual(prevBorderB, newBorderB) {
+		t.Fatalf("pane B border at rowIdx 0 did not change on focus toggle; theme may be missing an active/inactive distinction\nprev=%+v\nnew=%+v", prevBorderB, newBorderB)
 	}
 }

--- a/protocol/buffer_delta.go
+++ b/protocol/buffer_delta.go
@@ -23,6 +23,11 @@ const (
 	BufferDeltaAltScreen BufferDeltaFlags = 1 << 0
 )
 
+// MaxDecorRowIdx caps a decoration row's absolute rowIdx to a sane pane
+// height. Real panes never exceed a few thousand rows; values above this
+// signal a corrupt or hostile payload.
+const MaxDecorRowIdx uint16 = 4096
+
 // ColorModel represents how colours are encoded for a style.
 type ColorModel uint8
 
@@ -88,14 +93,24 @@ type RowDelta struct {
 	Spans []CellSpan
 }
 
+// DecorRowDelta carries a single positional decoration row (border, app
+// statusbar). RowIdx is the absolute rowIdx in the pane buffer — distinct
+// from RowDelta.Row, which is gid - RowBase. Wire byte layout matches
+// RowDelta exactly; the type is separate to prevent accidental mixing.
+type DecorRowDelta struct {
+	RowIdx uint16
+	Spans  []CellSpan
+}
+
 // BufferDelta is the payload sent by the server to update pane contents.
 type BufferDelta struct {
-	PaneID   [16]byte
-	Revision uint32
-	Flags    BufferDeltaFlags
-	RowBase  int64
-	Styles   []StyleEntry
-	Rows     []RowDelta
+	PaneID    [16]byte
+	Revision  uint32
+	Flags     BufferDeltaFlags
+	RowBase   int64
+	Styles    []StyleEntry
+	Rows      []RowDelta
+	DecorRows []DecorRowDelta // rows keyed by absolute rowIdx (borders + app decoration)
 }
 
 var (
@@ -240,6 +255,47 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 		}
 	}
 
+	if len(delta.DecorRows) > 0xFFFF {
+		return nil, ErrBufferTooLarge
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(delta.DecorRows))); err != nil {
+		return nil, err
+	}
+	for _, row := range delta.DecorRows {
+		if len(row.Spans) > 0xFFFF {
+			return nil, ErrBufferTooLarge
+		}
+		if err := binary.Write(buf, binary.LittleEndian, row.RowIdx); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, uint16(len(row.Spans))); err != nil {
+			return nil, err
+		}
+		for _, span := range row.Spans {
+			textBytes := []byte(span.Text)
+			if len(textBytes) > 0xFFFF {
+				return nil, ErrInvalidSpan
+			}
+			if int(span.StyleIndex) >= len(delta.Styles) {
+				return nil, ErrStyleIndexOutOfRange
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StartCol); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, uint16(len(textBytes))); err != nil {
+				return nil, err
+			}
+			if err := binary.Write(buf, binary.LittleEndian, span.StyleIndex); err != nil {
+				return nil, err
+			}
+			if len(textBytes) > 0 {
+				if _, err := buf.Write(textBytes); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
 	return buf.Bytes(), nil
 }
 
@@ -347,5 +403,51 @@ func DecodeBufferDelta(b []byte) (BufferDelta, error) {
 		delta.Rows[i] = RowDelta{Row: row, Spans: spans}
 	}
 
+	// v3 tail: DecorRows. The 2-byte count is mandatory — no v2 fallback.
+	if len(b) < 2 {
+		return delta, ErrPayloadShort
+	}
+	decorCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if decorCount > 0 {
+		delta.DecorRows = make([]DecorRowDelta, decorCount)
+		for i := 0; i < int(decorCount); i++ {
+			if len(b) < 4 {
+				return delta, ErrPayloadShort
+			}
+			rowIdx := binary.LittleEndian.Uint16(b[:2])
+			spanCount := binary.LittleEndian.Uint16(b[2:4])
+			b = b[4:]
+			// Defensive bound: a sane pane is at most a few thousand rows
+			// tall. A RowIdx beyond MaxDecorRowIdx indicates a corrupt or
+			// hostile payload — reject rather than balloon client memory.
+			if rowIdx > MaxDecorRowIdx {
+				return delta, ErrInvalidSpan
+			}
+			spans := make([]CellSpan, spanCount)
+			for s := 0; s < int(spanCount); s++ {
+				if len(b) < 6 {
+					return delta, ErrPayloadShort
+				}
+				startCol := binary.LittleEndian.Uint16(b[:2])
+				textLen := binary.LittleEndian.Uint16(b[2:4])
+				styleIndex := binary.LittleEndian.Uint16(b[4:6])
+				b = b[6:]
+				if len(b) < int(textLen) {
+					return delta, ErrPayloadShort
+				}
+				text := string(b[:textLen])
+				b = b[textLen:]
+				if int(styleIndex) >= int(styleCount) {
+					return delta, ErrStyleIndexOutOfRange
+				}
+				spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
+			}
+			delta.DecorRows[i] = DecorRowDelta{RowIdx: rowIdx, Spans: spans}
+		}
+	}
+	if len(b) != 0 {
+		return delta, ErrPayloadShort
+	}
 	return delta, nil
 }

--- a/protocol/buffer_delta.go
+++ b/protocol/buffer_delta.go
@@ -262,6 +262,9 @@ func EncodeBufferDelta(delta BufferDelta) ([]byte, error) {
 		return nil, err
 	}
 	for _, row := range delta.DecorRows {
+		if row.RowIdx > MaxDecorRowIdx {
+			return nil, ErrInvalidSpan
+		}
 		if len(row.Spans) > 0xFFFF {
 			return nil, ErrBufferTooLarge
 		}
@@ -409,42 +412,40 @@ func DecodeBufferDelta(b []byte) (BufferDelta, error) {
 	}
 	decorCount := binary.LittleEndian.Uint16(b[:2])
 	b = b[2:]
-	if decorCount > 0 {
-		delta.DecorRows = make([]DecorRowDelta, decorCount)
-		for i := 0; i < int(decorCount); i++ {
-			if len(b) < 4 {
+	delta.DecorRows = make([]DecorRowDelta, decorCount)
+	for i := 0; i < int(decorCount); i++ {
+		if len(b) < 4 {
+			return delta, ErrPayloadShort
+		}
+		rowIdx := binary.LittleEndian.Uint16(b[:2])
+		spanCount := binary.LittleEndian.Uint16(b[2:4])
+		b = b[4:]
+		// Defensive bound: a sane pane is at most a few thousand rows
+		// tall. A RowIdx beyond MaxDecorRowIdx indicates a corrupt or
+		// hostile payload — reject rather than balloon client memory.
+		if rowIdx > MaxDecorRowIdx {
+			return delta, ErrInvalidSpan
+		}
+		spans := make([]CellSpan, spanCount)
+		for s := 0; s < int(spanCount); s++ {
+			if len(b) < 6 {
 				return delta, ErrPayloadShort
 			}
-			rowIdx := binary.LittleEndian.Uint16(b[:2])
-			spanCount := binary.LittleEndian.Uint16(b[2:4])
-			b = b[4:]
-			// Defensive bound: a sane pane is at most a few thousand rows
-			// tall. A RowIdx beyond MaxDecorRowIdx indicates a corrupt or
-			// hostile payload — reject rather than balloon client memory.
-			if rowIdx > MaxDecorRowIdx {
-				return delta, ErrInvalidSpan
+			startCol := binary.LittleEndian.Uint16(b[:2])
+			textLen := binary.LittleEndian.Uint16(b[2:4])
+			styleIndex := binary.LittleEndian.Uint16(b[4:6])
+			b = b[6:]
+			if len(b) < int(textLen) {
+				return delta, ErrPayloadShort
 			}
-			spans := make([]CellSpan, spanCount)
-			for s := 0; s < int(spanCount); s++ {
-				if len(b) < 6 {
-					return delta, ErrPayloadShort
-				}
-				startCol := binary.LittleEndian.Uint16(b[:2])
-				textLen := binary.LittleEndian.Uint16(b[2:4])
-				styleIndex := binary.LittleEndian.Uint16(b[4:6])
-				b = b[6:]
-				if len(b) < int(textLen) {
-					return delta, ErrPayloadShort
-				}
-				text := string(b[:textLen])
-				b = b[textLen:]
-				if int(styleIndex) >= int(styleCount) {
-					return delta, ErrStyleIndexOutOfRange
-				}
-				spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
+			text := string(b[:textLen])
+			b = b[textLen:]
+			if int(styleIndex) >= int(styleCount) {
+				return delta, ErrStyleIndexOutOfRange
 			}
-			delta.DecorRows[i] = DecorRowDelta{RowIdx: rowIdx, Spans: spans}
+			spans[s] = CellSpan{StartCol: startCol, Text: text, StyleIndex: styleIndex}
 		}
+		delta.DecorRows[i] = DecorRowDelta{RowIdx: rowIdx, Spans: spans}
 	}
 	if len(b) != 0 {
 		return delta, ErrPayloadShort

--- a/protocol/buffer_delta_test.go
+++ b/protocol/buffer_delta_test.go
@@ -371,20 +371,78 @@ func TestDecodeBufferDelta_TruncatedMidDecorRow(t *testing.T) {
 }
 
 func TestDecodeBufferDelta_RejectsExcessiveRowIdx(t *testing.T) {
-	// Hand-craft a payload with RowIdx > MaxDecorRowIdx (out of sane pane height).
+	// Encode a valid delta with an in-range RowIdx, then patch the wire
+	// bytes to push RowIdx past MaxDecorRowIdx. This lets us exercise the
+	// decoder's bound-check independently of the encoder's matching check.
 	original := BufferDelta{
 		PaneID:   [16]byte{0x03},
 		Revision: 1,
 		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
 		DecorRows: []DecorRowDelta{
-			{RowIdx: MaxDecorRowIdx + 1, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}},
+			{RowIdx: 0, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}},
 		},
 	}
 	encoded, err := EncodeBufferDelta(original)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	if _, err := DecodeBufferDelta(encoded); !errors.Is(err, ErrInvalidSpan) {
+	// Locate the DecorRow's RowIdx bytes: tail consists of decorCount(2)
+	// then RowIdx(2). Patch the trailing RowIdx by scanning from the end.
+	// Layout for the single-decor-row tail:
+	//   ... decorCount=1(2) | rowIdx(2) | spanCount=1(2) | startCol=0(2)
+	//       | textLen=1(2) | styleIdx=0(2) | "x"(1)
+	// rowIdx sits 11 bytes before end.
+	patched := make([]byte, len(encoded))
+	copy(patched, encoded)
+	bad := MaxDecorRowIdx + 1
+	patched[len(patched)-11] = byte(bad)
+	patched[len(patched)-10] = byte(bad >> 8)
+	if _, err := DecodeBufferDelta(patched); !errors.Is(err, ErrInvalidSpan) {
 		t.Fatalf("expected ErrInvalidSpan for excessive RowIdx, got %v", err)
+	}
+}
+
+func TestDecodeBufferDelta_EmptyDecorRoundTripPreservesEmptyVsNil(t *testing.T) {
+	// Producer encodes an explicitly empty (non-nil) DecorRows. Decoder
+	// must produce a non-nil slice of length 0, matching the existing
+	// delta.Rows behaviour. Without unconditional make, this would
+	// round-trip to nil and break reflect.DeepEqual for callers that
+	// pre-allocate empty slices.
+	original := BufferDelta{
+		PaneID:    [16]byte{0xab},
+		Revision:  1,
+		Styles:    []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		Rows:      []RowDelta{{Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+		DecorRows: []DecorRowDelta{},
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.DecorRows == nil {
+		t.Fatal("expected non-nil empty DecorRows after round-trip, got nil")
+	}
+	if len(decoded.DecorRows) != 0 {
+		t.Fatalf("expected len 0, got %d", len(decoded.DecorRows))
+	}
+}
+
+func TestEncodeBufferDelta_RejectsExcessiveRowIdx(t *testing.T) {
+	// Encoder must enforce the same bound the decoder enforces. Avoids
+	// shipping wire bytes that consumers will reject.
+	delta := BufferDelta{
+		PaneID:   [16]byte{0xab},
+		Revision: 1,
+		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		DecorRows: []DecorRowDelta{
+			{RowIdx: MaxDecorRowIdx + 1, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}},
+		},
+	}
+	if _, err := EncodeBufferDelta(delta); !errors.Is(err, ErrInvalidSpan) {
+		t.Fatalf("expected ErrInvalidSpan, got %v", err)
 	}
 }

--- a/protocol/buffer_delta_test.go
+++ b/protocol/buffer_delta_test.go
@@ -8,7 +8,11 @@
 
 package protocol
 
-import "testing"
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
 
 func TestBufferDeltaRoundTrip(t *testing.T) {
 	var pane [16]byte
@@ -268,5 +272,119 @@ func TestEncodeBufferDeltaRejectsStyleIndexOutOfRange(t *testing.T) {
 				t.Errorf("EncodeBufferDelta err = %v, want ErrStyleIndexOutOfRange", err)
 			}
 		})
+	}
+}
+
+func TestEncodeDecodeBufferDelta_DecorRoundTrip(t *testing.T) {
+	original := BufferDelta{
+		PaneID:   [16]byte{0xab, 0xcd},
+		Revision: 7,
+		Flags:    BufferDeltaNone,
+		RowBase:  100,
+		Styles: []StyleEntry{
+			{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault},
+		},
+		Rows: []RowDelta{
+			{Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "hi", StyleIndex: 0}}},
+		},
+		DecorRows: []DecorRowDelta{
+			{RowIdx: 0, Spans: []CellSpan{{StartCol: 0, Text: "+", StyleIndex: 0}}},
+			{RowIdx: 22, Spans: []CellSpan{{StartCol: 0, Text: "-", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(original, decoded) {
+		t.Fatalf("round-trip mismatch:\n  want %+v\n  got  %+v", original, decoded)
+	}
+}
+
+func TestEncodeDecodeBufferDelta_EmptyDecorRoundTrip(t *testing.T) {
+	original := BufferDelta{
+		PaneID:   [16]byte{0xff},
+		Revision: 1,
+		Flags:    BufferDeltaAltScreen,
+		RowBase:  0,
+		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		Rows:     []RowDelta{{Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+		// DecorRows intentionally nil
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeBufferDelta(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(decoded.DecorRows) != 0 {
+		t.Fatalf("expected empty DecorRows, got %+v", decoded.DecorRows)
+	}
+}
+
+func TestDecodeBufferDelta_TruncatedDecorTailErrPayloadShort(t *testing.T) {
+	// Build a valid v3 payload then chop the trailing 2-byte decor count.
+	original := BufferDelta{
+		PaneID:   [16]byte{0x01},
+		Revision: 1,
+		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		Rows:     []RowDelta{{Row: 0, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}}},
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	truncated := encoded[:len(encoded)-2]
+	if _, err := DecodeBufferDelta(truncated); !errors.Is(err, ErrPayloadShort) {
+		t.Fatalf("expected ErrPayloadShort on truncated v3, got %v", err)
+	}
+}
+
+func TestDecodeBufferDelta_TruncatedMidDecorRow(t *testing.T) {
+	// Build a payload with one DecorRow that has one span, then truncate
+	// inside the per-row body (after the row+spanCount header but before
+	// the span itself).
+	original := BufferDelta{
+		PaneID:   [16]byte{0x02},
+		Revision: 1,
+		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		DecorRows: []DecorRowDelta{
+			{RowIdx: 0, Spans: []CellSpan{{StartCol: 0, Text: "border", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	// Chop off the last 6 bytes (the per-span StartCol+TextLen+StyleIdx
+	// header), leaving the row+spanCount header dangling without span data.
+	truncated := encoded[:len(encoded)-len("border")-6]
+	if _, err := DecodeBufferDelta(truncated); !errors.Is(err, ErrPayloadShort) {
+		t.Fatalf("expected ErrPayloadShort on mid-row truncation, got %v", err)
+	}
+}
+
+func TestDecodeBufferDelta_RejectsExcessiveRowIdx(t *testing.T) {
+	// Hand-craft a payload with RowIdx > MaxDecorRowIdx (out of sane pane height).
+	original := BufferDelta{
+		PaneID:   [16]byte{0x03},
+		Revision: 1,
+		Styles:   []StyleEntry{{AttrFlags: 0, FgModel: ColorModelDefault, BgModel: ColorModelDefault}},
+		DecorRows: []DecorRowDelta{
+			{RowIdx: MaxDecorRowIdx + 1, Spans: []CellSpan{{StartCol: 0, Text: "x", StyleIndex: 0}}},
+		},
+	}
+	encoded, err := EncodeBufferDelta(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if _, err := DecodeBufferDelta(encoded); !errors.Is(err, ErrInvalidSpan) {
+		t.Fatalf("expected ErrInvalidSpan for excessive RowIdx, got %v", err)
 	}
 }

--- a/protocol/messages.go
+++ b/protocol/messages.go
@@ -191,16 +191,18 @@ type ClientReady struct {
 
 // PaneSnapshot describes the full buffer content for a single pane.
 type PaneSnapshot struct {
-	PaneID    [16]byte
-	Revision  uint32
-	Title     string
-	Rows      []string
-	X         int32
-	Y         int32
-	Width     int32
-	Height    int32
-	AppType   string
-	AppConfig string
+	PaneID         [16]byte
+	Revision       uint32
+	Title          string
+	Rows           []string
+	X              int32
+	Y              int32
+	Width          int32
+	Height         int32
+	AppType        string
+	AppConfig      string
+	ContentTopRow  uint16 // first content rowIdx (ignored when NumContentRows == 0)
+	NumContentRows uint16 // count of content rows; 0 means the pane is all-decoration
 }
 
 // SplitKind describes how an internal node divides space among children.
@@ -1002,6 +1004,12 @@ func EncodeTreeSnapshot(snapshot TreeSnapshot) ([]byte, error) {
 		if err := encodeString(buf, pane.AppConfig); err != nil {
 			return nil, err
 		}
+		if err := binary.Write(buf, binary.LittleEndian, pane.ContentTopRow); err != nil {
+			return nil, err
+		}
+		if err := binary.Write(buf, binary.LittleEndian, pane.NumContentRows); err != nil {
+			return nil, err
+		}
 	}
 	if err := encodeTreeNode(buf, snapshot.Root); err != nil {
 		return nil, err
@@ -1059,6 +1067,12 @@ func DecodeTreeSnapshot(b []byte) (TreeSnapshot, error) {
 		}
 		pane.AppType = appType
 		pane.AppConfig = config
+		if len(remaining) < 4 {
+			return snapshot, ErrPayloadShort
+		}
+		pane.ContentTopRow = binary.LittleEndian.Uint16(remaining[0:2])
+		pane.NumContentRows = binary.LittleEndian.Uint16(remaining[2:4])
+		remaining = remaining[4:]
 		snapshot.Panes[i] = pane
 		b = remaining
 	}

--- a/protocol/messages_test.go
+++ b/protocol/messages_test.go
@@ -397,3 +397,56 @@ func BenchmarkEncodeBufferDelta(b *testing.B) {
 		}
 	}
 }
+
+func TestEncodeDecodeTreeSnapshot_ContentBoundsRoundTrip(t *testing.T) {
+	original := TreeSnapshot{
+		Panes: []PaneSnapshot{
+			{
+				PaneID:   [16]byte{0xaa},
+				Revision: 3,
+				Title:    "term",
+				Rows:     nil,
+				X:        0, Y: 0, Width: 80, Height: 24,
+				AppType:        "texelterm",
+				AppConfig:      "",
+				ContentTopRow:  1,
+				NumContentRows: 21,
+			},
+		},
+		Root: TreeNodeSnapshot{PaneIndex: 0, Split: SplitNone},
+	}
+	encoded, err := EncodeTreeSnapshot(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeTreeSnapshot(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Panes[0].ContentTopRow != 1 || decoded.Panes[0].NumContentRows != 21 {
+		t.Fatalf("content bounds mismatch: got top=%d num=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].NumContentRows)
+	}
+}
+
+func TestEncodeDecodeTreeSnapshot_ZeroContent(t *testing.T) {
+	original := TreeSnapshot{
+		Panes: []PaneSnapshot{{
+			PaneID:         [16]byte{0xbb},
+			Title:          "all-decor",
+			ContentTopRow:  0,
+			NumContentRows: 0, // unambiguous: no content rows
+		}},
+		Root: TreeNodeSnapshot{PaneIndex: 0, Split: SplitNone},
+	}
+	encoded, err := EncodeTreeSnapshot(original)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	decoded, err := DecodeTreeSnapshot(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if decoded.Panes[0].ContentTopRow != 0 || decoded.Panes[0].NumContentRows != 0 {
+		t.Fatalf("zero-content mismatch: got top=%d num=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].NumContentRows)
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -32,7 +32,7 @@ const (
 // PaneViewportState records). Bumping the version lets pre-Plan-B clients
 // receive an explicit handshake rejection instead of a mysterious
 // ErrPayloadShort on the first resume attempt.
-const Version uint8 = 2
+const Version uint8 = 3
 
 // MessageType enumerates the canonical message categories exchanged between
 // client and server.

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -126,3 +126,9 @@ func TestReadMessage_PayloadTooLarge(t *testing.T) {
 		t.Fatalf("expected ErrPayloadTooLarge, got %v", err)
 	}
 }
+
+func TestProtocolVersionIs3(t *testing.T) {
+	if Version != 3 {
+		t.Fatalf("expected Version=3, got %d", Version)
+	}
+}

--- a/texel/pane_render.go
+++ b/texel/pane_render.go
@@ -7,6 +7,8 @@
 package texel
 
 import (
+	"log"
+	"os"
 	"sync/atomic"
 
 	"github.com/framegrace/texelation/internal/debuglog"
@@ -15,6 +17,13 @@ import (
 	"github.com/framegrace/texelui/theme"
 	"github.com/gdamore/tcell/v2"
 )
+
+// renderDebug is gated by env var TEXELATION_DEBUG=1. When enabled, each
+// renderBuffer logs the pane id, dimensions, and the runes at (0,1), (1,1),
+// (w-1,1) so we can confirm the SERVER-side buffer has correct side borders
+// on the first interior row before publishing. Setting this on every
+// invocation would flood logs; we keep the check cheap and gated.
+var renderDebug = os.Getenv("TEXELATION_DEBUG") == "1"
 
 // markDirty flags this pane for re-render on the next snapshot cycle.
 func (p *pane) markDirty() {
@@ -186,6 +195,21 @@ func (p *pane) renderBuffer(applyEffects bool) [][]Cell {
 	p.prevBuf = buffer
 	p.prevTitle = currentTitle
 	p.lastRendered = gen
+
+	if renderDebug && h > 2 && w > 2 {
+		paneID := p.ID()
+		row1 := buffer[1]
+		appW, appH := 0, 0
+		if len(appBuffer) > 0 {
+			appH = len(appBuffer)
+			appW = len(appBuffer[0])
+		}
+		bx, by := p.bufferWidget.Position()
+		bw, bh := p.bufferWidget.Size()
+		log.Printf("renderDebug pane=%x w=%d h=%d row1=[%q,%q,%q] appBuf=%dx%d bufWidget=(%d,%d)+%dx%d",
+			paneID[:4], w, h, row1[0].Ch, row1[1].Ch, row1[w-1].Ch,
+			appW, appH, bx, by, bw, bh)
+	}
 
 	return buffer
 }

--- a/texel/pane_render.go
+++ b/texel/pane_render.go
@@ -145,8 +145,27 @@ func (p *pane) renderBuffer(applyEffects bool) [][]Cell {
 		p.wasActive = p.IsActive
 	}
 
-	// Swap buffer reference into the child widget.
+	// Swap buffer reference into the child widget, then re-clamp the
+	// widget to the border's ClientRect.
+	//
+	// BufferWidget.SetBuffer auto-resizes the widget to the buffer's
+	// dimensions. That's wrong here: when the embedded app's buffer
+	// happens to match the OUTER pane size (e.g. a non-resizing test
+	// fake, or a transient state where the app has not yet honoured the
+	// drawable shrink we requested in setDimensions), the widget's draw
+	// loop overruns the pane's right border at col W-1 and the bottom
+	// border at row H-1. Re-clamping to ClientRect (the inner
+	// W-2 × H-2 region at offset (1,1)) restores the contract: the
+	// child paints inside the border, never on top of it. The widget's
+	// Draw loop is bounded by min(widget.Size, len(buffer)), so a
+	// smaller widget with a larger buffer renders only the top-left
+	// portion that fits — the desired behaviour. This is the source-
+	// of-truth fix for the 1-column / 1-row "decoration overrun" the
+	// publisher then dutifully ships to the client.
 	p.bufferWidget.SetBuffer(appBuffer)
+	cr := p.border.ClientRect()
+	p.bufferWidget.SetPosition(cr.X, cr.Y)
+	p.bufferWidget.Resize(cr.W, cr.H)
 
 	// Draw through the persistent widget tree.
 	painter := texelcore.NewPainter(buffer, texelcore.Rect{X: 0, Y: 0, W: w, H: h})

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -367,12 +367,13 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 }
 
 // computeContentBounds returns (ContentTopRow, NumContentRows) for the
-// given RowGlobalIdx slice. If no row has gid>=0, returns (0, 0).
-// Requires contiguity: every index in [top, last] must have gid >= 0,
-// and every index outside that range must have gid < 0. Logs a warning
-// and returns (0, 0) on violation rather than producing a bogus range —
-// a non-contiguous layout is a bug somewhere up the stack and the
-// renderer falling back to all-decoration is recoverable.
+// given RowGlobalIdx slice. The bounds span from the first index with
+// gid>=0 to the last such index (inclusive). Mid-range rows with gid<0
+// are tolerated — they represent content rows that have not yet been
+// written (e.g., a fresh terminal where only the prompt row has a gid).
+// The renderer's gid-lookup naturally returns nil for those rows,
+// rendering them blank, which is the desired behaviour. If no row has
+// gid>=0, returns (0, 0).
 func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 	top := -1
 	last := -1
@@ -387,13 +388,6 @@ func computeContentBounds(rowIdx []int64) (uint16, uint16) {
 	}
 	if top < 0 {
 		return 0, 0
-	}
-	// Verify contiguity: every index in [top, last] must have gid >= 0.
-	for y := top; y <= last; y++ {
-		if rowIdx[y] < 0 {
-			log.Printf("texel: computeContentBounds: non-contiguous content rows at y=%d (top=%d, last=%d); treating pane as all-decoration", y, top, last)
-			return 0, 0
-		}
 	}
 	return uint16(top), uint16(last - top + 1)
 }

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -325,6 +325,8 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		},
 	}
 	// p.app might be nil if capturing during split before attach, or if app crashed
+	var appIdx []int64
+	hasRowProvider := false
 	if p.app != nil {
 		if provider, ok := p.app.(SnapshotProvider); ok {
 			appType, config := provider.SnapshotMetadata()
@@ -334,9 +336,10 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		// Terminal-like apps expose per-row globalIdxs for their rendered
 		// content. The content buffer sits inside a 1-cell border at (1,1),
 		// so offset entries by +1 and stop short of the bottom-border row.
-		rowProvider, hasRowProvider := p.app.(RowGlobalIdxProvider)
+		rowProvider, ok := p.app.(RowGlobalIdxProvider)
+		hasRowProvider = ok
 		if hasRowProvider {
-			appIdx := rowProvider.RowGlobalIdx()
+			appIdx = rowProvider.RowGlobalIdx()
 			h := len(buf)
 			// Last writable interior row is h-2 (h-1 is the bottom border).
 			maxInteriorRow := h - 2
@@ -362,7 +365,26 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		snap.Title = "Loading..."
 		snap.AltScreen = true
 	}
-	snap.ContentTopRow, snap.NumContentRows = computeContentBounds(snap.RowGlobalIdx)
+	// ContentTopRow / NumContentRows describe the STRUCTURAL content area
+	// of the pane, independent of which content rows have actually been
+	// written. The client uses NumContentRows to compute the viewport
+	// anchor (top = maxGid - (NumContentRows-1)); deriving it from
+	// populated-gid count makes the viewport collapse to a sliver as
+	// content trickles in, which causes the server-side clip to drop
+	// earlier rows. Compute structurally instead: 1..h-2 is the pane
+	// interior; if the app reports a trailing decoration row (texterm
+	// internal statusbar pattern, where appIdx[last] < 0), shrink by 1.
+	h := len(buf)
+	if hasRowProvider && !snap.AltScreen && h > 2 {
+		n := h - 2
+		if len(appIdx) > 0 && appIdx[len(appIdx)-1] < 0 {
+			n--
+		}
+		if n > 0 {
+			snap.ContentTopRow = 1
+			snap.NumContentRows = uint16(n)
+		}
+	}
 	return snap
 }
 

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -35,6 +35,14 @@ type PaneSnapshot struct {
 	Rect      Rectangle
 	AppType   string
 	AppConfig map[string]interface{}
+	// ContentTopRow is the first rowIdx in Buffer with RowGlobalIdx[y] >= 0.
+	// NumContentRows is the count of indices with RowGlobalIdx[y] >= 0.
+	// NumContentRows == 0 means zero content rows (status panes, all-decoration
+	// apps); in that case ContentTopRow is meaningless. For alt-screen panes
+	// the fields are populated but unused — clients render alt-screen
+	// positionally regardless.
+	ContentTopRow  uint16
+	NumContentRows uint16
 }
 
 // Rectangle stores pane position and size in screen coordinates.
@@ -354,7 +362,40 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		snap.Title = "Loading..."
 		snap.AltScreen = true
 	}
+	snap.ContentTopRow, snap.NumContentRows = computeContentBounds(snap.RowGlobalIdx)
 	return snap
+}
+
+// computeContentBounds returns (ContentTopRow, NumContentRows) for the
+// given RowGlobalIdx slice. If no row has gid>=0, returns (0, 0).
+// Requires contiguity: every index in [top, last] must have gid >= 0,
+// and every index outside that range must have gid < 0. Logs a warning
+// and returns (0, 0) on violation rather than producing a bogus range —
+// a non-contiguous layout is a bug somewhere up the stack and the
+// renderer falling back to all-decoration is recoverable.
+func computeContentBounds(rowIdx []int64) (uint16, uint16) {
+	top := -1
+	last := -1
+	for y, gid := range rowIdx {
+		if gid < 0 {
+			continue
+		}
+		if top < 0 {
+			top = y
+		}
+		last = y
+	}
+	if top < 0 {
+		return 0, 0
+	}
+	// Verify contiguity: every index in [top, last] must have gid >= 0.
+	for y := top; y <= last; y++ {
+		if rowIdx[y] < 0 {
+			log.Printf("texel: computeContentBounds: non-contiguous content rows at y=%d (top=%d, last=%d); treating pane as all-decoration", y, top, last)
+			return 0, 0
+		}
+	}
+	return uint16(top), uint16(last - top + 1)
 }
 
 // allMinusOne returns a slice of length n filled with -1. Used as the

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -199,6 +199,16 @@ func (d *DesktopEngine) GeometryForClient() TreeCapture {
 							Height: n.Pane.Height(),
 						},
 					}
+					// Populate structural content bounds + AltScreen flag so
+					// the geometry-only snapshot carries the same content/layout
+					// metadata the full snapshot would. Without these, the client
+					// applies the snapshot during a resize, overwrites the pane's
+					// previously-correct ContentTopRow / NumContentRows with
+					// zeros, and then routes every interior rowIdx through the
+					// decoration-only branch of rowSourceForPane — leaving the
+					// content rows blank until the next full snapshot arrives.
+					// See issue #199 follow-up: "resize blanks content."
+					applyStructuralBounds(&snap, n.Pane)
 					paneIndex[n.Pane] = len(capture.Panes)
 					capture.Panes = append(capture.Panes, snap)
 				}
@@ -224,6 +234,45 @@ func (d *DesktopEngine) GeometryForClient() TreeCapture {
 		capture.Panes = append(capture.Panes, floating...)
 	}
 	return capture
+}
+
+// applyStructuralBounds populates snap.ContentTopRow, snap.NumContentRows,
+// and snap.AltScreen from the pane's app metadata WITHOUT rendering the
+// pane buffer. Mirrors the structural calculation in capturePaneSnapshot
+// (lines around `if hasRowProvider && !snap.AltScreen && h > 2`) so the
+// geometry-only snapshot used during resize carries the same bounds the
+// full snapshot would. The pane's height drives the structural answer; we
+// only need RowGlobalIdx() to detect the texterm "trailing statusbar"
+// pattern (last entry < 0).
+func applyStructuralBounds(snap *PaneSnapshot, p *pane) {
+	if p == nil || p.app == nil {
+		// Placeholder pane: no content bounds, alt-screen-equivalent.
+		snap.AltScreen = true
+		return
+	}
+	h := p.Height()
+	rowProvider, hasRowProvider := p.app.(RowGlobalIdxProvider)
+	if !hasRowProvider {
+		snap.AltScreen = true
+		return
+	}
+	if altProvider, ok := p.app.(AltScreenProvider); ok && altProvider.InAltScreen() {
+		snap.AltScreen = true
+		return
+	}
+	if h <= 2 {
+		return
+	}
+	n := h - 2
+	appIdx := rowProvider.RowGlobalIdx()
+	if len(appIdx) > 0 && appIdx[len(appIdx)-1] < 0 {
+		n--
+	}
+	if n <= 0 {
+		return
+	}
+	snap.ContentTopRow = 1
+	snap.NumContentRows = uint16(n)
 }
 
 // CaptureTree gathers panes and the layout tree for persistence or transport.

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -237,3 +237,159 @@ func TestApplyStructuralBounds_NonTerminalPane(t *testing.T) {
 		t.Fatalf("expected NumContentRows=0 for non-terminal app, got %d", snap.NumContentRows)
 	}
 }
+
+// snapshotTestStyledTerminalApp paints a non-default-styled content row.
+// This exercises the case where the BufferWidget actually paints into the
+// pane buffer (cells with style != tcell.StyleDefault are NOT skipped).
+type snapshotTestStyledTerminalApp struct {
+	snapshotTestTerminalApp
+}
+
+func (a *snapshotTestStyledTerminalApp) Render() [][]Cell {
+	rows := a.rows
+	cols := a.cols
+	if rows <= 0 {
+		rows = 1
+	}
+	if cols <= 0 {
+		cols = 1
+	}
+	// Use a style with explicit foreground so it is non-zero — BufferWidget
+	// will paint these cells into the pane buffer instead of skipping them.
+	contentStyle := tcell.StyleDefault.Foreground(tcell.ColorRed)
+	out := make([][]Cell, rows)
+	for y := range out {
+		out[y] = make([]Cell, cols)
+		for x := range out[y] {
+			out[y][x] = Cell{Ch: 'X', Style: contentStyle}
+		}
+	}
+	return out
+}
+
+// snapshotTestNoResizeApp is a styled terminal app that IGNORES Resize
+// requests and always returns a render buffer at its initial dimensions.
+// This mimics the sparseFakeApp pattern (Resize is a no-op) which makes
+// it possible for appBuffer to be larger than the pane's drawable area.
+type snapshotTestNoResizeApp struct {
+	snapshotTestStyledTerminalApp
+}
+
+func (a *snapshotTestNoResizeApp) Resize(cols, rows int) {
+	// no-op — keep initial dimensions
+}
+
+// TestPaneRenderBuffer_BordersSurviveOversizedAppBuffer reproduces the
+// d3921cb concern: an app whose Render() returns a buffer LARGER than the
+// pane's ClientRect. Without the d3921cb clamp, BufferWidget would paint
+// past col W-1 and row H-1, overwriting the borders. With d3921cb the
+// clamp keeps the child painting inside.
+func TestPaneRenderBuffer_BordersSurviveOversizedAppBuffer(t *testing.T) {
+	const w, h = 20, 6
+	rowIdx := []int64{100, 101, 102, 103}
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = w, h
+	app := &snapshotTestNoResizeApp{
+		snapshotTestStyledTerminalApp: snapshotTestStyledTerminalApp{
+			snapshotTestTerminalApp: snapshotTestTerminalApp{
+				// Initialize with FULL pane dims, so Render returns a w×h
+				// buffer instead of the expected (w-2)×(h-2).
+				snapshotTestApp: snapshotTestApp{title: "term", cols: w, rows: h},
+				rowIdx:          rowIdx,
+			},
+		},
+	}
+	p.app = app
+
+	buf := p.renderBuffer(false)
+	if len(buf) != h {
+		t.Fatalf("render buffer height = %d, want %d", len(buf), h)
+	}
+	for y, row := range buf {
+		if len(row) != w {
+			t.Fatalf("row %d width = %d, want %d", y, len(row), w)
+		}
+	}
+
+	// Interior rows must keep '│' at col 0 and col W-1 even though the
+	// app's render buffer was oversized.
+	for y := 1; y < h-1; y++ {
+		got0 := buf[y][0].Ch
+		gotR := buf[y][w-1].Ch
+		if got0 != '│' && got0 != '|' {
+			t.Errorf("row %d col 0 = %q, want '│' (left border overwritten by oversized app buffer)", y, got0)
+		}
+		if gotR != '│' && gotR != '|' {
+			t.Errorf("row %d col W-1 = %q, want '│' (right border overwritten by oversized app buffer)", y, gotR)
+		}
+	}
+	// Bottom row keeps its horizontal border characters.
+	if buf[h-1][1].Ch != '─' && buf[h-1][1].Ch != '-' {
+		t.Errorf("bottom border row col 1 = %q, want '─'", buf[h-1][1].Ch)
+	}
+	// Top row corners are still '╭' and '╮' (or '┌' / '┐').
+	if buf[0][0].Ch != '╭' && buf[0][0].Ch != '┌' {
+		t.Errorf("top border row col 0 = %q, want corner glyph", buf[0][0].Ch)
+	}
+	if buf[0][w-1].Ch != '╮' && buf[0][w-1].Ch != '┐' {
+		t.Errorf("top border row col W-1 = %q, want corner glyph", buf[0][w-1].Ch)
+	}
+}
+
+// TestPaneRenderBuffer_BordersSurviveStyledContent reproduces the server-side
+// half of the issue #199 follow-up "patchy border / 1-col left shift" bug.
+//
+// Setup: a terminal-style app whose Render() returns a (w-2, h-2) buffer
+// of cells with a NON-DEFAULT style (so BufferWidget paints them, not
+// skips them). This mirrors texterm after `ls<enter>` — the prompt is
+// painted with explicit fg/bg from the palette, no longer pure
+// StyleDefault. The pane must still produce border chars at col 0 and
+// col W-1 of every interior row.
+//
+// If this fails, the SetBuffer-then-clamp dance in pane_render.go is
+// not actually keeping the BufferWidget inside ClientRect, and the
+// child is overwriting the side borders.
+func TestPaneRenderBuffer_BordersSurviveStyledContent(t *testing.T) {
+	const w, h = 20, 6
+	rowIdx := []int64{100, 101, 102, 103} // h-2 = 4 entries, all content
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = w, h
+	app := &snapshotTestStyledTerminalApp{
+		snapshotTestTerminalApp: snapshotTestTerminalApp{
+			snapshotTestApp: snapshotTestApp{title: "term", cols: w - 2, rows: h - 2},
+			rowIdx:          rowIdx,
+		},
+	}
+	p.app = app
+
+	buf := p.renderBuffer(false)
+	if len(buf) != h {
+		t.Fatalf("render buffer height = %d, want %d", len(buf), h)
+	}
+	for y, row := range buf {
+		if len(row) != w {
+			t.Fatalf("row %d width = %d, want %d", y, len(row), w)
+		}
+	}
+
+	// Top and bottom rows are the horizontal border rows; corners/horizontals.
+	// Interior rows (y in [1, h-2]) must have a vertical bar at col 0 and col w-1.
+	for y := 1; y < h-1; y++ {
+		got0 := buf[y][0].Ch
+		gotR := buf[y][w-1].Ch
+		if got0 != '│' && got0 != '|' {
+			t.Errorf("row %d col 0 = %q, want '│' (left border overwritten by content)", y, got0)
+		}
+		if gotR != '│' && gotR != '|' {
+			t.Errorf("row %d col W-1 = %q, want '│' (right border overwritten by content)", y, gotR)
+		}
+		// Interior content cells (col 1..w-2) should be the app's 'X'.
+		for x := 1; x < w-1; x++ {
+			if buf[y][x].Ch != 'X' {
+				t.Errorf("row %d col %d = %q, want 'X' (content shifted)", y, x, buf[y][x].Ch)
+			}
+		}
+	}
+}

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -104,3 +104,37 @@ func TestPaneSnapshot_RowGlobalIdxLengthMatchesBuffer(t *testing.T) {
 		}
 	}
 }
+
+func TestCapturePaneSnapshot_ContentBoundsComputed(t *testing.T) {
+	// 6-row pane: [0]=-1 (top border), [1..3]=content, [4]=-1 (app statusbar), [5]=-1 (bottom border)
+	rowIdx := []int64{-1, 100, 101, 102, -1, -1}
+	top, num := computeContentBounds(rowIdx)
+	if top != 1 || num != 3 {
+		t.Fatalf("expected top=1 num=3, got top=%d num=%d", top, num)
+	}
+}
+
+func TestCapturePaneSnapshot_ContentBoundsAllDecoration(t *testing.T) {
+	// All -1 rows: zero content, top=0 num=0.
+	rowIdx := []int64{-1, -1, -1}
+	top, num := computeContentBounds(rowIdx)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected top=0 num=0, got top=%d num=%d", top, num)
+	}
+}
+
+func TestCapturePaneSnapshot_ContentBoundsEmpty(t *testing.T) {
+	top, num := computeContentBounds(nil)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected top=0 num=0, got top=%d num=%d", top, num)
+	}
+}
+
+func TestComputeContentBounds_NonContiguous(t *testing.T) {
+	// Hole in the middle of the content range.
+	rowIdx := []int64{-1, 100, -1, 102, -1}
+	top, num := computeContentBounds(rowIdx)
+	if top != 0 || num != 0 {
+		t.Fatalf("expected (0, 0) on non-contiguous layout, got (%d, %d)", top, num)
+	}
+}

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -140,3 +140,100 @@ func TestComputeContentBounds_MidRangeHolesTolerated(t *testing.T) {
 		t.Fatalf("expected (1, 3) for [first..last] span across mid-hole, got (%d, %d)", top, num)
 	}
 }
+
+// snapshotTestTerminalApp implements RowGlobalIdxProvider so applyStructuralBounds
+// can exercise the texterm-shaped content path.
+type snapshotTestTerminalApp struct {
+	snapshotTestApp
+	rowIdx []int64
+}
+
+func (a *snapshotTestTerminalApp) RowGlobalIdx() []int64 {
+	out := make([]int64, len(a.rowIdx))
+	copy(out, a.rowIdx)
+	return out
+}
+
+func newTerminalSnapshotPane(w, h int, rowIdx []int64) *pane {
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = w, h
+	app := &snapshotTestTerminalApp{
+		snapshotTestApp: snapshotTestApp{title: "term", cols: w - 2, rows: h - 2},
+		rowIdx:          rowIdx,
+	}
+	p.app = app
+	return p
+}
+
+// TestApplyStructuralBounds_TerminalPane verifies the geometry-only bounds
+// helper used by GeometryForClient. The pane is a 6-tall texterm-style
+// pane with three populated content gids; the helper must report
+// ContentTopRow=1, NumContentRows=h-2 (=4), AltScreen=false. This is the
+// same answer capturePaneSnapshot returns for the same pane — the two
+// must agree so the resize path (GeometryForClient) does not silently
+// blank the client's content bounds.
+func TestApplyStructuralBounds_TerminalPane(t *testing.T) {
+	rowIdx := []int64{100, 101, 102, 103} // h-2 = 4 entries
+	p := newTerminalSnapshotPane(20, 6, rowIdx)
+
+	var snap PaneSnapshot
+	applyStructuralBounds(&snap, p)
+
+	if snap.AltScreen {
+		t.Fatalf("expected AltScreen=false for terminal pane")
+	}
+	if snap.ContentTopRow != 1 {
+		t.Fatalf("expected ContentTopRow=1, got %d", snap.ContentTopRow)
+	}
+	if snap.NumContentRows != 4 {
+		t.Fatalf("expected NumContentRows=4 (h=6 → h-2), got %d", snap.NumContentRows)
+	}
+
+	// And the answer must match capturePaneSnapshot for the same pane —
+	// otherwise the geometry-only path drifts from the full path.
+	full := capturePaneSnapshot(p)
+	if full.ContentTopRow != snap.ContentTopRow || full.NumContentRows != snap.NumContentRows {
+		t.Fatalf("structural bounds drift: full=(top=%d,num=%d) geometry=(top=%d,num=%d)",
+			full.ContentTopRow, full.NumContentRows, snap.ContentTopRow, snap.NumContentRows)
+	}
+}
+
+// TestApplyStructuralBounds_TerminalPaneWithStatusbar tests the texterm
+// internal-statusbar pattern: appIdx[len-1] < 0 reduces NumContentRows by 1.
+func TestApplyStructuralBounds_TerminalPaneWithStatusbar(t *testing.T) {
+	rowIdx := []int64{100, 101, 102, -1} // statusbar at the bottom
+	p := newTerminalSnapshotPane(20, 6, rowIdx)
+
+	var snap PaneSnapshot
+	applyStructuralBounds(&snap, p)
+
+	if snap.NumContentRows != 3 {
+		t.Fatalf("expected NumContentRows=3 (h=6 → h-2-1), got %d", snap.NumContentRows)
+	}
+	if snap.ContentTopRow != 1 {
+		t.Fatalf("expected ContentTopRow=1, got %d", snap.ContentTopRow)
+	}
+
+	// Must agree with the full snapshot path.
+	full := capturePaneSnapshot(p)
+	if full.ContentTopRow != snap.ContentTopRow || full.NumContentRows != snap.NumContentRows {
+		t.Fatalf("structural bounds drift with trailing statusbar: full=(top=%d,num=%d) geometry=(top=%d,num=%d)",
+			full.ContentTopRow, full.NumContentRows, snap.ContentTopRow, snap.NumContentRows)
+	}
+}
+
+// TestApplyStructuralBounds_NonTerminalPane verifies that an app without
+// RowGlobalIdxProvider gets AltScreen=true and zero content bounds —
+// matching what capturePaneSnapshot would set.
+func TestApplyStructuralBounds_NonTerminalPane(t *testing.T) {
+	p := newSnapshotTestPane(20, 6)
+	var snap PaneSnapshot
+	applyStructuralBounds(&snap, p)
+	if !snap.AltScreen {
+		t.Fatalf("expected AltScreen=true for non-RowGlobalIdxProvider app")
+	}
+	if snap.NumContentRows != 0 {
+		t.Fatalf("expected NumContentRows=0 for non-terminal app, got %d", snap.NumContentRows)
+	}
+}

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -130,11 +130,13 @@ func TestCapturePaneSnapshot_ContentBoundsEmpty(t *testing.T) {
 	}
 }
 
-func TestComputeContentBounds_NonContiguous(t *testing.T) {
-	// Hole in the middle of the content range.
+func TestComputeContentBounds_MidRangeHolesTolerated(t *testing.T) {
+	// Mid-range gid<0 holes are legitimate — they represent unwritten
+	// content rows in a fresh terminal. The bounds span from the first
+	// to the last gid>=0; the renderer renders the holes as blank cells.
 	rowIdx := []int64{-1, 100, -1, 102, -1}
 	top, num := computeContentBounds(rowIdx)
-	if top != 0 || num != 0 {
-		t.Fatalf("expected (0, 0) on non-contiguous layout, got (%d, %d)", top, num)
+	if top != 1 || num != 3 {
+		t.Fatalf("expected (1, 3) for [first..last] span across mid-hole, got (%d, %d)", top, num)
 	}
 }

--- a/texel/workspace_navigation.go
+++ b/texel/workspace_navigation.go
@@ -84,6 +84,30 @@ func (w *Workspace) setBorderResizing(border *selectedBorder, resizing bool) {
 	})
 }
 
+// FocusByID activates the pane in this workspace whose ID matches the given
+// 16-byte identifier. Returns true if the focus actually moved (i.e. the
+// target was found and was not already active). Used by integration tests
+// and any external caller that needs to drive focus without simulating
+// keyboard navigation.
+func (w *Workspace) FocusByID(id [16]byte) bool {
+	if w == nil || w.tree == nil {
+		return false
+	}
+	var target *Node
+	w.tree.Traverse(func(n *Node) {
+		if target != nil {
+			return
+		}
+		if n.Pane != nil && n.Pane.ID() == id {
+			target = n
+		}
+	})
+	if target == nil {
+		return false
+	}
+	return w.activateLeaf(target)
+}
+
 func (w *Workspace) activateLeaf(node *Node) bool {
 	if w == nil || node == nil || node.Pane == nil || w.tree == nil {
 		return false


### PR DESCRIPTION
## Summary

Fixes the pre-existing pane border / content-row rendering bug for issue #199. Server stays authoritative for all visible cells; protocol bumps v2→v3 with new `PaneSnapshot.{ContentTopRow, NumContentRows}` and a distinct `BufferDelta.DecorRowDelta` type that carries decoration rows (borders, app statusbars) AND a positional copy of every content row so the renderer can resolve them under wrapped chains and erased-row gaps that break the gid-math invariant.

- 16 plan tasks executed via subagent-driven development (commits `2aef3c2` … `8a7f13c`)
- 7 runtime-driven follow-ups landed after manual e2e (commits `bb495b2` … `e56ccec`)
- 24 commits total; +5500/-100 lines across 27 files

## Root causes (in order discovered)

1. `bufferToDelta`'s `gid<0` filter dropped border + app-statusbar rows — the bug that made D2's rehydrate UX show 3 blank rows. Fixed by routing them into `DecorRowDelta`.
2. Initial `computeContentBounds` enforced contiguity over `RowGlobalIdx`, but real terminals have legitimate `gid<0` holes for unwritten rows → `NumContentRows=0` → renderer treated everything as decoration. Switched to structural computation in `capturePaneSnapshot`.
3. `GeometryForClient` (resize path) built `PaneSnapshot` without populating the new content-bound fields, so resize blanked them on the client. Added `applyStructuralBounds`.
4. `BufferWidget.SetBuffer` auto-resized the widget to the buffer dims, allowing it to overrun pane borders. Re-clamped to `ClientRect` after every `SetBuffer`.
5. Renderer's gid-math `gid := vc.ViewTopIdx + (rowIdx - ContentTopRow)` assumed contiguous 1:1 rowIdx→gid mapping, which breaks under wrapped chains and erased-row gaps. Server now also emits content rows positionally; renderer prefers the positional path.
6. `RepositionForPromptOverwrite` returned no-op when the saved promptLine sat below the pre-resize default vterm viewport — produced the duplicated-prompt visual on first start. Mirrored the existing rewind branch.

## Test plan

- [x] All 16 plan tasks have unit + integration tests under `-race`
- [x] `go test ./...` clean
- [x] Manual e2e: clean start, daemon-restart rehydrate, scrolled mid-history, focus change, resize, multi-pane — all render correctly
- [x] User-confirmed runtime fix: content rows align, side borders intact, scroll-back holds position across multi-pane sessions
- [x] Duplicated-prompt edge case fix verified to recur much less often (one occurrence on a brand-new pane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)