### PR TITLE
Plan E: statusbar slow-fetch indicator (#199)

### DIFF
--- a/apps/statusbar/blend_info_line.go
+++ b/apps/statusbar/blend_info_line.go
@@ -45,6 +45,12 @@ type BlendInfoLine struct {
 	toastSeverity texel.ToastSeverity
 	toastExpiry   time.Time
 	toastActive   bool
+
+	// Fetch-pending indicator (Issue #199 Plan E). Aggregated across panes
+	// from FetchPending events on the desktop dispatcher; renders a spinner
+	// + count between the title zone and the date/clock zone whenever the
+	// count is > 0. Hidden at 0.
+	fetchPending int
 }
 
 // NewBlendInfoLine creates a BlendInfoLine with sensible defaults from the theme.
@@ -105,6 +111,24 @@ func (bil *BlendInfoLine) SetTitle(title string) {
 	bil.title = title
 	bil.mu.Unlock()
 	bil.invalidate()
+}
+
+// SetFetchPending sets the slow-fetch indicator count. Aggregated across
+// all panes; the BlendInfoLine renders the indicator only when count is
+// strictly positive. Negative inputs are clamped to 0 so out-of-order
+// dispatcher deltas (rare, see fetch_pending_timer.go) can't render a
+// nonsense "-N" in the bar.
+func (bil *BlendInfoLine) SetFetchPending(count int) {
+	if count < 0 {
+		count = 0
+	}
+	bil.mu.Lock()
+	changed := bil.fetchPending != count
+	bil.fetchPending = count
+	bil.mu.Unlock()
+	if changed {
+		bil.invalidate()
+	}
 }
 
 // SetClock sets the date and clock strings for the right-side display.
@@ -171,6 +195,7 @@ func (bil *BlendInfoLine) Draw(painter *core.Painter) {
 	clock := bil.clock
 	toastMsg := bil.toastMessage
 	toastSev := bil.toastSeverity
+	fetchPending := bil.fetchPending
 	bil.mu.Unlock()
 
 	if w <= 0 {
@@ -243,6 +268,22 @@ func (bil *BlendInfoLine) Draw(painter *core.Painter) {
 	}
 	leftStr := " " + modeIcon + title + " "
 
+	// --- Fetch-pending indicator (rendered between title and right zone) ---
+	// Spinner advances with painter time so the animation registers as
+	// MarkAnimated(); the count is the live aggregate from FetchPending
+	// events. Hidden entirely when count is 0 (the common case).
+	fetchStr := ""
+	if fetchPending > 0 {
+		spinner := []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+		idx := int(painter.Time()*10) % len(spinner)
+		if idx < 0 {
+			idx = -idx % len(spinner)
+		}
+		fetchStr = fmt.Sprintf(" %c %d ", spinner[idx], fetchPending)
+		painter.MarkAnimated()
+	}
+	fetchWidth := utf8.RuneCountInString(fetchStr)
+
 	// --- Right side (date + clock with icons) ---
 	calendarIcon := " \U000F00ED " // nf-md-calendar
 	clockIcon := " \U000F0954 "    // nf-md-clock-outline
@@ -291,6 +332,20 @@ func (bil *BlendInfoLine) Draw(painter *core.Painter) {
 		col = x + w - rightWidth
 		for _, r := range rightStr {
 			if col >= x+w {
+				break
+			}
+			painter.SetDynamicCellKeepBG(col, y, r, accentDS)
+			col++
+		}
+	}
+
+	// Draw the fetch-pending indicator just left of the right-side zone.
+	// Skipped silently when there isn't room (the right zone takes priority
+	// because it's always visible) or when no fetches are pending.
+	if fetchWidth > 0 && fetchWidth+rightWidth <= w {
+		col = x + w - rightWidth - fetchWidth
+		for _, r := range fetchStr {
+			if col >= x+w-rightWidth {
 				break
 			}
 			painter.SetDynamicCellKeepBG(col, y, r, accentDS)

--- a/apps/statusbar/statusbar.go
+++ b/apps/statusbar/statusbar.go
@@ -50,6 +50,14 @@ type StatusBarApp struct {
 	smoothTheoFPS  float64
 	lastFPSInt     int
 	lastTheoFPSInt int
+
+	// Slow-fetch indicator state (Issue #199 Plan E). Per-pane counts
+	// from FetchPending events; aggregate sum is what the BlendInfoLine
+	// renders. Stored separately from the bar so a future +1 / -1 race
+	// can't drive a single bare counter negative — the per-pane map
+	// lets us clamp at 0 per pane before summing.
+	fetchPendingMu sync.Mutex
+	fetchPendingBy map[[16]byte]int
 }
 
 // New creates a new StatusBarApp.
@@ -227,7 +235,37 @@ func (sb *StatusBarApp) OnEvent(event texel.Event) {
 		if p, ok := event.Payload.(texel.ToastPayload); ok {
 			sb.blendLine.ShowToast(p.Message, p.Severity, p.Duration)
 		}
+	case texel.EventFetchPending:
+		if p, ok := event.Payload.(texel.FetchPendingPayload); ok {
+			sb.handleFetchPending(p)
+		}
 	}
+}
+
+// handleFetchPending applies a +1 / -1 delta to the per-pane slow-fetch
+// counter and pushes the aggregate sum to the BlendInfoLine. Per-pane
+// values are clamped at 0 so an out-of-order or duplicate dispatcher
+// delta can't drive the visible count negative.
+func (sb *StatusBarApp) handleFetchPending(p texel.FetchPendingPayload) {
+	sb.fetchPendingMu.Lock()
+	if sb.fetchPendingBy == nil {
+		sb.fetchPendingBy = make(map[[16]byte]int)
+	}
+	v := sb.fetchPendingBy[p.PaneID] + p.Delta
+	if v < 0 {
+		v = 0
+	}
+	if v == 0 {
+		delete(sb.fetchPendingBy, p.PaneID)
+	} else {
+		sb.fetchPendingBy[p.PaneID] = v
+	}
+	total := 0
+	for _, n := range sb.fetchPendingBy {
+		total += n
+	}
+	sb.fetchPendingMu.Unlock()
+	sb.blendLine.SetFetchPending(total)
 }
 
 // handleWorkspacesChanged rebuilds the tab bar preserving user-defined tab order.

--- a/apps/statusbar/statusbar_test.go
+++ b/apps/statusbar/statusbar_test.go
@@ -70,6 +70,56 @@ func TestStatusBar_ReceivesToast(t *testing.T) {
 	}
 }
 
+// TestStatusBar_FetchPendingAggregates — feeds two panes' +1/-1
+// deltas through OnEvent and asserts the per-pane map sums correctly,
+// clamps at zero on stray -1, and clears entirely when both panes
+// resolve.
+func TestStatusBar_FetchPendingAggregates(t *testing.T) {
+	sb := New()
+	sb.Resize(80, 2)
+
+	paneA := [16]byte{0xa}
+	paneB := [16]byte{0xb}
+
+	send := func(paneID [16]byte, delta int) {
+		sb.OnEvent(texel.Event{
+			Type:    texel.EventFetchPending,
+			Payload: texel.FetchPendingPayload{PaneID: paneID, Delta: delta},
+		})
+	}
+
+	send(paneA, +1)
+	send(paneB, +1)
+	send(paneB, +1)
+	if got := sb.fetchPendingTotal(); got != 3 {
+		t.Errorf("after +1/+1/+1 across two panes, total = %d, want 3", got)
+	}
+
+	send(paneA, -1)
+	if got := sb.fetchPendingTotal(); got != 2 {
+		t.Errorf("after paneA resolved, total = %d, want 2", got)
+	}
+
+	// Stray -1 below zero on paneB should clamp; total decreases by 1.
+	send(paneB, -1)
+	send(paneB, -1)
+	send(paneB, -1) // would drive paneB negative; clamp at 0.
+	if got := sb.fetchPendingTotal(); got != 0 {
+		t.Errorf("after over-decrementing, total = %d, want 0 (clamped)", got)
+	}
+}
+
+// fetchPendingTotal exposes the aggregated count for tests.
+func (sb *StatusBarApp) fetchPendingTotal() int {
+	sb.fetchPendingMu.Lock()
+	defer sb.fetchPendingMu.Unlock()
+	total := 0
+	for _, n := range sb.fetchPendingBy {
+		total += n
+	}
+	return total
+}
+
 func TestStatusBar_Lifecycle(t *testing.T) {
 	sb := New()
 	sb.Resize(80, 2)

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -14,6 +14,7 @@ import (
 	"log"
 
 	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelation/texel"
 )
 
 func (c *connection) handleMessage(prefix string, header protocol.Header, payload []byte) error {
@@ -497,6 +498,26 @@ func (c *connection) handleFetchRange(payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("decode: %w", err)
 	}
+
+	// Pending-fetch indicator: schedule a 50ms timer that broadcasts
+	// FetchPending(+1) if it fires before we send the response. On
+	// response (success or error path), we always cancel the timer and
+	// — if the timer had already fired — broadcast FetchPending(-1) so
+	// listeners' counts stay paired.
+	//
+	// We capture sink/desktop here once; if either is unavailable we
+	// silently skip the indicator (the response path still runs).
+	pendingSink, _ := c.sink.(*DesktopSink)
+	var pendingDesktop *texel.DesktopEngine
+	if pendingSink != nil {
+		pendingDesktop = pendingSink.Desktop()
+	}
+	var broadcast fetchPendingBroadcaster
+	if pendingDesktop != nil {
+		broadcast = pendingDesktop.BroadcastFetchPending
+	}
+	pendingTimer, pendingCancel := startFetchPendingTimer(broadcast, req.PaneID)
+	defer pendingCancel(pendingTimer)
 
 	// sendStub sends a minimal response with the given flags and no rows.
 	sendStub := func(flags protocol.FetchRangeFlags) error {

--- a/internal/runtime/server/fetch_pending_timer.go
+++ b/internal/runtime/server/fetch_pending_timer.go
@@ -1,0 +1,94 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/fetch_pending_timer.go
+// Summary: Background timer that surfaces a "fetch pending" event when
+// a MsgFetchRange takes longer than 50ms to resolve. The connection
+// handler arms this once per request and cancels it on response —
+// pairing +1/-1 deltas so listeners can aggregate to a stable
+// in-flight count.
+
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+// fetchPendingThreshold is how long a MsgFetchRange may take before we
+// surface a "fetch pending" event on the desktop dispatcher. Tuned for
+// the spec's "missed-deadline handling": below this, the round-trip is
+// fast enough that any UI indicator would just flicker; above, the
+// user perceives a real wait and benefits from a statusbar hint.
+//
+// Declared as a var (not const) so tests can shorten it without waiting
+// 50ms per case.
+var fetchPendingThreshold = 50 * time.Millisecond
+
+// fetchPendingBroadcaster is the broadcast callback the timer fires.
+// Implemented in production by *texel.DesktopEngine.BroadcastFetchPending,
+// substituted with a recording fake in tests.
+type fetchPendingBroadcaster func(paneID [16]byte, delta int)
+
+// fetchPendingTimer holds the per-request state for the slow-fetch
+// indicator. The mutex synchronises the timer's goroutine with the
+// cancel path so the +1 and matching -1 broadcasts always emit in
+// order (atomic-only would let a late goroutine emit +1 *after* cancel
+// emitted -1, leaving listeners' counts briefly negative).
+type fetchPendingTimer struct {
+	mu        sync.Mutex
+	broadcast fetchPendingBroadcaster
+	paneID    [16]byte
+	timer     *time.Timer
+	fired     bool // goroutine has broadcast +1
+	cancelled bool // cancel path has run; goroutine must skip
+}
+
+// startFetchPendingTimer arms a one-shot 50ms timer that broadcasts
+// +1 for the given pane if the request hasn't been cancelled by then.
+// Returns the timer (or nil if broadcast is nil) plus a cancel function
+// the caller MUST defer.
+func startFetchPendingTimer(broadcast fetchPendingBroadcaster, paneID [16]byte) (*fetchPendingTimer, func(*fetchPendingTimer)) {
+	if broadcast == nil {
+		return nil, fetchPendingCancel
+	}
+	ft := &fetchPendingTimer{
+		broadcast: broadcast,
+		paneID:    paneID,
+	}
+	ft.timer = time.AfterFunc(fetchPendingThreshold, func() {
+		ft.mu.Lock()
+		defer ft.mu.Unlock()
+		if ft.cancelled {
+			return
+		}
+		ft.fired = true
+		broadcast(paneID, +1)
+	})
+	return ft, fetchPendingCancel
+}
+
+// fetchPendingCancel stops the timer and, if it had already fired,
+// broadcasts the matching -1. Safe to call with a nil timer (the
+// no-broadcaster case).
+//
+// The mutex pairing with the goroutine guarantees that:
+//   - If the goroutine ran first: the +1 was broadcast, fired=true
+//     when we lock; we broadcast -1.
+//   - If we ran first: cancelled=true when the goroutine eventually
+//     locks; goroutine returns without broadcasting +1, and we don't
+//     broadcast -1 either (no pair to close).
+//   - Concurrent races serialise on the mutex; broadcasts are always
+//     ordered +1 then -1.
+func fetchPendingCancel(ft *fetchPendingTimer) {
+	if ft == nil {
+		return
+	}
+	ft.timer.Stop()
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	ft.cancelled = true
+	if ft.fired {
+		ft.broadcast(ft.paneID, -1)
+	}
+}

--- a/internal/runtime/server/fetch_pending_timer_test.go
+++ b/internal/runtime/server/fetch_pending_timer_test.go
@@ -1,0 +1,157 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordedFetchPending captures the (paneID, delta) sequence broadcast
+// by a fetch-pending timer. Used by tests to assert events fire in the
+// right order with the right counts.
+type recordedFetchPending struct {
+	mu     sync.Mutex
+	events []recordedFetchPendingEvent
+}
+
+type recordedFetchPendingEvent struct {
+	PaneID [16]byte
+	Delta  int
+}
+
+func (r *recordedFetchPending) record(paneID [16]byte, delta int) {
+	r.mu.Lock()
+	r.events = append(r.events, recordedFetchPendingEvent{PaneID: paneID, Delta: delta})
+	r.mu.Unlock()
+}
+
+func (r *recordedFetchPending) snapshot() []recordedFetchPendingEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedFetchPendingEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// TestFetchPendingCancel_NilBroadcasterSafe — startFetchPendingTimer
+// with a nil broadcaster yields a nil timer; cancel must be a no-op.
+func TestFetchPendingCancel_NilBroadcasterSafe(t *testing.T) {
+	timer, cancel := startFetchPendingTimer(nil, [16]byte{0xab})
+	if timer != nil {
+		t.Errorf("nil broadcaster should yield nil timer, got %v", timer)
+	}
+	// Should not panic.
+	cancel(timer)
+}
+
+// TestFetchPendingTimer_PairedDeltas — when the timer fires before
+// cancel, both +1 and -1 events emit, in order, with the same paneID.
+func TestFetchPendingTimer_PairedDeltas(t *testing.T) {
+	prev := fetchPendingThreshold
+	fetchPendingThreshold = 5 * time.Millisecond
+	defer func() { fetchPendingThreshold = prev }()
+
+	rec := &recordedFetchPending{}
+	paneID := [16]byte{0xde, 0xad, 0xbe, 0xef}
+
+	timer, cancel := startFetchPendingTimer(rec.record, paneID)
+	if timer == nil {
+		t.Fatalf("expected timer with valid broadcaster, got nil")
+	}
+
+	// Wait long enough for the timer to fire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Cancel: should emit the matching -1.
+	cancel(timer)
+
+	events := rec.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (+1 / -1), got %d: %+v", len(events), events)
+	}
+	if events[0].PaneID != paneID || events[0].Delta != +1 {
+		t.Errorf("event[0] = %+v, want PaneID=%x Delta=+1", events[0], paneID)
+	}
+	if events[1].PaneID != paneID || events[1].Delta != -1 {
+		t.Errorf("event[1] = %+v, want PaneID=%x Delta=-1", events[1], paneID)
+	}
+}
+
+// TestFetchPendingTimer_FastCancelBeforeFire — when cancel runs before
+// the timer fires (the common "fast fetch" case), no events emit.
+func TestFetchPendingTimer_FastCancelBeforeFire(t *testing.T) {
+	prev := fetchPendingThreshold
+	fetchPendingThreshold = 50 * time.Millisecond
+	defer func() { fetchPendingThreshold = prev }()
+
+	rec := &recordedFetchPending{}
+	paneID := [16]byte{0xca, 0xfe}
+
+	timer, cancel := startFetchPendingTimer(rec.record, paneID)
+	if timer == nil {
+		t.Fatalf("expected timer with valid broadcaster, got nil")
+	}
+	cancel(timer)
+
+	// Wait past the threshold to make sure no late firing happens.
+	time.Sleep(80 * time.Millisecond)
+
+	events := rec.snapshot()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events (cancel before fire), got %d: %+v", len(events), events)
+	}
+}
+
+// TestFetchPendingTimer_ConcurrentRaces — repeatedly arm/cancel the
+// timer with timing close to the threshold and assert the broadcast
+// count is balanced (+ count == - count) and that no -1 ever precedes
+// its matching +1.
+func TestFetchPendingTimer_ConcurrentRaces(t *testing.T) {
+	prev := fetchPendingThreshold
+	fetchPendingThreshold = 1 * time.Millisecond
+	defer func() { fetchPendingThreshold = prev }()
+
+	rec := &recordedFetchPending{}
+	paneID := [16]byte{0x1, 0x2, 0x3}
+
+	const iters = 200
+	for i := 0; i < iters; i++ {
+		timer, cancel := startFetchPendingTimer(rec.record, paneID)
+		// Sleep ~ threshold to maximise the race window.
+		time.Sleep(time.Duration(i%3) * time.Millisecond)
+		cancel(timer)
+	}
+
+	// Drain any in-flight goroutines (their broadcasts run synchronously
+	// while they hold the timer mutex; once cancel returns, no more
+	// emissions for that iteration are possible).
+	time.Sleep(20 * time.Millisecond)
+
+	events := rec.snapshot()
+	plus, minus := 0, 0
+	running := 0
+	for _, e := range events {
+		switch e.Delta {
+		case +1:
+			plus++
+			running++
+		case -1:
+			minus++
+			running--
+			if running < 0 {
+				t.Errorf("running count went negative at event %+v (a -1 preceded its +1)", e)
+			}
+		default:
+			t.Errorf("unexpected delta in event %+v", e)
+		}
+	}
+	if plus != minus {
+		t.Errorf("unbalanced events: %d +1 vs %d -1", plus, minus)
+	}
+	if running != 0 {
+		t.Errorf("non-zero running count at end: %d", running)
+	}
+}

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -371,6 +371,18 @@ func (d *DesktopEngine) Unsubscribe(listener Listener) {
 	d.dispatcher.Unsubscribe(listener)
 }
 
+// BroadcastFetchPending dispatches a FetchPending event with the given
+// delta. Used by the connection handler when a slow MsgFetchRange
+// crosses the 50ms threshold (delta=+1) or finally resolves (delta=-1).
+// Plumbed here rather than exposing dispatcher.Broadcast so the broadcast
+// surface stays curated.
+func (d *DesktopEngine) BroadcastFetchPending(paneID [16]byte, delta int) {
+	d.dispatcher.Broadcast(Event{
+		Type:    EventFetchPending,
+		Payload: FetchPendingPayload{PaneID: paneID, Delta: delta},
+	})
+}
+
 // Registry returns the app registry for this desktop.
 func (d *DesktopEngine) Registry() *AppRegistry {
 	return d.registry

--- a/texel/dispatcher.go
+++ b/texel/dispatcher.go
@@ -39,7 +39,23 @@ const (
 	EventActivePaneChanged
 	EventPerformanceUpdate
 	EventToast
+	// EventFetchPending fires from the server's connection handler when a
+	// MsgFetchRange takes longer than 50ms to satisfy. Payload is
+	// FetchPendingPayload — Delta is +1 when the request crosses the
+	// 50ms threshold without resolving, -1 when the response is finally
+	// sent. Listeners (currently the statusbar) aggregate to derive an
+	// "in-flight slow fetches" count and surface it as an indicator.
+	EventFetchPending
 )
+
+// FetchPendingPayload carries an incremental delta for the server's
+// pending-slow-fetch counter. Listeners maintain their own per-pane or
+// aggregated count by summing deltas; payloads always come in matched
+// +1 / -1 pairs (one per slow fetch).
+type FetchPendingPayload struct {
+	PaneID [16]byte
+	Delta  int // +1 (became pending) or -1 (resolved)
+}
 
 // Event represents a message passed through the system.
 // It has a type and can carry an arbitrary data payload.


### PR DESCRIPTION
## Summary

When a `MsgFetchRange` takes longer than 50ms to satisfy, surface a small spinner + count on the bottom statusbar's `blendInfoLine`. User gets feedback during fast scroll-jumps without inline placeholder text in the content area (explicitly out of scope per the spec).

No protocol change — the indicator is plumbed through the existing in-process `EventDispatcher` between the server's connection handler and the statusbar app.

## Architecture

```
handleFetchRange → startFetchPendingTimer (50ms one-shot)
                        │
                        ├── fired? → desktop.BroadcastFetchPending(paneID, +1)
                        │
                        └── cancel (defer) → if fired, BroadcastFetchPending(paneID, -1)

EventDispatcher → StatusBarApp.OnEvent → fetchPendingBy[paneID] += delta
                                       → BlendInfoLine.SetFetchPending(sum)
                                       → spinner + count rendered between title and clock zones
```

## Why a mutex (not atomic CAS) on the timer

Atomic-only let a late goroutine emit `+1` *after* the cancel path emitted `-1`, briefly driving listeners' counts negative. The mutex pairs the goroutine's broadcast with the cancel's broadcast so order is always `+1` then `-1`.

## Test plan

- [x] `TestFetchPendingCancel_NilBroadcasterSafe` — nil broadcaster yields nil timer; cancel is a no-op.
- [x] `TestFetchPendingTimer_PairedDeltas` — timer fires before cancel; both events emit with same paneID, in order.
- [x] `TestFetchPendingTimer_FastCancelBeforeFire` — cancel before threshold emits nothing.
- [x] `TestFetchPendingTimer_ConcurrentRaces` — 200 iterations close to threshold; running count never goes negative; +/- balanced at end. Race-detector clean.
- [x] `TestStatusBar_FetchPendingAggregates` — multi-pane delta sum + clamp on stray `-1`.
- [x] `go test -race ./...` clean modulo two pre-existing flakes (`apps/configeditor` widget race, `apps/texelterm/parser` adaptive-persistence concurrency).

## Acceptance per the plan stub

- [x] Pending event fires when fetch exceeds 50ms; clears on response.
- [x] Statusbar renders indicator only while `pendingCount > 0` (`SetFetchPending(0)` hides it).
- [x] Aggregate count across multiple panes correct (per-pane map → sum).
- [x] AltScreen pane never contributes — `handleFetchRange` returns the `FetchRangeAltScreenActive` stub before the 50ms timer can fire (cancel runs synchronously on return; no broadcast).

## Files

| File | Purpose |
|------|---------|
| `texel/dispatcher.go` | `EventFetchPending` + `FetchPendingPayload{PaneID, Delta}`. |
| `texel/desktop_engine_core.go` | `DesktopEngine.BroadcastFetchPending(paneID, delta)`. |
| `internal/runtime/server/fetch_pending_timer.go` | `startFetchPendingTimer` + `fetchPendingCancel`. |
| `internal/runtime/server/connection_handler.go` | Wire the timer into `handleFetchRange`. |
| `apps/statusbar/blend_info_line.go` | `SetFetchPending` + spinner render. |
| `apps/statusbar/statusbar.go` | Subscribe + per-pane aggregator. |

## References

- Spec: `docs/superpowers/specs/2026-04-20-issue-199-viewport-only-rendering-design.md` — sub-problem 4 "missed-deadline handling" + sequencing step 8.
- Plan stub: `docs/superpowers/plans/2026-04-25-issue-199-plan-e-statusbar-fetch-indicator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)