### PR TITLE
Smooth top-edge pane resize: defer app.Resize until drag commits

### DIFF
--- a/texel/pane_input.go
+++ b/texel/pane_input.go
@@ -140,12 +140,34 @@ func (p *pane) SetActive(active bool) {
 	}
 }
 
-// SetResizing changes the resizing state of the pane
+// SetResizing changes the resizing state of the pane.
+//
+// While IsResizing is true, setDimensions skips the embedded app/pipeline
+// Resize call (the visible frame still tracks the drag, but the terminal
+// grid does not reflow on every motion event). On the true → false
+// transition we fire the deferred resize exactly once with the current
+// drawable dimensions so the embedded app catches up to the committed
+// frame in a single reflow. The branching mirrors setDimensions.
 func (p *pane) SetResizing(resizing bool) {
 	if p.IsResizing == resizing {
 		return
 	}
+	wasResizing := p.IsResizing
 	p.IsResizing = resizing
+
+	if wasResizing && !resizing {
+		drawableW := p.drawableWidth()
+		drawableH := p.drawableHeight()
+		if p.pipeline != nil {
+			p.pipeline.Resize(drawableW, drawableH)
+		} else if app := p.currentApp(); app != nil {
+			app.Resize(drawableW, drawableH)
+		}
+		// Force a re-render with the committed grid.
+		p.prevBuf = nil
+		p.markDirty()
+	}
+
 	p.notifyStateChange()
 	if p.screen != nil {
 		p.screen.Refresh()

--- a/texel/pane_render.go
+++ b/texel/pane_render.go
@@ -257,6 +257,15 @@ func (p *pane) setDimensions(x0, y0, x1, y1 int) {
 	p.prevBuf = nil
 	p.markDirty()
 
+	// Defer the underlying app/pipeline Resize while the pane is in an
+	// active mouse-driven resize. The visible frame slides smoothly with
+	// every motion event, but reflowing the embedded terminal grid on
+	// every pixel produces a perceived flicker at the moving edge. The
+	// deferred resize fires once on drag release (see SetResizing).
+	if p.IsResizing {
+		return
+	}
+
 	drawableW := p.drawableWidth()
 	drawableH := p.drawableHeight()
 

--- a/texel/pane_render_test.go
+++ b/texel/pane_render_test.go
@@ -1,0 +1,117 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texel/pane_render_test.go
+// Summary: Regression tests for setDimensions / SetResizing deferral. While
+// the user is dragging a pane border (IsResizing=true), the visible pane
+// rectangle must update on every motion event but the embedded app's
+// Resize must be deferred until the drag releases. This avoids a per-pixel
+// terminal grid reflow that visually flickers at the moving edge.
+
+package texel
+
+import (
+	"sync"
+	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
+	"github.com/gdamore/tcell/v2"
+)
+
+// resizeCountingApp is a minimal App that records every Resize call so the
+// tests can assert deferral while IsResizing=true and the single deferred
+// fire on SetResizing(false). Mirrors the recordingApp shape from
+// internal/runtime/server/desktop_sink_test.go but tracks Resize instead
+// of HandleKey.
+type resizeCountingApp struct {
+	mu    sync.Mutex
+	calls []resizeCall
+	title string
+}
+
+type resizeCall struct {
+	cols int
+	rows int
+}
+
+func (a *resizeCountingApp) Run() error { return nil }
+func (a *resizeCountingApp) Stop()      {}
+func (a *resizeCountingApp) Resize(cols, rows int) {
+	a.mu.Lock()
+	a.calls = append(a.calls, resizeCall{cols: cols, rows: rows})
+	a.mu.Unlock()
+}
+func (a *resizeCountingApp) Render() [][]texelcore.Cell     { return [][]texelcore.Cell{{}} }
+func (a *resizeCountingApp) GetTitle() string               { return a.title }
+func (a *resizeCountingApp) HandleKey(*tcell.EventKey)      {}
+func (a *resizeCountingApp) SetRefreshNotifier(chan<- bool) {}
+
+func (a *resizeCountingApp) snapshot() []resizeCall {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]resizeCall, len(a.calls))
+	copy(out, a.calls)
+	return out
+}
+
+// newDeferralTestPane builds a bare pane with a resizeCountingApp attached
+// directly to p.app — bypassing AttachApp so we can observe Resize calls
+// driven only by setDimensions / SetResizing without the AttachApp-time
+// initial Resize muddying the count.
+func newDeferralTestPane() (*pane, *resizeCountingApp) {
+	p := newPane(nil)
+	app := &resizeCountingApp{title: "mock"}
+	p.setApp(app)
+	return p, app
+}
+
+func TestSetDimensions_DefersAppResizeWhileResizing(t *testing.T) {
+	p, app := newDeferralTestPane()
+	p.IsResizing = true
+
+	p.setDimensions(0, 0, 10, 10)
+	p.setDimensions(0, 0, 20, 20)
+
+	calls := app.snapshot()
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 Resize calls while IsResizing=true, got %d: %+v", len(calls), calls)
+	}
+	if p.absX1 != 20 || p.absY1 != 20 {
+		t.Fatalf("expected abs coords to track latest setDimensions (20,20), got (%d,%d)", p.absX1, p.absY1)
+	}
+}
+
+func TestSetDimensions_AppResizesWhenNotResizing(t *testing.T) {
+	p, app := newDeferralTestPane()
+	p.IsResizing = false
+
+	p.setDimensions(0, 0, 20, 20)
+
+	calls := app.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 Resize call, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].cols != 18 || calls[0].rows != 18 {
+		t.Fatalf("expected Resize(18, 18) for drawable interior, got Resize(%d, %d)", calls[0].cols, calls[0].rows)
+	}
+}
+
+func TestSetResizing_FalseTriggersDeferredResize(t *testing.T) {
+	p, app := newDeferralTestPane()
+	p.IsResizing = true
+
+	p.setDimensions(0, 0, 20, 20)
+	if got := app.snapshot(); len(got) != 0 {
+		t.Fatalf("expected no Resize during drag, got %d calls", len(got))
+	}
+
+	p.SetResizing(false)
+
+	calls := app.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 deferred Resize on drag release, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].cols != 18 || calls[0].rows != 18 {
+		t.Fatalf("expected deferred Resize(18, 18), got Resize(%d, %d)", calls[0].cols, calls[0].rows)
+	}
+}


