### PR TITLE
Gate resize anchor snap on CommandActive (shell-prompt jump fix)

### DIFF
--- a/apps/texelterm/parser/resize_anchor_test.go
+++ b/apps/texelterm/parser/resize_anchor_test.go
@@ -38,6 +38,13 @@ func TestResize_Expand_DoesNotRetreatBelowPreResizeWriteTop(t *testing.T) {
 	v.MarkInputStart()
 	parseString(p, "claude\r\n")
 	v.MarkCommandStart()
+	// Direct MarkCommandStart() only sets CommandStartGlobalLine; the
+	// real OSC 133;C path also flips CommandActive=true. The resize
+	// anchor snap is gated on CommandActive in production (so shell-
+	// idle resizes don't shove the prompt to the top of the screen),
+	// so set it here to mirror the running-TUI scenario this test
+	// covers.
+	v.CommandActive = true
 
 	// A few rows of TUI output, but stay within the small window so HWM
 	// stays small. The HWM-anchor formula on a later expand will land
@@ -103,6 +110,54 @@ func TestResize_Shrink_PreservesScrollback(t *testing.T) {
 			t.Errorf("scrollback row %d col %d: was %q, now %q (resize destroyed scrollback)",
 				canary, i, canaryRow[i].Rune, got[i].Rune)
 		}
+	}
+}
+
+// TestResize_ShellIdle_DoesNotSnapToAnchor — when no foreground command
+// is active (CommandActive=false, e.g. an idle shell prompt), the
+// resize anchor snap must NOT fire. Otherwise WriteWindow.Resize's
+// natural HWM-anchor restoration is undone and the prompt jumps to row
+// 0 of the viewport on every resize. Regression: PR #213's snap was
+// firing for shell idle and produced exactly that visual.
+func TestResize_ShellIdle_DoesNotSnapToAnchor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	v := NewVTerm(40, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+
+	// Some prior shell activity, then a fresh idle prompt.
+	for i := 0; i < 3; i++ {
+		parseString(p, "old line\r\n")
+	}
+	v.MarkPromptStart()
+	parseString(p, "$ ")
+	v.MarkInputStart()
+	// CommandActive is false — no command running. The OSC 133;C escape
+	// would set it; an idle prompt is the absence of that.
+
+	preResizeTop := v.mainScreen.WriteTop()
+
+	// Resize larger.
+	v.Resize(40, 30)
+	postExpandTop := v.mainScreen.WriteTop()
+
+	// HWM-anchor formula in WriteWindow.Resize would put writeTop at
+	// HWM - 30 + 1, which (given HWM is the cursor row) lets the prompt
+	// stay at the bottom of the new viewport rather than jumping to
+	// the top. The snap must not have fired here.
+	//
+	// We assert that writeTop did NOT snap forward to the anchor
+	// (PromptStart+1 or InputStart+1). If it did, postExpandTop would
+	// equal anchor — typically > preResizeTop in this scenario.
+	anchor := v.PromptStartGlobalLine
+	if v.InputStartGlobalLine >= 0 {
+		anchor = v.InputStartGlobalLine + 1
+	} else if v.PromptStartGlobalLine >= 0 {
+		anchor = v.PromptStartGlobalLine + 1
+	}
+	if postExpandTop == anchor && anchor > preResizeTop {
+		t.Errorf("shell-idle expand snapped writeTop forward to anchor=%d (pre-resize=%d, post-expand=%d) — prompt would jump to row 0",
+			anchor, preResizeTop, postExpandTop)
 	}
 }
 

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -360,7 +360,15 @@ func (v *VTerm) mainScreenResize(width, height int) {
 	}
 	v.mainScreen.Resize(width, height)
 
-	if !v.inAltScreen {
+	// The snap is only meaningful when a foreground command is actively
+	// painting (CommandActive). In that case a TUI repaint is incoming
+	// and pulling writeTop into pre-command scrollback would let the
+	// repaint overwrite committed history. In shell-idle mode there's
+	// no repaint coming — the HWM-anchor formula in WriteWindow.Resize
+	// already keeps the prompt visible at a sensible row, and forcing
+	// writeTop forward to the prompt anchor here just jumps the prompt
+	// to the top of the viewport on every resize.
+	if !v.inAltScreen && v.CommandActive {
 		anchor := int64(-1)
 		switch {
 		case v.CommandStartGlobalLine >= 0:


### PR DESCRIPTION
## Symptom

After PR #213, idle shell prompts jumped to the top of the viewport on every resize. WriteWindow.Resize's HWM-anchor formula correctly placed the prompt at the bottom (cursor's natural position), but the post-resize snap in mainScreenResize then forced writeTop forward to the prompt anchor (PromptStart+1 / InputStart+1), shifting the prompt to row 0.

## Root cause

The snap was designed to protect Claude's pre-command scrollback from being overwritten by a TUI's post-SIGWINCH redraw. That problem only exists *while* a TUI is actively painting — i.e. while \`CommandActive\` is true (between OSC 133;C and 133;D). Outside that window, no repaint is incoming, the HWM-anchor formula's natural behaviour is correct, and the snap just shifts the viewport for no benefit.

## Fix

Gate the snap on \`CommandActive\`. Idle shell prompts now follow the HWM-anchor restoration like every other terminal. Claude / running-TUI scenario unchanged (\`CommandActive\` is set by OSC 133;C in production).

## Test plan

- [x] \`TestResize_Expand_DoesNotRetreatBelowPreResizeWriteTop\` — updated to set \`CommandActive=true\` (which is what OSC 133;C does in production). Direct \`MarkCommandStart()\` calls only set the gid; the parser path also flips the flag.
- [x] \`TestResize_ShellIdle_DoesNotSnapToAnchor\` — NEW. Sets up an idle prompt (no \`CommandActive\`), expands, asserts writeTop did NOT snap forward to the anchor.
- [x] All existing \`TestResize_*\` tests pass.
- [x] \`go test ./apps/texelterm/parser/...\` clean.
- [ ] Manual: open a fresh shell pane, resize wider, prompt should stay at the bottom of the viewport.

## Files

- \`apps/texelterm/parser/vterm_main_screen.go\` — gate the snap on \`v.CommandActive\`.
- \`apps/texelterm/parser/resize_anchor_test.go\` — update existing test + add the regression test.

## References

- PR #213 — \"Snap writeTop to prompt anchor on resize\" — original snap.
- User report: \"the shell prompt (end of history) jumps to the top of the screen when resizing.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)