### PR TITLE
Fix pane.app data race when AttachApp swaps a running app

### DIFF
--- a/texel/app_lifecycle.go
+++ b/texel/app_lifecycle.go
@@ -13,34 +13,13 @@ import "sync"
 // app's Run loop in a goroutine and delegates Stop calls directly.
 type LocalAppLifecycle struct {
 	wg sync.WaitGroup
-
-	// onExitDoneMu protects onExitDoneByApp. Each running app gets a
-	// channel closed *after* its onExit callback returns. AttachApp uses
-	// this to wait for the outgoing app's exit handler to finish before
-	// rewriting pane.app, which the handler reads to perform staleness
-	// checks. Without this barrier, the swap races with the handler.
-	onExitDoneMu    sync.Mutex
-	onExitDoneByApp map[App]chan struct{}
 }
 
 // StartApp launches the app's Run method asynchronously.
 func (l *LocalAppLifecycle) StartApp(app App, onExit func(error)) {
-	onExitDone := make(chan struct{})
-	l.onExitDoneMu.Lock()
-	if l.onExitDoneByApp == nil {
-		l.onExitDoneByApp = make(map[App]chan struct{})
-	}
-	l.onExitDoneByApp[app] = onExitDone
-	l.onExitDoneMu.Unlock()
 	l.wg.Add(1)
 	go func() {
 		defer l.wg.Done()
-		defer func() {
-			l.onExitDoneMu.Lock()
-			delete(l.onExitDoneByApp, app)
-			l.onExitDoneMu.Unlock()
-			close(onExitDone)
-		}()
 		err := app.Run()
 		if onExit != nil {
 			onExit(err)
@@ -51,24 +30,9 @@ func (l *LocalAppLifecycle) StartApp(app App, onExit func(error)) {
 // StopApp forwards the stop request to the app implementation. It does not
 // wait for the goroutine to exit — pane teardown calls StopApp from inside
 // the goroutine itself (via handleAppExit -> Close), so a wait would
-// deadlock. WaitForExit is the explicit barrier for callers that need
-// synchronization.
+// deadlock.
 func (l *LocalAppLifecycle) StopApp(app App) {
 	app.Stop()
-}
-
-// WaitForExit blocks until the app's Run goroutine and onExit callback
-// have returned, then drops the bookkeeping. Safe to call after StopApp.
-// If the app was never started or has already been waited on, returns
-// immediately. Callers must not invoke this from inside the app's own
-// goroutine — that would self-deadlock.
-func (l *LocalAppLifecycle) WaitForExit(app App) {
-	l.onExitDoneMu.Lock()
-	done := l.onExitDoneByApp[app]
-	l.onExitDoneMu.Unlock()
-	if done != nil {
-		<-done
-	}
 }
 
 // Wait blocks until all started apps have exited. Primarily useful for tests.

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -774,8 +774,10 @@ func (d *DesktopEngine) CloseWorkspace(id int) {
 			if n == nil {
 				return
 			}
-			if n.Pane != nil && n.Pane.app != nil {
-				d.appLifecycle.StopApp(n.Pane.app)
+			if n.Pane != nil {
+				if app := n.Pane.currentApp(); app != nil {
+					d.appLifecycle.StopApp(app)
+				}
 			}
 			for _, child := range n.Children {
 				stopAll(child)
@@ -845,7 +847,7 @@ func (d *DesktopEngine) AppByID(id [16]byte) App {
 			return
 		}
 		if p.ID() == id {
-			result = p.app
+			result = p.currentApp()
 		}
 	})
 	return result

--- a/texel/desktop_engine_test.go
+++ b/texel/desktop_engine_test.go
@@ -242,7 +242,7 @@ func TestWorkspaceRemovesPaneWhenAppExits(t *testing.T) {
 	if ws.tree.ActiveLeaf == nil || ws.tree.ActiveLeaf.Pane == nil {
 		t.Fatalf("expected active pane after removing shell")
 	}
-	if ws.tree.ActiveLeaf.Pane.app != welcomeApp {
+	if ws.tree.ActiveLeaf.Pane.currentApp() != welcomeApp {
 		t.Fatalf("expected welcome app to remain active after shell exit")
 	}
 
@@ -256,7 +256,7 @@ func TestWorkspaceRemovesPaneWhenAppExits(t *testing.T) {
 		t.Fatalf("expected active pane after welcome restart")
 	}
 	newWelcome := lifecycle.started[2]
-	if ws.tree.ActiveLeaf.Pane.app != newWelcome {
+	if ws.tree.ActiveLeaf.Pane.currentApp() != newWelcome {
 		t.Fatalf("expected new welcome app to be active after restart")
 	}
 }
@@ -300,7 +300,7 @@ func TestCloseActivePaneRespawnsWelcome(t *testing.T) {
 		t.Fatalf("expected a new pane to exist after closing the last one")
 	}
 
-	if ws.tree.ActiveLeaf.Pane.app != newWelcome {
+	if ws.tree.ActiveLeaf.Pane.currentApp() != newWelcome {
 		t.Fatalf("expected the new welcome app to be active after respawn")
 	}
 }

--- a/texel/desktop_input.go
+++ b/texel/desktop_input.go
@@ -130,8 +130,8 @@ func (d *DesktopEngine) handleEvent(ev tcell.Event) {
 			// Route to pipeline (or app as fallback)
 			if d.zoomedPane.Pane.pipeline != nil {
 				d.zoomedPane.Pane.pipeline.HandleKey(key)
-			} else if d.zoomedPane.Pane.app != nil {
-				d.zoomedPane.Pane.app.HandleKey(key)
+			} else if app := d.zoomedPane.Pane.currentApp(); app != nil {
+				app.HandleKey(key)
 			}
 			d.zoomedPane.Pane.markDirty()
 		}

--- a/texel/desktop_overlays.go
+++ b/texel/desktop_overlays.go
@@ -302,10 +302,14 @@ func (d *DesktopEngine) activeAppTarget() string {
 		return ""
 	}
 	pane := d.activeWorkspace.ActivePane()
-	if pane == nil || pane.app == nil {
+	if pane == nil {
 		return ""
 	}
-	if provider, ok := pane.app.(SnapshotProvider); ok {
+	app := pane.currentApp()
+	if app == nil {
+		return ""
+	}
+	if provider, ok := app.(SnapshotProvider); ok {
 		appType, _ := provider.SnapshotMetadata()
 		return appType
 	}
@@ -395,10 +399,11 @@ func (d *DesktopEngine) reloadKeybindings() {
 			continue
 		}
 		forEachLeafPane(ws.tree.Root, func(p *pane) {
-			if p.app == nil {
+			app := p.currentApp()
+			if app == nil {
 				return
 			}
-			if setter, ok := p.app.(KeybindingSetter); ok {
+			if setter, ok := app.(KeybindingSetter); ok {
 				setter.SetKeybindings(newReg)
 			}
 		})
@@ -446,13 +451,13 @@ func (d *DesktopEngine) notifyAppConfigChanged() {
 			continue
 		}
 		forEachLeafPane(ws.tree.Root, func(p *pane) {
-			if p.app == nil {
+			app := p.currentApp()
+			if app == nil {
 				return
 			}
-			if reloader, ok := p.app.(ConfigReloader); ok {
+			if reloader, ok := app.(ConfigReloader); ok {
 				reloader.ReloadConfig()
 			}
 		})
 	}
 }
-

--- a/texel/pane.go
+++ b/texel/pane.go
@@ -13,6 +13,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"log"
+	"sync/atomic"
 
 	"github.com/framegrace/texelation/config"
 	"github.com/framegrace/texelation/internal/debuglog"
@@ -36,14 +37,22 @@ const (
 // Pane represents a rectangular area on the screen that hosts an App.
 type pane struct {
 	absX0, absY0, absX1, absY1 int
-	app                        App            // The real app - for interfaces only
-	pipeline                   RenderPipeline // For events and rendering (from PipelineProvider)
-	name                       string
-	prevBuf                    [][]Cell
-	screen                     *Workspace
-	id                         [16]byte
-	mouseHandler               MouseHandler
-	handlesMouse               bool
+	// app holds the currently attached application as an atomic interface
+	// pointer. AttachApp may run on a different goroutine than the
+	// lifecycle's onExit callback (which calls handleAppExit and reads the
+	// current app for a staleness check), so the swap and the staleness
+	// read must be race-free without locking — locks would deadlock when a
+	// running app like the launcher triggers ReplaceWithApp from inside its
+	// own onExit / handler goroutine. Use currentApp() / setApp() to
+	// access. The underlying value is nil when no app is attached.
+	app          atomic.Pointer[App]
+	pipeline     RenderPipeline // For events and rendering (from PipelineProvider)
+	name         string
+	prevBuf      [][]Cell
+	screen       *Workspace
+	id           [16]byte
+	mouseHandler MouseHandler
+	handlesMouse bool
 
 	// Persistent border and buffer widgets (created once, updated each frame).
 	border       *widgets.Border
@@ -55,16 +64,35 @@ type pane struct {
 	// Uses a generation counter instead of a boolean flag to avoid TOCTOU
 	// races: markDirty increments the counter, renderBuffer records the
 	// value before rendering and only caches when the counter hasn't moved.
-	renderGen     int32          // atomic: monotonically increasing dirty generation
-	lastRendered  int32          // generation when prevBuf was last produced
-	refreshStop   chan struct{}  // stop signal for refresh forwarder goroutine
-	prevTitle     string         // title when prevBuf was last rendered
+	renderGen    int32         // atomic: monotonically increasing dirty generation
+	lastRendered int32         // generation when prevBuf was last produced
+	refreshStop  chan struct{} // stop signal for refresh forwarder goroutine
+	prevTitle    string        // title when prevBuf was last rendered
 
 	// Public state fields
 	IsActive       bool
 	IsResizing     bool
 	RoundedCorners bool
 	ZOrder         int // Higher values render on top, default is 0
+}
+
+// currentApp returns the currently attached App, or nil if no app is
+// attached. Safe to call from any goroutine.
+func (p *pane) currentApp() App {
+	if a := p.app.Load(); a != nil {
+		return *a
+	}
+	return nil
+}
+
+// setApp installs (or clears, when app is nil) the pane's app pointer
+// atomically. Safe to call from any goroutine.
+func (p *pane) setApp(app App) {
+	if app == nil {
+		p.app.Store(nil)
+		return
+	}
+	p.app.Store(&app)
 }
 
 // newPane creates a new, empty Pane. The App is attached later.
@@ -177,21 +205,17 @@ func (p *pane) refreshBorderStyles() {
 // and starts its main run loop.
 func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 	debuglog.Printf("AttachApp: Starting attachment of app '%s'", app.GetTitle())
-	if p.app != nil {
-		debuglog.Printf("AttachApp: Stopping existing app '%s'", p.app.GetTitle())
-		oldApp := p.app
-		p.screen.appLifecycle.StopApp(oldApp)
-		// Wait for the outgoing app's Run goroutine and onExit handler
-		// to finish before rewriting p.app — otherwise the handler's
-		// staleness check (handleAppExit reads p.app) races with the
-		// write below. Implementations that don't spawn goroutines
-		// (e.g. NoopAppLifecycle in tests) skip the AppExitWaiter
-		// interface and the wait is a no-op.
-		if waiter, ok := p.screen.appLifecycle.(AppExitWaiter); ok {
-			waiter.WaitForExit(oldApp)
-		}
+	if existing := p.currentApp(); existing != nil {
+		debuglog.Printf("AttachApp: Stopping existing app '%s'", existing.GetTitle())
+		p.screen.appLifecycle.StopApp(existing)
+		// Don't wait for the outgoing app's onExit to fire — when the
+		// caller is the outgoing app itself (e.g. the launcher pushing
+		// a control bus event from its own goroutine, which is also
+		// the lifecycle goroutine that runs onExit), waiting would
+		// self-deadlock. The atomic swap below makes
+		// handleAppExit's staleness check race-free without blocking.
 	}
-	p.app = app
+	p.setApp(app)
 	p.name = app.GetTitle()
 
 	// Get pipeline directly from app if it provides one
@@ -211,7 +235,7 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 	if p.pipeline != nil {
 		p.pipeline.SetRefreshNotifier(paneRefresh)
 	} else {
-		p.app.SetRefreshNotifier(paneRefresh)
+		app.SetRefreshNotifier(paneRefresh)
 	}
 	debuglog.Printf("AttachApp: Refresh notifier set")
 
@@ -270,7 +294,7 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 	if p.pipeline != nil {
 		p.pipeline.Resize(p.drawableWidth(), p.drawableHeight())
 	} else {
-		p.app.Resize(p.drawableWidth(), p.drawableHeight())
+		app.Resize(p.drawableWidth(), p.drawableHeight())
 	}
 
 	// Register control bus handlers BEFORE StartApp to avoid race conditions.
@@ -322,9 +346,9 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 
 	// Start the app lifecycle AFTER all ControlBus handlers are registered.
 	debuglog.Printf("AttachApp: Starting app lifecycle for '%s'", p.getTitle())
-	currentApp := p.app
-	p.screen.appLifecycle.StartApp(p.app, func(err error) {
-		p.screen.handleAppExit(p, currentApp, err)
+	startedApp := app
+	p.screen.appLifecycle.StartApp(startedApp, func(err error) {
+		p.screen.handleAppExit(p, startedApp, err)
 	})
 
 	debuglog.Printf("AttachApp: Notifying pane state for '%s'", p.getTitle())
@@ -341,11 +365,11 @@ func (p *pane) AttachApp(app App, refreshChan chan<- bool) {
 // before starting apps. Call StartPreparedApp after layout is calculated.
 func (p *pane) PrepareAppForRestore(app App, refreshChan chan<- bool) {
 	debuglog.Printf("PrepareAppForRestore: Preparing app '%s'", app.GetTitle())
-	if p.app != nil {
-		debuglog.Printf("PrepareAppForRestore: Stopping existing app '%s'", p.app.GetTitle())
-		p.screen.appLifecycle.StopApp(p.app)
+	if existing := p.currentApp(); existing != nil {
+		debuglog.Printf("PrepareAppForRestore: Stopping existing app '%s'", existing.GetTitle())
+		p.screen.appLifecycle.StopApp(existing)
 	}
-	p.app = app
+	p.setApp(app)
 	p.name = app.GetTitle()
 
 	// Get pipeline directly from app if it provides one
@@ -365,7 +389,7 @@ func (p *pane) PrepareAppForRestore(app App, refreshChan chan<- bool) {
 	if p.pipeline != nil {
 		p.pipeline.SetRefreshNotifier(paneRefresh)
 	} else {
-		p.app.SetRefreshNotifier(paneRefresh)
+		app.SetRefreshNotifier(paneRefresh)
 	}
 
 	// Pass pane ID to apps that need it (e.g., for per-pane history)
@@ -426,7 +450,8 @@ func (p *pane) PrepareAppForRestore(app App, refreshChan chan<- bool) {
 // StartPreparedApp resizes and starts an app that was prepared via PrepareAppForRestore.
 // Should be called after layout is calculated so pane has proper dimensions.
 func (p *pane) StartPreparedApp() {
-	if p.app == nil {
+	app := p.currentApp()
+	if app == nil {
 		return
 	}
 	debuglog.Printf("StartPreparedApp: Starting app '%s' with size %dx%d", p.getTitle(), p.drawableWidth(), p.drawableHeight())
@@ -435,18 +460,18 @@ func (p *pane) StartPreparedApp() {
 	if p.pipeline != nil {
 		p.pipeline.Resize(p.drawableWidth(), p.drawableHeight())
 	} else {
-		p.app.Resize(p.drawableWidth(), p.drawableHeight())
+		app.Resize(p.drawableWidth(), p.drawableHeight())
 	}
 
 	// Start the app lifecycle
-	currentApp := p.app
-	p.screen.appLifecycle.StartApp(p.app, func(err error) {
-		p.screen.handleAppExit(p, currentApp, err)
+	startedApp := app
+	p.screen.appLifecycle.StartApp(startedApp, func(err error) {
+		p.screen.handleAppExit(p, startedApp, err)
 	})
 
 	// Register control bus handlers if this is a launcher app in a pane
-	if p.app.GetTitle() == "Launcher" {
-		if provider, ok := p.app.(ControlBusProvider); ok {
+	if app.GetTitle() == "Launcher" {
+		if provider, ok := app.(ControlBusProvider); ok {
 			provider.RegisterControl("launcher.select-app", "Launch selected app in this pane", func(payload interface{}) error {
 				appName, ok := payload.(string)
 				if !ok {
@@ -466,7 +491,7 @@ func (p *pane) StartPreparedApp() {
 	}
 
 	// Register decorator control bus handlers for all apps with a ControlBus.
-	if provider, ok := p.app.(ControlBusProvider); ok {
+	if provider, ok := app.(ControlBusProvider); ok {
 		provider.RegisterControl("decorator.add", "Add decorator action", func(payload interface{}) error {
 			if a, ok := payload.(DecoratorAction); ok {
 				p.decorator.AddAppAction(a)
@@ -506,8 +531,8 @@ func (p *pane) ReplaceWithApp(name string, config map[string]interface{}) {
 	}
 
 	// Check if current app wants to show a confirmation dialog before being replaced
-	if p.app != nil {
-		if requester, ok := p.app.(CloseCallbackRequester); ok {
+	if existing := p.currentApp(); existing != nil {
+		if requester, ok := existing.(CloseCallbackRequester); ok {
 			// Pass a callback that performs the actual replacement
 			if !requester.RequestCloseWithCallback(func() {
 				p.doReplaceWithApp(name, config)
@@ -583,8 +608,8 @@ func (p *pane) setTitle(t string) {
 }
 
 func (p *pane) getTitle() string {
-	if p.app != nil {
-		return p.app.GetTitle()
+	if app := p.currentApp(); app != nil {
+		return app.GetTitle()
 	}
 	return p.name
 }
@@ -594,10 +619,11 @@ func (p *pane) getTitle() string {
 // SetGraphicsProviderFactory when the factory becomes available after apps
 // are already running.
 func (p *pane) injectGraphicsProvider(factory func(paneID [16]byte) GraphicsProvider) {
-	if factory == nil || p.app == nil {
+	app := p.currentApp()
+	if factory == nil || app == nil {
 		return
 	}
-	if ua, ok := p.app.(interface{ UI() *texelcore.UIManager }); ok {
+	if ua, ok := app.(interface{ UI() *texelcore.UIManager }); ok {
 		if mgr := ua.UI(); mgr != nil {
 			gp := factory(p.id)
 			if gp != nil {
@@ -615,10 +641,11 @@ func (p *pane) Close() {
 		p.refreshStop = nil
 	}
 	// Clean up app
-	if listener, ok := p.app.(Listener); ok {
+	app := p.currentApp()
+	if listener, ok := app.(Listener); ok {
 		p.screen.Unsubscribe(listener)
 	}
-	if p.app != nil {
-		p.screen.appLifecycle.StopApp(p.app)
+	if app != nil {
+		p.screen.appLifecycle.StopApp(app)
 	}
 }

--- a/texel/pane_input.go
+++ b/texel/pane_input.go
@@ -27,8 +27,8 @@ func (p *pane) handlePaste(data []byte) {
 		}
 	}
 	// Fallback to app
-	if p.app != nil {
-		if handler, ok := p.app.(PasteHandler); ok {
+	if app := p.currentApp(); app != nil {
+		if handler, ok := app.(PasteHandler); ok {
 			handler.HandlePaste(data)
 			p.markDirty()
 			return
@@ -57,8 +57,8 @@ func (p *pane) handlePaste(data []byte) {
 		}
 		if p.pipeline != nil {
 			p.pipeline.HandleKey(ev)
-		} else if p.app != nil {
-			p.app.HandleKey(ev)
+		} else if app := p.currentApp(); app != nil {
+			app.HandleKey(ev)
 		}
 	}
 	p.markDirty()

--- a/texel/pane_render.go
+++ b/texel/pane_render.go
@@ -115,8 +115,9 @@ func (p *pane) renderBuffer(applyEffects bool) [][]Cell {
 	// Reset graphics placements before rendering so only visible widgets
 	// re-place their images. This mirrors the standalone runtime's
 	// graphicsProvider.Reset() → app.Render() → Flush() cycle.
-	if p.app != nil {
-		if ua, ok := p.app.(interface{ UI() *texelcore.UIManager }); ok {
+	app := p.currentApp()
+	if app != nil {
+		if ua, ok := app.(interface{ UI() *texelcore.UIManager }); ok {
 			if mgr := ua.UI(); mgr != nil {
 				if gp := mgr.GraphicsProvider(); gp != nil {
 					gp.Reset()
@@ -129,8 +130,8 @@ func (p *pane) renderBuffer(applyEffects bool) [][]Cell {
 	var appBuffer [][]Cell
 	if p.pipeline != nil {
 		appBuffer = p.pipeline.Render()
-	} else if p.app != nil {
-		appBuffer = p.app.Render()
+	} else if app != nil {
+		appBuffer = app.Render()
 	}
 
 	// Update persistent border widget state.
@@ -262,8 +263,8 @@ func (p *pane) setDimensions(x0, y0, x1, y1 int) {
 	// Resize pipeline (or app as fallback)
 	if p.pipeline != nil {
 		p.pipeline.Resize(drawableW, drawableH)
-	} else if p.app != nil {
-		p.app.Resize(drawableW, drawableH)
+	} else if app := p.currentApp(); app != nil {
+		app.Resize(drawableW, drawableH)
 	} else {
 		debuglog.Printf("setDimensions: Pane '%s' has no app yet!", p.getTitle())
 	}

--- a/texel/restore_pane_viewport_test.go
+++ b/texel/restore_pane_viewport_test.go
@@ -56,7 +56,7 @@ func (d *DesktopEngine) firstPaneIDAndApp() ([16]byte, App) {
 			return
 		}
 		id = p.ID()
-		app = p.app
+		app = p.currentApp()
 	})
 	return id, app
 }
@@ -66,7 +66,7 @@ func (d *DesktopEngine) firstPaneIDAndApp() ([16]byte, App) {
 func (d *DesktopEngine) swapPaneApp(id [16]byte, newApp App) {
 	d.forEachPane(func(p *pane) {
 		if p.ID() == id {
-			p.app = newApp
+			p.setApp(newApp)
 		}
 	})
 }

--- a/texel/runtime_interfaces.go
+++ b/texel/runtime_interfaces.go
@@ -47,13 +47,3 @@ type AppLifecycleManager interface {
 	StartApp(app App, onExit func(error))
 	StopApp(app App)
 }
-
-// AppExitWaiter is an optional capability some lifecycle managers provide.
-// When AttachApp swaps an old app for a new one it calls StopApp followed by
-// WaitForExit on the old app, which lets the lifecycle drain the outgoing
-// app's onExit callback before pane state is rewritten. Implementations that
-// don't need this synchronization (notably NoopAppLifecycle in tests where
-// no goroutine is spawned) can skip the interface entirely.
-type AppExitWaiter interface {
-	WaitForExit(app App)
-}

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -245,18 +245,23 @@ func (d *DesktopEngine) GeometryForClient() TreeCapture {
 // only need RowGlobalIdx() to detect the texterm "trailing statusbar"
 // pattern (last entry < 0).
 func applyStructuralBounds(snap *PaneSnapshot, p *pane) {
-	if p == nil || p.app == nil {
+	if p == nil {
+		snap.AltScreen = true
+		return
+	}
+	app := p.currentApp()
+	if app == nil {
 		// Placeholder pane: no content bounds, alt-screen-equivalent.
 		snap.AltScreen = true
 		return
 	}
 	h := p.Height()
-	rowProvider, hasRowProvider := p.app.(RowGlobalIdxProvider)
+	rowProvider, hasRowProvider := app.(RowGlobalIdxProvider)
 	if !hasRowProvider {
 		snap.AltScreen = true
 		return
 	}
-	if altProvider, ok := p.app.(AltScreenProvider); ok && altProvider.InAltScreen() {
+	if altProvider, ok := app.(AltScreenProvider); ok && altProvider.InAltScreen() {
 		snap.AltScreen = true
 		return
 	}
@@ -376,8 +381,8 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 	// p.app might be nil if capturing during split before attach, or if app crashed
 	var appIdx []int64
 	hasRowProvider := false
-	if p.app != nil {
-		if provider, ok := p.app.(SnapshotProvider); ok {
+	if app := p.currentApp(); app != nil {
+		if provider, ok := app.(SnapshotProvider); ok {
 			appType, config := provider.SnapshotMetadata()
 			snap.AppType = appType
 			snap.AppConfig = cloneAppConfig(config)
@@ -385,7 +390,7 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		// Terminal-like apps expose per-row globalIdxs for their rendered
 		// content. The content buffer sits inside a 1-cell border at (1,1),
 		// so offset entries by +1 and stop short of the bottom-border row.
-		rowProvider, ok := p.app.(RowGlobalIdxProvider)
+		rowProvider, ok := app.(RowGlobalIdxProvider)
 		hasRowProvider = ok
 		if hasRowProvider {
 			appIdx = rowProvider.RowGlobalIdx()
@@ -405,7 +410,7 @@ func capturePaneSnapshot(p *pane) PaneSnapshot {
 		// terminal apps). In both cases clients key rows by flat index.
 		if !hasRowProvider {
 			snap.AltScreen = true
-		} else if altProvider, ok := p.app.(AltScreenProvider); ok && altProvider.InAltScreen() {
+		} else if altProvider, ok := app.(AltScreenProvider); ok && altProvider.InAltScreen() {
 			snap.AltScreen = true
 		}
 	} else {

--- a/texel/snapshot_restore.go
+++ b/texel/snapshot_restore.go
@@ -26,7 +26,7 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 	// 1. Prepare all panes (they are flat list)
 	// We need a map to look them up by index
 	panes := make([]*pane, len(capture.Panes))
-	
+
 	// We need a dummy screen for creating panes initially, but we'll re-assign them to correct workspaces
 	// Ensure at least one workspace exists
 	if len(d.workspaces) == 0 {
@@ -44,7 +44,7 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 	}
 
 	// 2. Restore Workspaces
-	
+
 	// If legacy capture (Root only), treat as single workspace
 	if len(capture.WorkspaceRoots) == 0 && capture.Root != nil {
 		capture.WorkspaceRoots = map[int]*TreeNodeCapture{1: capture.Root}
@@ -55,7 +55,7 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 
 	for id, rootCapture := range capture.WorkspaceRoots {
 		restoredIDs[id] = true
-		
+
 		// Ensure workspace exists
 		if _, exists := d.workspaces[id]; !exists {
 			// Manually create workspace to avoid triggering side-effects of SwitchToWorkspace
@@ -65,9 +65,9 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 			}
 			d.workspaces[id] = ws
 		}
-		
+
 		screen := d.workspaces[id]
-		
+
 		// Stop existing apps in this workspace
 		if screen.tree != nil {
 			stopApps(screen.tree.Root, screen.appLifecycle)
@@ -82,10 +82,10 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 		if screen.tree == nil {
 			screen.tree = NewTree()
 		}
-		
+
 		// Re-assign panes to this workspace
 		assignPanesToWorkspace(root, screen)
-		
+
 		if active == nil {
 			active = findFirstLeaf(root)
 		}
@@ -98,7 +98,7 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 		// Calculate layout for this workspace
 		screen.recalculateLayout()
 	}
-	
+
 	// 3. Apply workspace metadata (name and color) from the snapshot.
 	// Skip empty values to preserve defaults from newWorkspace (old snapshots
 	// lack metadata entirely).
@@ -150,16 +150,17 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 		}
 	}
 	isStatusOrphan := func(p *pane) bool {
-		if p.app == nil {
+		app := p.currentApp()
+		if app == nil {
 			return false
 		}
-		title := p.app.GetTitle()
+		title := app.GetTitle()
 		if statusTitles[title] {
 			return true
 		}
 		// Belt-and-braces: the captured StatusBar app reports
 		// AppType="statusbar" via SnapshotMetadata; check that too.
-		if provider, ok := p.app.(SnapshotProvider); ok {
+		if provider, ok := app.(SnapshotProvider); ok {
 			if appType, _ := provider.SnapshotMetadata(); appType == "statusbar" {
 				return true
 			}
@@ -180,9 +181,9 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 			// to drain, panic on nil internal state, or block waiting
 			// for goroutines that never started. Wrap in recover() so
 			// a misbehaving Stop cannot abort boot snapshot restore.
-			if p.app != nil {
-				stopOrphanAppSafely(d.appLifecycle, p.app)
-				p.app = nil
+			if app := p.currentApp(); app != nil {
+				stopOrphanAppSafely(d.appLifecycle, app)
+				p.setApp(nil)
 			}
 			continue
 		}
@@ -191,7 +192,7 @@ func (d *DesktopEngine) ApplyTreeCapture(capture TreeCapture) error {
 	d.pendingAppStartsMu.Lock()
 	d.pendingAppStarts = append(d.pendingAppStarts, startable...)
 	d.pendingAppStartsMu.Unlock()
-	
+
 	// 5. Activate correct workspace
 	if capture.ActiveWorkspaceID > 0 {
 		if _, exists := d.workspaces[capture.ActiveWorkspaceID]; exists {
@@ -235,8 +236,8 @@ func assignPanesToWorkspace(node *Node, ws *Workspace) {
 		node.Pane.markDirty()
 		if node.Pane.pipeline != nil {
 			node.Pane.pipeline.SetRefreshNotifier(paneRefresh)
-		} else if node.Pane.app != nil {
-			node.Pane.app.SetRefreshNotifier(paneRefresh)
+		} else if app := node.Pane.currentApp(); app != nil {
+			app.SetRefreshNotifier(paneRefresh)
 		}
 	}
 	for _, child := range node.Children {
@@ -248,8 +249,10 @@ func stopApps(node *Node, lifecycle AppLifecycleManager) {
 	if node == nil {
 		return
 	}
-	if node.Pane != nil && node.Pane.app != nil {
-		lifecycle.StopApp(node.Pane.app)
+	if node.Pane != nil {
+		if app := node.Pane.currentApp(); app != nil {
+			lifecycle.StopApp(app)
+		}
 	}
 	for _, child := range node.Children {
 		stopApps(child, lifecycle)

--- a/texel/snapshot_test.go
+++ b/texel/snapshot_test.go
@@ -53,7 +53,7 @@ func newSnapshotTestPane(w, h int) *pane {
 	p.absX1, p.absY1 = w, h
 	// Inner app content sits at (1,1) inside a (w,h) border.
 	app := &snapshotTestApp{title: "mock", cols: w - 2, rows: h - 2}
-	p.app = app
+	p.setApp(app)
 	return p
 }
 
@@ -162,7 +162,7 @@ func newTerminalSnapshotPane(w, h int, rowIdx []int64) *pane {
 		snapshotTestApp: snapshotTestApp{title: "term", cols: w - 2, rows: h - 2},
 		rowIdx:          rowIdx,
 	}
-	p.app = app
+	p.setApp(app)
 	return p
 }
 
@@ -300,7 +300,7 @@ func TestPaneRenderBuffer_BordersSurviveOversizedAppBuffer(t *testing.T) {
 			},
 		},
 	}
-	p.app = app
+	p.setApp(app)
 
 	buf := p.renderBuffer(false)
 	if len(buf) != h {
@@ -362,7 +362,7 @@ func TestPaneRenderBuffer_BordersSurviveStyledContent(t *testing.T) {
 			rowIdx:          rowIdx,
 		},
 	}
-	p.app = app
+	p.setApp(app)
 
 	buf := p.renderBuffer(false)
 	if len(buf) != h {

--- a/texel/tree.go
+++ b/texel/tree.go
@@ -265,8 +265,10 @@ func (t *Tree) Traverse(f func(*Node)) {
 
 // ActiveTitle returns the title of the active application.
 func (t *Tree) ActiveTitle() string {
-	if t.ActiveLeaf != nil && t.ActiveLeaf.Pane != nil && t.ActiveLeaf.Pane.app != nil {
-		return t.ActiveLeaf.Pane.app.GetTitle()
+	if t.ActiveLeaf != nil && t.ActiveLeaf.Pane != nil {
+		if app := t.ActiveLeaf.Pane.currentApp(); app != nil {
+			return app.GetTitle()
+		}
 	}
 	return ""
 }

--- a/texel/workspace.go
+++ b/texel/workspace.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/framegrace/texelation/internal/debuglog"
 	"github.com/framegrace/texelation/internal/keybind"
-	"github.com/gdamore/tcell/v2"
 	"github.com/framegrace/texelui/theme"
+	"github.com/gdamore/tcell/v2"
 )
 
 type Direction int
@@ -40,7 +40,6 @@ type DebuggableApp interface {
 }
 
 type AppFactory func() App
-
 
 const (
 	ResizeStep float64 = 0.05 // Resize by 5%
@@ -253,8 +252,8 @@ func (w *Workspace) handleEvent(ev *tcell.EventKey) {
 		pane := w.tree.ActiveLeaf.Pane
 		if pane.pipeline != nil {
 			pane.pipeline.HandleKey(ev)
-		} else if pane.app != nil {
-			pane.app.HandleKey(ev)
+		} else if app := pane.currentApp(); app != nil {
+			app.HandleKey(ev)
 		}
 		// Mark pane dirty synchronously so the immediate Publish() call
 		// in DesktopSink.HandleKeyEvent sees updated state.
@@ -280,7 +279,8 @@ func (w *Workspace) handleAppExit(p *pane, exitedApp App, runErr error) {
 	}
 
 	// Ignore stale callbacks if the pane has already attached a new app.
-	if exitedApp != nil && p.app != nil && p.app != exitedApp {
+	current := p.currentApp()
+	if exitedApp != nil && current != nil && current != exitedApp {
 		debuglog.Printf("handleAppExit: ignoring exit for stale app '%s'", exitedApp.GetTitle())
 		return
 	}
@@ -288,8 +288,8 @@ func (w *Workspace) handleAppExit(p *pane, exitedApp App, runErr error) {
 	title := "unknown"
 	if exitedApp != nil {
 		title = exitedApp.GetTitle()
-	} else if p.app != nil {
-		title = p.app.GetTitle()
+	} else if current != nil {
+		title = current.GetTitle()
 	}
 
 	if runErr != nil {
@@ -365,4 +365,3 @@ func (w *Workspace) Close() {
 		}
 	})
 }
-

--- a/texel/workspace_layout.go
+++ b/texel/workspace_layout.go
@@ -194,11 +194,13 @@ func (w *Workspace) CloseActivePane() {
 
 	// Check if the app wants to intercept the close request (e.g., to show confirmation)
 	pane := w.tree.ActiveLeaf.Pane
-	if pane != nil && pane.app != nil {
-		if requester, ok := pane.app.(CloseRequester); ok {
-			if !requester.RequestClose() {
-				// App intercepted the close (showing confirmation, etc.)
-				return
+	if pane != nil {
+		if app := pane.currentApp(); app != nil {
+			if requester, ok := app.(CloseRequester); ok {
+				if !requester.RequestClose() {
+					// App intercepted the close (showing confirmation, etc.)
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

PR #208's `WaitForExit(oldApp)` synchronization in `pane.AttachApp` introduced a deadlock for the launcher → app-swap path: the launcher's ControlBus handler runs on the launcher's own lifecycle goroutine, calls `ReplaceWithApp → AttachApp`, and `WaitForExit(launcher)` then blocks waiting for the lifecycle goroutine that's currently inside `WaitForExit`. New terminals couldn't be created via the launcher.

This PR replaces the blocking barrier with `atomic.Pointer[App]` for `pane.app`. Race-detector clean (no `WARNING: DATA RACE` between `AttachApp`'s store and `handleAppExit`'s staleness load) without any chance of self-deadlock.

## Changes

- `texel/pane.go` — `pane.app atomic.Pointer[App]` + `currentApp()` / `setApp()` helpers; all reads/writes go through them
- `texel/workspace.go`, `texel/desktop_overlays.go`, `texel/desktop_engine_core.go`, `texel/desktop_input.go`, `texel/pane_input.go`, `texel/pane_render.go`, `texel/tree.go`, `texel/snapshot.go`, `texel/snapshot_restore.go`, `texel/workspace_layout.go` — call sites migrated to the helpers
- `texel/runtime_interfaces.go` — removed dead `AppExitWaiter` interface
- `texel/app_lifecycle.go` — removed dead `WaitForExit` method, `onExitDoneByApp` map, `onExitDoneMu`
- Test files updated for the helper migration

## Test plan

- [x] `go test -race -count=20 ./internal/runtime/server/ -run "TestSnapshotRemovesCrashedApp|TestSnapshotRestoresMultipleWorkspaces|TestSnapshotSavedOnLayoutChange"` — race-clean (the regression PR #208 was originally fixing stays fixed)
- [x] `go test -race -count=1 ./...` — no new races introduced
- [x] `go test -count=1 ./...` — clean
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)