### PR DESCRIPTION
## Summary

Resizing a pane from its **top** edge produced visible flicker (content briefly scrolled up, then expanded). Resizing from the **bottom** edge was silk-smooth despite identical code paths. The asymmetry was perceptual: the bottom-edge case keeps the pane's top-left corner anchored on screen, so the eye sees a stable origin while only the bottom changes; the top edge moves the pane's frame **and** triggers a terminal reflow on every mouse-motion event — two simultaneous shifts the brain reads as flicker.

This PR defers `p.app.Resize` (and `p.pipeline.Resize`) while a pane has `IsResizing=true`. The pane's screen rectangle (`absX0/Y0/X1/Y1`) updates freely on every motion event so the bordered frame slides smoothly, but the underlying terminal grid only reflows once on drag release. Result: top-edge resize now matches the bottom-edge smoothness.

## Changes

- `texel/pane_render.go` — `setDimensions` early-returns before `pipeline.Resize`/`app.Resize` when `p.IsResizing` is true. Coords + `markDirty` always update.
- `texel/pane_input.go` — `SetResizing(false)` fires the deferred resize on the `true→false` transition with the same pipeline-or-app branching as `setDimensions`, then clears `prevBuf` and marks dirty.
- `texel/pane_render_test.go` — three new tests (deferred while resizing, normal path when not resizing, transition fires the commit) using a `resizeCountingApp` mock.

`Workspace.handleMouseResize` already calls `setBorderResizing` on both panes adjacent to the dragged border via `forEachLeafPane`, so no plumbing change there.

## Test plan

- [x] `go test -race -count=10 ./texel/ -run "SetDimensions|SetResizing"` — clean
- [x] `go test -race -count=1 ./...` — no regressions (pre-existing `apps/configeditor` race in upstream `texelui/widgets/tablayout.go` reproduces on main; unrelated)
- [x] `go vet` clean; `gofmt` clean
- [ ] Manual: split horizontally; drag the divider up/down — content stays put during the drag, reflows once on release.

## Note on PR #209

PR #209 (`fix/pane-app-swap-deadlock`) introduces `atomic.Pointer[App]` for `pane.app`. If #209 lands first, this branch needs a small rebase to thread the new helpers (`p.currentApp()` / `p.setApp()`) through the touched code paths in `pane_render.go` and `pane_input.go`. Mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)