### PR TITLE
Coalesce client render after geometry-changing tree snapshot

### DIFF
--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -361,7 +361,13 @@ func Run(opts Options) error {
 					continue
 				}
 			}
+			if remaining := state.holdRenderRemaining(time.Now()); remaining > 0 {
+				scheduleRenderWakeup(renderCh, remaining)
+				state.frameDT = 0
+				continue
+			}
 			render(state, screen)
+			state.clearHoldRender()
 			state.frameDT = 0
 
 		case <-renderCh:
@@ -370,7 +376,12 @@ func Run(opts Options) error {
 			if state.effects != nil {
 				state.effects.Update(0)
 			}
+			if remaining := state.holdRenderRemaining(time.Now()); remaining > 0 {
+				scheduleRenderWakeup(renderCh, remaining)
+				continue
+			}
 			render(state, screen)
+			state.clearHoldRender()
 
 		case ev, ok := <-events:
 			if !ok {
@@ -390,6 +401,23 @@ func Run(opts Options) error {
 			screen.SetClipboard(clip.Data)
 		}
 	}
+}
+
+// scheduleRenderWakeup ensures the render loop wakes up again after the
+// given duration so a deferred render can fire. Used when the render loop
+// observes an active hold (set after a geometry-changing TreeSnapshot)
+// and needs to bound the wait in case no BufferDelta arrives.
+//
+// The wakeup is non-blocking: if renderCh's buffer is already saturated,
+// the upcoming consumer will already trigger a render, so dropping the
+// extra signal is safe.
+func scheduleRenderWakeup(renderCh chan<- struct{}, after time.Duration) {
+	time.AfterFunc(after, func() {
+		select {
+		case renderCh <- struct{}{}:
+		default:
+		}
+	})
 }
 
 func loadKeybindings() *keybind.Registry {

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -141,6 +141,56 @@ type clientState struct {
 	// post-resume reset so a fresh session can re-log misses. Issue #199.
 	decorMissMu   sync.Mutex
 	decorMissSeen map[decorationMissKey]struct{}
+
+	// holdRenderMu guards holdRenderUntil. The protocol-handler goroutine
+	// writes it after a TreeSnapshot that changes pane geometry; the main
+	// event-loop goroutine reads (and clears) it before each render.
+	holdRenderMu    sync.Mutex
+	holdRenderUntil time.Time
+}
+
+// renderCoalesceWindow is how long the client defers rendering after a
+// TreeSnapshot whose pane geometry changed, so the buffer delta(s) that
+// follow the snapshot on the wire have time to land in the same render
+// frame. This eliminates the one-frame "jump" when a pane is resized from
+// its top edge (snapshot updates the pane Rect but PaneCache still holds
+// the old viewport rows). Server emits both messages back-to-back; on a
+// unix socket the inter-message latency is sub-millisecond, so 20ms is
+// generous without being noticeable.
+const renderCoalesceWindow = 20 * time.Millisecond
+
+// setHoldRenderUntil records that the render loop should defer rendering
+// until at least the given instant. Repeated calls take the latest
+// (furthest-future) hold so back-to-back geometry-changing snapshots all
+// extend the window.
+func (s *clientState) setHoldRenderUntil(t time.Time) {
+	s.holdRenderMu.Lock()
+	defer s.holdRenderMu.Unlock()
+	if t.After(s.holdRenderUntil) {
+		s.holdRenderUntil = t
+	}
+}
+
+// holdRenderRemaining returns how much longer the render loop must wait
+// before rendering, or 0 if the hold has elapsed (or was never set).
+func (s *clientState) holdRenderRemaining(now time.Time) time.Duration {
+	s.holdRenderMu.Lock()
+	defer s.holdRenderMu.Unlock()
+	if s.holdRenderUntil.IsZero() {
+		return 0
+	}
+	if !now.Before(s.holdRenderUntil) {
+		return 0
+	}
+	return s.holdRenderUntil.Sub(now)
+}
+
+// clearHoldRender resets the hold marker. Called after a render so a
+// subsequent geometry-changing snapshot can establish a fresh window.
+func (s *clientState) clearHoldRender() {
+	s.holdRenderMu.Lock()
+	defer s.holdRenderMu.Unlock()
+	s.holdRenderUntil = time.Time{}
 }
 
 // decorationMissKey is the dedup key for once-per-pane-row decoration miss logging.

--- a/internal/runtime/client/coalesce_render_test.go
+++ b/internal/runtime/client/coalesce_render_test.go
@@ -1,0 +1,167 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/coalesce_render_test.go
+// Summary: Tests for the render-coalescing window that defers a render
+// after a TreeSnapshot whose pane geometry changed, so the BufferDelta
+// that follows on the wire lands in the same render frame and the user
+// does not see a one-frame "jump" while resizing a pane.
+// Issue #199.
+
+package clientruntime
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/client"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// makeCoalesceTestState builds a clientState with an empty BufferCache
+// and pane-cache map, suitable for driving handleControlMessage with
+// MsgTreeSnapshot payloads. We do not wire renderCh here — the hold flag
+// is set on state regardless of channel state, which is the contract the
+// render loop relies on.
+func makeCoalesceTestState() *clientState {
+	return &clientState{
+		cache:      client.NewBufferCache(),
+		paneCaches: make(map[[16]byte]*client.PaneCache),
+	}
+}
+
+// snapshotWithPane returns a single-pane TreeSnapshot at the given rect.
+func snapshotWithPane(id [16]byte, x, y, w, h int32) protocol.TreeSnapshot {
+	return protocol.TreeSnapshot{
+		Panes: []protocol.PaneSnapshot{{
+			PaneID: id,
+			X:      x,
+			Y:      y,
+			Width:  w,
+			Height: h,
+		}},
+	}
+}
+
+// applySnapshot drives the MsgTreeSnapshot path of handleControlMessage,
+// matching how readLoop dispatches a real wire message.
+func applySnapshot(t *testing.T, state *clientState, snap protocol.TreeSnapshot) {
+	t.Helper()
+	payload, err := protocol.EncodeTreeSnapshot(snap)
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+	hdr := protocol.Header{Type: protocol.MsgTreeSnapshot}
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+}
+
+// TestRenderCoalescing_HoldsAfterGeometryChange asserts that a
+// TreeSnapshot whose pane rect differs from the cached rect arms the
+// render-hold flag, and that the hold has roughly renderCoalesceWindow
+// duration remaining immediately after.
+func TestRenderCoalescing_HoldsAfterGeometryChange(t *testing.T) {
+	state := makeCoalesceTestState()
+	var id [16]byte
+	id[0] = 1
+
+	// Seed the cache with an initial geometry.
+	applySnapshot(t, state, snapshotWithPane(id, 0, 0, 80, 24))
+
+	// First snapshot is a brand-new pane (no prior cache entry), so it
+	// already armed a hold. Clear it so we can isolate the second
+	// snapshot's effect.
+	state.clearHoldRender()
+
+	before := time.Now()
+	// Apply a snapshot that changes the pane's rect (simulating a resize
+	// from the top edge: Y and Height shift).
+	applySnapshot(t, state, snapshotWithPane(id, 0, 5, 80, 19))
+	after := time.Now()
+
+	remaining := state.holdRenderRemaining(after)
+	if remaining <= 0 {
+		t.Fatalf("hold should be active after geometry change, remaining=%v", remaining)
+	}
+	// Sanity: remaining must be at most the configured window minus the
+	// elapsed time between the call and the measurement, but no more than
+	// the configured window.
+	maxExpected := renderCoalesceWindow + 5*time.Millisecond
+	if remaining > maxExpected {
+		t.Fatalf("hold remaining %v exceeds window+slack %v", remaining, maxExpected)
+	}
+	// And remaining should still be positive for at least a few ms after
+	// `after`, since we just armed the hold.
+	if remaining < time.Millisecond {
+		t.Fatalf("hold remaining %v unexpectedly small (called at %v, measured at %v)",
+			remaining, before, after)
+	}
+
+	// A second snapshot with no rect change must not shorten the hold.
+	prevHold := state.holdRenderUntil
+	applySnapshot(t, state, snapshotWithPane(id, 0, 5, 80, 19))
+	state.holdRenderMu.Lock()
+	curHold := state.holdRenderUntil
+	state.holdRenderMu.Unlock()
+	if !curHold.Equal(prevHold) {
+		t.Fatalf("no-op snapshot must not change hold: prev=%v cur=%v", prevHold, curHold)
+	}
+}
+
+// TestRenderCoalescing_DoesNotHoldOnNoChange asserts that a TreeSnapshot
+// whose pane rects match the current cache does NOT arm the hold flag.
+// This protects steady-state snapshots (e.g., focus or revision changes
+// without geometry shifts) from being unnecessarily delayed.
+func TestRenderCoalescing_DoesNotHoldOnNoChange(t *testing.T) {
+	state := makeCoalesceTestState()
+	var id [16]byte
+	id[0] = 1
+
+	// Seed the cache.
+	applySnapshot(t, state, snapshotWithPane(id, 0, 0, 80, 24))
+	state.clearHoldRender()
+
+	// Apply an identical snapshot.
+	applySnapshot(t, state, snapshotWithPane(id, 0, 0, 80, 24))
+
+	if rem := state.holdRenderRemaining(time.Now()); rem != 0 {
+		t.Fatalf("hold should be zero after identical snapshot, got %v", rem)
+	}
+	state.holdRenderMu.Lock()
+	zero := state.holdRenderUntil.IsZero()
+	state.holdRenderMu.Unlock()
+	if !zero {
+		t.Fatalf("holdRenderUntil should remain zero after identical snapshot")
+	}
+}
+
+// TestRenderCoalescing_HoldClearsAfterRender asserts that
+// clearHoldRender resets the hold marker so a subsequent
+// holdRenderRemaining call returns zero (matching what the render loop
+// sees after it consumes a frame).
+func TestRenderCoalescing_HoldClearsAfterRender(t *testing.T) {
+	state := makeCoalesceTestState()
+	state.setHoldRenderUntil(time.Now().Add(50 * time.Millisecond))
+	if rem := state.holdRenderRemaining(time.Now()); rem <= 0 {
+		t.Fatalf("hold should be active, remaining=%v", rem)
+	}
+	state.clearHoldRender()
+	if rem := state.holdRenderRemaining(time.Now()); rem != 0 {
+		t.Fatalf("hold remaining should be zero after clear, got %v", rem)
+	}
+}
+
+// TestRenderCoalescing_HoldExpires asserts that holdRenderRemaining
+// returns 0 once the hold instant has passed, even if clearHoldRender
+// has not yet been called. This is what lets a tickCh fire after the
+// window even if no BufferDelta arrived.
+func TestRenderCoalescing_HoldExpires(t *testing.T) {
+	state := makeCoalesceTestState()
+	past := time.Now().Add(-1 * time.Second)
+	state.setHoldRenderUntil(past)
+	if rem := state.holdRenderRemaining(time.Now()); rem != 0 {
+		t.Fatalf("hold remaining for past instant should be zero, got %v", rem)
+	}
+}

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/framegrace/texelation/client"
 	"github.com/framegrace/texelation/internal/debuglog"
 	"github.com/framegrace/texelation/internal/effects"
 	"github.com/framegrace/texelation/protocol"
@@ -47,8 +48,19 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 			log.Printf("decode snapshot failed: %v", err)
 			return false
 		}
