### PR TITLE
D2 Task 17: deferred-medium cleanups

### DIFF
--- a/cmd/texel-server/main.go
+++ b/cmd/texel-server/main.go
@@ -254,6 +254,14 @@ func main() {
 			// is populated before any client can send MsgResumeRequest.
 			if err := manager.EnablePersistence(filepath.Dir(snapPath), 250*time.Millisecond); err != nil {
 				log.Printf("warning: could not enable persistence: %v", err)
+				// Plan D2 17.D: a single warning above is easy to miss
+				// in a busy boot log. Emit a follow-up "DISABLED" line
+				// and verify via Manager.Stats so operators have an
+				// observable surface for the silent-failure mode.
+				stats := manager.Stats()
+				if !stats.PersistEnabled {
+					log.Printf("[BOOT] PERSISTENCE DISABLED: cross-restart session resume will not work this process lifetime")
+				}
 			}
 		}
 	} else {

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -380,7 +380,9 @@ func handleResetState(ctx context.Context, paths *Paths, socketPath string) erro
 // Returns the count of paths successfully removed. Extracted from
 // handleResetState so the wipe can be exercised by tests without
 // stdin/daemon plumbing (Plan D2 17.E).
-func wipeResetStatePaths(stderr, stdout interface{ Write(p []byte) (n int, err error) }, configDir, clientStateDir, socketPath string, legacyFiles []string) int {
+func wipeResetStatePaths(stderr, stdout interface {
+	Write(p []byte) (n int, err error)
+}, configDir, clientStateDir, socketPath string, legacyFiles []string) int {
 	removed := 0
 
 	// Remove the entire state directory (~/.texelation/)

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -364,28 +364,46 @@ func handleResetState(ctx context.Context, paths *Paths, socketPath string) erro
 		_ = daemon.Stop(ctx) // Best effort
 	}
 
+	removed := wipeResetStatePaths(os.Stderr, os.Stdout, paths.ConfigDir, clientStateDir, socketPath, legacyFiles)
+
+	fmt.Printf("\nState reset complete (%d items removed)\n", removed)
+	return nil
+}
+
+// wipeResetStatePaths removes all state covered by --reset-state:
+//   - configDir (entire ~/.texelation/ tree, including Plan D2's
+//     sessions/ subdir written by atomicjson)
+//   - legacy per-pane files (~/.texel-env-*, ~/.texel-history-*)
+//   - clientStateDir (Plan D's client-side sessionID + viewports)
+//   - the daemon's Unix socket
+//
+// Returns the count of paths successfully removed. Extracted from
+// handleResetState so the wipe can be exercised by tests without
+// stdin/daemon plumbing (Plan D2 17.E).
+func wipeResetStatePaths(stderr, stdout interface{ Write(p []byte) (n int, err error) }, configDir, clientStateDir, socketPath string, legacyFiles []string) int {
 	removed := 0
 
 	// Remove the entire state directory (~/.texelation/)
 	// This covers: scrollback/*.hist3, scrollback/*.index.db, storage/,
-	// texelbrowse/, snapshot.json, server.log, texelation.pid
-	if err := os.RemoveAll(paths.ConfigDir); err != nil {
-		fmt.Fprintf(os.Stderr, "  warning: failed to remove %s: %v\n", paths.ConfigDir, err)
+	// texelbrowse/, snapshot.json, server.log, texelation.pid, AND
+	// Plan D2's sessions/ subdir (atomicjson session-state files).
+	if err := os.RemoveAll(configDir); err != nil {
+		fmt.Fprintf(stderr, "  warning: failed to remove %s: %v\n", configDir, err)
 	} else {
-		fmt.Printf("  removed %s/\n", paths.ConfigDir)
+		fmt.Fprintf(stdout, "  removed %s/\n", configDir)
 		removed++
 	}
 
 	// Remove legacy per-pane files (~/.texel-env-*, ~/.texel-history-*)
 	for _, f := range legacyFiles {
 		if err := os.Remove(f); err != nil {
-			fmt.Fprintf(os.Stderr, "  warning: failed to remove %s: %v\n", f, err)
+			fmt.Fprintf(stderr, "  warning: failed to remove %s: %v\n", f, err)
 		} else {
 			removed++
 		}
 	}
 	if len(legacyFiles) > 0 {
-		fmt.Printf("  removed %d legacy pane files\n", len(legacyFiles))
+		fmt.Fprintf(stdout, "  removed %d legacy pane files\n", len(legacyFiles))
 	}
 
 	// Remove Plan D's client persistence directory if it exists.
@@ -395,9 +413,9 @@ func handleResetState(ctx context.Context, paths *Paths, socketPath string) erro
 	if clientStateDir != "" {
 		if _, err := os.Stat(clientStateDir); err == nil {
 			if err := os.RemoveAll(clientStateDir); err != nil {
-				fmt.Fprintf(os.Stderr, "  warning: failed to remove %s: %v\n", clientStateDir, err)
+				fmt.Fprintf(stderr, "  warning: failed to remove %s: %v\n", clientStateDir, err)
 			} else {
-				fmt.Printf("  removed %s/\n", clientStateDir)
+				fmt.Fprintf(stdout, "  removed %s/\n", clientStateDir)
 				removed++
 			}
 		}
@@ -405,12 +423,11 @@ func handleResetState(ctx context.Context, paths *Paths, socketPath string) erro
 
 	// Remove socket file
 	if err := os.Remove(socketPath); err == nil {
-		fmt.Printf("  removed %s\n", socketPath)
+		fmt.Fprintf(stdout, "  removed %s\n", socketPath)
 		removed++
 	}
 
-	fmt.Printf("\nState reset complete (%d items removed)\n", removed)
-	return nil
+	return removed
 }
 
 // resolveClientStateDir returns the path that holds Plan D's client

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -458,5 +458,30 @@ func handleStatus(ctx context.Context, paths *Paths, socketPath string) error {
 		fmt.Printf("  Snapshot modified: %s\n", info.ModTime().Format("2006-01-02 15:04:05"))
 	}
 
+	// Plan D2 17.D: report cross-restart session-persistence state so
+	// a permissions issue (e.g. sessions/ owned by root after a sudo
+	// misadventure) doesn't silently break resume across restarts.
+	// We check by inspecting <ConfigDir>/sessions/ since the running
+	// daemon doesn't expose Manager.Stats over the socket today.
+	sessionsDir := filepath.Join(paths.ConfigDir, "sessions")
+	if info, err := os.Stat(sessionsDir); err == nil && info.IsDir() {
+		entries, readErr := os.ReadDir(sessionsDir)
+		if readErr != nil {
+			fmt.Printf("  Persistence: directory unreadable (%v)\n", readErr)
+		} else {
+			count := 0
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+					count++
+				}
+			}
+			fmt.Printf("  Persistence: enabled (%d persisted session(s) at %s)\n", count, sessionsDir)
+		}
+	} else if os.IsNotExist(err) {
+		fmt.Printf("  Persistence: no sessions directory yet (%s)\n", sessionsDir)
+	} else if err != nil {
+		fmt.Printf("  Persistence: cannot stat %s: %v\n", sessionsDir, err)
+	}
+
 	return nil
 }

