### PR TITLE
Fix race-detector flakes in snapshot tests

### DIFF
--- a/internal/runtime/server/desktop_sink_test.go
+++ b/internal/runtime/server/desktop_sink_test.go
@@ -39,13 +39,38 @@ type recordingApp struct {
 	title string
 	mu    sync.Mutex
 	keys  []*tcell.EventKey
+	// stopOnce guards stopCh so that Stop is idempotent. stopCh is lazily
+	// created on first Run/Stop so existing tests that construct the app
+	// inline (`&recordingApp{title: ...}`) continue to work without an
+	// explicit init step.
+	stopOnce sync.Once
+	stopCh   chan struct{}
 }
 
-func (r *recordingApp) Run() error                        { return nil }
-func (r *recordingApp) Stop()                             {}
-func (r *recordingApp) Resize(cols, rows int)             {}
-func (r *recordingApp) Render() [][]texelcore.Cell        { return [][]texelcore.Cell{{}} }
-func (r *recordingApp) GetTitle() string                  { return r.title }
+func (r *recordingApp) ensureStopCh() chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopCh == nil {
+		r.stopCh = make(chan struct{})
+	}
+	return r.stopCh
+}
+
+// Run blocks until Stop is called, mirroring real apps that hold a goroutine
+// for their lifetime. Returning immediately would let LocalAppLifecycle
+// invoke handleAppExit — which mutates the pane tree from a non-event-loop
+// goroutine — and race with concurrent tree readers (e.g. CaptureTree).
+func (r *recordingApp) Run() error {
+	<-r.ensureStopCh()
+	return nil
+}
+func (r *recordingApp) Stop() {
+	ch := r.ensureStopCh()
+	r.stopOnce.Do(func() { close(ch) })
+}
+func (r *recordingApp) Resize(cols, rows int)      {}
+func (r *recordingApp) Render() [][]texelcore.Cell { return [][]texelcore.Cell{{}} }
+func (r *recordingApp) GetTitle() string           { return r.title }
 func (r *recordingApp) HandleKey(ev *tcell.EventKey) {
 	r.mu.Lock()
 	r.keys = append(r.keys, ev)

--- a/internal/runtime/server/server.go
+++ b/internal/runtime/server/server.go
@@ -24,7 +24,10 @@ import (
 type Server struct {
 	addr             string
 	manager          *Manager
+	lifecycleMu      sync.Mutex // protects listener, snapshotQuit, started/stopped state
 	listener         net.Listener
+	started          bool
+	stopped          bool
 	quit             chan struct{}
 	wg               sync.WaitGroup
 	sink             EventSink
@@ -100,6 +103,17 @@ func (s *Server) SetSnapshotStore(store *SnapshotStore, interval time.Duration) 
 }
 
 func (s *Server) Start() error {
+	s.lifecycleMu.Lock()
+	if s.stopped {
+		s.lifecycleMu.Unlock()
+		return nil
+	}
+	if s.started {
+		s.lifecycleMu.Unlock()
+		return nil
+	}
+	s.lifecycleMu.Unlock()
+
 	if err := os.RemoveAll(s.addr); err != nil {
 		return err
 	}
@@ -107,18 +121,31 @@ func (s *Server) Start() error {
 	if err != nil {
 		return err
 	}
+
+	s.lifecycleMu.Lock()
+	if s.stopped {
+		s.lifecycleMu.Unlock()
+		_ = l.Close()
+		return nil
+	}
 	s.listener = l
-	// Note: loadBootSnapshot is called from SetSnapshotStore, not here
+	// Note: loadBootSnapshot is called from SetSnapshotStore, not here.
+	// Add to the WaitGroup and initialize the snapshot loop's quit channel
+	// under the mutex so Stop sees a consistent set of fields even when
+	// called concurrently with Start (common in tests via `go srv.Start()`).
 	s.wg.Add(1)
-	go s.acceptLoop()
-	s.startSnapshotLoop()
+	s.startSnapshotLoopLocked()
+	s.started = true
+	s.lifecycleMu.Unlock()
+
+	go s.acceptLoop(l)
 	return nil
 }
 
-func (s *Server) acceptLoop() {
+func (s *Server) acceptLoop(l net.Listener) {
 	defer s.wg.Done()
 	for {
-		conn, err := s.listener.Accept()
+		conn, err := l.Accept()
 		if err != nil {
 			select {
 			case <-s.quit:
@@ -160,19 +187,29 @@ func (s *Server) acceptLoop() {
 }
 
 func (s *Server) Stop(ctx context.Context) error {
+	s.lifecycleMu.Lock()
+	if s.stopped {
+		s.lifecycleMu.Unlock()
+		return nil
+	}
+	s.stopped = true
+	listener := s.listener
+	s.listener = nil
+	snapshotQuit := s.snapshotQuit
+	s.snapshotQuit = nil
+	s.lifecycleMu.Unlock()
+
 	select {
 	case <-s.quit:
-		// Already stopped
-		return nil
 	default:
 		close(s.quit)
 	}
 
-	if s.snapshotQuit != nil {
-		close(s.snapshotQuit)
+	if snapshotQuit != nil {
+		close(snapshotQuit)
 	}
-	if s.listener != nil {
-		_ = s.listener.Close()
+	if listener != nil {
+		_ = listener.Close()
 	}
 	done := make(chan struct{})
 	go func() {

--- a/internal/runtime/server/server_boot.go
+++ b/internal/runtime/server/server_boot.go
@@ -76,7 +76,10 @@ func (s *Server) applyBootSnapshot() {
 	}
 }
 
-func (s *Server) startSnapshotLoop() {
+// startSnapshotLoopLocked initializes the periodic snapshot loop.
+// MUST be called with s.lifecycleMu held. The caller is responsible for
+// initializing s.snapshotQuit (this method does it) and adding to s.wg.
+func (s *Server) startSnapshotLoopLocked() {
 	if s.snapshotStore == nil || s.desktopSink == nil {
 		return
 	}
@@ -84,7 +87,8 @@ func (s *Server) startSnapshotLoop() {
 	if interval <= 0 {
 		interval = 5 * time.Second
 	}
-	s.snapshotQuit = make(chan struct{})
+	quitCh := make(chan struct{})
+	s.snapshotQuit = quitCh
 	ticker := time.NewTicker(interval)
 	s.wg.Add(1)
 	go func() {
@@ -97,7 +101,7 @@ func (s *Server) startSnapshotLoop() {
 			select {
 			case <-ticker.C:
 				s.persistSnapshot()
-			case <-s.snapshotQuit:
+			case <-quitCh:
 				return
 			case <-s.quit:
 				return

--- a/internal/runtime/server/snapshot_persistence_test.go
+++ b/internal/runtime/server/snapshot_persistence_test.go
@@ -152,12 +152,12 @@ func TestSnapshotSavedOnLayoutChange(t *testing.T) {
 	// Force a sleep to ensure fs timestamp resolution is met
 	time.Sleep(1 * time.Second)
 
-	go func() {
-		srv.Stop(context.Background())
-	}()
-
-	// Wait for server to stop (SnapshotLoop exits)
-	srv.wg.Wait()
+	// srv.Stop blocks until Start's goroutines (including the snapshot
+	// loop's deferred final persist) have all returned, so we can rely on
+	// it to quiesce the server before reading the snapshot file below.
+	if err := srv.Stop(context.Background()); err != nil {
+		t.Fatalf("server stop failed: %v", err)
+	}
 
 	finalInfo, err := os.Stat(path)
 	if err != nil {

--- a/texel/app_lifecycle.go
+++ b/texel/app_lifecycle.go
@@ -13,13 +13,34 @@ import "sync"
 // app's Run loop in a goroutine and delegates Stop calls directly.
 type LocalAppLifecycle struct {
 	wg sync.WaitGroup
+
+	// onExitDoneMu protects onExitDoneByApp. Each running app gets a
+	// channel closed *after* its onExit callback returns. AttachApp uses
+	// this to wait for the outgoing app's exit handler to finish before
+	// rewriting pane.app, which the handler reads to perform staleness
+	// checks. Without this barrier, the swap races with the handler.
+	onExitDoneMu    sync.Mutex
+	onExitDoneByApp map[App]chan struct{}
 }
 
 // StartApp launches the app's Run method asynchronously.
 func (l *LocalAppLifecycle) StartApp(app App, onExit func(error)) {
+	onExitDone := make(chan struct{})
+	l.onExitDoneMu.Lock()
+	if l.onExitDoneByApp == nil {
+		l.onExitDoneByApp = make(map[App]chan struct{})
+	}
+	l.onExitDoneByApp[app] = onExitDone
+	l.onExitDoneMu.Unlock()
 	l.wg.Add(1)
 	go func() {
 		defer l.wg.Done()
+		defer func() {
+			l.onExitDoneMu.Lock()
+			delete(l.onExitDoneByApp, app)
+			l.onExitDoneMu.Unlock()
+			close(onExitDone)
+		}()
 		err := app.Run()
 		if onExit != nil {
 			onExit(err)
@@ -27,9 +48,27 @@ func (l *LocalAppLifecycle) StartApp(app App, onExit func(error)) {
 	}()
 }
 
-// StopApp forwards the stop request to the app implementation.
+// StopApp forwards the stop request to the app implementation. It does not
+// wait for the goroutine to exit — pane teardown calls StopApp from inside
+// the goroutine itself (via handleAppExit -> Close), so a wait would
+// deadlock. WaitForExit is the explicit barrier for callers that need
+// synchronization.
 func (l *LocalAppLifecycle) StopApp(app App) {
 	app.Stop()
+}
+
+// WaitForExit blocks until the app's Run goroutine and onExit callback
+// have returned, then drops the bookkeeping. Safe to call after StopApp.
+// If the app was never started or has already been waited on, returns
+// immediately. Callers must not invoke this from inside the app's own
+// goroutine — that would self-deadlock.
+func (l *LocalAppLifecycle) WaitForExit(app App) {
+	l.onExitDoneMu.Lock()
+	done := l.onExitDoneByApp[app]
+	l.onExitDoneMu.Unlock()
+	if done != nil {
+		<-done
+	}
 }
 
 // Wait blocks until all started apps have exited. Primarily useful for tests.

--- a/texel/pane.go
+++ b/texel/pane.go
@@ -179,7 +179,17 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 	debuglog.Printf("AttachApp: Starting attachment of app '%s'", app.GetTitle())
 	if p.app != nil {
 		debuglog.Printf("AttachApp: Stopping existing app '%s'", p.app.GetTitle())
-		p.screen.appLifecycle.StopApp(p.app)
+		oldApp := p.app
+		p.screen.appLifecycle.StopApp(oldApp)
+		// Wait for the outgoing app's Run goroutine and onExit handler
+		// to finish before rewriting p.app — otherwise the handler's
+		// staleness check (handleAppExit reads p.app) races with the
+		// write below. Implementations that don't spawn goroutines
+		// (e.g. NoopAppLifecycle in tests) skip the AppExitWaiter
+		// interface and the wait is a no-op.
+		if waiter, ok := p.screen.appLifecycle.(AppExitWaiter); ok {
+			waiter.WaitForExit(oldApp)
+		}
 	}
 	p.app = app
 	p.name = app.GetTitle()

--- a/texel/runtime_interfaces.go
+++ b/texel/runtime_interfaces.go
@@ -47,3 +47,13 @@ type AppLifecycleManager interface {
 	StartApp(app App, onExit func(error))
 	StopApp(app App)
 }
+
+// AppExitWaiter is an optional capability some lifecycle managers provide.
+// When AttachApp swaps an old app for a new one it calls StopApp followed by
+// WaitForExit on the old app, which lets the lifecycle drain the outgoing
+// app's onExit callback before pane state is rewritten. Implementations that
+// don't need this synchronization (notably NoopAppLifecycle in tests where
+// no goroutine is spawned) can skip the interface entirely.
+type AppExitWaiter interface {
+	WaitForExit(app App)
+}


### PR DESCRIPTION
## Summary

Eliminates the three pre-existing race-detector failures that have been flaking across multiple PRs:
- `TestSnapshotRemovesCrashedApp`
- `TestSnapshotRestoresMultipleWorkspaces`
- `TestSnapshotSavedOnLayoutChange`

## Root causes

**Race A — Server lifecycle** (commit `c2b11ad`)
`Server.Start` writes `s.listener`, `s.snapshotQuit`, and calls `s.wg.Add(1)` while the test goroutine (or a deferred Stop) reads/touches the same fields. New `lifecycleMu` covers `listener`, `snapshotQuit`, and `started/stopped` flags; `Start` bails if Stop already ran; `acceptLoop` takes the listener as a parameter so it never re-reads `s.listener`; `startSnapshotLoopLocked` captures the quit channel locally so Stop swapping it out doesn't poison the select. The test stop helper is now synchronous (Stop already waits on wg internally).

**Race B — `pane.app` swap** (commit `8b6c9f6`)
`AttachApp` writes `p.app` while the lifecycle goroutine's `handleAppExit` reads it. New optional `AppExitWaiter` interface on `LocalAppLifecycle` gives `AttachApp` a way to wait for the outgoing exit handler to complete before rewriting `p.app`. `StopApp` itself stays non-blocking (avoids self-deadlock when called from `pane.Close`). `recordingApp.Run` now blocks on a `stopCh` until `Stop()` closes it, mirroring real apps.

## Test plan

- [x] `go test -race -count=20 ./internal/runtime/server/ -run "TestSnapshotRemovesCrashedApp|TestSnapshotRestoresMultipleWorkspaces|TestSnapshotSavedOnLayoutChange"` — 20 consecutive clean passes
- [x] `go test -race -count=1 ./internal/runtime/server/...` — no regressions
- [x] `go test -race -count=1 ./texel/...` — clean
- [x] `go test -count=1 ./...` — clean
- [x] `gofmt -d` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)