### PR TITLE
Fix client protocol deadlock under write back-pressure

### DIFF
--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -14,7 +14,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -106,7 +105,8 @@ func Run(opts Options) error {
 	// `defer conn.Close()` shape.
 	defer func() { conn.Close() }()
 
-	var writeMu sync.Mutex
+	writer := newMessageWriter(conn, 256)
+	defer writer.Close()
 
 	debuglog.Printf("Connected to session %s", client.FormatUUID(accept.SessionID))
 
@@ -125,7 +125,7 @@ func Run(opts Options) error {
 
 	// Wire connection context for FlushFrame (set once, never mutated).
 	state.conn = conn
-	state.writeMu = &writeMu
+	state.writer = writer
 	state.sessionID = accept.SessionID
 
 	// Load keybindings from config file or use platform defaults.
@@ -198,7 +198,7 @@ func Run(opts Options) error {
 			// state and recovery is the user's job.
 			return fmt.Errorf("resume request failed: %w", err)
 		}
-		handleControlMessage(state, conn, hdr, payload, sessionID, &lastSequence, &writeMu, &pendingAck, ackSignal)
+		handleControlMessage(state, hdr, payload, sessionID, &lastSequence, writer, &pendingAck, ackSignal)
 	}
 
 	// Plan D: install debounced persistence Writer. nil-safe — if path
@@ -243,14 +243,14 @@ func Run(opts Options) error {
 	state.setRenderChannel(renderCh)
 	doneCh := make(chan struct{})
 	panicLogger.Go("readLoop", func() {
-		readLoop(conn, state, sessionID, &lastSequence, renderCh, doneCh, &writeMu, &pendingAck, ackSignal)
+		readLoop(conn, state, sessionID, &lastSequence, renderCh, doneCh, writer, &pendingAck, ackSignal)
 	})
 	pingStop := make(chan struct{})
 	panicLogger.Go("pingLoop", func() {
-		pingLoop(conn, sessionID, doneCh, pingStop, &writeMu)
+		pingLoop(sessionID, doneCh, pingStop, writer)
 	})
 	panicLogger.Go("ackLoop", func() {
-		ackLoop(conn, sessionID, &writeMu, doneCh, &pendingAck, &lastAck, ackSignal)
+		ackLoop(sessionID, writer, doneCh, &pendingAck, &lastAck, ackSignal)
 	})
 
 	screen, err := tcell.NewScreen()
@@ -282,7 +282,7 @@ func Run(opts Options) error {
 	}
 
 	// Send ClientReady with our dimensions so server can send properly-sized snapshot
-	sendClientReady(&writeMu, conn, sessionID, screen)
+	sendClientReady(writer, sessionID, screen)
 
 	render(state, screen)
 
@@ -376,7 +376,7 @@ func Run(opts Options) error {
 			if !ok {
 				return nil
 			}
-			if !handleScreenEvent(ev, state, screen, conn, sessionID, &writeMu) {
+			if !handleScreenEvent(ev, state, screen, sessionID, writer) {
 				return nil
 			}
 

--- a/internal/runtime/client/background_tasks.go
+++ b/internal/runtime/client/background_tasks.go
@@ -9,15 +9,13 @@ package clientruntime
 
 import (
 	"log"
-	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/framegrace/texelation/protocol"
 )
 
-func pingLoop(conn net.Conn, sessionID [16]byte, done <-chan struct{}, stop <-chan struct{}, writeMu *sync.Mutex) {
+func pingLoop(sessionID [16]byte, done <-chan struct{}, stop <-chan struct{}, writer *messageWriter) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -34,7 +32,7 @@ func pingLoop(conn net.Conn, sessionID [16]byte, done <-chan struct{}, stop <-ch
 				continue
 			}
 			header := protocol.Header{Version: protocol.Version, Type: protocol.MsgPing, Flags: protocol.FlagChecksum, SessionID: sessionID}
-			if err := writeMessage(writeMu, conn, header, payload); err != nil {
+			if err := writer.Send(header, payload); err != nil {
 				log.Printf("send ping failed: %v", err)
 				return
 			}
@@ -58,7 +56,7 @@ func scheduleAck(pending *atomic.Uint64, signal chan<- struct{}, seq uint64) {
 	}
 }
 
-func ackLoop(conn net.Conn, sessionID [16]byte, writeMu *sync.Mutex, done <-chan struct{}, pending *atomic.Uint64, lastAck *atomic.Uint64, signal <-chan struct{}) {
+func ackLoop(sessionID [16]byte, writer *messageWriter, done <-chan struct{}, pending *atomic.Uint64, lastAck *atomic.Uint64, signal <-chan struct{}) {
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -83,7 +81,7 @@ func ackLoop(conn net.Conn, sessionID [16]byte, writeMu *sync.Mutex, done <-chan
 			Flags:     protocol.FlagChecksum,
 			SessionID: sessionID,
 		}
-		if err := writeMessage(writeMu, conn, header, payload); err != nil {
+		if err := writer.Send(header, payload); err != nil {
 			log.Printf("ack send failed: %v", err)
 			return
 		}

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -56,7 +56,7 @@ type clientState struct {
 
 	// Wire for FlushFrame — set once after connect, never mutated thereafter.
 	conn      net.Conn
-	writeMu   *sync.Mutex
+	writer    *messageWriter
 	sessionID [16]byte
 
 	clipboardMu          sync.Mutex
@@ -204,7 +204,7 @@ func (s *clientState) setThemeValue(section, key string, value interface{}) {
 	sec[key] = value
 }
 
-func (s *clientState) scheduleResize(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, resize protocol.Resize) {
+func (s *clientState) scheduleResize(writer *messageWriter, sessionID [16]byte, resize protocol.Resize) {
 	if s == nil {
 		return
 	}
@@ -223,7 +223,7 @@ func (s *clientState) scheduleResize(writeMu *sync.Mutex, conn net.Conn, session
 		}
 		res := s.pendingResize
 		s.resizeMu.Unlock()
-		sendResizeMessage(writeMu, conn, sessionID, res)
+		sendResizeMessage(writer, sessionID, res)
 	}()
 }
 

--- a/internal/runtime/client/input_handler.go
+++ b/internal/runtime/client/input_handler.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"sync"
 	"unicode/utf8"
 
 	"github.com/framegrace/texelation/internal/debuglog"
@@ -22,7 +21,7 @@ import (
 	"github.com/framegrace/texelation/protocol"
 )
 
-func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, conn net.Conn, sessionID [16]byte, writeMu *sync.Mutex) bool {
+func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, sessionID [16]byte, writer *messageWriter) bool {
 	switch ev := ev.(type) {
 	case *tcell.EventKey:
 		// Dismiss restart notification on any key press
@@ -55,7 +54,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 		if state.controlMode && ev.Modifiers() == 0 {
 			r := ev.Rune()
 			if r == 'q' || r == 'Q' {
-				if err := sendKeyEvent(writeMu, conn, sessionID, tcell.KeyEsc, 0, 0); err != nil {
+				if err := sendKeyEvent(writer, sessionID, tcell.KeyEsc, 0, 0); err != nil {
 					log.Printf("control reset failed: %v", err)
 				}
 				state.controlMode = false
@@ -92,7 +91,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 			}
 			render(state, screen)
 		}
-		if err := sendKeyEvent(writeMu, conn, sessionID, ev.Key(), ev.Rune(), ev.Modifiers()); err != nil {
+		if err := sendKeyEvent(writer, sessionID, ev.Key(), ev.Rune(), ev.Modifiers()); err != nil {
 			log.Printf("send key failed: %v", err)
 		} else if state.effects != nil {
 			r := ev.Rune()
@@ -126,7 +125,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 		x, y := ev.Position()
 		mouse := protocol.MouseEvent{X: int16(x), Y: int16(y), ButtonMask: uint32(ev.Buttons()), Modifiers: uint16(ev.Modifiers())}
 		payload, _ := protocol.EncodeMouseEvent(mouse)
-		if err := writeMessage(writeMu, conn, protocol.Header{Version: protocol.Version, Type: protocol.MsgMouseEvent, Flags: protocol.FlagChecksum, SessionID: sessionID}, payload); err != nil {
+		if err := writer.Send(protocol.Header{Version: protocol.Version, Type: protocol.MsgMouseEvent, Flags: protocol.FlagChecksum, SessionID: sessionID}, payload); err != nil {
 			log.Printf("send mouse failed: %v", err)
 		}
 		if selectionChanged {
@@ -135,7 +134,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 		if state.selection.consumePendingCopy() {
 			if data, mime, ok := state.selectionClipboardData(); ok {
 				screen.SetClipboard(data)
-				sendClipboardSet(writeMu, conn, sessionID, mime, data)
+				sendClipboardSet(writer, sessionID, mime, data)
 			}
 		}
 		if state.idleWatcher != nil {
@@ -143,7 +142,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 		}
 	case *tcell.EventResize:
 		cols, rows := screen.Size()
-		state.scheduleResize(writeMu, conn, sessionID, protocol.Resize{Cols: uint16(cols), Rows: uint16(rows)})
+		state.scheduleResize(writer, sessionID, protocol.Resize{Cols: uint16(cols), Rows: uint16(rows)})
 		state.fullRenderNeeded = true
 		state.triggerRender()
 	case *tcell.EventInterrupt:
@@ -156,7 +155,7 @@ func handleScreenEvent(ev tcell.Event, state *clientState, screen tcell.Screen, 
 			state.pasting = false
 			if len(state.pasteBuf) > 0 {
 				data := append([]byte(nil), state.pasteBuf...)
-				if err := sendPaste(writeMu, conn, sessionID, data); err != nil {
+				if err := sendPaste(writer, sessionID, data); err != nil {
 					log.Printf("send paste failed: %v", err)
 				}
 				state.pasteBuf = state.pasteBuf[:0]

--- a/internal/runtime/client/message_sender.go
+++ b/internal/runtime/client/message_sender.go
@@ -9,16 +9,13 @@ package clientruntime
 
 import (
 	"log"
-	"net"
-	"sync"
 
-	"github.com/framegrace/texelation/internal/debuglog"
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/framegrace/texelation/protocol"
 )
 
-func sendClientReady(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, screen tcell.Screen) {
+func sendClientReady(writer *messageWriter, sessionID [16]byte, screen tcell.Screen) {
 	cols, rows := screen.Size()
 	if cols == 0 || rows == 0 {
 		return
@@ -29,17 +26,17 @@ func sendClientReady(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, scr
 		return
 	}
 	header := protocol.Header{Version: protocol.Version, Type: protocol.MsgClientReady, Flags: protocol.FlagChecksum, SessionID: sessionID}
-	if err := writeMessage(writeMu, conn, header, payload); err != nil {
+	if err := writer.Send(header, payload); err != nil {
 		log.Printf("send client ready failed: %v", err)
 	}
 }
 
-func sendResize(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, screen tcell.Screen) {
+func sendResize(writer *messageWriter, sessionID [16]byte, screen tcell.Screen) {
 	cols, rows := screen.Size()
-	sendResizeMessage(writeMu, conn, sessionID, protocol.Resize{Cols: uint16(cols), Rows: uint16(rows)})
+	sendResizeMessage(writer, sessionID, protocol.Resize{Cols: uint16(cols), Rows: uint16(rows)})
 }
 
-func sendResizeMessage(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, resize protocol.Resize) {
+func sendResizeMessage(writer *messageWriter, sessionID [16]byte, resize protocol.Resize) {
 	if resize.Cols == 0 || resize.Rows == 0 {
 		return
 	}
@@ -49,32 +46,31 @@ func sendResizeMessage(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, r
 		return
 	}
 	header := protocol.Header{Version: protocol.Version, Type: protocol.MsgResize, Flags: protocol.FlagChecksum, SessionID: sessionID}
-	if err := writeMessage(writeMu, conn, header, payload); err != nil {
+	if err := writer.Send(header, payload); err != nil {
 		log.Printf("send resize failed: %v", err)
 	}
 }
 
-func sendKeyEvent(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, key tcell.Key, r rune, mods tcell.ModMask) error {
+func sendKeyEvent(writer *messageWriter, sessionID [16]byte, key tcell.Key, r rune, mods tcell.ModMask) error {
 	event := protocol.KeyEvent{KeyCode: uint32(key), RuneValue: r, Modifiers: uint16(mods)}
-	// log.Printf("send key: key=%v rune=%q mods=%v", key, r, mods)
 	payload, err := protocol.EncodeKeyEvent(event)
 	if err != nil {
 		return err
 	}
 	header := protocol.Header{Version: protocol.Version, Type: protocol.MsgKeyEvent, Flags: protocol.FlagChecksum, SessionID: sessionID}
-	return writeMessage(writeMu, conn, header, payload)
+	return writer.Send(header, payload)
 }
 
-func sendPaste(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, data []byte) error {
+func sendPaste(writer *messageWriter, sessionID [16]byte, data []byte) error {
 	payload, err := protocol.EncodePaste(protocol.Paste{Data: data})
 	if err != nil {
 		return err
 	}
 	header := protocol.Header{Version: protocol.Version, Type: protocol.MsgPaste, Flags: protocol.FlagChecksum, SessionID: sessionID}
-	return writeMessage(writeMu, conn, header, payload)
+	return writer.Send(header, payload)
 }
 
-func sendClipboardSet(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, mime string, data []byte) {
+func sendClipboardSet(writer *messageWriter, sessionID [16]byte, mime string, data []byte) {
 	msg := protocol.ClipboardSet{MimeType: mime, Data: data}
 	payload, err := protocol.EncodeClipboardSet(msg)
 	if err != nil {
@@ -82,14 +78,7 @@ func sendClipboardSet(writeMu *sync.Mutex, conn net.Conn, sessionID [16]byte, mi
 		return
 	}
 	header := protocol.Header{Version: protocol.Version, Type: protocol.MsgClipboardSet, Flags: protocol.FlagChecksum, SessionID: sessionID}
-	if err := writeMessage(writeMu, conn, header, payload); err != nil {
+	if err := writer.Send(header, payload); err != nil {
 		log.Printf("send clipboard set failed: %v", err)
 	}
-}
-
-func writeMessage(mu *sync.Mutex, conn net.Conn, header protocol.Header, payload []byte) error {
-	mu.Lock()
-	defer mu.Unlock()
-	debuglog.Printf("client tx type=%d seq=%d len=%d", header.Type, header.Sequence, len(payload))
-	return protocol.WriteMessage(conn, header, payload)
 }

--- a/internal/runtime/client/message_writer.go
+++ b/internal/runtime/client/message_writer.go
@@ -1,0 +1,177 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/message_writer.go
+// Summary: Async message writer that decouples the read loop from socket
+// back-pressure. Replaces the bare writeMu+conn pattern that deadlocked
+// when the read loop tried to issue a fetch-range write while the kernel
+// send buffer was full (see commit log around the resize-storm freeze).
+//
+// Invariant: the caller of Send/TrySend never holds the OS write side; a
+// single dedicated goroutine drains the queue. This means the readLoop can
+// keep draining incoming frames even when the write side is congested,
+// breaking the symmetric "both sides blocked on Write" deadlock.
+
+package clientruntime
+
+import (
+	"errors"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/framegrace/texelation/internal/debuglog"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// queuedMessage is one pending wire message held by the writer queue. When
+// flushed is non-nil the entry is a synchronization barrier — the writer
+// goroutine closes it without writing anything. Used by tests via
+// flushPending to wait for all preceding writes to land on the conn.
+type queuedMessage struct {
+	header  protocol.Header
+	payload []byte
+	flushed chan struct{}
+}
+
+// errWriterClosed is returned by Send when the writer has shut down (either
+// the writer goroutine returned after a write error, or Close was called).
+var errWriterClosed = errors.New("client: message writer closed")
+
+// messageWriter serializes writes to a net.Conn through a buffered channel
+// drained by a single goroutine. All writeMessage call sites enqueue here
+// instead of holding a mutex across socket I/O.
+type messageWriter struct {
+	conn     net.Conn
+	queue    chan queuedMessage
+	shutdown chan struct{}         // closed by Close to signal goroutine + senders
+	done     chan struct{}         // closed when the writer goroutine has exited
+	err      atomic.Pointer[error] // last write error, set before done is closed
+
+	closeOnce sync.Once
+}
+
+// newMessageWriter starts a writer goroutine that drains queued messages and
+// writes them serially to conn. bufSize sets the queue capacity: large enough
+// that bursts (a flashy resize) absorb without back-pressure on senders, but
+// small enough that a stuck socket surfaces as queue saturation rather than
+// unbounded memory growth. 256 fits ~16 KiB of typical client→server traffic.
+func newMessageWriter(conn net.Conn, bufSize int) *messageWriter {
+	w := &messageWriter{
+		conn:     conn,
+		queue:    make(chan queuedMessage, bufSize),
+		shutdown: make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	go w.run()
+	return w
+}
+
+// run drains the queue serially. Exits on shutdown signal OR on a terminal
+// write error. We never close the queue (callers may race with shutdown);
+// the shutdown channel is the explicit termination signal that makes Send
+// return an error rather than panicking on send-to-closed-channel.
+func (w *messageWriter) run() {
+	defer close(w.done)
+	for {
+		select {
+		case msg := <-w.queue:
+			if msg.flushed != nil {
+				close(msg.flushed)
+				continue
+			}
+			debuglog.Printf("client tx type=%d seq=%d len=%d", msg.header.Type, msg.header.Sequence, len(msg.payload))
+			if err := protocol.WriteMessage(w.conn, msg.header, msg.payload); err != nil {
+				w.err.Store(&err)
+				log.Printf("client write failed: %v", err)
+				return
+			}
+		case <-w.shutdown:
+			return
+		}
+	}
+}
+
+// Send enqueues a message, blocking on a full queue until space frees up or
+// the writer shuts down. Use from goroutines that are NOT on the read path
+// (eventPoll, ackLoop, pingLoop, scheduleResize). Returns an error if the
+// writer is no longer running.
+func (w *messageWriter) Send(header protocol.Header, payload []byte) error {
+	// Fast-path: refuse new sends once the writer goroutine has set a
+	// terminal error. This matters for callers (flushFrame) that gate
+	// state-machine transitions on the send result — after a write
+	// failure they need to skip the pane rather than lock in a
+	// reservation that will never get sent.
+	if ep := w.err.Load(); ep != nil {
+		return *ep
+	}
+	select {
+	case w.queue <- queuedMessage{header: header, payload: payload}:
+		return nil
+	case <-w.shutdown:
+		return errWriterClosed
+	case <-w.done:
+		if ep := w.err.Load(); ep != nil {
+			return *ep
+		}
+		return errWriterClosed
+	}
+}
+
+// TrySend enqueues a message non-blocking. Returns false if the queue is
+// full OR if the writer has shut down due to a previous write error. Use
+// from readLoop and any code path where blocking on the write side would
+// back up the read pump and deadlock the protocol. Dropped messages must
+// be idempotent or self-recovering (fetch-range requests are re-issued on
+// the next flushFrame; pongs are best-effort — if we fail to pong, the
+// server will time us out and close, which is the right thing).
+func (w *messageWriter) TrySend(header protocol.Header, payload []byte) bool {
+	if ep := w.err.Load(); ep != nil {
+		return false
+	}
+	select {
+	case <-w.shutdown:
+		return false
+	default:
+	}
+	select {
+	case w.queue <- queuedMessage{header: header, payload: payload}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Close stops the writer goroutine and waits for it to exit. Safe to call
+// multiple times and safe under concurrent Send/TrySend (we close shutdown
+// rather than the queue, so racing senders return errWriterClosed instead
+// of panicking on send-to-closed-channel). After Close returns, the writer
+// goroutine has exited and any messages still in the queue are dropped.
+func (w *messageWriter) Close() {
+	w.closeOnce.Do(func() {
+		close(w.shutdown)
+	})
+	<-w.done
+}
+
+// flushPending blocks until all messages enqueued before the call have been
+// drained by the writer goroutine. Test-only synchronization barrier — the
+// production code never reads from the conn we write to, so it has no need
+// for this. The flush sentinel travels through the queue in FIFO order, so
+// when it lands on the writer side every prior queuedMessage has already
+// been written. Returns immediately if the writer has shut down.
+func (w *messageWriter) flushPending() {
+	flushed := make(chan struct{})
+	select {
+	case w.queue <- queuedMessage{flushed: flushed}:
+	case <-w.shutdown:
+		return
+	case <-w.done:
+		return
+	}
+	select {
+	case <-flushed:
+	case <-w.done:
+	}
+}

--- a/internal/runtime/client/message_writer_testutil_test.go
+++ b/internal/runtime/client/message_writer_testutil_test.go
@@ -1,0 +1,23 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Test helpers for the async message writer. The writer drains queued
+// messages from a goroutine; tests inspecting the underlying conn need
+// (a) deterministic shutdown (Close) and (b) a synchronization barrier
+// after each Send (flushPending) before reading.
+
+package clientruntime
+
+import (
+	"net"
+	"testing"
+)
+
+// newTestWriter wraps conn with a messageWriter and registers a Cleanup
+// hook so the writer goroutine exits when the test ends.
+func newTestWriter(t testing.TB, conn net.Conn) *messageWriter {
+	t.Helper()
+	w := newMessageWriter(conn, 256)
+	t.Cleanup(func() { w.Close() })
+	return w
+}

--- a/internal/runtime/client/pane_cache_dispatch_test.go
+++ b/internal/runtime/client/pane_cache_dispatch_test.go
@@ -88,7 +88,7 @@ func TestClientState_BufferDeltaAppliesToPaneCache(t *testing.T) {
 	var pendingAck atomic.Uint64
 	ackCh := make(chan struct{}, 1)
 
-	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
 
 	pc := state.paneCacheFor(paneID)
 	row, ok := pc.RowAt(500)
@@ -139,7 +139,7 @@ func TestClientState_FetchRangeResponseAppliesToPaneCache(t *testing.T) {
 	var pendingAck atomic.Uint64
 	ackCh := make(chan struct{}, 1)
 
-	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
 
 	pc := state.paneCacheFor(paneID)
 	row, ok := pc.RowAt(1000)
@@ -183,7 +183,7 @@ func TestClientState_SnapshotPrunesPaneCache(t *testing.T) {
 	var pendingAck atomic.Uint64
 	ackCh := make(chan struct{}, 1)
 
-	handleControlMessage(state, nil, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
 
 	state.paneCachesMu.RLock()
 	_, has1 := state.paneCaches[id1]

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -10,7 +10,6 @@ package clientruntime
 import (
 	"log"
 	"net"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 	"github.com/framegrace/texelation/protocol"
 )
 
-func readLoop(conn net.Conn, state *clientState, sessionID [16]byte, lastSequence *atomic.Uint64, renderCh chan<- struct{}, doneCh chan<- struct{}, writeMu *sync.Mutex, pendingAck *atomic.Uint64, ackSignal chan<- struct{}) {
+func readLoop(conn net.Conn, state *clientState, sessionID [16]byte, lastSequence *atomic.Uint64, renderCh chan<- struct{}, doneCh chan<- struct{}, writer *messageWriter, pendingAck *atomic.Uint64, ackSignal chan<- struct{}) {
 	for {
 		hdr, payload, err := protocol.ReadMessage(conn)
 		if err != nil {
@@ -29,7 +28,7 @@ func readLoop(conn net.Conn, state *clientState, sessionID [16]byte, lastSequenc
 			close(doneCh)
 			return
 		}
-		if handleControlMessage(state, conn, hdr, payload, sessionID, lastSequence, writeMu, pendingAck, ackSignal) {
+		if handleControlMessage(state, hdr, payload, sessionID, lastSequence, writer, pendingAck, ackSignal) {
 			select {
 			case renderCh <- struct{}{}:
 			default:
@@ -38,7 +37,7 @@ func readLoop(conn net.Conn, state *clientState, sessionID [16]byte, lastSequenc
 	}
 }
 
-func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header, payload []byte, sessionID [16]byte, lastSequence *atomic.Uint64, writeMu *sync.Mutex, pendingAck *atomic.Uint64, ackSignal chan<- struct{}) bool {
+func handleControlMessage(state *clientState, hdr protocol.Header, payload []byte, sessionID [16]byte, lastSequence *atomic.Uint64, writer *messageWriter, pendingAck *atomic.Uint64, ackSignal chan<- struct{}) bool {
 	cache := state.cache
 	switch hdr.Type {
 	case protocol.MsgTreeSnapshot:
@@ -113,7 +112,7 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		// Clear inflight flag and emit pending fetch if one was stashed.
 		if state.viewports != nil {
 			if lo, hi, send := state.onFetchRangeResponse(resp.PaneID); send {
-				if !sendFetchRange(state, conn, writeMu, sessionID, resp.PaneID, lo, hi) {
+				if !sendFetchRange(state, writer, sessionID, resp.PaneID, lo, hi) {
 					// Write failed after we drained pendingFetch — restore
 					// the window so flushFrame retries instead of silently
 					// losing the request.
@@ -124,13 +123,17 @@ func handleControlMessage(state *clientState, conn net.Conn, hdr protocol.Header
 		return true
 	case protocol.MsgPing:
 		pong, _ := protocol.EncodePong(protocol.Pong{Timestamp: time.Now().UnixNano()})
-		if err := writeMessage(writeMu, conn, protocol.Header{
+		// Pong is on the read path: blocking on a full writer queue would
+		// stop us from draining the socket and could deadlock the protocol
+		// (see message_writer.go). Drop the pong if the queue is saturated;
+		// the server's keep-alive timeout will surface a real disconnect.
+		if !writer.TrySend(protocol.Header{
 			Version:   protocol.Version,
 			Type:      protocol.MsgPong,
 			Flags:     protocol.FlagChecksum,
 			SessionID: sessionID,
-		}, pong); err != nil {
-			log.Printf("send pong failed: %v", err)
+		}, pong) {
+			log.Printf("dropped pong: writer queue full")
 		}
 		return false
 	case protocol.MsgClipboardSet:

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -381,7 +381,7 @@ func render(state *clientState, screen tcell.Screen) {
 	// This puts MsgViewportUpdate on the wire before the frame is rendered,
 	// so the server's next emission window is already correct.
 	if state.viewports != nil {
-		flushFrame(state, state.conn, state.writeMu, state.sessionID)
+		flushFrame(state, state.writer, state.sessionID)
 	}
 
 	width, height := screen.Size()

--- a/internal/runtime/client/viewport_tracker.go
+++ b/internal/runtime/client/viewport_tracker.go
@@ -16,7 +16,6 @@ package clientruntime
 
 import (
 	"log"
-	"net"
 	"sync"
 	"sync/atomic"
 
@@ -402,11 +401,10 @@ func (s *clientState) paneViewportFor(id [16]byte) (paneViewportCopy, bool) {
 //  6. Evicts rows outside the hysteresis band from PaneCache.
 func flushFrame(
 	state *clientState,
-	conn net.Conn,
-	writeMu *sync.Mutex,
+	writer *messageWriter,
 	sessionID [16]byte,
 ) {
-	if conn == nil {
+	if writer == nil {
 		return
 	}
 	entries, rawPanes := state.viewports.snapshotDirty()
@@ -457,7 +455,7 @@ func flushFrame(
 			Flags:     protocol.FlagChecksum,
 			SessionID: sessionID,
 		}
-		if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
+		if err := writer.Send(hdr, payload); err != nil {
 			log.Printf("send viewport update: %v", err)
 			continue
 		}
@@ -486,7 +484,7 @@ func flushFrame(
 				rawVP.inflightFetch = true
 				rawVP.mu.Unlock()
 				lo, hi := miss[0], miss[len(miss)-1]+1
-				if !sendFetchRange(state, conn, writeMu, sessionID, id, lo, hi) {
+				if !sendFetchRange(state, writer, sessionID, id, lo, hi) {
 					// Write failed — release the inflight slot so the next
 					// frame can retry instead of staying wedged forever.
 					rawVP.mu.Lock()
@@ -517,10 +515,17 @@ func flushFrame(
 // sendFetchRange encodes and sends a MsgFetchRange to the server. Returns
 // true on success.  On false the caller must roll back any reservation
 // (e.g. inflightFetch) so the request can be retried on the next frame.
+//
+// Uses TrySend (non-blocking): this call site is reached from the read
+// loop's MsgFetchRangeResponse handler, where blocking on a full writer
+// queue would prevent the read loop from draining the socket and could
+// deadlock the protocol if both client and server have congested write
+// buffers. flushFrame's caller (also using this path) is the main render
+// goroutine; dropping a fetch there is fine because the next render frame
+// will re-detect the missing-rows window and retry.
 func sendFetchRange(
 	state *clientState,
-	conn net.Conn,
-	writeMu *sync.Mutex,
+	writer *messageWriter,
 	sessionID [16]byte,
 	paneID [16]byte,
 	lo, hi int64,
@@ -542,8 +547,8 @@ func sendFetchRange(
 		Flags:     protocol.FlagChecksum,
 		SessionID: sessionID,
 	}
-	if err := writeMessage(writeMu, conn, hdr, payload); err != nil {
-		log.Printf("send fetch range: %v", err)
+	if !writer.TrySend(hdr, payload) {
+		log.Printf("dropped fetch range: writer queue full (will retry next frame)")
 		return false
 	}
 	return true

--- a/internal/runtime/client/viewport_tracker_test.go
+++ b/internal/runtime/client/viewport_tracker_test.go
@@ -253,8 +253,9 @@ func TestViewportTracker_AutoFollowAdvancesFromGidZero(t *testing.T) {
 	// Drain the initial dirty state via flushFrame so subsequent dirty
 	// assertions are clean. Use a testConn so nothing writes to a real socket.
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	// First-ever BufferDelta at gid=0 on the main screen.
 	delta := protocol.BufferDelta{
@@ -358,8 +359,9 @@ func TestFlushFrame_SendsViewportUpdate(t *testing.T) {
 	state.onTreeSnapshot(snap)
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	n := conn.countType(protocol.MsgViewportUpdate)
 	if n != 1 {
@@ -387,8 +389,9 @@ func TestFlushFrame_CoalescesMultipleChangesInFrame(t *testing.T) {
 	}
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	// Must only emit one update per pane per frame (dirty was cleared once).
 	n := conn.countType(protocol.MsgViewportUpdate)
@@ -417,8 +420,9 @@ func TestFlushFrame_IssuesFetchForMissingRows(t *testing.T) {
 	vp.mu.Unlock()
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	n := conn.countType(protocol.MsgFetchRange)
 	if n != 1 {
@@ -447,8 +451,9 @@ func TestFlushFrame_AtMostOneInflightFetchPerPane(t *testing.T) {
 	vp.mu.Unlock()
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	// No new MsgFetchRange should be sent.
 	n := conn.countType(protocol.MsgFetchRange)
@@ -483,7 +488,7 @@ func TestFlushFrame_EmitsPendingFetchOnResponse(t *testing.T) {
 	vp.mu.Unlock()
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
+	writer := newTestWriter(t, conn)
 
 	// Simulate the onFetchRangeResponse path.
 	lo, hi, send := state.onFetchRangeResponse(paneID(8))
@@ -507,7 +512,8 @@ func TestFlushFrame_EmitsPendingFetchOnResponse(t *testing.T) {
 	}
 
 	// Verify we can send the fetch range.
-	sendFetchRange(state, conn, &writeMu, [16]byte{}, paneID(8), lo, hi)
+	sendFetchRange(state, writer, [16]byte{}, paneID(8), lo, hi)
+	writer.flushPending()
 	n := conn.countType(protocol.MsgFetchRange)
 	if n != 1 {
 		t.Errorf("expected 1 MsgFetchRange after consuming pending, got %d", n)
@@ -584,14 +590,13 @@ func TestViewportTracker_PruneRemovesStalePane(t *testing.T) {
 // Additional: TestFlushFrame_NilConnIsNoop
 // --------------------------------------------------------------------------
 
-func TestFlushFrame_NilConnIsNoop(t *testing.T) {
+func TestFlushFrame_NilWriterIsNoop(t *testing.T) {
 	state := makeStateWithViewports()
 	snap := makeTreeSnapshot(paneID(12), 80, 24)
 	state.onTreeSnapshot(snap)
 
-	var writeMu sync.Mutex
 	// Must not panic.
-	flushFrame(state, nil, &writeMu, [16]byte{})
+	flushFrame(state, nil, [16]byte{})
 }
 
 // --------------------------------------------------------------------------
@@ -724,12 +729,13 @@ func (f *failingConn) Write(_ []byte) (int, error) {
 	return 0, io.ErrClosedPipe
 }
 
-func TestFlushFrame_ReleasesInflightOnSendFailure(t *testing.T) {
+func TestFlushFrame_WriterReportsBrokenAfterSendFailure(t *testing.T) {
 	state := makeStateWithViewports()
 	id := paneID(0xD0)
 	state.onTreeSnapshot(makeTreeSnapshot(id, 80, 24))
 
-	// Force a missing-rows window.
+	// Force a missing-rows window so flushFrame attempts both a viewport
+	// update and a fetch-range write.
 	vp := state.viewports.get(id)
 	vp.mu.Lock()
 	vp.ViewTopIdx = 1000
@@ -741,16 +747,21 @@ func TestFlushFrame_ReleasesInflightOnSendFailure(t *testing.T) {
 	vp.mu.Unlock()
 
 	conn := &failingConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
-	vp.mu.Lock()
-	defer vp.mu.Unlock()
-	// The viewport-update write fails first (before any inflight reservation),
-	// so inflight stays false — but the guarantee we're asserting is that no
-	// stuck reservation blocks retry on the next frame.
-	if vp.inflightFetch {
-		t.Error("inflightFetch should be false after send failure (retry must be unblocked)")
+	// After the failing write, the writer goroutine has exited and stored
+	// the error. Subsequent Send/TrySend must surface the broken state so
+	// the next frame doesn't silently buffer messages into a dead queue.
+	// This is the recovery guarantee that the previous synchronous-write
+	// version expressed via a "rolled-back inflight reservation" — with
+	// async writes the equivalent invariant is observable here.
+	if err := writer.Send(protocol.Header{Type: protocol.MsgPing}, nil); err == nil {
+		t.Error("Send should return error after writer goroutine exits on write failure")
+	}
+	if writer.TrySend(protocol.Header{Type: protocol.MsgPing}, nil) {
+		t.Error("TrySend should return false after writer goroutine exits on write failure")
 	}
 }
 
@@ -770,8 +781,9 @@ func TestFlushFrame_ZeroDimSkipped(t *testing.T) {
 	vp.mu.Unlock()
 
 	conn := &testConn{}
-	var writeMu sync.Mutex
-	flushFrame(state, conn, &writeMu, [16]byte{})
+	writer := newTestWriter(t, conn)
+	flushFrame(state, writer, [16]byte{})
+	writer.flushPending()
 
 	n := conn.countType(protocol.MsgViewportUpdate)
 	if n != 0 {


### PR DESCRIPTION
## Summary

- Resize-storm freeze diagnosed as a deadlock between `ackLoop`, `readLoop`, `pingLoop`, and the main event loop on the client's shared `writeMu` — once any holder blocked in the kernel `write()` (server side not draining), every other writer parked behind the mutex, including the `readLoop` doing inline `sendFetchRange`. With the readLoop wedged the client stopped consuming bytes, so the server couldn't drain *its* send side either, and both endpoints sat on `Write` forever.
- Replace the `*sync.Mutex` + `net.Conn` plumbing with `messageWriter`: a buffered channel drained by a single dedicated goroutine. `readLoop` and the per-frame `flushFrame` now `TrySend` for fetch-ranges and pongs (idempotent / best-effort) so a saturated write side can never block the read pump. Other senders use blocking `Send`.
- After a write error the writer goroutine stores the error and exits; subsequent `Send`/`TrySend` surface the broken state rather than silently buffering into a dead queue. `Close` uses a separate `shutdown` channel rather than closing the queue, so the resize-debounce goroutine (which can outlive structured shutdown) can never panic on send-to-closed-channel.

## Test plan

- [x] `go test -race -count=3 ./internal/runtime/client/` passes
- [x] `go test -race -count=1 ./...` clean except for two pre-existing flakes (`apps/configeditor` widget race, `apps/texelterm/parser` adaptive-persistence concurrency tests) confirmed via `git stash` on clean main
- [ ] Manual: trigger flashy horizontal-divider resize storm under `texelation`; client should keep responding instead of locking up
- [ ] Manual: kill server while client running; client should exit cleanly without panicking the resize-debounce goroutine

🤖 Generated with [Claude Code](https://claude.com/claude-code)