--- a/cmd/texelation/main_test.go
+++ b/cmd/texelation/main_test.go
@@ -1,0 +1,116 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWipeResetStatePaths_WipesD2Sessions is the Plan D2 17.E
+// regression: --reset-state must wipe ~/.texelation/sessions/ (the
+// Plan D2 atomicjson session-state directory) so a future refactor
+// that drops this from the wipe list cannot silently leave cross-
+// restart viewport state on disk.
+func TestWipeResetStatePaths_WipesD2Sessions(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	sessionsDir := filepath.Join(configDir, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-populate a fake stored session.
+	if err := os.WriteFile(filepath.Join(sessionsDir, "deadbeefdeadbeefdeadbeefdeadbeef.json"), []byte(`{"schemaVersion":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate Plan D client state dir.
+	clientStateDir := filepath.Join(root, "client")
+	if err := os.MkdirAll(clientStateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clientStateDir, "session.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate a fake socket file.
+	socketPath := filepath.Join(root, "test.sock")
+	if err := os.WriteFile(socketPath, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	removed := wipeResetStatePaths(&stderr, &stdout, configDir, clientStateDir, socketPath, nil)
+
+	// Verify ConfigDir is gone (which includes sessions/).
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Fatalf("configDir still exists after wipe: stat err=%v", err)
+	}
+	if _, err := os.Stat(sessionsDir); !os.IsNotExist(err) {
+		t.Fatalf("sessionsDir still exists after wipe: stat err=%v", err)
+	}
+
+	// Verify client state dir is gone.
+	if _, err := os.Stat(clientStateDir); !os.IsNotExist(err) {
+		t.Fatalf("clientStateDir still exists after wipe: stat err=%v", err)
+	}
+
+	// Verify socket is gone.
+	if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+		t.Fatalf("socket still exists after wipe: stat err=%v", err)
+	}
+
+	if removed < 3 {
+		t.Errorf("expected >=3 items removed, got %d (stdout: %q)", removed, stdout.String())
+	}
+}
+
+// TestWipeResetStatePaths_HandlesMissingPaths confirms the wipe
+// tolerates each input path being absent (idempotent re-run case).
+func TestWipeResetStatePaths_HandlesMissingPaths(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, "absent-config")
+	clientStateDir := filepath.Join(root, "absent-client")
+	socketPath := filepath.Join(root, "absent.sock")
+
+	var stdout, stderr bytes.Buffer
+	removed := wipeResetStatePaths(&stderr, &stdout, configDir, clientStateDir, socketPath, nil)
+
+	// RemoveAll on non-existent dir returns nil (so configDir's
+	// removal counts), but Remove on non-existent socket returns
+	// an error (so socket doesn't count). Just assert no panic
+	// and removed >= 0.
+	if removed < 0 {
+		t.Fatalf("removed < 0: %d", removed)
+	}
+}
+
+// TestWipeResetStatePaths_RemovesLegacyFiles verifies legacy per-pane
+// files are removed.
+func TestWipeResetStatePaths_RemovesLegacyFiles(t *testing.T) {
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy1 := filepath.Join(root, ".texel-env-pane1")
+	legacy2 := filepath.Join(root, ".texel-history-pane1")
+	for _, f := range []string{legacy1, legacy2} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	wipeResetStatePaths(&stderr, &stdout, configDir, "", "", []string{legacy1, legacy2})
+
+	for _, f := range []string{legacy1, legacy2} {
+		if _, err := os.Stat(f); !os.IsNotExist(err) {
+			t.Errorf("legacy file %s still exists after wipe: %v", f, err)
+		}
+	}
+}

--- a/internal/runtime/server/manager.go
+++ b/internal/runtime/server/manager.go
@@ -31,6 +31,16 @@ type Manager struct {
 	// atomicjson writer at <persistBasedir>/sessions/<hex-id>.json.
 	persistBasedir  string
 	persistDebounce time.Duration
+
+	// Plan D2 17.B: per-ID "closing" markers serialize Close vs
+	// LookupOrRehydrate for the same ID. Without this, Close drops
+	// m.mu before flushing the atomicjson writer, and a concurrent
+	// rehydrate could construct a fresh Session pointing at the
+	// same on-disk path — two stores then race on rename(). Entries
+	// are short-lived: created by Close on entry, deleted on exit.
+	// LookupOrRehydrate waits while a marker exists for its ID.
+	closingMu sync.Mutex
+	closing   map[[16]byte]chan struct{}
 }
 
 func NewManager() *Manager {
@@ -38,6 +48,47 @@ func NewManager() *Manager {
 		sessions:          make(map[[16]byte]*Session),
 		persistedSessions: make(map[[16]byte]*StoredSession),
 		maxDiffs:          512,
+		closing:           make(map[[16]byte]chan struct{}),
+	}
+}
+
+// markClosing records that id is in the middle of Manager.Close. Returns
+// a channel that closes when the close completes. If id is already
+// being closed, returns the existing channel (no-op).
+func (m *Manager) markClosing(id [16]byte) chan struct{} {
+	m.closingMu.Lock()
+	defer m.closingMu.Unlock()
+	if ch, ok := m.closing[id]; ok {
+		return ch
+	}
+	ch := make(chan struct{})
+	m.closing[id] = ch
+	return ch
+}
+
+// unmarkClosing signals completion of Manager.Close for id and removes
+// the marker.
+func (m *Manager) unmarkClosing(id [16]byte) {
+	m.closingMu.Lock()
+	ch, ok := m.closing[id]
+	if ok {
+		delete(m.closing, id)
+	}
+	m.closingMu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+// waitClosing blocks until any in-flight Close for id has completed.
+// Returns immediately if no Close is in flight. Used by
+// LookupOrRehydrate to avoid the 17.B rename race.
+func (m *Manager) waitClosing(id [16]byte) {
+	m.closingMu.Lock()
+	ch, ok := m.closing[id]
+	m.closingMu.Unlock()
+	if ok {
+		<-ch
 	}
 }
 
@@ -130,6 +181,14 @@ func (m *Manager) SetPersistedSessions(loaded map[[16]byte]*StoredSession) {
 // 0, while live sessions retain their accumulated counters across
 // reconnects.
 func (m *Manager) LookupOrRehydrate(id [16]byte) (sess *Session, rehydrated bool, err error) {
+	// Plan D2 17.B: wait out any in-flight Close for the same ID
+	// before consulting the persisted index. Otherwise a fresh
+	// rehydrate could construct a new Session pointing at the same
+	// on-disk file the closing session is still flushing, causing
+	// two atomicjson stores to race on rename(). The wait is bounded
+	// by Close's own duration (one synchronous flush).
+	m.waitClosing(id)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if s, ok := m.sessions[id]; ok {
@@ -232,16 +291,28 @@ func (m *Manager) SetDiffRetentionLimit(limit int) {
 // teardown call (which now blocks on disk I/O via the atomicjson
 // writer's flush) runs OUTSIDE m.mu so other Manager methods don't
 // stall behind a slow flush.
+//
+// Plan D2 17.B: Close registers a per-ID "closing" marker before
+// dropping m.mu and clears it after session.Close returns.
+// LookupOrRehydrate consults the same marker so a fresh resume for
+// the same ID waits out the disk flush instead of constructing a
+// new Session pointing at the same on-disk path.
 func (m *Manager) Close(id [16]byte) {
 	m.mu.Lock()
 	session, ok := m.sessions[id]
 	if ok {
 		delete(m.sessions, id)
 	}
-	m.mu.Unlock()
-	if ok {
-		session.Close() // disk flush — outside m.mu
+	if !ok {
+		m.mu.Unlock()
+		return
 	}
+	// Mark before dropping m.mu so any LookupOrRehydrate that grabs
+	// m.mu next sees the marker via waitClosing on its way in.
+	m.markClosing(id)
+	m.mu.Unlock()
+	defer m.unmarkClosing(id)
+	session.Close() // disk flush — outside m.mu
 }
 
 // ShutdownSessions closes all live sessions, synchronously flushing
@@ -262,10 +333,17 @@ func (m *Manager) ShutdownSessions() {
 	m.mu.Lock()
 	live := m.sessions
 	m.sessions = make(map[[16]byte]*Session)
+	// Mark every live session as closing under m.mu so any concurrent
+	// LookupOrRehydrate after we release m.mu blocks until the per-
+	// session flush completes (Plan D2 17.B).
+	for id := range live {
+		m.markClosing(id)
+	}
 	m.mu.Unlock()
 
-	for _, session := range live {
+	for id, session := range live {
 		session.Close() // disk flush — outside m.mu
+		m.unmarkClosing(id)
 	}
 }
 

--- a/internal/runtime/server/manager.go
+++ b/internal/runtime/server/manager.go
@@ -353,6 +353,30 @@ func (m *Manager) ActiveSessions() int {
 	return len(m.sessions)
 }
 
+// ManagerStats captures Manager-level observable state. Used by
+// operators to detect silent failures — primarily Plan D2 17.D where
+// EnablePersistence's failure path leaves persistence disabled for
+// the rest of the process lifetime.
+type ManagerStats struct {
+	ActiveSessions    int
+	PersistedSessions int
+	PersistEnabled    bool
+	PersistBasedir    string
+}
+
+// Stats returns a snapshot of manager-level metrics. Does NOT include
+// per-session stats — for those see SessionStats.
+func (m *Manager) Stats() ManagerStats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return ManagerStats{
+		ActiveSessions:    len(m.sessions),
+		PersistedSessions: len(m.persistedSessions),
+		PersistEnabled:    m.persistBasedir != "",
+		PersistBasedir:    m.persistBasedir,
+	}
+}
+
 func (m *Manager) SessionStats() []SessionStats {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/runtime/server/manager.go
+++ b/internal/runtime/server/manager.go
@@ -44,6 +44,11 @@ func NewManager() *Manager {
 func (m *Manager) NewSession() (*Session, error) {
 	var id [16]byte
 	if _, err := rand.Read(id[:]); err != nil {
+		// Plan D2 17.C: log at the point of failure so operators
+		// investigating "users can't connect" have a breadcrumb pointing
+		// at the entropy pool. Without this, the error propagates up to
+		// the handshake and surfaces as a generic "connect failed".
+		log.Printf("session: crypto/rand failed: %v", err)
 		return nil, err
 	}
 

--- a/internal/runtime/server/manager_test.go
+++ b/internal/runtime/server/manager_test.go
@@ -262,6 +262,39 @@ func TestManagerNewSessionWithID_RejectsDuplicates(t *testing.T) {
 	}
 }
 
+// TestManagerStats_PersistDisabledWhenNoBasedir verifies the Plan D2
+// 17.D observability surface: with EnablePersistence skipped (or
+// failing), Manager.Stats reports PersistEnabled=false so callers
+// can detect the silent-failure mode.
+func TestManagerStats_PersistDisabledWhenNoBasedir(t *testing.T) {
+	mgr := NewManager()
+	stats := mgr.Stats()
+	if stats.PersistEnabled {
+		t.Fatalf("PersistEnabled must be false before EnablePersistence")
+	}
+	if stats.PersistBasedir != "" {
+		t.Fatalf("PersistBasedir must be empty before EnablePersistence, got %q", stats.PersistBasedir)
+	}
+}
+
+// TestManagerStats_PersistEnabledAfterEnable verifies the happy path:
+// after EnablePersistence succeeds, Stats reports the enabled state
+// and the basedir.
+func TestManagerStats_PersistEnabledAfterEnable(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager()
+	if err := mgr.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	stats := mgr.Stats()
+	if !stats.PersistEnabled {
+		t.Fatalf("PersistEnabled must be true after EnablePersistence")
+	}
+	if stats.PersistBasedir != dir {
+		t.Fatalf("PersistBasedir = %q, want %q", stats.PersistBasedir, dir)
+	}
+}
+
 // TestManagerCloseSerializesWithLookupOrRehydrate is the Plan D2 17.B
 // regression: a Close racing with a same-ID LookupOrRehydrate must
 // not let the rehydrate path attach a fresh atomicjson writer to the

--- a/internal/runtime/server/manager_test.go
+++ b/internal/runtime/server/manager_test.go
@@ -261,3 +261,88 @@ func TestManagerNewSessionWithID_RejectsDuplicates(t *testing.T) {
 		t.Fatalf("expected error on duplicate id")
 	}
 }
+
+// TestManagerCloseSerializesWithLookupOrRehydrate is the Plan D2 17.B
+// regression: a Close racing with a same-ID LookupOrRehydrate must
+// not let the rehydrate path attach a fresh atomicjson writer to the
+// same on-disk path while Close is still flushing — otherwise two
+// stores race on rename(). The serialization is provided by per-ID
+// "closing" markers consulted by LookupOrRehydrate via waitClosing.
+func TestManagerCloseSerializesWithLookupOrRehydrate(t *testing.T) {
+	dir := t.TempDir()
+	mgr := NewManager()
+	if err := mgr.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	id := [16]byte{0xcc}
+	// Pre-seed a persisted entry so LookupOrRehydrate has something to
+	// rehydrate against once the live session is closed.
+	stored := &StoredSession{SchemaVersion: StoredSessionSchemaVersion, SessionID: id, LastActive: time.Now()}
+	mgr.SetPersistedSessions(map[[16]byte]*StoredSession{id: stored})
+
+	sess, _, err := mgr.LookupOrRehydrate(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Apply a few updates to make Close's flush non-trivial.
+	for i := 0; i < 5; i++ {
+		sess.ApplyViewportUpdate(protocol.ViewportUpdate{
+			PaneID: [16]byte{byte(i)}, ViewBottomIdx: int64(i), Rows: 1, Cols: 1,
+		})
+	}
+
+	// Re-seed the persisted entry so the post-Close rehydrate has
+	// something to find. (Close consumed the live session; the
+	// persisted index was consumed during the original rehydrate.)
+	mgr.SetPersistedSessions(map[[16]byte]*StoredSession{id: stored})
+
+	closeStarted := make(chan struct{})
+	closeDone := make(chan struct{})
+	go func() {
+		close(closeStarted)
+		mgr.Close(id)
+		close(closeDone)
+	}()
+	<-closeStarted
+
+	// Concurrent rehydrate attempt for the same ID. Must wait for
+	// Close to finish (no rename race), then succeed against the
+	// re-seeded persisted entry.
+	rehydrateDone := make(chan struct{})
+	go func() {
+		defer close(rehydrateDone)
+		_, _, _ = mgr.LookupOrRehydrate(id)
+	}()
+
+	// rehydrate must NOT complete before close.
+	select {
+	case <-rehydrateDone:
+		select {
+		case <-closeDone:
+			// Both done; verify ordering by ensuring close finished
+			// at-or-before rehydrate. We can't introspect order
+			// directly here, so instead require rehydrate didn't
+			// finish before close started its flush. Best-effort:
+			// re-check by allowing both to finish then asserting
+			// the persisted file is valid JSON.
+		default:
+			t.Fatal("rehydrate completed while Close was still in flight — 17.B race")
+		}
+	case <-closeDone:
+		// Close finished first; rehydrate should follow shortly.
+		<-rehydrateDone
+	case <-time.After(2 * time.Second):
+		t.Fatal("close/rehydrate deadlock")
+	}
+
+	// Persisted file must exist and be valid JSON.
+	path := SessionFilePath(dir, id)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("session file unreadable after close+rehydrate: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("session file empty — likely overwritten during rename race")
+	}
+}

--- a/internal/runtime/server/session_test.go
+++ b/internal/runtime/server/session_test.go
@@ -11,6 +11,7 @@ package server
 import (
 	"encoding/json"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -164,5 +165,76 @@ func TestSessionWriterCloseFlushes(t *testing.T) {
 
 	if _, err := os.Stat(SessionFilePath(dir, id)); err != nil {
 		t.Fatalf("Close did not flush: %v", err)
+	}
+}
+
+// TestSession_CloseRacesWithApplyViewportUpdate is the Plan D2 17.F
+// regression: Session.Close races directly with ApplyViewportUpdate
+// from a concurrent goroutine. Must not panic, the persisted file
+// (if any) must be valid JSON, and the schedulePersist lock-discipline
+// note in session.go must continue to hold up under -race. This is
+// defense-in-depth on top of TestStoreUpdateAfterCloseIsNoop in the
+// atomicjson package.
+func TestSession_CloseRacesWithApplyViewportUpdate(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0xab}
+	sess := NewSession(id, 100)
+	sess.AttachWriter(SessionFilePath(dir, id), 1*time.Millisecond)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stop := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sess.ApplyViewportUpdate(protocol.ViewportUpdate{
+				PaneID:        [16]byte{byte(i % 256)},
+				ViewBottomIdx: int64(i),
+				Rows:          1,
+				Cols:          1,
+			})
+			i++
+			if i > 5000 {
+				return
+			}
+		}
+	}()
+
+	// Let the goroutine run briefly so Close has live writes to race
+	// against. 5ms is enough for the debounce-driven writer ticker
+	// to fire at least once.
+	time.Sleep(5 * time.Millisecond)
+
+	// Close races with the goroutine. Must not panic.
+	sess.Close()
+	close(stop)
+	wg.Wait()
+
+	// Post-condition: the persisted file (if any) must parse as
+	// valid JSON. atomicjson's atomic temp+rename guarantees a torn
+	// write cannot land on disk; this assertion verifies that
+	// guarantee end-to-end through the Session.schedulePersist path.
+	path := SessionFilePath(dir, id)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		// No file is acceptable: writer may not have flushed at all
+		// before Close, depending on goroutine scheduling.
+		return
+	}
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	var got StoredSession
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("persisted file is not valid JSON: %v\n%s", err, string(data))
+	}
+	if got.SessionID != id {
+		t.Fatalf("sessionID mismatch: got %x want %x", got.SessionID, id)
 	}
 }

--- a/texel/snapshot_restore.go
+++ b/texel/snapshot_restore.go
@@ -8,6 +8,8 @@
 package texel
 
 import (
+	"log"
+
 	"github.com/gdamore/tcell/v2"
 )
 
@@ -169,8 +171,17 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 		if isStatusOrphan(p) {
 			// Stop the orphan's app and detach so it doesn't dangle.
 			// The real status pane (from AddStatusPane) is unaffected.
+			//
+			// Lock-discipline / lifecycle note (Plan D2 Task 17.A):
+			// The orphan app was constructed via appFromSnapshot →
+			// factory and PrepareAppForRestore'd, but Run() was never
+			// invoked. Calling Stop() on a never-Run() app is per-app
+			// undefined: it may close channels its Run() was supposed
+			// to drain, panic on nil internal state, or block waiting
+			// for goroutines that never started. Wrap in recover() so
+			// a misbehaving Stop cannot abort boot snapshot restore.
 			if p.app != nil {
-				d.appLifecycle.StopApp(p.app)
+				stopOrphanAppSafely(d.appLifecycle, p.app)
 				p.app = nil
 			}
 			continue
@@ -351,3 +362,15 @@ func (s *snapshotApp) GetTitle() string { return s.title }
 func (s *snapshotApp) HandleKey(*tcell.EventKey) {}
 
 func (s *snapshotApp) SetRefreshNotifier(ch chan<- bool) { s.notify = ch }
+
+// stopOrphanAppSafely calls lifecycle.StopApp(app) with a recover so a
+// panicking Stop on a never-Run() factory-built app cannot abort boot
+// snapshot restore. See ApplyTreeCapture's orphan filter (Plan D2 17.A).
+func stopOrphanAppSafely(lifecycle AppLifecycleManager, app App) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("snapshot_restore: orphan StopApp panicked, recovering: %v", r)
+		}
+	}()
+	lifecycle.StopApp(app)
+}

--- a/texel/snapshot_restore_test.go
+++ b/texel/snapshot_restore_test.go
@@ -1,0 +1,119 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package texel
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// panickingStopApp implements App but panics in Stop. Used to verify
+// the orphan filter in ApplyTreeCapture does not abort boot snapshot
+// restore when a factory-built app's Stop misbehaves (Plan D2 17.A).
+type panickingStopApp struct {
+	title string
+}
+
+func (p *panickingStopApp) Run() error                       { return nil }
+func (p *panickingStopApp) Stop()                            { panic("orphan Stop must not abort restore") }
+func (p *panickingStopApp) Resize(cols, rows int)            {}
+func (p *panickingStopApp) Render() [][]Cell                 { return [][]Cell{{{Ch: ' '}}} }
+func (p *panickingStopApp) GetTitle() string                 { return p.title }
+func (p *panickingStopApp) HandleKey(*tcell.EventKey)        {}
+func (p *panickingStopApp) SetRefreshNotifier(c chan<- bool) {}
+
+// passthroughLifecycle calls Stop on the app directly; used so the
+// panickingStopApp's panic actually fires through StopApp.
+type passthroughLifecycle struct{}
+
+func (passthroughLifecycle) StartApp(_ App, _ func(error)) {}
+func (passthroughLifecycle) StopApp(app App) {
+	if app != nil {
+		app.Stop()
+	}
+}
+
+// TestStopOrphanAppSafely_RecoversFromPanic confirms the helper
+// recovers from a panicking Stop so callers can call it from the
+// orphan filter without aborting boot.
+func TestStopOrphanAppSafely_RecoversFromPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("stopOrphanAppSafely propagated panic: %v", r)
+		}
+	}()
+	stopOrphanAppSafely(passthroughLifecycle{}, &panickingStopApp{title: "boom"})
+}
+
+// TestApplyTreeCapture_OrphanStopPanicDoesNotAbortRestore is the
+// integration regression: if a status-orphan pane's app panics in
+// Stop during the orphan filter, ApplyTreeCapture must still return
+// nil and complete the rest of the restore (Plan D2 17.A).
+func TestApplyTreeCapture_OrphanStopPanicDoesNotAbortRestore(t *testing.T) {
+	driver := &stubScreenDriver{width: 80, height: 24}
+	lifecycle := passthroughLifecycle{}
+	shellFactory := func() App { return newFakeApp("shell") }
+
+	desktop, err := NewDesktopEngineWithDriver(driver, shellFactory, "", lifecycle)
+	if err != nil {
+		t.Fatalf("desktop init failed: %v", err)
+	}
+	desktop.SwitchToWorkspace(1)
+
+	// Add a real status pane so its title is in statusTitles. Its app
+	// is *not* the panicking one — we want the orphan in the snapshot
+	// to be filtered out via title match.
+	desktop.AddStatusPane(newFakeApp("statuspane-title"), SideTop, 1)
+
+	// Register a snapshot factory for "panic-bar" that returns a
+	// panicking-Stop app. The orphan filter checks AppType=="statusbar"
+	// or title-in-statusTitles. We use the title path for portability.
+	desktop.RegisterSnapshotFactory("panic-bar", func(title string, _ map[string]interface{}) App {
+		return &panickingStopApp{title: title}
+	})
+
+	// Build a TreeCapture with two panes:
+	//  - pane 0: a regular shell pane (kept by orphan filter)
+	//  - pane 1: an orphan with title matching the live status pane
+	capture := TreeCapture{
+		Panes: []PaneSnapshot{
+			{
+				ID:      [16]byte{0x01},
+				Title:   "shell",
+				Buffer:  [][]Cell{{{Ch: ' '}}},
+				Rect:    Rectangle{X: 0, Y: 1, Width: 80, Height: 23},
+				AppType: "",
+			},
+			{
+				ID:      [16]byte{0x02},
+				Title:   "statuspane-title", // matches AddStatusPane above
+				Buffer:  [][]Cell{{{Ch: ' '}}},
+				Rect:    Rectangle{X: 0, Y: 0, Width: 80, Height: 1},
+				AppType: "panic-bar",
+			},
+		},
+		WorkspaceRoots: map[int]*TreeNodeCapture{
+			1: {
+				PaneIndex: 0, // only pane 0 is referenced; pane 1 is the orphan
+			},
+		},
+		ActiveWorkspaceID: 1,
+	}
+
+	// Apply; must NOT panic, must NOT return error.
+	err = desktop.ApplyTreeCapture(capture)
+	if err != nil {
+		t.Fatalf("ApplyTreeCapture returned error after orphan-Stop panic: %v", err)
+	}
+
+	// Verify the desktop is still usable: the active workspace exists
+	// and has a pane.
+	if desktop.activeWorkspace == nil {
+		t.Fatal("active workspace is nil after restore")
+	}
+	if desktop.activeWorkspace.tree == nil || desktop.activeWorkspace.tree.Root == nil {
+		t.Fatal("workspace tree empty after restore")
+	}
+}


### PR DESCRIPTION
## Summary

Knocks off the six deferred medium-severity items from the Plan D2 final pre-PR review (Task 17 in `2026-04-25-issue-199-plan-d2-server-viewport-persistence.md`). All concerns verified valid against current `main` before fixing.

| Tag | Fix | Commit |
|-----|-----|--------|
| 17.A | `recover()` wrapper on the orphan-pane `StopApp` call in `ApplyTreeCapture` so a panicking factory-built `Stop()` no longer aborts boot snapshot restore | `13fed7b` |
| 17.B | Per-ID "closing" channel marker in `Manager` serializes `Close` vs concurrent `LookupOrRehydrate` for the same sessionID without holding `m.mu` during disk I/O | `65366c7` |
| 17.C | `log.Printf` breadcrumb at point of `crypto/rand.Read` failure in `NewSession` | `e01e60d` |
| 17.D | `Manager.Stats()` returns `ManagerStats{PersistEnabled, PersistBasedir, ...}`; `cmd/texel-server` emits explicit "PERSISTENCE DISABLED" line on boot failure; `texelation status` reports persistence state | `582fa62` |
| 17.E | Extracted `wipeResetStatePaths()` from `handleResetState`; three direct tests (D2 sessions wipe, missing-path tolerance, legacy-file removal) | `9a466f6` + gofmt `475815c` |
| 17.F | Direct race test `TestSession_CloseRacesWithApplyViewportUpdate`; passes under `-race -count=20` | `8e4b5ce` |

## Test plan

- [x] `go test -count=1 ./...` — clean
- [x] `go test -race -count=1 ./internal/runtime/server/...` — new tests pass
- [x] `go test -race -count=20 ./internal/runtime/server/ -run TestSession_CloseRacesWithApplyViewportUpdate` — pass
- [x] `go test -race -count=10 ./internal/runtime/server/ -run TestManagerCloseSerializesWithLookupOrRehydrate` — pass
- [x] `go vet` clean on all touched packages

Pre-existing race-test flakes (`TestSnapshotRemovesCrashedApp`, `TestSnapshotRestoresMultipleWorkspaces`, `TestSnapshotSavedOnLayoutChange`) reproduce on plain `main` and are not introduced by this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)