+		// Snapshot pre-snap pane geometry so we can detect rect changes
+		// AFTER ApplySnapshot. ApplySnapshot overwrites pane.Rect, so the
+		// diff must be captured first. If any pane's rect changed, defer
+		// the next render briefly to give the BufferDelta(s) that follow
+		// this snapshot on the wire time to land in the same frame —
+		// otherwise the user sees one frame with new pane Rect but stale
+		// PaneCache content (the resize-from-top-edge "jump"). Issue #199.
+		geomChanged := snapshotChangesPaneGeometry(cache, snap)
 		// Always apply snapshots - empty snapshots clear the cache (e.g., when switching to empty workspace)
 		cache.ApplySnapshot(snap)
+		if geomChanged {
+			state.setHoldRenderUntil(time.Now().Add(renderCoalesceWindow))
+		}
 		applyPostResumeReset(state, lastSequence) // Plan D2: one-shot reset on post-resume snapshot
 		state.fullRenderNeeded = true
 		if state.effects != nil {
@@ -245,6 +257,32 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		}
 		cache.ImageCache().ResetPlacements(reset.PaneID)
 		return true
+	}
+	return false
+}
+
+// snapshotChangesPaneGeometry reports whether any pane in snap has a
+// different rect (X/Y/Width/Height) than the corresponding pane currently
+// in cache. Newly-introduced panes (no prior cache entry) count as
+// geometry changes — they enter the layout with a brand-new rect, and the
+// buffer delta(s) that follow likely carry their initial content. Removed
+// panes do not by themselves require coalescing.
+//
+// Must be called BEFORE cache.ApplySnapshot(snap), since ApplySnapshot
+// overwrites pane.Rect with the snapshot's values.
+func snapshotChangesPaneGeometry(cache *client.BufferCache, snap protocol.TreeSnapshot) bool {
+	if cache == nil {
+		return false
+	}
+	for _, p := range snap.Panes {
+		prev := cache.PaneByID(p.PaneID)
+		if prev == nil {
+			return true
+		}
+		r := prev.Rect
+		if r.X != int(p.X) || r.Y != int(p.Y) || r.Width != int(p.Width) || r.Height != int(p.Height) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Eliminates the intermediate "jump" frame visible when resizing a pane (most visible on top-edge resize of a bottom-stacked pane). The client was rendering twice per resize tick: once after the `MsgTreeSnapshot` (with new pane.Rect but stale PaneCache mapping derived from the pre-snapshot `ContentTopRow`/`NumContentRows`), and once after the trailing `MsgBufferDelta`. The first render painted a misaligned frame for ~1ms before the corrected second render landed — the brain reads that as a flicker/jump.

This PR adds a 20 ms hold on the render loop after applying a tree snapshot whose pane geometry changed. The trailing buffer delta arrives within that window (sub-ms RTT on a unix socket), the render fires once, and the user sees one coherent frame.

## How it works

- New field `holdRenderUntil time.Time` on `clientState`, with helpers `setHoldRenderUntil` / `holdRenderRemaining` / `clearHoldRender` (lock-protected).
- `protocol_handler.go MsgTreeSnapshot`: after applying the snapshot, diff post-snap pane Rects against the pre-snap snapshot. If any pane's Rect changed, set the hold deadline to `now + renderCoalesceWindow` (20 ms).
- `app.go` render loop: in the `<-renderCh` and `<-tickCh` cases, check `holdRenderRemaining`. If positive, schedule a wakeup via `time.AfterFunc` at the deadline and skip the render. After rendering, clear the hold.

20 ms is the published constant `renderCoalesceWindow` — generous for adjacent-publish-cycle messages, invisible to the user.

## Test plan

- [x] `go test -race -count=10 ./internal/runtime/client/ -run "Coalescing"` — clean
- [x] `go test -race -count=1 ./...` — clean (modulo two pre-existing flakes: `apps/configeditor` upstream `texelui/widgets/tablayout.go` race, and `apps/texelterm/parser/TestBurstWriteRecovery_DirtyClose_AfterIdleFlush` reproducing intermittently on plain main — both unaffected by this change, verified by stash/restore)
- [x] `go vet`, `gofmt` clean
- [ ] Manual: split horizontally into two stacked bash terminals, drag the divider rapidly. Bottom pane should now match the top pane's smoothness during the drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)