### PR TITLE
Wrap-aware selection mapping (issue #224) + multi-click clipboard fix

### DIFF
--- a/apps/texelterm/mouse_coordinator.go
+++ b/apps/texelterm/mouse_coordinator.go
@@ -8,6 +8,7 @@ package texelterm
 
 import (
 	"sync"
+	"time"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
 	"github.com/gdamore/tcell/v2"
@@ -57,6 +58,18 @@ type MouseCoordinator struct {
 	lastMouseButtons tcell.ButtonMask
 	lastMouseX       int
 	lastMouseY       int
+
+	// Deferred multi-click clipboard write. A double/triple/quadruple
+	// click chain produces an escalating-but-superseded selection on
+	// each release; firing SetClipboard on every release yields one
+	// OSC52 event per click level (and one host-terminal "Content
+	// copied" toast each). Multi-click releases stash the payload here
+	// and arm pendingClipTimer to fire after DefaultMultiClickTimeout.
+	// A subsequent press inside that window cancels the pending write
+	// before it reaches the host terminal.
+	pendingClipMime  string
+	pendingClipData  []byte
+	pendingClipTimer *time.Timer
 
 	// Callbacks
 	onDirty   func() // Called when display needs refresh
@@ -164,6 +177,11 @@ func (m *MouseCoordinator) HandleMouse(ev *tcell.EventMouse) bool {
 	dragging := buttons&tcell.Button1 != 0 && prevButtons&tcell.Button1 != 0
 
 	if start {
+		// A new press starts a fresh selection action; any deferred
+		// multi-click clipboard write from the previous click in this
+		// chain is now superseded and must not reach the host terminal.
+		m.cancelPendingClipboardLocked()
+
 		// Cancel any existing selection
 		if m.selectionMachine.IsActive() {
 			m.selectionMachine.Cancel()
@@ -201,13 +219,26 @@ func (m *MouseCoordinator) HandleMouse(ev *tcell.EventMouse) bool {
 	if release && m.selectionMachine.IsActive() {
 		m.autoScroll.Stop()
 
+		// Snapshot the state before Finish so we know whether this
+		// release came out of a multi-click chain (StateMultiClickHeld)
+		// or a single drag (StateDragging). Finish itself transitions
+		// the state, so the read must happen before the call.
+		wasMultiClick := m.selectionMachine.State() == StateMultiClickHeld
+
 		logicalLine, charOffset, viewportRow := m.resolvePositionLocked(x, y)
 		mime, data, ok := m.selectionMachine.Finish(logicalLine, charOffset, viewportRow, modifiers)
 		m.markDirty()
 
-		// Copy to clipboard
+		// Copy to clipboard. Multi-click releases defer; a follow-up
+		// click within the multi-click window will cancel the deferred
+		// write before it surfaces. Single-drag releases copy
+		// immediately — there is no escalation gesture to wait for.
 		if ok && len(data) > 0 && m.clipboardSetter != nil {
-			m.clipboardSetter.SetClipboard(mime, data)
+			if wasMultiClick {
+				m.schedulePendingClipboardLocked(mime, data)
+			} else {
+				m.clipboardSetter.SetClipboard(mime, data)
+			}
 		}
 		return true
 	}
@@ -215,6 +246,7 @@ func (m *MouseCoordinator) HandleMouse(ev *tcell.EventMouse) bool {
 	// Right-click: cancel selection
 	if buttons&tcell.Button3 != 0 && prevButtons&tcell.Button3 == 0 {
 		if m.selectionMachine.IsActive() || m.selectionMachine.IsRendered() {
+			m.cancelPendingClipboardLocked()
 			m.selectionMachine.Cancel()
 			m.autoScroll.Stop()
 			m.markDirty()
@@ -289,6 +321,56 @@ func (m *MouseCoordinator) resolvePositionLocked(x, y int) (logicalLine int64, c
 	}
 
 	return logicalLine, charOffset, viewportRow
+}
+
+// schedulePendingClipboardLocked queues a multi-click clipboard write
+// to fire after DefaultMultiClickTimeout, replacing any earlier
+// pending write. This collapses a triple/quadruple-click chain — where
+// each release produces an escalating-but-superseded selection — into
+// a single OSC52 event the host terminal toasts once.
+//
+// The timer fires from a separate goroutine; it re-acquires m.mu and
+// no-ops if the pending write was cancelled or replaced before firing
+// (verified by comparing m.pendingClipTimer to the timer captured in
+// the closure).
+func (m *MouseCoordinator) schedulePendingClipboardLocked(mime string, data []byte) {
+	m.cancelPendingClipboardLocked()
+	setter := m.clipboardSetter
+	if setter == nil {
+		return
+	}
+	m.pendingClipMime = mime
+	m.pendingClipData = append([]byte(nil), data...)
+	var timer *time.Timer
+	timer = time.AfterFunc(DefaultMultiClickTimeout, func() {
+		m.mu.Lock()
+		if m.pendingClipTimer != timer {
+			m.mu.Unlock()
+			return
+		}
+		mime := m.pendingClipMime
+		data := m.pendingClipData
+		m.pendingClipMime = ""
+		m.pendingClipData = nil
+		m.pendingClipTimer = nil
+		m.mu.Unlock()
+		setter.SetClipboard(mime, data)
+	})
+	m.pendingClipTimer = timer
+}
+
+// cancelPendingClipboardLocked drops any deferred clipboard write so a
+// subsequent press starting a fresh selection (or right-click cancel)
+// supersedes the earlier multi-click result without firing it. Stop()
+// races with the timer goroutine; the goroutine guards itself by
+// checking m.pendingClipTimer against its captured timer reference.
+func (m *MouseCoordinator) cancelPendingClipboardLocked() {
+	if m.pendingClipTimer != nil {
+		m.pendingClipTimer.Stop()
+		m.pendingClipTimer = nil
+	}
+	m.pendingClipMime = ""
+	m.pendingClipData = nil
 }
 
 // markDirty marks the terminal display as needing a refresh.

--- a/apps/texelterm/mouse_coordinator_test.go
+++ b/apps/texelterm/mouse_coordinator_test.go
@@ -9,6 +9,7 @@ package texelterm
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/framegrace/texelation/apps/texelterm/parser"
 	"github.com/gdamore/tcell/v2"
@@ -163,7 +164,14 @@ func (m *mockWheelHandler) getEvents() []wheelEvent {
 
 // mockClipboardSetter tracks clipboard operations.
 type mockClipboardSetter struct {
-	mu   sync.Mutex
+	mu    sync.Mutex
+	mime  string
+	data  []byte
+	calls int
+	all   []clipboardCall
+}
+
+type clipboardCall struct {
 	mime string
 	data []byte
 }
@@ -173,6 +181,23 @@ func (m *mockClipboardSetter) SetClipboard(mime string, data []byte) {
 	defer m.mu.Unlock()
 	m.mime = mime
 	m.data = data
+	m.calls++
+	m.all = append(m.all, clipboardCall{mime: mime, data: append([]byte(nil), data...)})
+}
+
+func (m *mockClipboardSetter) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+func (m *mockClipboardSetter) lastData() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.data == nil {
+		return nil
+	}
+	return append([]byte(nil), m.data...)
 }
 
 // TestMouseCoordinator_New tests coordinator creation.
@@ -471,5 +496,193 @@ func TestVTermGridAdapter_NilVTerm(t *testing.T) {
 	adapter := NewVTermGridAdapter(nil)
 	if adapter != nil {
 		t.Error("expected nil adapter for nil vterm")
+	}
+}
+
+// pressRelease drives a complete press+release cycle through the
+// coordinator at the given viewport position. Each call advances the
+// click count if it falls within DefaultMultiClickTimeout of the
+// previous one (the click detector is position+timeout sensitive).
+func pressRelease(coord *MouseCoordinator, x, y int) {
+	coord.HandleMouse(tcell.NewEventMouse(x, y, tcell.Button1, 0))
+	coord.HandleMouse(tcell.NewEventMouse(x, y, tcell.ButtonNone, 0))
+}
+
+// hasPendingClipboard reports whether a deferred multi-click clipboard
+// write is currently armed. Drops out from under the coordinator's
+// mutex so it can race-safely observe internal state.
+func hasPendingClipboard(coord *MouseCoordinator) bool {
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	return coord.pendingClipTimer != nil
+}
+
+// TestMouseCoordinator_MultiClickChainSingleClipboard verifies that
+// double→triple→quadruple click on the same position fires
+// SetClipboard exactly once after the multi-click timeout, instead of
+// once per release. This is the regression guard for the "ghostty
+// shows continuous Content copied toasts on multi-click" bug — every
+// extra OSC52 hop translates to a host-terminal toast.
+func TestMouseCoordinator_MultiClickChainSingleClipboard(t *testing.T) {
+	vtermProv := newMockVTermProviderForCoord()
+	vtermProv.contentText = "selected"
+	// Provide a non-empty current line so SelectionModeLine /
+	// SelectionModeWord / SelectionModeSpaceWord all produce a
+	// non-empty selection that triggers the clipboard write.
+	vtermProv.currentLine = []parser.Cell{
+		{Rune: 'h'}, {Rune: 'e'}, {Rune: 'l'}, {Rune: 'l'}, {Rune: 'o'},
+	}
+	gridProv := newMockGridProvider(80, 24)
+	config := AutoScrollConfig{EdgeZone: 2, MaxScrollSpeed: 15}
+
+	coord := NewMouseCoordinator(vtermProv, gridProv, nil, config)
+	coord.SetSize(80, 24)
+	coord.SetCallbacks(func() {}, func() {})
+
+	clipboard := &mockClipboardSetter{}
+	coord.SetClipboardSetter(clipboard)
+
+	// Click 1 (single — empty drag, no clipboard write expected).
+	pressRelease(coord, 2, 0)
+	// Clicks 2/3/4 within the multi-click window at the same position
+	// escalate the selection. Each release defers the clipboard write,
+	// and the next press cancels the previously deferred one.
+	pressRelease(coord, 2, 0)
+	pressRelease(coord, 2, 0)
+	pressRelease(coord, 2, 0)
+
+	// While the window is still open, no SetClipboard call should
+	// have reached the host terminal yet.
+	if got := clipboard.callCount(); got != 0 {
+		t.Fatalf("expected 0 clipboard writes during click chain, got %d", got)
+	}
+	if !hasPendingClipboard(coord) {
+		t.Fatal("expected a pending deferred clipboard write after multi-click chain")
+	}
+
+	// Wait past the multi-click timeout for the deferred write to fire.
+	deadline := time.Now().Add(DefaultMultiClickTimeout * 4)
+	for time.Now().Before(deadline) {
+		if clipboard.callCount() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := clipboard.callCount(); got != 1 {
+		t.Fatalf("expected exactly 1 clipboard write after timeout, got %d", got)
+	}
+}
+
+// TestMouseCoordinator_NewPressCancelsPendingClipboard verifies that
+// starting a fresh selection inside the multi-click window cancels the
+// previously-armed deferred clipboard write — the user's intent has
+// shifted to a new selection and the superseded payload must not
+// surface to the host terminal.
+func TestMouseCoordinator_NewPressCancelsPendingClipboard(t *testing.T) {
+	vtermProv := newMockVTermProviderForCoord()
+	vtermProv.contentText = "word"
+	vtermProv.currentLine = []parser.Cell{{Rune: 'a'}, {Rune: 'b'}, {Rune: 'c'}}
+	gridProv := newMockGridProvider(80, 24)
+	config := AutoScrollConfig{EdgeZone: 2, MaxScrollSpeed: 15}
+
+	coord := NewMouseCoordinator(vtermProv, gridProv, nil, config)
+	coord.SetSize(80, 24)
+	coord.SetCallbacks(func() {}, func() {})
+
+	clipboard := &mockClipboardSetter{}
+	coord.SetClipboardSetter(clipboard)
+
+	// Two clicks at the same position → double-click selection,
+	// release defers the clipboard write.
+	pressRelease(coord, 1, 0)
+	pressRelease(coord, 1, 0)
+	if !hasPendingClipboard(coord) {
+		t.Fatal("expected pending clipboard write after double-click")
+	}
+
+	// A third press at a different position cancels the pending
+	// write before it can fire.
+	coord.HandleMouse(tcell.NewEventMouse(40, 10, tcell.Button1, 0))
+	if hasPendingClipboard(coord) {
+		t.Fatal("expected pending clipboard write to be cancelled by new press")
+	}
+
+	// Release without drag — empty selection, no clipboard write.
+	coord.HandleMouse(tcell.NewEventMouse(40, 10, tcell.ButtonNone, 0))
+
+	// Wait long enough that any leaked deferred write would have fired.
+	time.Sleep(DefaultMultiClickTimeout * 2)
+	if got := clipboard.callCount(); got != 0 {
+		t.Fatalf("expected 0 clipboard writes after cancellation, got %d", got)
+	}
+}
+
+// TestMouseCoordinator_SingleDragImmediateClipboard verifies that
+// single-click drag selections continue to copy synchronously on
+// release — there is no escalation gesture to wait for, and deferring
+// would add user-visible latency.
+func TestMouseCoordinator_SingleDragImmediateClipboard(t *testing.T) {
+	vtermProv := newMockVTermProviderForCoord()
+	vtermProv.contentText = "drag-selected"
+	gridProv := newMockGridProvider(80, 24)
+	config := AutoScrollConfig{EdgeZone: 2, MaxScrollSpeed: 15}
+
+	coord := NewMouseCoordinator(vtermProv, gridProv, nil, config)
+	coord.SetSize(80, 24)
+	coord.SetCallbacks(func() {}, func() {})
+
+	clipboard := &mockClipboardSetter{}
+	coord.SetClipboardSetter(clipboard)
+
+	// Press, drag to a different column, release.
+	coord.HandleMouse(tcell.NewEventMouse(5, 0, tcell.Button1, 0))
+	coord.HandleMouse(tcell.NewEventMouse(15, 0, tcell.Button1, 0))
+	coord.HandleMouse(tcell.NewEventMouse(15, 0, tcell.ButtonNone, 0))
+
+	if got := clipboard.callCount(); got != 1 {
+		t.Fatalf("expected 1 immediate clipboard write for single drag, got %d", got)
+	}
+	if hasPendingClipboard(coord) {
+		t.Fatal("expected no deferred write after single-drag release")
+	}
+}
+
+// TestMouseCoordinator_RightClickCancelsPendingClipboard verifies that
+// right-click cancellation drops a deferred multi-click clipboard
+// write, mirroring the way it drops the visible selection.
+func TestMouseCoordinator_RightClickCancelsPendingClipboard(t *testing.T) {
+	vtermProv := newMockVTermProviderForCoord()
+	vtermProv.contentText = "word"
+	vtermProv.currentLine = []parser.Cell{{Rune: 'a'}, {Rune: 'b'}, {Rune: 'c'}}
+	gridProv := newMockGridProvider(80, 24)
+	config := AutoScrollConfig{EdgeZone: 2, MaxScrollSpeed: 15}
+
+	coord := NewMouseCoordinator(vtermProv, gridProv, nil, config)
+	coord.SetSize(80, 24)
+	coord.SetCallbacks(func() {}, func() {})
+
+	clipboard := &mockClipboardSetter{}
+	coord.SetClipboardSetter(clipboard)
+
+	// Double-click → deferred write.
+	pressRelease(coord, 1, 0)
+	pressRelease(coord, 1, 0)
+	if !hasPendingClipboard(coord) {
+		t.Fatal("expected pending clipboard write after double-click")
+	}
+
+	// Right-click cancels the rendered selection AND the pending
+	// clipboard write.
+	coord.HandleMouse(tcell.NewEventMouse(1, 0, tcell.Button3, 0))
+	coord.HandleMouse(tcell.NewEventMouse(1, 0, tcell.ButtonNone, 0))
+
+	if hasPendingClipboard(coord) {
+		t.Fatal("expected right-click to cancel the pending clipboard write")
+	}
+
+	time.Sleep(DefaultMultiClickTimeout * 2)
+	if got := clipboard.callCount(); got != 0 {
+		t.Fatalf("expected 0 clipboard writes after right-click cancel, got %d", got)
 	}
 }

--- a/apps/texelterm/parser/main_screen.go
+++ b/apps/texelterm/parser/main_screen.go
@@ -3,6 +3,25 @@
 
 package parser
 
+// RowOrigin is the (gid, col) of the FIRST cell of a reflowed visual row.
+// Used by the selection mapping (ContentToViewport / ViewportToContent) to
+// project content positions to viewport coordinates without re-deriving the
+// renderer's chain walk.
+//
+// Sentinel: Gid == -1 means the row has no real content (blank row inside
+// a chain-walk gap, or bottom padding when the viewport is taller than the
+// rendered content). Selection callers fall back to naive math on such
+// rows.
+//
+// Defined in the parser package (rather than parser/sparse) so callers of
+// the MainScreen interface don't have to import parser/sparse internals
+// directly. sparse.RowOrigin is a type alias for this type — the values
+// are produced at render time by the sparse view's chain walk.
+type RowOrigin struct {
+	Gid int64
+	Col int
+}
+
 // ClearNotifier is the minimal interface the persistence layer must implement
 // so that the MainScreen can propagate range clears (tombstones) to disk.
 // AdaptivePersistence satisfies this interface via its NotifyClearRange method.
@@ -72,6 +91,13 @@ type MainScreen interface {
 	// The two slices are lockstep-consistent — callers that need both should
 	// use this method rather than calling RenderReflow and querying separately.
 	RenderReflowWithRowIdx() ([][]Cell, []int64)
+
+	// RenderReflowFull returns the rendered grid plus parallel slices for
+	// per-row chain-head gid (publisher clipping) and per-row cell-bearing
+	// origin (selection mapping). RenderReflow / RenderReflowWithRowIdx
+	// stay on the interface as discard-shims for callers that only need
+	// some of the output.
+	RenderReflowFull() ([][]Cell, []int64, []RowOrigin)
 
 	// CursorToView maps the current cursor to its viewport-relative (row, col)
 	// in the reflowed view. Returns ok=false if the cursor's globalIdx is not

--- a/apps/texelterm/parser/sparse/live_anchor_writetop_test.go
+++ b/apps/texelterm/parser/sparse/live_anchor_writetop_test.go
@@ -51,7 +51,7 @@ func TestLiveAnchor_ClampsAtWriteTop(t *testing.T) {
 
 	// Render must not paint any scrollback cells. The scrollback chain is
 	// all a/b/c/d runs; a correctly-clamped render shows only blanks.
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 	for row, cells := range out {
 		text := cellsToStringSparse(cells)
 		for _, bad := range []string{"aaaa", "bbbb", "cccc", "dddd"} {

--- a/apps/texelterm/parser/sparse/reflow_clone_test.go
+++ b/apps/texelterm/parser/sparse/reflow_clone_test.go
@@ -46,7 +46,7 @@ func TestRender_PaddedLines_NoCloneAtWiderViewport(t *testing.T) {
 
 	vw := NewViewWindow(storageWidth, lineCount)
 	vw.SetViewAnchor(0, 0)
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 
 	if len(out) != lineCount {
 		t.Fatalf("got %d rows, want %d", len(out), lineCount)
@@ -79,7 +79,7 @@ func TestRender_PaddedLines_NoCloneAtNarrowerViewport(t *testing.T) {
 
 	vw := NewViewWindow(renderWidth, lineCount)
 	vw.SetViewAnchor(0, 0)
-	out, gi := vw.Render(s)
+	out, gi, _ := vw.Render(s)
 
 	if len(out) != lineCount {
 		t.Fatalf("got %d rows, want %d", len(out), lineCount)
@@ -113,20 +113,20 @@ func TestRender_PaddedLines_ResizeTransition(t *testing.T) {
 	// Initial render at 80.
 	vw := NewViewWindow(storageWidth, lineCount)
 	vw.SetViewAnchor(0, 0)
-	out80, _ := vw.Render(s)
+	out80, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "width 80", out80)
 
 	// Resize narrower, re-render.
 	vw.Resize(40, lineCount, int64(lineCount-1))
 	vw.SetViewAnchor(0, 0)
-	out40, _ := vw.Render(s)
+	out40, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "width 40", out40)
 
 	// Resize back to 80, re-render. Make sure post-resize render is also
 	// clone-free (catches state leaking between renders).
 	vw.Resize(80, lineCount, int64(lineCount-1))
 	vw.SetViewAnchor(0, 0)
-	out80b, _ := vw.Render(s)
+	out80b, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "width 80 again", out80b)
 }
 
@@ -149,19 +149,19 @@ func TestRender_AutoFollowResize_NoClones(t *testing.T) {
 	cursorGI := int64(lineCount - 1)
 	vw.RecomputeLiveAnchor(s, cursorGI, 6, 0) // writeTop=0, cursor at last row col 6
 
-	out80, _ := vw.Render(s)
+	out80, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "auto-follow width 80", out80)
 
 	// Narrow the viewport.
 	vw.Resize(40, viewHeight, cursorGI)
 	vw.RecomputeLiveAnchor(s, cursorGI, 6, 0)
-	out40, _ := vw.Render(s)
+	out40, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "auto-follow width 40", out40)
 
 	// Widen back.
 	vw.Resize(80, viewHeight, cursorGI)
 	vw.RecomputeLiveAnchor(s, cursorGI, 6, 0)
-	out80b, _ := vw.Render(s)
+	out80b, _, _ := vw.Render(s)
 	checkNoClonesInRender(t, "auto-follow width 80 again", out80b)
 }
 
@@ -251,19 +251,19 @@ func TestRender_AutoFollowResize_WrappedContent_NoClones(t *testing.T) {
 	// from narrow-width reflow look identical but have monotone gi (all
 	// from the same chain), so this is the correct invariant to check.
 	vw.RecomputeLiveAnchor(s, cursorGI, 19, 0)
-	_, gi80 := vw.Render(s)
+	_, gi80, _ := vw.Render(s)
 	checkGIMonotone(t, "wrap+padding width 80", gi80)
 
 	// Narrow to 40 — content width 100 chars per chain reflows to 3 rows.
 	vw.Resize(40, viewHeight, cursorGI)
 	vw.RecomputeLiveAnchor(s, cursorGI, 19, 0)
-	_, gi40 := vw.Render(s)
+	_, gi40, _ := vw.Render(s)
 	checkGIMonotone(t, "wrap+padding width 40", gi40)
 
 	// Narrow to 5 — extreme case (very narrow).
 	vw.Resize(5, viewHeight, cursorGI)
 	vw.RecomputeLiveAnchor(s, cursorGI, 4, 0)
-	_, gi5 := vw.Render(s)
+	_, gi5, _ := vw.Render(s)
 	checkGIMonotone(t, "wrap+padding width 5", gi5)
 }
 

--- a/apps/texelterm/parser/sparse/reflow_tail_test.go
+++ b/apps/texelterm/parser/sparse/reflow_tail_test.go
@@ -119,7 +119,7 @@ func TestRender_EmptyContinuationEmitsRow(t *testing.T) {
 
 	vw := NewViewWindow(80, 5)
 	vw.SetViewAnchor(0, 0)
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 
 	if len(out) < 3 {
 		t.Fatalf("Render too short: %d rows", len(out))
@@ -161,7 +161,7 @@ func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
 	vw := NewViewWindow(40, 3)
 	// Start by anchoring at the tail (line 4) so we're "past" the chain.
 	vw.SetViewAnchor(4, 0)
-	baselineRows, _ := vw.Render(s)
+	baselineRows, _, _ := vw.Render(s)
 	baseline := cellsToStringSparse(baselineRows[0])
 	if !strings.HasPrefix(baseline, "tail") {
 		t.Fatalf("baseline row 0 = %q; expected tail", baseline)
@@ -180,7 +180,7 @@ func TestScrollUp_ReflowedChainNoFragment(t *testing.T) {
 
 	// Top of viewport should show a non-fragmented reflowed row from the
 	// chain. Row 6 of the reflow = cells [240..280] = all 'd' (40 cells).
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 	row0 := cellsToStringSparse(out[0])
 	if !strings.HasPrefix(row0, strings.Repeat("d", 40)) {
 		t.Errorf("ScrollUp(1) top row = %q; want 40 d's (last reflowed row)", row0)

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -314,7 +314,8 @@ func (t *Terminal) RenderReflow() [][]parser.Cell {
 func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
 	cursorGI, cursorCol := t.write.Cursor()
 	t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
-	return t.view.Render(t.store)
+	rows, gids, _ := t.view.Render(t.store)
+	return rows, gids
 }
 
 // Grid builds a dense height x width grid from the current view range by

--- a/apps/texelterm/parser/sparse/terminal.go
+++ b/apps/texelterm/parser/sparse/terminal.go
@@ -296,13 +296,24 @@ func (t *Terminal) PointFromView(viewRow, viewCol int) (globalIdx int64, col int
 	return t.view.ViewToCursor(t.store, viewRow, viewCol)
 }
 
+// RenderReflowFull is the full render output: rows, per-row chain-head
+// gid (for publisher clipping), and per-row cell-bearing origin (for
+// selection mapping). Internal callers that only need rows or rows+gids
+// use the existing shims; selection consults the origin slice via
+// VTerm's cache.
+func (t *Terminal) RenderReflowFull() ([][]parser.Cell, []int64, []RowOrigin) {
+	cursorGI, cursorCol := t.write.Cursor()
+	t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
+	return t.view.Render(t.store)
+}
+
 // RenderReflow produces the viewport via the reflow-aware ViewWindow.Render
 // path. Recomputes the live anchor from the cursor's chain first so that
 // autoFollow keeps the cursor on the bottom row of the viewport. This is the
 // bridge method; callers switch over from Grid() in a later step.
 func (t *Terminal) RenderReflow() [][]parser.Cell {
-	cells, _ := t.RenderReflowWithRowIdx()
-	return cells
+	rows, _, _ := t.RenderReflowFull()
+	return rows
 }
 
 // RenderReflowWithRowIdx is the RenderReflow variant that also returns the
@@ -312,9 +323,7 @@ func (t *Terminal) RenderReflow() [][]parser.Cell {
 // positions (e.g., the publisher's per-row clipping, the texelterm app's
 // RowGlobalIdxProvider) should use this variant to avoid re-walking.
 func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
-	cursorGI, cursorCol := t.write.Cursor()
-	t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
-	rows, gids, _ := t.view.Render(t.store)
+	rows, gids, _ := t.RenderReflowFull()
 	return rows, gids
 }
 

--- a/apps/texelterm/parser/sparse/view_reflow.go
+++ b/apps/texelterm/parser/sparse/view_reflow.go
@@ -5,6 +5,19 @@ package sparse
 
 import "github.com/framegrace/texelation/apps/texelterm/parser"
 
+// RowOrigin is the (gid, col) of the FIRST cell of a reflowed visual row.
+// Used by the selection mapping to project content positions to viewport
+// coordinates without re-deriving the renderer's chain walk.
+//
+// Sentinel: Gid == -1 means the row has no real content (blank row inside
+// a chain-walk gap, or bottom padding when the viewport is taller than
+// the rendered content). Selection callers fall back to naive math on
+// such rows.
+type RowOrigin struct {
+	Gid int64
+	Col int
+}
+
 // walkChain returns the end globalIdx of the Wrapped chain starting at
 // startGI, plus whether any row in the chain is marked NoWrap (chain
 // propagation). Walks at most maxSteps rows to bound pathological inputs.
@@ -50,23 +63,33 @@ func walkChain(s *Store, startGI int64, maxSteps int) (end int64, nowrap bool) {
 // the right-side content on a NEW row (issue #193). Lines without gaps
 // (everything autowrap or shell-typed contiguously from col 0) reflow
 // normally — `ls -l` output etc. continues to wrap on shrink (issue #197).
-func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell {
+func reflowChain(s *Store, startGI, endGI int64, viewWidth int) (rows [][]parser.Cell, origin []RowOrigin) {
 	if viewWidth <= 0 {
-		return nil
+		return nil, nil
 	}
 	if startGI == endGI && rowHasPositionalGap(s, startGI) {
-		return [][]parser.Cell{s.GetLine(startGI)}
+		return [][]parser.Cell{s.GetLine(startGI)}, []RowOrigin{{Gid: startGI, Col: 0}}
 	}
 	var logical []parser.Cell
+	var cellOrigin []RowOrigin
 	for gi := startGI; gi <= endGI; gi++ {
-		logical = append(logical, s.GetLine(gi)...)
+		line := s.GetLine(gi)
+		for col := range line {
+			logical = append(logical, line[col])
+			cellOrigin = append(cellOrigin, RowOrigin{Gid: gi, Col: col})
+		}
 	}
+	// Trim logical AND cellOrigin from the same length so origin[i] stays
+	// aligned with logical[i]. trimTrailingPadding returns a possibly-
+	// shorter slice (it does cells[:n]); reassign logical to it and shrink
+	// cellOrigin to match.
 	logical = trimTrailingPadding(logical)
+	cellOrigin = cellOrigin[:len(logical)]
+
 	trailing := trailingEmptyRows(s, startGI, endGI)
 	if len(logical) == 0 && trailing == 0 {
-		return [][]parser.Cell{nil}
+		return [][]parser.Cell{nil}, []RowOrigin{{Gid: -1}}
 	}
-	var rows [][]parser.Cell
 	for off := 0; off < len(logical); off += viewWidth {
 		end := off + viewWidth
 		if end > len(logical) {
@@ -75,11 +98,13 @@ func reflowChain(s *Store, startGI, endGI int64, viewWidth int) [][]parser.Cell 
 		row := make([]parser.Cell, end-off)
 		copy(row, logical[off:end])
 		rows = append(rows, row)
+		origin = append(origin, cellOrigin[off])
 	}
 	for i := 0; i < trailing; i++ {
 		rows = append(rows, nil)
+		origin = append(origin, RowOrigin{Gid: endGI, Col: len(s.GetLine(endGI))})
 	}
-	return rows
+	return rows, origin
 }
 
 // trimTrailingPadding drops trailing PADDING cells (space rune, default

--- a/apps/texelterm/parser/sparse/view_reflow.go
+++ b/apps/texelterm/parser/sparse/view_reflow.go
@@ -5,18 +5,11 @@ package sparse
 
 import "github.com/framegrace/texelation/apps/texelterm/parser"
 
-// RowOrigin is the (gid, col) of the FIRST cell of a reflowed visual row.
-// Used by the selection mapping to project content positions to viewport
-// coordinates without re-deriving the renderer's chain walk.
-//
-// Sentinel: Gid == -1 means the row has no real content (blank row inside
-// a chain-walk gap, or bottom padding when the viewport is taller than
-// the rendered content). Selection callers fall back to naive math on
-// such rows.
-type RowOrigin struct {
-	Gid int64
-	Col int
-}
+// RowOrigin is a type alias for parser.RowOrigin. The canonical definition
+// lives in the parser package so MainScreen interface callers don't need to
+// import parser/sparse internals; this alias keeps existing intra-package
+// references (reflowChain, ViewWindow.Render) terse.
+type RowOrigin = parser.RowOrigin
 
 // walkChain returns the end globalIdx of the Wrapped chain starting at
 // startGI, plus whether any row in the chain is marked NoWrap (chain

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -367,3 +367,33 @@ func TestReflowChain_OriginTrailingEmptyBranch(t *testing.T) {
 		t.Fatalf("rows=%d origin=%d, want 1 each", len(rows), len(origin))
 	}
 }
+
+func TestReflowChain_OriginWithTrailingPaddingTrimmed(t *testing.T) {
+	s := NewStore(80)
+	// 60 chars of content + 20 trailing padding cells (default-bg space).
+	// Chain head Wrapped=false so the chain is single-gid.
+	cells := make([]parser.Cell, 80)
+	for i := 0; i < 60; i++ {
+		cells[i] = parser.Cell{Rune: 'x'}
+	}
+	for i := 60; i < 80; i++ {
+		cells[i] = parser.Cell{Rune: ' '}
+	}
+	s.SetLine(5, cells)
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1", len(rows))
+	}
+	// After trim, logical has 60 cells; the row is 60 cells wide.
+	if len(rows[0]) != 60 {
+		t.Errorf("row width=%d, want 60 (trailing 20 padding cells trimmed)", len(rows[0]))
+	}
+	// origin[0] must point at gid 5 col 0 — trim is symmetric.
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if len(origin) != 1 {
+		t.Errorf("origin len=%d, want 1", len(origin))
+	}
+}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -397,3 +397,21 @@ func TestReflowChain_OriginWithTrailingPaddingTrimmed(t *testing.T) {
 		t.Errorf("origin len=%d, want 1", len(origin))
 	}
 }
+
+func TestReflowChain_OriginPositionalGap(t *testing.T) {
+	s := NewStore(80)
+	// Powerline-style row: write at col 89 directly via Set so the
+	// row carries unwritten cells before the last-written col.
+	s.Set(5, 89, parser.Cell{Rune: 'x'})
+	if !rowHasPositionalGap(s, 5) {
+		t.Fatalf("row 5 has no positional gap; setup invalid")
+	}
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1 (positional-gap path returns single row)", len(rows))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -76,7 +76,7 @@ func TestReflowChain_SingleLogical(t *testing.T) {
 	fillRow(s, 0, "0123456789", true)
 	fillRow(s, 1, "abcde", false)
 	// chain at width 5 → 3 rows: "01234", "56789", "abcde"
-	rows := reflowChain(s, 0, 1, 5)
+	rows, _ := reflowChain(s, 0, 1, 5)
 	if len(rows) != 3 {
 		t.Fatalf("expected 3 rows, got %d", len(rows))
 	}
@@ -146,7 +146,7 @@ func TestReflowChain_TrimsTrailingPadding(t *testing.T) {
 	s := NewStore(10)
 	fillRow(s, 0, "Hello"+strings.Repeat(" ", 75), false) // width-80 padded line
 
-	rows := reflowChain(s, 0, 0, 40)
+	rows, _ := reflowChain(s, 0, 0, 40)
 	if len(rows) != 1 {
 		t.Errorf("padded line at half width: got %d rows, want 1 (trailing padding should not wrap)", len(rows))
 	}
@@ -161,7 +161,7 @@ func TestReflowChain_TrimsTrailingPaddingAcrossChain(t *testing.T) {
 	s := NewStore(10)
 	fillRow(s, 0, "hello   ", true)
 	fillRow(s, 1, "        ", false)
-	rows := reflowChain(s, 0, 1, 20)
+	rows, _ := reflowChain(s, 0, 1, 20)
 	if len(rows) != 1 {
 		t.Errorf("chain ending in padding across rows: got %d rows, want 1", len(rows))
 	}
@@ -175,7 +175,7 @@ func TestReflowChain_TrimsTrailingPaddingAcrossChain(t *testing.T) {
 func TestReflowChain_PreservesEmbeddedSpaces(t *testing.T) {
 	s := NewStore(10)
 	fillRow(s, 0, "a    b", false)
-	rows := reflowChain(s, 0, 0, 20)
+	rows, _ := reflowChain(s, 0, 0, 20)
 	if len(rows) != 1 || cellsToStringSparse(rows[0]) != "a    b" {
 		t.Errorf("embedded spaces: got %q, want %q", cellsToStringSparse(rows[0]), "a    b")
 	}
@@ -195,7 +195,7 @@ func TestReflowChain_PreservesColoredTrailingSpaces(t *testing.T) {
 	}
 	s.SetLine(0, cells)
 
-	rows := reflowChain(s, 0, 0, 10)
+	rows, _ := reflowChain(s, 0, 0, 10)
 	// 31 cells reflowed at width 10 → 4 rows (3 full + 1 with the
 	// final coloured space). Coloured bar must wrap, not clip.
 	if len(rows) != 4 {
@@ -211,7 +211,7 @@ func TestReflowChain_PreservesReverseAttributeTrailingSpace(t *testing.T) {
 	cells := []parser.Cell{{Rune: 'X'}, {Rune: ' ', Attr: parser.AttrReverse}}
 	s.SetLine(0, cells)
 
-	rows := reflowChain(s, 0, 0, 20)
+	rows, _ := reflowChain(s, 0, 0, 20)
 	if len(rows) != 1 {
 		t.Fatalf("got %d rows, want 1", len(rows))
 	}
@@ -242,4 +242,20 @@ func cellsToStringSparse(cells []parser.Cell) string {
 		}
 	}
 	return b.String()
+}
+
+func TestReflowChain_OriginNonWrapped(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 5, "hello world", false) // single non-wrapped gid
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1", len(rows))
+	}
+	if len(origin) != 1 {
+		t.Fatalf("origin len=%d, want 1", len(origin))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
 }

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -283,3 +283,25 @@ func TestReflowChain_OriginWrappedSingleGid(t *testing.T) {
 		t.Errorf("origin[1]=%+v, want {Gid:6, Col:0}", origin[1])
 	}
 }
+
+func TestReflowChain_OriginWrappedCrossingGidMidRow(t *testing.T) {
+	s := NewStore(80)
+	// Same setup as the previous test: 80 chars in gid 5 (Wrapped) +
+	// 20 chars in gid 6. But reflow at narrower width 50 — the wrap
+	// boundary now falls mid-gid.
+	fillRow(s, 5, strings.Repeat("x", 80), true)
+	fillRow(s, 6, strings.Repeat("y", 20), false)
+
+	// At width 50: row 0 = gid 5 cols 0..49 (50 cells), row 1 = gid 5
+	// cols 50..79 + gid 6 cols 0..19 (30+20=50 cells).
+	rows, origin := reflowChain(s, 5, 6, 50)
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 5, Col: 50}) {
+		t.Errorf("origin[1]=%+v, want {Gid:5, Col:50}", origin[1])
+	}
+}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -259,3 +259,27 @@ func TestReflowChain_OriginNonWrapped(t *testing.T) {
 		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
 	}
 }
+
+func TestReflowChain_OriginWrappedSingleGid(t *testing.T) {
+	s := NewStore(80)
+	// 100-char line in one gid, last cell Wrapped (chain head before tail).
+	long := strings.Repeat("x", 80)
+	fillRow(s, 5, long, true)
+	// Continuation gid with the remaining 20 chars, last cell not wrapped.
+	fillRow(s, 6, strings.Repeat("y", 20), false)
+
+	// At width 80: row 0 is gid 5's 80 chars; row 1 is gid 6's 20 chars.
+	rows, origin := reflowChain(s, 5, 6, 80)
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
+	}
+	if len(origin) != 2 {
+		t.Fatalf("origin len=%d, want 2", len(origin))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 6, Col: 0}) {
+		t.Errorf("origin[1]=%+v, want {Gid:6, Col:0}", origin[1])
+	}
+}

--- a/apps/texelterm/parser/sparse/view_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_reflow_test.go
@@ -305,3 +305,65 @@ func TestReflowChain_OriginWrappedCrossingGidMidRow(t *testing.T) {
 		t.Errorf("origin[1]=%+v, want {Gid:5, Col:50}", origin[1])
 	}
 }
+
+func TestReflowChain_OriginTrailingEmptyRows(t *testing.T) {
+	s := NewStore(80)
+	// Two-gid chain head; both gids carry content + Wrapped=true. After
+	// reflow, with a trailing-empty path simulated by a chain whose
+	// trailingEmptyRows is non-zero, we'd want a setup where end > start
+	// and an interior gid in [start+1, end] is empty.
+	//
+	// Direct setup: gid 5 has 80 wrapped chars, gid 6 has 80 wrapped chars,
+	// gid 7 has empty cells but is in the store. walkChain will return
+	// end=6 (it bails when next is nil), so trailingEmptyRows returns 0.
+	// Fall back to confirming the absence-of-trailing-empties path
+	// emits all origins from the cell walk.
+	fillRow(s, 5, strings.Repeat("a", 80), true)
+	fillRow(s, 6, "bb", false)
+
+	rows, origin := reflowChain(s, 5, 6, 80)
+	if len(rows) != len(origin) {
+		t.Fatalf("rows/origin length mismatch: %d vs %d", len(rows), len(origin))
+	}
+	// Two rows: one for gid 5 (80 a's), one for "bb".
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 6, Col: 0}) {
+		t.Errorf("origin[1]=%+v, want {Gid:6, Col:0}", origin[1])
+	}
+}
+
+func TestReflowChain_OriginTrailingEmptyBranch(t *testing.T) {
+	// Verify the trailing-empty branch by reflecting on the function
+	// directly. trailingEmptyRows's contract: counts rows in (start, end]
+	// whose len == 0. Pick a chain where end > start and the in-between
+	// gids are empty; this only happens when SetLine pre-creates an empty
+	// row in the middle of a chain — fragile but representative.
+	s := NewStore(80)
+	// Chain head fully filled, Wrapped=true.
+	cells := make([]parser.Cell, 80)
+	for i := range cells {
+		cells[i] = parser.Cell{Rune: 'a'}
+	}
+	cells[79].Wrapped = true
+	s.SetLine(5, cells)
+	// gid 6: pre-create an empty row. walkChain will see gid 6 has no
+	// cells via len(cells) == 0 and return end=5. So trailingEmptyRows
+	// runs over [5, 5] and returns 0. This means trailing branch isn't
+	// reachable from public APIs in a unit-testable way without a parser
+	// driving cursor moves. Skip the assert path; the trailing-empty
+	// branch is structurally tested via the integration tests in Phase 8.
+	end, _ := walkChain(s, 5, 100)
+	if end != 5 {
+		t.Fatalf("unexpected walkChain end=%d", end)
+	}
+	// Confirm the chain-head-only path still emits origins correctly.
+	rows, origin := reflowChain(s, 5, end, 80)
+	if len(rows) != 1 || len(origin) != 1 {
+		t.Fatalf("rows=%d origin=%d, want 1 each", len(rows), len(origin))
+	}
+}

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -102,7 +102,7 @@ func (v *ViewWindow) SetAutoJumpOnInput(enabled bool) {
 // lockstep even under concurrent Render calls — callers receive a
 // self-consistent pair, and no per-instance state has to straddle the
 // walk/publish boundary.
-func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
+func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64, []RowOrigin) {
 	v.mu.Lock()
 	width := v.width
 	height := v.height
@@ -113,6 +113,7 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 
 	out := make([][]parser.Cell, 0, height)
 	rowGI := make([]int64, 0, height)
+	rowOrigin := make([]RowOrigin, 0, height)
 	maxSteps := 4 * height
 	if maxSteps < 4 {
 		maxSteps = 4
@@ -135,6 +136,7 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 			// Blank/pad rows with no real content track as -1 so callers
 			// don't conflate them with a written row at that globalIdx.
 			rowGI = append(rowGI, -1)
+			rowOrigin = append(rowOrigin, RowOrigin{Gid: -1})
 			gi++
 			continue
 		}
@@ -142,11 +144,13 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 
 		var rows [][]parser.Cell
 		var rowsGI []int64
+		var rowsOrigin []RowOrigin
 		if reflowOff || nowrap {
 			// Each physical row is its own globalIdx: gi, gi+1, ..., end.
 			for r := gi; r <= end; r++ {
 				rows = append(rows, clipRow(s.GetLine(r), width))
 				rowsGI = append(rowsGI, r)
+				rowsOrigin = append(rowsOrigin, RowOrigin{Gid: r, Col: 0})
 			}
 		} else {
 			// Wrapped chain reflowed to this viewport's width: all reflowed
@@ -154,10 +158,11 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 			// would require tracking cell-range provenance through
 			// reflowChain; the publisher only needs "does this row belong
 			// to a real store position" which the chain head answers.
-			reflowed, _ := reflowChain(s, gi, end, width)
-			for _, row := range reflowed {
+			reflowed, originSlice := reflowChain(s, gi, end, width)
+			for i, row := range reflowed {
 				rows = append(rows, clipRow(row, width))
 				rowsGI = append(rowsGI, gi)
+				rowsOrigin = append(rowsOrigin, originSlice[i])
 			}
 		}
 
@@ -166,9 +171,11 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 			if skip < len(rows) {
 				rows = rows[skip:]
 				rowsGI = rowsGI[skip:]
+				rowsOrigin = rowsOrigin[skip:]
 			} else {
 				rows = nil
 				rowsGI = nil
+				rowsOrigin = nil
 			}
 		}
 
@@ -178,6 +185,7 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 			}
 			out = append(out, row)
 			rowGI = append(rowGI, rowsGI[i])
+			rowOrigin = append(rowOrigin, rowsOrigin[i])
 		}
 		gi = end + 1
 	}
@@ -185,14 +193,18 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 	for len(out) < height {
 		out = append(out, make([]parser.Cell, width))
 		rowGI = append(rowGI, -1)
+		rowOrigin = append(rowOrigin, RowOrigin{Gid: -1})
 	}
 
 	// Trim to height in case any loop appended one extra entry.
 	if len(rowGI) > height {
 		rowGI = rowGI[:height]
 	}
+	if len(rowOrigin) > height {
+		rowOrigin = rowOrigin[:height]
+	}
 
-	return out, rowGI
+	return out, rowGI, rowOrigin
 }
 
 // RecomputeLiveAnchor repositions viewAnchor/viewAnchorOffset so that the

--- a/apps/texelterm/parser/sparse/view_window.go
+++ b/apps/texelterm/parser/sparse/view_window.go
@@ -154,7 +154,7 @@ func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64) {
 			// would require tracking cell-range provenance through
 			// reflowChain; the publisher only needs "does this row belong
 			// to a real store position" which the chain head answers.
-			reflowed := reflowChain(s, gi, end, width)
+			reflowed, _ := reflowChain(s, gi, end, width)
 			for _, row := range reflowed {
 				rows = append(rows, clipRow(row, width))
 				rowsGI = append(rowsGI, gi)

--- a/apps/texelterm/parser/sparse/view_window_reflow_test.go
+++ b/apps/texelterm/parser/sparse/view_window_reflow_test.go
@@ -13,7 +13,7 @@ func TestViewWindow_Render_ReflowsOnNarrow(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 
 	if len(out) != 5 {
 		t.Fatalf("Render should return viewHeight=5 rows, got %d", len(out))
@@ -35,7 +35,7 @@ func TestViewWindow_Render_NoWrapChainStays1to1(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out, _ := vw.Render(s)
+	out, _, _ := vw.Render(s)
 
 	if !strings.HasPrefix(cellsToStringSparse(out[0]), "01234567890123456789") {
 		t.Errorf("NoWrap row 0 should be clipped 1:1, got %q", cellsToStringSparse(out[0]))

--- a/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
+++ b/apps/texelterm/parser/sparse/view_window_rowglobalidx_test.go
@@ -16,7 +16,7 @@ func TestViewWindow_RowGlobalIdx_MatchesRender(t *testing.T) {
 
 	vw := NewViewWindow(40, 10)
 	vw.SetViewAnchor(5, 0)
-	out, gi := vw.Render(s)
+	out, gi, _ := vw.Render(s)
 	if len(out) != 10 {
 		t.Fatalf("Render returned %d rows, want 10", len(out))
 	}
@@ -46,7 +46,7 @@ func TestViewWindow_RowGlobalIdx_ReflowedChain(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	out, gi := vw.Render(s)
+	out, gi, _ := vw.Render(s)
 	if len(out) != 5 {
 		t.Fatalf("Render returned %d rows, want 5", len(out))
 	}
@@ -76,7 +76,7 @@ func TestViewWindow_RowGlobalIdx_BlankPadded(t *testing.T) {
 
 	vw := NewViewWindow(40, 5)
 	vw.SetViewAnchor(0, 0)
-	_, gi := vw.Render(s)
+	_, gi, _ := vw.Render(s)
 	if len(gi) != 5 {
 		t.Fatalf("Render returned gi len %d, want 5", len(gi))
 	}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -258,3 +258,89 @@ func TestContentToViewport_RoundTripWrappedChain(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderedGridAgreesWithRowOrigin(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// Mix of short non-wrapping lines and a long wrapped line so the
+	// origin slice has both per-gid and per-cell-offset entries.
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "short" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	for i := 0; i < 5; i++ {
+		for _, r := range "after" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	grid, _ := v.GridWithRowIdx()
+
+	for y, o := range v.mainScreenRowOrigin {
+		if o.Gid == -1 {
+			continue
+		}
+		drewRune := grid[y][0].Rune
+		storeCells := v.mainScreen.ReadLine(o.Gid)
+		if o.Col >= len(storeCells) {
+			t.Errorf("row %d: origin (%d,%d) points past store row (len=%d)",
+				y, o.Gid, o.Col, len(storeCells))
+			continue
+		}
+		want := storeCells[o.Col].Rune
+		if drewRune != want {
+			t.Errorf("row %d col 0: drew rune=%q, but origin (%d,%d) says store rune=%q",
+				y, drewRune, o.Gid, o.Col, want)
+		}
+	}
+}
+
+func TestRenderedGridAgreesWithMapperInterior(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	grid, _ := v.GridWithRowIdx()
+
+	cases := []struct{ y, x int }{
+		{0, 5}, {0, 79}, {1, 0}, {1, 15},
+	}
+	for _, c := range cases {
+		gid, col, _, ok := v.ViewportToContent(c.y, c.x)
+		if !ok {
+			t.Errorf("(%d,%d): ViewportToContent failed", c.y, c.x)
+			continue
+		}
+		drew := grid[c.y][c.x].Rune
+		storeCells := v.mainScreen.ReadLine(gid)
+		if col >= len(storeCells) {
+			t.Errorf("(%d,%d): mapped (%d,%d) past store len=%d",
+				c.y, c.x, gid, col, len(storeCells))
+			continue
+		}
+		want := storeCells[col].Rune
+		if drew != want {
+			t.Errorf("(%d,%d): drew %q, mapper says (%d,%d)→%q",
+				c.y, c.x, drew, gid, col, want)
+		}
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -180,3 +180,36 @@ func TestViewportToContent_WrappedContinuationRow(t *testing.T) {
 			gid, col, wantGid, wantCol)
 	}
 }
+
+func TestContentToViewport_RoundTripNonWrapped(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "hello" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	_, _ = v.GridWithRowIdx()
+
+	for y := 0; y < 5; y++ {
+		for x := 0; x < 5; x++ {
+			gid, col, _, ok := v.ViewportToContent(y, x)
+			if !ok {
+				t.Fatalf("ViewportToContent(%d,%d) ok=false", y, x)
+			}
+			ry, rx, vis := v.ContentToViewport(gid, col)
+			if !vis {
+				t.Errorf("(%d,%d) → (%d,%d) → not visible", y, x, gid, col)
+				continue
+			}
+			if ry != y || rx != x {
+				t.Errorf("round-trip (%d,%d) → (gid=%d,col=%d) → (%d,%d)",
+					y, x, gid, col, ry, rx)
+			}
+		}
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -1,0 +1,67 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Tests for the origin-based viewport <-> content mapping.
+
+package parser
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAdvanceCells_StaysInGid(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 30)
+	for i := range cells {
+		cells[i] = Cell{Rune: rune('a' + (i % 26))}
+	}
+	v.mainScreen.SetLine(5, cells)
+
+	gid, col := v.advanceCells(5, 0, 10)
+	if gid != 5 || col != 10 {
+		t.Errorf("advanceCells(5,0,10) = (%d,%d), want (5,10)", gid, col)
+	}
+}
+
+func TestAdvanceCells_CrossesGidBoundary(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	left := make([]Cell, 80)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	left[79].Wrapped = true
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 60)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	gid, col := v.advanceCells(5, 50, 40)
+	if gid != 6 || col != 10 {
+		t.Errorf("advanceCells(5,50,40) = (%d,%d), want (6,10)", gid, col)
+	}
+}
+
+func TestAdvanceCells_PastContentTerminates(t *testing.T) {
+	// Regression: walking past the store's last written gid must not
+	// loop indefinitely.
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	v.mainScreen.SetLine(5, []Cell{{Rune: 'a'}, {Rune: 'b'}})
+
+	done := make(chan struct{})
+	go func() {
+		v.advanceCells(5, 5, 100)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Returned cleanly.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("advanceCells did not terminate within 100ms — likely infinite loop")
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -65,3 +65,64 @@ func TestAdvanceCells_PastContentTerminates(t *testing.T) {
 		t.Fatal("advanceCells did not terminate within 100ms — likely infinite loop")
 	}
 }
+
+func TestCellsBetween_StaysInGid(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 30)
+	for i := range cells {
+		cells[i] = Cell{Rune: 'a'}
+	}
+	v.mainScreen.SetLine(5, cells)
+
+	steps, ok := v.cellsBetween(5, 0, 5, 10, 80)
+	if !ok || steps != 10 {
+		t.Errorf("cellsBetween(5,0 -> 5,10) = (%d,%v), want (10,true)", steps, ok)
+	}
+}
+
+func TestCellsBetween_CrossesGidBoundary(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	left := make([]Cell, 80)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	left[79].Wrapped = true
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 60)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	// Origin (5, 50), target (6, 10), max 80 cells. Steps: 30 (rest of gid 5) + 10 = 40.
+	steps, ok := v.cellsBetween(5, 50, 6, 10, 80)
+	if !ok || steps != 40 {
+		t.Errorf("cellsBetween(5,50 -> 6,10) = (%d,%v), want (40,true)", steps, ok)
+	}
+}
+
+func TestCellsBetween_TargetOutOfRange(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 10)
+	v.mainScreen.SetLine(5, cells)
+
+	_, ok := v.cellsBetween(5, 0, 100, 0, 50)
+	if ok {
+		t.Errorf("cellsBetween(5,0 -> 100,0) returned ok=true; expected false")
+	}
+}
+
+func TestCellsBetween_TargetBeforeOrigin(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 30)
+	v.mainScreen.SetLine(5, cells)
+
+	_, ok := v.cellsBetween(5, 20, 5, 5, 80)
+	if ok {
+		t.Errorf("cellsBetween(5,20 -> 5,5) returned ok=true; expected false")
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -396,3 +396,34 @@ func TestContentToViewport_OffViewportReturnsFalse(t *testing.T) {
 		t.Errorf("ContentToViewport(9999, 0) returned visible=true; expected false")
 	}
 }
+
+func TestContentToViewport_AfterResize(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab"
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	gid80, col80, _, ok := v.ViewportToContent(1, 0)
+	if !ok {
+		t.Fatalf("pre-resize ViewportToContent(1,0) failed")
+	}
+
+	v.Resize(40, 24)
+	_, _ = v.GridWithRowIdx()
+
+	y, x, vis := v.ContentToViewport(gid80, col80)
+	if !vis {
+		t.Fatalf("post-resize: (%d,%d) not visible", gid80, col80)
+	}
+	if y != 2 || x != 0 {
+		t.Errorf("post-resize: (gid=%d,col=%d) → (%d,%d), want (2,0)",
+			gid80, col80, y, x)
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -126,3 +126,57 @@ func TestCellsBetween_TargetBeforeOrigin(t *testing.T) {
 		t.Errorf("cellsBetween(5,20 -> 5,5) returned ok=true; expected false")
 	}
 }
+
+func TestViewportToContent_WrappedContinuationRow(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// 100-char line wraps once at width 80, then resize to 40 forces
+	// a mid-gid wrap continuation: row 0 starts at (gid=0, col=0),
+	// row 1 starts at (gid=0, col=40) — same gid. This is precisely
+	// the case naive math gets wrong.
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	v.Resize(40, 24)
+	// Render so mainScreenRowOrigin is populated.
+	_, _ = v.GridWithRowIdx()
+
+	// Sanity-check the test is exercising the intended layout:
+	// row 1 must be a mid-gid wrap continuation (Col != 0), otherwise
+	// the test reduces to naive math and tells us nothing.
+	if v.mainScreenRowOrigin[1].Col == 0 {
+		t.Fatalf("test setup didn't produce a mid-gid wrap continuation at row 1; got %+v",
+			v.mainScreenRowOrigin[1])
+	}
+
+	// Click at row 1, col 5. The naive implementation returns
+	// (visibleTop+1, 5). The origin-based implementation must return
+	// the cell-bearing (gid, col) — origin[1].Gid + col-walk-from-origin.
+	gid, col, _, ok := v.ViewportToContent(1, 5)
+	if !ok {
+		t.Fatalf("ViewportToContent(1, 5) ok=false")
+	}
+
+	// Independently re-derive what the answer should be from the cached
+	// origin slice — this gives a check that doesn't pre-suppose the
+	// implementation, but does require the origin slice to be built
+	// correctly (which Phase 1 covers).
+	o := v.mainScreenRowOrigin[1]
+	wantGid, wantCol := o.Gid, o.Col+5
+	// If +5 crosses a gid boundary in the chain, expand:
+	storeCells := v.mainScreen.ReadLine(o.Gid)
+	if wantCol >= len(storeCells) {
+		wantCol -= len(storeCells)
+		wantGid++
+	}
+	if gid != wantGid || col != wantCol {
+		t.Errorf("ViewportToContent(1,5)=(gid=%d,col=%d), want (%d,%d)",
+			gid, col, wantGid, wantCol)
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -344,3 +344,55 @@ func TestRenderedGridAgreesWithMapperInterior(t *testing.T) {
 		}
 	}
 }
+
+func TestViewportToContent_FallsBackToNaiveOnSentinel(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	p := NewParser(v)
+	for _, r := range "only-line" {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	var sentY = -1
+	for y, o := range v.mainScreenRowOrigin {
+		if o.Gid == -1 {
+			sentY = y
+			break
+		}
+	}
+	if sentY < 0 {
+		t.Skip("no sentinel row to exercise")
+	}
+
+	gid, col, _, ok := v.ViewportToContent(sentY, 5)
+	if !ok {
+		t.Fatalf("ViewportToContent on sentinel row returned ok=false")
+	}
+	visibleTop, _ := v.mainScreen.VisibleRange()
+	wantGid := visibleTop + int64(sentY)
+	if gid != wantGid || col != 5 {
+		t.Errorf("sentinel fallback = (%d,%d), want (%d,5)", gid, col, wantGid)
+	}
+}
+
+func TestContentToViewport_OffViewportReturnsFalse(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	p := NewParser(v)
+	for _, r := range "anchor-line" {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	_, _, vis := v.ContentToViewport(9999, 0)
+	if vis {
+		t.Errorf("ContentToViewport(9999, 0) returned visible=true; expected false")
+	}
+}

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -66,6 +66,116 @@ func TestAdvanceCells_PastContentTerminates(t *testing.T) {
 	}
 }
 
+func TestAdvanceCells_StopsAtChainEnd(t *testing.T) {
+	// Non-wrapped row: last cell is NOT Wrapped. Walking past the row's
+	// content should clamp at row end (gid_N, len) — not advance into
+	// the next gid (which would be a different logical line).
+	//
+	// Bug class: dragging a selection past the end of a non-wrapped
+	// line incorrectly extends into the next gid's content; the
+	// resulting selection covers blank cells of every intermediate
+	// row, then partial content of a far row.
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	left := make([]Cell, 5)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	// last cell .Wrapped is the zero value (false) — chain ends here.
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 80)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	gid, col := v.advanceCells(5, 0, 50)
+	if gid != 5 || col != 5 {
+		t.Errorf("advanceCells(5,0,50) = (%d,%d), want (5,5) — should clamp at chain end",
+			gid, col)
+	}
+}
+
+func TestContentToViewport_ExclusiveEndOfRow(t *testing.T) {
+	// Bug class: selectLine sets head = (gid, len(cells)) — "one past
+	// the last cell of the line." ContentToViewport must map that to
+	// the row containing the line, at col=len, so the highlight code
+	// can paint cells [0, len). Without this fix the mapper rejected
+	// such positions and the highlight extended to the viewport bottom.
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "hello" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	_, _ = v.GridWithRowIdx()
+
+	// "hello" at gid 2 has 5 cells. The exclusive end is at col 5.
+	y, x, vis := v.ContentToViewport(2, 5)
+	if !vis {
+		t.Fatalf("ContentToViewport(2, 5) returned visible=false; expected (row, 5, true)")
+	}
+	// gid 2 renders on viewport row 2 (lines are non-wrapped, no scroll).
+	if y != 2 || x != 5 {
+		t.Errorf("ContentToViewport(2, 5) = (%d, %d), want (2, 5)", y, x)
+	}
+}
+
+func TestContentToViewport_NextRowOriginStillStrictMatch(t *testing.T) {
+	// Sanity: when target IS the cell-bearing position of a later row's
+	// origin (e.g. (gid=3, col=0) for a row that displays gid 3), the
+	// mapper must return THAT row, not the previous row whose extent
+	// boundary happens to coincide with the target.
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "hello" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	_, _ = v.GridWithRowIdx()
+
+	y, x, vis := v.ContentToViewport(3, 0)
+	if !vis {
+		t.Fatalf("ContentToViewport(3, 0) returned visible=false")
+	}
+	if y != 3 || x != 0 {
+		t.Errorf("ContentToViewport(3, 0) = (%d, %d), want (3, 0)", y, x)
+	}
+}
+
+func TestAdvanceCells_ContinuesAcrossWrappedChain(t *testing.T) {
+	// Sanity check that the chain-end guard doesn't break wrapped
+	// chains: when the current row's last cell IS Wrapped, advancing
+	// continues into the next gid.
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	left := make([]Cell, 80)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	left[79].Wrapped = true // chain continues
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 60)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	// From (5, 0) advance 100 cells: 80 of gid 5 (chain continues), 20 of gid 6.
+	gid, col := v.advanceCells(5, 0, 100)
+	if gid != 6 || col != 20 {
+		t.Errorf("advanceCells(5,0,100) = (%d,%d), want (6,20)", gid, col)
+	}
+}
+
 func TestCellsBetween_StaysInGid(t *testing.T) {
 	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()

--- a/apps/texelterm/parser/viewport_mapping_test.go
+++ b/apps/texelterm/parser/viewport_mapping_test.go
@@ -213,3 +213,48 @@ func TestContentToViewport_RoundTripNonWrapped(t *testing.T) {
 		}
 	}
 }
+
+func TestContentToViewport_RoundTripWrappedChain(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// 160-char single logical line that fully fills both wrap rows at
+	// width 80. (A 100-char line leaves row 1 with only 20 cells, where
+	// x=40,79 are past-content positions that legitimately collapse via
+	// advanceCells's past-content terminator — that's not what this
+	// test is about.)
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUV" // 62+62+32 = 156 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	// Pad to exactly 160 chars.
+	for _, r := range "WXYZ" {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// Round-trip every (y, x) on the first two rows (the wrap chain).
+	// All positions are within rendered content.
+	for _, y := range []int{0, 1} {
+		for _, x := range []int{0, 5, 40, 79} {
+			gid, col, _, ok := v.ViewportToContent(y, x)
+			if !ok {
+				t.Fatalf("ViewportToContent(%d,%d) failed", y, x)
+			}
+			ry, rx, vis := v.ContentToViewport(gid, col)
+			if !vis {
+				t.Errorf("(%d,%d) → (%d,%d) → not visible", y, x, gid, col)
+				continue
+			}
+			if ry != y || rx != x {
+				t.Errorf("round-trip (%d,%d) → (gid=%d,col=%d) → (%d,%d)",
+					y, x, gid, col, ry, rx)
+			}
+		}
+	}
+}

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -594,6 +594,14 @@ func (v *VTerm) HistoryLineCopy(index int) []Cell {
 // ViewportToContent converts viewport coordinates to content coordinates.
 // Returns (logicalLine, charOffset, isCurrentLine, ok).
 // logicalLine is -1 for the current uncommitted line.
+//
+// Consults the per-render mainScreenRowOrigin cache to project (y, x)
+// onto the cell-bearing (gid, col), so wrap-continuation rows resolve
+// to the correct logical position even when a single logical line
+// spans multiple visual rows. Falls back to naive (visibleTop+y, x)
+// math for sentinel rows (Gid == -1) and rows outside the cached
+// window — preserving prior behaviour for blank gaps and bottom
+// padding. Issue #224.
 func (v *VTerm) ViewportToContent(y, x int) (logicalLine int64, charOffset int, isCurrentLine bool, ok bool) {
 	if v.inAltScreen {
 		// Alt screen: treat as current line equivalent
@@ -603,19 +611,29 @@ func (v *VTerm) ViewportToContent(y, x int) (logicalLine int64, charOffset int, 
 	if v.mainScreen == nil {
 		return 0, 0, false, false
 	}
-	// Naive 1-gid-per-row mapping. KNOWN LIMITATION: when a logical
-	// line wraps across multiple visual rows the click→content gid is
-	// off by the wrap continuation count — fixing that requires a
-	// reflow-aware walk that's coupled to how the renderer actually
-	// laid out the chains, and an earlier attempt at it (b1cc1ee, now
-	// reverted) drifted away from the renderer's chain-head row tagging
-	// in production. Leaving the simpler-and-stable behaviour here
-	// until the rendering side exposes a definitive (gid, col) → row
-	// table the selection layer can consult instead of computing.
+	cursorLine, _ := v.mainScreen.Cursor()
+
+	// Snapshot the cached origin for row y. Don't hold rowOriginMu
+	// across advanceCells — it acquires other locks via ReadLine.
+	v.mainScreenRowOriginMu.RLock()
+	var origin RowOrigin
+	inWindow := y >= 0 && y < len(v.mainScreenRowOrigin)
+	if inWindow {
+		origin = v.mainScreenRowOrigin[y]
+	}
+	v.mainScreenRowOriginMu.RUnlock()
+
+	if inWindow && origin.Gid != -1 {
+		gid, col := v.advanceCells(origin.Gid, origin.Col, x)
+		return gid, col, gid == cursorLine, true
+	}
+
+	// Fallback for rows outside the cached window or sentinel rows:
+	// use the naive (visibleTop + y, x) math, preserving pre-reflow
+	// behaviour for blank gaps and bottom padding.
 	visibleTop, _ := v.mainScreen.VisibleRange()
 	logicalLine = visibleTop + int64(y)
 	charOffset = x
-	cursorLine, _ := v.mainScreen.Cursor()
 	isCurrentLine = logicalLine == cursorLine
 	ok = true
 	return

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -33,6 +33,21 @@ type VTerm struct {
 	mainScreenPersistence *AdaptivePersistence
 	// mainScreenPageStore is the page-based disk storage (optional).
 	mainScreenPageStore *PageStore
+	// mainScreenRowOrigin caches the per-row cell-bearing (gid, col) emitted
+	// by the sparse view's last render. Length matches the rendered grid;
+	// Gid == -1 sentinel for blank rows / unwritten gaps. Read by
+	// ContentToViewport / ViewportToContent (Tasks 11/12) to project
+	// (gid, col) selection points onto reflowed rows without re-walking
+	// the chain.
+	//
+	// Lock model: Option B — a dedicated rowOriginMu protects this field.
+	// We can't reuse v.mu because mainScreenGridWithRowIdx (where this is
+	// written) is called under v.mu.RLock() in Grid() / GridWithRowIdx();
+	// a write under an RLock is a race. There is no existing cache field
+	// on VTerm whose pattern we can match. Tasks 11/12 RLock rowOriginMu
+	// when reading. Issue #224.
+	mainScreenRowOrigin   []RowOrigin
+	mainScreenRowOriginMu sync.RWMutex
 	// Terminal state
 	currentFG, currentBG               Color
 	currentAttr                        Attribute

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -651,6 +651,47 @@ func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, 
 	return
 }
 
+// advanceCells walks `n` cells forward from (originGid, originCol) through
+// the store, crossing gid boundaries when a row's cells are exhausted.
+// Returns the resulting (gid, col). Used by ViewportToContent to resolve
+// a viewport (y, x) given the row's origin.
+//
+// Bounded against runaway: when ReadLine returns nil (gid past the
+// store), break — the position is "past content" and further advancing
+// just walks empty space. Without this break, a click on a trailing-
+// empty wrap-continuation row could loop forever (each iteration:
+// available=0, gid++, no progress on `remaining`).
+//
+// The result for past-content positions is a (gid, col) just past the
+// store's max gid; selection callers handle that as a zero-width
+// selection (selectAtom finds no word; capture reads no cells).
+func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int) {
+	if v.mainScreen == nil {
+		return originGid, originCol
+	}
+	gid := originGid
+	col := originCol
+	remaining := n
+	for remaining > 0 {
+		cells := v.mainScreen.ReadLine(gid)
+		if cells == nil {
+			return gid, col
+		}
+		rowLen := len(cells)
+		available := rowLen - col
+		if remaining < available {
+			return gid, col + remaining
+		}
+		if available < 0 {
+			available = 0
+		}
+		remaining -= available
+		gid++
+		col = 0
+	}
+	return gid, col
+}
+
 // GetContentText extracts text from a content coordinate range.
 func (v *VTerm) GetContentText(startLine int64, startOffset int, endLine int64, endOffset int) string {
 	if v.inAltScreen {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -642,9 +642,11 @@ func (v *VTerm) ViewportToContent(y, x int) (logicalLine int64, charOffset int, 
 // ContentToViewport converts content coordinates to viewport coordinates.
 // Returns (y, x, visible) where visible is true if content is on screen.
 //
-// Same naive-math caveat as ViewportToContent — the highlight tracks
-// the wrong visual row for cells inside a wrap continuation. Don't
-// consult the reflow walk until it's clearly inverse-of-renderer.
+// Linear-scans the cached mainScreenRowOrigin slice; for each row whose
+// origin is set (Gid != -1), uses cellsBetween bounded by the viewport
+// width to test whether (logicalLine, charOffset) lies within that
+// row's cell-walked extent. Round-trips correctly with
+// ViewportToContent regardless of wrap reflow. Issue #224.
 func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, visible bool) {
 	if v.inAltScreen {
 		if v.width <= 0 {
@@ -658,15 +660,57 @@ func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, 
 	if v.mainScreen == nil {
 		return 0, 0, false
 	}
-	visibleTop, visibleBottom := v.mainScreen.VisibleRange()
-	rowOffset := logicalLine - visibleTop
-	if rowOffset < 0 || rowOffset > visibleBottom-visibleTop {
-		return 0, 0, false
+
+	// Snapshot the slice header. The underlying array is replaced on
+	// each render (mainScreenGridWithRowIdx assigns a fresh slice),
+	// so a header copy is safe to iterate without holding the lock —
+	// and we must release it before calling cellsBetween, which
+	// touches the store via ReadLine.
+	v.mainScreenRowOriginMu.RLock()
+	origins := v.mainScreenRowOrigin
+	v.mainScreenRowOriginMu.RUnlock()
+
+	for ry, o := range origins {
+		if o.Gid == -1 {
+			continue
+		}
+		steps, ok := v.cellsBetween(o.Gid, o.Col, logicalLine, charOffset, v.width)
+		if !ok {
+			continue
+		}
+		if steps >= v.width {
+			// Target lies past this row's full viewport-width extent;
+			// let a later row whose origin starts there claim it.
+			continue
+		}
+		// For non-wrapped chains cellsBetween happily walks past a
+		// row's visible end into the next gid (the helper has no
+		// notion of where a visual row ends). Bound by the next set
+		// row's origin: if the next origin lies at or before our
+		// target on the chain walk, the target belongs to that
+		// later row, not this one.
+		if next, found := nextSetOrigin(origins, ry); found {
+			rowExtent, rok := v.cellsBetween(o.Gid, o.Col, next.Gid, next.Col, v.width)
+			if rok && steps >= rowExtent {
+				continue
+			}
+		}
+		return ry, steps, true
 	}
-	y = int(rowOffset)
-	x = charOffset
-	visible = y >= 0 && y < v.height
-	return
+	return 0, 0, false
+}
+
+// nextSetOrigin returns the next origin after index ry whose Gid is not
+// the -1 sentinel, or (zero, false) if none exists. Used by
+// ContentToViewport to bound a row's visible extent by the start of the
+// next populated row.
+func nextSetOrigin(origins []RowOrigin, ry int) (RowOrigin, bool) {
+	for i := ry + 1; i < len(origins); i++ {
+		if origins[i].Gid != -1 {
+			return origins[i], true
+		}
+	}
+	return RowOrigin{}, false
 }
 
 // advanceCells walks `n` cells forward from (originGid, originCol) through

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -692,6 +692,62 @@ func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int)
 	return gid, col
 }
 
+// cellsBetween counts cells from (originGid, originCol) forward to
+// (targetGid, targetCol), crossing gid boundaries. Returns
+// (stepsTaken, true) if the target is reached within maxCells steps,
+// or (0, false) if the walk runs past maxCells without finding the
+// target. Used by ContentToViewport to compute the visual x within a
+// row whose origin is known.
+//
+// "Before origin" cases (target is reachable only by going backward)
+// return (0, false) — the caller continues scanning to the next row.
+//
+// Safety: the loop is bounded both by step count AND by gid distance.
+// Walking through many consecutive empty gids contributes 0 to `steps`
+// per iteration; without a separate gid-based bound, a fixed iteration
+// cap can cut the walk short before reaching the target through gappy
+// stores. Bounding by (targetGid - originGid + 2) is provably tight —
+// the walk visits exactly the gids in [originGid, targetGid].
+func (v *VTerm) cellsBetween(originGid int64, originCol int, targetGid int64, targetCol, maxCells int) (int, bool) {
+	if v.mainScreen == nil {
+		return 0, false
+	}
+	if targetGid < originGid || (targetGid == originGid && targetCol < originCol) {
+		return 0, false
+	}
+	gid := originGid
+	col := originCol
+	steps := 0
+	iterCap := int(targetGid-originGid) + 2
+	for i := 0; i < iterCap; i++ {
+		if gid == targetGid {
+			if targetCol < col {
+				return 0, false
+			}
+			delta := targetCol - col
+			if steps+delta > maxCells {
+				return 0, false
+			}
+			return steps + delta, true
+		}
+		cells := v.mainScreen.ReadLine(gid)
+		if cells == nil {
+			return 0, false
+		}
+		available := len(cells) - col
+		if available < 0 {
+			available = 0
+		}
+		steps += available
+		if steps > maxCells {
+			return 0, false
+		}
+		gid++
+		col = 0
+	}
+	return 0, false
+}
+
 // GetContentText extracts text from a content coordinate range.
 func (v *VTerm) GetContentText(startLine int64, startOffset int, endLine int64, endOffset int) string {
 	if v.inAltScreen {

--- a/apps/texelterm/parser/vterm.go
+++ b/apps/texelterm/parser/vterm.go
@@ -670,6 +670,16 @@ func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, 
 	origins := v.mainScreenRowOrigin
 	v.mainScreenRowOriginMu.RUnlock()
 
+	// Track an "exclusive-end-of-row" candidate. When a row's content
+	// ends at exactly `target` (steps == rowExtent), the position is
+	// shared between this row's exclusive end and the next row's
+	// inclusive start. If a later row strict-claims the target via its
+	// own origin, we return that. If no row strict-claims it, we fall
+	// back to the candidate — that's the "selection's exclusive end at
+	// this row's last col" semantics needed by selectLine and by drag
+	// selections that end past the line's content.
+	candidateY, candidateX, candidateValid := 0, 0, false
+
 	for ry, o := range origins {
 		if o.Gid == -1 {
 			continue
@@ -692,10 +702,20 @@ func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, 
 		if next, found := nextSetOrigin(origins, ry); found {
 			rowExtent, rok := v.cellsBetween(o.Gid, o.Col, next.Gid, next.Col, v.width)
 			if rok && steps >= rowExtent {
+				if steps == rowExtent && !candidateValid {
+					// Boundary case: exclusive-end-of-row. Save as
+					// fallback; a later strict match still wins.
+					candidateY = ry
+					candidateX = steps
+					candidateValid = true
+				}
 				continue
 			}
 		}
 		return ry, steps, true
+	}
+	if candidateValid {
+		return candidateY, candidateX, true
 	}
 	return 0, 0, false
 }
@@ -714,19 +734,27 @@ func nextSetOrigin(origins []RowOrigin, ry int) (RowOrigin, bool) {
 }
 
 // advanceCells walks `n` cells forward from (originGid, originCol) through
-// the store, crossing gid boundaries when a row's cells are exhausted.
+// the store, crossing gid boundaries when a row's cells are exhausted
+// AND the chain continues (current gid's last cell has Wrapped=true).
 // Returns the resulting (gid, col). Used by ViewportToContent to resolve
 // a viewport (y, x) given the row's origin.
 //
-// Bounded against runaway: when ReadLine returns nil (gid past the
-// store), break — the position is "past content" and further advancing
-// just walks empty space. Without this break, a click on a trailing-
-// empty wrap-continuation row could loop forever (each iteration:
-// available=0, gid++, no progress on `remaining`).
+// Two termination guards:
 //
-// The result for past-content positions is a (gid, col) just past the
-// store's max gid; selection callers handle that as a zero-width
-// selection (selectAtom finds no word; capture reads no cells).
+//  1. Past-content (`cells == nil`): the gid was never written. Stop.
+//     Without this, a click on a trailing-empty wrap-continuation row
+//     could loop forever (available=0, gid++, no progress).
+//
+//  2. Chain end (current row's last cell has Wrapped=false): the
+//     logical line ends here. Don't advance into the next gid — that
+//     would be a different logical line, and the user dragging past
+//     a non-wrapped line's visible content shouldn't suddenly select
+//     content from the next line. Clamp at the row's end col.
+//
+// The chain-end guard is the fix for issue #224's drag-past-line bug:
+// dragging the mouse past the last cell of a non-wrapped line used to
+// resolve to a position deep in some later gid, causing the highlight
+// to cover blank padding cells of every intermediate row.
 func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int) {
 	if v.mainScreen == nil {
 		return originGid, originCol
@@ -743,6 +771,11 @@ func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int)
 		available := rowLen - col
 		if remaining < available {
 			return gid, col + remaining
+		}
+		// Chain-end guard: stop at this row's exclusive-end col when
+		// the chain doesn't continue into the next gid.
+		if rowLen > 0 && !cells[rowLen-1].Wrapped {
+			return gid, rowLen
 		}
 		if available < 0 {
 			available = 0

--- a/apps/texelterm/parser/vterm_main_screen.go
+++ b/apps/texelterm/parser/vterm_main_screen.go
@@ -496,11 +496,20 @@ func (v *VTerm) mainScreenGrid() [][]Cell {
 // parallel per-row globalIdx slice from the same view walk. Space-padding
 // and search highlighting are applied on the rendered grid just as in
 // mainScreenGrid; the rowIdx slice is passed through unchanged.
+//
+// Side effect: stashes the per-row RowOrigin slice on
+// v.mainScreenRowOrigin so ContentToViewport / ViewportToContent can map
+// selection points onto reflowed rows without re-walking the chain. The
+// stash is guarded by v.mainScreenRowOriginMu — see the field comment in
+// vterm.go for the lock-model rationale (Option B / Issue #224).
 func (v *VTerm) mainScreenGridWithRowIdx() ([][]Cell, []int64) {
 	if v.mainScreen == nil {
 		return nil, nil
 	}
-	grid, rowIdx := v.mainScreen.RenderReflowWithRowIdx()
+	grid, rowIdx, rowOrigin := v.mainScreen.RenderReflowFull()
+	v.mainScreenRowOriginMu.Lock()
+	v.mainScreenRowOrigin = rowOrigin
+	v.mainScreenRowOriginMu.Unlock()
 	// Sparse Grid() returns Cell{} (Rune=0) for unwritten/erased cells.
 	// Convert to space so callers see consistent blank cells.
 	for _, row := range grid {

--- a/apps/texelterm/selection_wrap_resize_test.go
+++ b/apps/texelterm/selection_wrap_resize_test.go
@@ -1,0 +1,220 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: apps/texelterm/selection_wrap_resize_test.go
+// Summary: Integration test driving applySelectionHighlightLocked across a
+// width-change resize that re-wraps the selected line.
+// Issue #224 plan, Task 16: confirms (gid, col) anchors held in
+// SelectionStateMachine survive a resize because ContentToViewport projects
+// them onto the post-resize wrap chain.
+
+package texelterm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+
+	texelcore "github.com/framegrace/texelui/core"
+
+	"github.com/framegrace/texelation/internal/theming"
+)
+
+// TestSelection_HighlightTracksWrappedContentAfterResize types a 100-char line
+// that wraps at width 80, drives a double-click selection on the second visual
+// row, captures the highlighted text, then narrows the terminal so the line
+// re-wraps over more rows. The same selection (anchored in (gid, col) content
+// coordinates) must paint over cells that contain the same text.
+func TestSelection_HighlightTracksWrappedContentAfterResize(t *testing.T) {
+	const (
+		wideCols   = 80
+		narrowCols = 40
+		rows       = 24
+	)
+
+	tt := NewTestTerm(wideCols, rows)
+	a := tt.term
+
+	// Install the mouse coordinator so applySelectionHighlightLocked has
+	// somewhere to consult for the active selection. NewTestTerm intentionally
+	// skips the heavy initializeVTermFirstRun path (no PTY, no config), so we
+	// wire the minimum surface ourselves.
+	a.mouseCoordinator = NewMouseCoordinator(
+		NewVTermAdapter(a.vterm),
+		NewVTermGridAdapter(a.vterm),
+		nil, // no wheel handler
+		AutoScrollConfig{EdgeZone: 2, MaxScrollSpeed: 15},
+	)
+	a.mouseCoordinator.SetSize(wideCols, rows)
+	a.mouseCoordinator.SetCallbacks(func() {}, func() {})
+
+	// Type a 100-char single token (no separators, so a double-click selects
+	// the whole token). At width 80 with autowrap on the line occupies row 0
+	// (cols 0..79) and row 1 (cols 0..19).
+	const line = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+	if len(line) != 100 {
+		t.Fatalf("test fixture: expected 100-char line, got %d", len(line))
+	}
+	tt.Write([]byte(line))
+
+	// Force a render so mainScreenRowOrigin is populated. Render returns
+	// vterm rows + a status-bar row; with NewTestTerm there is no statusBar,
+	// so we just take rendered slice as-is.
+	bufBefore := a.Render()
+	if len(bufBefore) == 0 {
+		t.Fatal("Render produced no buffer before resize")
+	}
+
+	// Drive a double-click on viewport row 1, col 5 — the wrap continuation
+	// row. press → (synthesised single-click), press → (synthesised double-
+	// click via DetectClick at the same row/col), release → finishes as a
+	// multi-click selection that stays rendered.
+	pressDouble(t, a.mouseCoordinator, 5, 1)
+
+	bufHi := a.Render()
+	highlightBg := highlightBgColor()
+
+	cellsBefore := highlightedCells(bufHi, highlightBg)
+	if len(cellsBefore) == 0 {
+		t.Fatalf("no highlighted cells in pre-resize render; selection didn't activate")
+	}
+	textBefore := selectionText(bufHi, cellsBefore)
+	if strings.TrimSpace(textBefore) == "" {
+		t.Fatalf("highlighted text empty before resize; got runes=%q", textBefore)
+	}
+
+	// Sanity: selectionMachine should still be reporting the multi-click
+	// selection — that's what carries the (gid,col) anchors across resize.
+	if !a.mouseCoordinator.IsSelectionRendered() {
+		t.Fatal("expected selection to remain rendered after double-click")
+	}
+
+	// Narrow the viewport. We bypass TexelTerm.Resize (which would touch
+	// statusbar / config panel state we never initialised) and resize the
+	// vterm + mouse coordinator directly. Either path is sufficient: the
+	// invariant under test is that ContentToViewport, applied during the
+	// next Render, projects the still-anchored (gid,col) onto the new
+	// row layout.
+	a.vterm.Resize(narrowCols, rows)
+	a.mouseCoordinator.SetSize(narrowCols, rows)
+	a.width = narrowCols
+	a.height = rows
+
+	bufAfter := a.Render()
+	if len(bufAfter) == 0 {
+		t.Fatal("Render produced no buffer after resize")
+	}
+	cellsAfter := highlightedCells(bufAfter, highlightBg)
+	if len(cellsAfter) == 0 {
+		t.Fatalf("highlight disappeared after resize — selection mapping regressed")
+	}
+	textAfter := selectionText(bufAfter, cellsAfter)
+
+	// The text under the highlight must be identical before/after — same
+	// content, just laid out across a different number of rows.
+	if textAfter != textBefore {
+		t.Errorf("highlighted text drifted after resize:\n  before=%q\n  after =%q",
+			textBefore, textAfter)
+	}
+}
+
+// pressDouble drives the mouseCoordinator with a button-press / button-release
+// pair at (col, row), waits long enough for the click detector to escalate to
+// a double click on the second press, and finishes the selection. Because the
+// multi-click decision is owned entirely by ClickDetector inside the
+// coordinator (timing-based), we synthesise two press/release cycles at the
+// same coordinate.
+func pressDouble(t *testing.T, m *MouseCoordinator, col, row int) {
+	t.Helper()
+
+	// First click: press + release.
+	m.HandleMouse(tcell.NewEventMouse(col, row, tcell.Button1, 0))
+	m.HandleMouse(tcell.NewEventMouse(col, row, tcell.ButtonNone, 0))
+
+	// Second click: press + release. This second press is detected as
+	// DoubleClick by ClickDetector (same row/col, within multi-click
+	// timeout), which routes Start through SelectionModeSpaceWord →
+	// StateMultiClickHeld and leaves the selection rendered after release.
+	m.HandleMouse(tcell.NewEventMouse(col, row, tcell.Button1, 0))
+	m.HandleMouse(tcell.NewEventMouse(col, row, tcell.ButtonNone, 0))
+}
+
+// highlightBgColor returns the configured selection.highlight_bg color, in the
+// exact form applySelectionHighlightLocked uses (.TrueColor()) so equality
+// comparisons against painted cells work.
+func highlightBgColor() tcell.Color {
+	cfg := theming.ForApp("texelterm")
+	defaultBg := tcell.NewRGBColor(232, 217, 255)
+	highlight := cfg.GetColor("selection", "highlight_bg", defaultBg)
+	if !highlight.Valid() {
+		highlight = defaultBg
+	}
+	return highlight.TrueColor()
+}
+
+// highlightedCells walks the rendered buffer and returns (y, x) for every
+// cell whose background equals the configured highlight color. Used to find
+// the painted selection extent without depending on the SelectionRange API.
+func highlightedCells(buf [][]texelcore.Cell, hi tcell.Color) [][2]int {
+	var out [][2]int
+	for y, row := range buf {
+		for x, cell := range row {
+			_, bg, _ := cell.Style.Decompose()
+			if bg == hi {
+				out = append(out, [2]int{y, x})
+			}
+		}
+	}
+	return out
+}
+
+// selectionText reads the runes at the given highlighted cell positions in
+// row-major order, joining consecutive cells on the same row and inserting a
+// newline between rows. NUL runes (cleared cells) are skipped at the trailing
+// edge of a row but preserved internally as spaces, matching what a user
+// would see.
+func selectionText(buf [][]texelcore.Cell, cells [][2]int) string {
+	if len(cells) == 0 {
+		return ""
+	}
+	// Group by row, collecting min/max x per row.
+	rowMin := map[int]int{}
+	rowMax := map[int]int{}
+	for _, p := range cells {
+		y, x := p[0], p[1]
+		if v, ok := rowMin[y]; !ok || x < v {
+			rowMin[y] = x
+		}
+		if v, ok := rowMax[y]; !ok || x > v {
+			rowMax[y] = x
+		}
+	}
+	// Emit rows in ascending y order.
+	ys := make([]int, 0, len(rowMin))
+	for y := range rowMin {
+		ys = append(ys, y)
+	}
+	// Tiny insertion sort; we never have many rows here.
+	for i := 1; i < len(ys); i++ {
+		for j := i; j > 0 && ys[j-1] > ys[j]; j-- {
+			ys[j-1], ys[j] = ys[j], ys[j-1]
+		}
+	}
+	var b strings.Builder
+	for i, y := range ys {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		row := buf[y]
+		for x := rowMin[y]; x <= rowMax[y] && x < len(row); x++ {
+			r := row[x].Ch
+			if r == 0 {
+				r = ' '
+			}
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/docs/superpowers/plans/2026-05-02-issue-224-wrap-highlight.md
+++ b/docs/superpowers/plans/2026-05-02-issue-224-wrap-highlight.md
@@ -1,0 +1,1617 @@
+# Wrap-aware selection mapping (issue #224) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Selection highlights track the cells they cover when a logical line wraps across multiple visual rows, even after a resize that shifts the wrap boundary.
+
+**Architecture:** Thread a per-row `[]RowOrigin` slice (cell-bearing `(gid, col)` of each row's first cell) from `reflowChain` through `view.Render` up to `VTerm`. `ContentToViewport` and `ViewportToContent` consult the cached slice instead of computing `y = gid - visibleTop`. Selection state stays as `(gid, col)`; capture path and wire protocol are unchanged.
+
+**Tech Stack:** Go 1.24.3. Existing testing patterns under `apps/texelterm/parser/sparse/` (table-driven `fillRow` helper, `cellsToStringSparse` for comparisons). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-issue-224-wrap-highlight-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `apps/texelterm/parser/sparse/view_reflow.go` | `reflowChain` consolidated to emit origin alongside rows. New `RowOrigin` type. | Modify |
+| `apps/texelterm/parser/sparse/view_reflow_test.go` | New origin-emission tests + update existing reflowChain callers to discard the second return. | Modify |
+| `apps/texelterm/parser/sparse/view_window.go` | `Render` returns three slices: rows, rowGI, rowOrigin. | Modify |
+| `apps/texelterm/parser/sparse/terminal.go` | New `RenderReflowFull` returning all three; existing methods become discard-shims. | Modify |
+| `apps/texelterm/parser/main_screen.go` | Interface adds `RenderReflowFull`. New `RowOrigin` type alias. | Modify |
+| `apps/texelterm/parser/vterm.go` | Cache `mainScreenRowOrigin`. Rewrite `ContentToViewport` / `ViewportToContent` using new helpers. | Modify |
+| `apps/texelterm/parser/vterm_main_screen.go` | `mainScreenGridFull` captures all three returns; old name becomes shim. | Modify |
+| `apps/texelterm/parser/viewport_mapping_test.go` | New: round-trip + agreement tests on the new mappers. | Create |
+| `apps/texelterm/selection_wrap_resize_test.go` | New: integration test — selection survives resize that re-wraps. | Create |
+
+---
+
+## Phase 1: `RowOrigin` type and reflowChain origin emission (non-wrapped)
+
+### Task 1: Define `RowOrigin` type and update reflowChain signature with non-wrapped origin
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow.go`
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+- Modify: `apps/texelterm/parser/sparse/view_window.go:157`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `apps/texelterm/parser/sparse/view_reflow_test.go` (append at end of file):
+
+```go
+func TestReflowChain_OriginNonWrapped(t *testing.T) {
+	s := NewStore(80)
+	fillRow(s, 5, "hello world", false) // single non-wrapped gid
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1", len(rows))
+	}
+	if len(origin) != 1 {
+		t.Fatalf("origin len=%d, want 1", len(origin))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -run TestReflowChain_OriginNonWrapped ./apps/texelterm/parser/sparse/
+```
+
+Expected: FAIL — `reflowChain` returns one value, not two; `RowOrigin` undefined.
+
+- [ ] **Step 3: Define `RowOrigin` and update reflowChain signature for the non-wrapped case**
+
+In `apps/texelterm/parser/sparse/view_reflow.go`, near the top (after imports):
+
+```go
+// RowOrigin is the (gid, col) of the FIRST cell of a reflowed visual row.
+// Used by the selection mapping to project content positions to viewport
+// coordinates without re-deriving the renderer's chain walk.
+//
+// Sentinel: Gid == -1 means the row has no real content (blank row inside
+// a chain-walk gap, or bottom padding when the viewport is taller than
+// the rendered content). Selection callers fall back to naive math on
+// such rows.
+type RowOrigin struct {
+	Gid int64
+	Col int
+}
+```
+
+Then change the signature of `reflowChain` and the body to also build the origin slice:
+
+```go
+func reflowChain(s *Store, startGI, endGI int64, viewWidth int) (rows [][]parser.Cell, origin []RowOrigin) {
+	if viewWidth <= 0 {
+		return nil, nil
+	}
+	if startGI == endGI && rowHasPositionalGap(s, startGI) {
+		return [][]parser.Cell{s.GetLine(startGI)}, []RowOrigin{{Gid: startGI, Col: 0}}
+	}
+	var logical []parser.Cell
+	var cellOrigin []RowOrigin
+	for gi := startGI; gi <= endGI; gi++ {
+		line := s.GetLine(gi)
+		for col := range line {
+			logical = append(logical, line[col])
+			cellOrigin = append(cellOrigin, RowOrigin{Gid: gi, Col: col})
+		}
+	}
+	// trimTrailingPadding shortens logical; cellOrigin must shrink in lockstep
+	// so origin[i] still matches logical[i] after trimming.
+	trimmedLen := len(trimTrailingPadding(logical))
+	logical = logical[:trimmedLen]
+	cellOrigin = cellOrigin[:trimmedLen]
+
+	trailing := trailingEmptyRows(s, startGI, endGI)
+	if len(logical) == 0 && trailing == 0 {
+		return [][]parser.Cell{nil}, []RowOrigin{{Gid: -1}}
+	}
+	for off := 0; off < len(logical); off += viewWidth {
+		end := off + viewWidth
+		if end > len(logical) {
+			end = len(logical)
+		}
+		row := make([]parser.Cell, end-off)
+		copy(row, logical[off:end])
+		rows = append(rows, row)
+		origin = append(origin, cellOrigin[off])
+	}
+	for i := 0; i < trailing; i++ {
+		rows = append(rows, nil)
+		origin = append(origin, RowOrigin{Gid: endGI, Col: len(s.GetLine(endGI))})
+	}
+	return rows, origin
+}
+```
+
+- [ ] **Step 4: Update existing reflowChain callers to discard the new return**
+
+In `apps/texelterm/parser/sparse/view_window.go` line 157:
+
+```go
+reflowed, _ := reflowChain(s, gi, end, width)
+```
+
+In `apps/texelterm/parser/sparse/view_reflow_test.go`, update each existing `rows := reflowChain(...)` call to `rows, _ := reflowChain(...)`. There are six such lines (79, 149, 164, 178, 198, 214 in current file).
+
+- [ ] **Step 5: Run all sparse-package tests**
+
+```
+go test ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — including the new `TestReflowChain_OriginNonWrapped` and all pre-existing tests that just discarded the new return.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow.go \
+        apps/texelterm/parser/sparse/view_reflow_test.go \
+        apps/texelterm/parser/sparse/view_window.go
+git commit -m "Add RowOrigin to reflowChain (non-wrapped baseline)
+
+reflowChain now returns (rows, origin) — origin[i] tracks the (gid, col)
+of the first cell on output row i. Existing callers updated to discard
+the new return so behaviour is unchanged at this point.
+
+Issue #224 plan, Task 1."
+```
+
+---
+
+### Task 2: Origin emission for wrapped chain (single gid, multi-row)
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/texelterm/parser/sparse/view_reflow_test.go`:
+
+```go
+func TestReflowChain_OriginWrappedSingleGid(t *testing.T) {
+	s := NewStore(80)
+	// 100-char line in one gid, last cell Wrapped (chain head before tail).
+	long := strings.Repeat("x", 80)
+	fillRow(s, 5, long, true)
+	// Continuation gid with the remaining 20 chars, last cell not wrapped.
+	fillRow(s, 6, strings.Repeat("y", 20), false)
+
+	// At width 80: row 0 is gid 5's 80 chars; row 1 is gid 6's 20 chars.
+	rows, origin := reflowChain(s, 5, 6, 80)
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
+	}
+	if len(origin) != 2 {
+		t.Fatalf("origin len=%d, want 2", len(origin))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 6, Col: 0}) {
+		t.Errorf("origin[1]=%+v, want {Gid:6, Col:0}", origin[1])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```
+go test -run TestReflowChain_OriginWrappedSingleGid ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — Task 1's implementation already handles this case (origin tracks each cell's origin during concat).
+
+If it fails, revisit Task 1's concat loop.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "Test: reflowChain origin emission for wrapped chain at gid boundary
+
+Issue #224 plan, Task 2."
+```
+
+---
+
+### Task 3: Origin emission for wrapped chain (cross-gid mid-row)
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestReflowChain_OriginWrappedCrossingGidMidRow(t *testing.T) {
+	s := NewStore(80)
+	// Same setup as the previous test: 80 chars in gid 5 (Wrapped) +
+	// 20 chars in gid 6. But reflow at narrower width 50 — the wrap
+	// boundary now falls mid-gid.
+	fillRow(s, 5, strings.Repeat("x", 80), true)
+	fillRow(s, 6, strings.Repeat("y", 20), false)
+
+	// At width 50: row 0 = gid 5 cols 0..49 (50 cells), row 1 = gid 5
+	// cols 50..79 + gid 6 cols 0..19 (30+20=50 cells).
+	rows, origin := reflowChain(s, 5, 6, 50)
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 5, Col: 50}) {
+		t.Errorf("origin[1]=%+v, want {Gid:5, Col:50}", origin[1])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```
+go test -run TestReflowChain_OriginWrappedCrossingGidMidRow ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — `cellOrigin[off]` for `off=50` is `(gid 5, col 50)` because we walked 50 cells of gid 5 during concat.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "Test: reflowChain origin tracks cross-gid mid-row boundary
+
+Issue #224 plan, Task 3."
+```
+
+---
+
+### Task 4: Origin emission for trailing empty rows in chain
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestReflowChain_OriginTrailingEmptyRows(t *testing.T) {
+	s := NewStore(80)
+	// Chain with content in head, blank continuation rows that count
+	// via trailingEmptyRows.
+	fillRow(s, 5, "hello", true)
+	// Force trailing empties: gid 6 exists but has no cells.
+	s.SetLine(6, nil)
+	// Walk the chain to confirm shape (sanity).
+	end, _ := walkChain(s, 5, 100)
+	if end < 5 {
+		t.Skip("chain walk did not reach trailing empties; pattern unsupported")
+	}
+
+	rows, origin := reflowChain(s, 5, end, 80)
+	if len(rows) != len(origin) {
+		t.Fatalf("rows/origin length mismatch: %d vs %d", len(rows), len(origin))
+	}
+	if len(rows) < 1 {
+		t.Fatalf("expected at least 1 row")
+	}
+	// The trailing empty rows (any rows past the head's content) must
+	// have origin (endGI, len(endGI's cells)).
+	for i := 1; i < len(rows); i++ {
+		want := RowOrigin{Gid: end, Col: len(s.GetLine(end))}
+		if origin[i] != want {
+			t.Errorf("trailing row %d origin=%+v, want %+v", i, origin[i], want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```
+go test -run TestReflowChain_OriginTrailingEmptyRows ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — Task 1's trailing-empty-rows loop already emits `RowOrigin{Gid: endGI, Col: len(s.GetLine(endGI))}`.
+
+If it fails, the trailing-empty-rows handling needs adjustment.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "Test: reflowChain origin for trailing empty wrap-continuation rows
+
+Issue #224 plan, Task 4."
+```
+
+---
+
+## Phase 2: `view.Render` exposes the origin slice
+
+### Task 5: `view.Render` returns three slices
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_window.go`
+- Modify: `apps/texelterm/parser/sparse/terminal.go`
+
+- [ ] **Step 1: Verify the current `view.Render` contract**
+
+Read `apps/texelterm/parser/sparse/view_window.go` lines 105–195. Confirm:
+- Return type is `([][]parser.Cell, []int64)`.
+- `rowGI` is appended in three branches: blank rows (line 137 sets `-1`), nowrap branch (line 149 appends `r`), wrapped branch (line 160 appends `gi`).
+
+- [ ] **Step 2: Modify `view.Render` to return a third slice**
+
+Change the signature:
+
+```go
+func (v *ViewWindow) Render(s *Store) ([][]parser.Cell, []int64, []RowOrigin) {
+```
+
+Inside, immediately after `rowGI := make([]int64, 0, height)`, add the parallel output slice:
+
+```go
+rowOrigin := make([]RowOrigin, 0, height)
+```
+
+In the per-chain loop, alongside the existing `var rows [][]parser.Cell` and `var rowsGI []int64`, add:
+
+```go
+var rowsOrigin []RowOrigin
+```
+
+In the blank-row branch (current line 134–139), where the code does `rowGI = append(rowGI, -1)`, also append to `rowOrigin`:
+
+```go
+rowGI = append(rowGI, -1)
+rowOrigin = append(rowOrigin, RowOrigin{Gid: -1})
+```
+
+In the nowrap / reflowOff branch, append `(r, 0)` per row:
+
+```go
+if reflowOff || nowrap {
+    for r := gi; r <= end; r++ {
+        rows = append(rows, clipRow(s.GetLine(r), width))
+        rowsGI = append(rowsGI, r)
+        rowsOrigin = append(rowsOrigin, RowOrigin{Gid: r, Col: 0})
+    }
+}
+```
+
+In the wrapped branch, capture both returns of `reflowChain`:
+
+```go
+} else {
+    reflowed, originSlice := reflowChain(s, gi, end, width)
+    for i, row := range reflowed {
+        rows = append(rows, clipRow(row, width))
+        rowsGI = append(rowsGI, gi)
+        rowsOrigin = append(rowsOrigin, originSlice[i])
+    }
+}
+```
+
+- For the nowrap / reflowOff branch:
+
+```go
+if reflowOff || nowrap {
+    for r := gi; r <= end; r++ {
+        rows = append(rows, clipRow(s.GetLine(r), width))
+        rowsGI = append(rowsGI, r)
+        rowsOrigin = append(rowsOrigin, RowOrigin{Gid: r, Col: 0})
+    }
+}
+```
+
+- The skip / first-chain trim must apply to all three slices in lockstep:
+
+```go
+if first {
+    first = false
+    if skip < len(rows) {
+        rows = rows[skip:]
+        rowsGI = rowsGI[skip:]
+        rowsOrigin = rowsOrigin[skip:]
+    } else {
+        rows = nil
+        rowsGI = nil
+        rowsOrigin = nil
+    }
+}
+```
+
+- The append-to-output loop appends to all three:
+
+```go
+for i, row := range rows {
+    if len(out) >= height {
+        break
+    }
+    out = append(out, row)
+    rowGI = append(rowGI, rowsGI[i])
+    rowOrigin = append(rowOrigin, rowsOrigin[i])
+}
+```
+
+- Bottom padding:
+
+```go
+for len(out) < height {
+    out = append(out, make([]parser.Cell, width))
+    rowGI = append(rowGI, -1)
+    rowOrigin = append(rowOrigin, RowOrigin{Gid: -1})
+}
+```
+
+- Trim:
+
+```go
+if len(rowGI) > height {
+    rowGI = rowGI[:height]
+}
+if len(rowOrigin) > height {
+    rowOrigin = rowOrigin[:height]
+}
+```
+
+- Return: `return out, rowGI, rowOrigin`.
+
+- [ ] **Step 3: Update `Terminal.RenderReflowWithRowIdx` to drop the third return**
+
+In `apps/texelterm/parser/sparse/terminal.go` line ~314:
+
+```go
+func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
+    cursorGI, cursorCol := t.write.Cursor()
+    t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
+    rows, gids, _ := t.view.Render(t.store)
+    return rows, gids
+}
+```
+
+- [ ] **Step 4: Run sparse-package tests to confirm no regression**
+
+```
+go test ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — no behaviour change for callers that discard the third return.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_window.go apps/texelterm/parser/sparse/terminal.go
+git commit -m "view.Render returns rowOrigin slice alongside rowGI
+
+The new slice carries cell-bearing (gid, col) per row. Existing
+RenderReflowWithRowIdx wraps the new return and drops the slice;
+chain-head clipping in the publisher path stays unchanged.
+
+Issue #224 plan, Task 5."
+```
+
+---
+
+### Task 6: `Terminal.RenderReflowFull` exposing all three slices
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/terminal.go`
+
+- [ ] **Step 1: Add `RenderReflowFull` next to the existing render methods**
+
+In `apps/texelterm/parser/sparse/terminal.go`, near the existing `RenderReflowWithRowIdx`:
+
+```go
+// RenderReflowFull is the full render output: rows, per-row chain-head
+// gid (for publisher clipping), and per-row cell-bearing origin (for
+// selection mapping). Internal callers that only need rows or rows+gids
+// use the existing shims; selection consults the origin slice via
+// VTerm's cache.
+func (t *Terminal) RenderReflowFull() ([][]parser.Cell, []int64, []RowOrigin) {
+    cursorGI, cursorCol := t.write.Cursor()
+    t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
+    return t.view.Render(t.store)
+}
+```
+
+Also collapse `RenderReflowWithRowIdx` and `RenderReflow` to thin shims that go through `RenderReflowFull` (avoids two RecomputeLiveAnchor calls if both methods get invoked in one frame):
+
+```go
+func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
+    rows, gids, _ := t.RenderReflowFull()
+    return rows, gids
+}
+
+func (t *Terminal) RenderReflow() [][]parser.Cell {
+    rows, _, _ := t.RenderReflowFull()
+    return rows
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+```
+go build ./apps/texelterm/...
+```
+
+Expected: clean build.
+
+- [ ] **Step 3: Run tests**
+
+```
+go test ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/terminal.go
+git commit -m "Terminal.RenderReflowFull: single source of truth for render output
+
+Existing render methods become thin shims that delegate to RenderReflowFull
+and drop the slices they don't need. Issue #224 plan, Task 6."
+```
+
+---
+
+## Phase 3: `MainScreen` interface + parser-package alias
+
+### Task 7: Add `RenderReflowFull` to `MainScreen` interface and `RowOrigin` alias
+
+**Files:**
+- Modify: `apps/texelterm/parser/main_screen.go`
+
+- [ ] **Step 1: Add the `RowOrigin` type alias and interface method**
+
+In `apps/texelterm/parser/main_screen.go`, near the existing types (top of file):
+
+```go
+// RowOrigin is re-exported from the sparse package so callers of the
+// MainScreen interface don't have to import parser/sparse internals
+// directly. The values are produced at render time by the sparse view's
+// chain walk (see sparse.RowOrigin for semantics).
+type RowOrigin = sparse.RowOrigin
+```
+
+(If `sparse` isn't already imported in this file, add the import.)
+
+In the `MainScreen` interface, near `RenderReflowWithRowIdx`:
+
+```go
+// RenderReflowFull returns the rendered grid plus parallel slices for
+// per-row chain-head gid (publisher clipping) and per-row cell-bearing
+// origin (selection mapping). RenderReflow / RenderReflowWithRowIdx
+// stay on the interface as discard-shims for callers that only need
+// some of the output.
+RenderReflowFull() ([][]Cell, []int64, []RowOrigin)
+```
+
+- [ ] **Step 2: Build to confirm sparse.Terminal already satisfies the interface**
+
+```
+go build ./apps/texelterm/parser/...
+```
+
+Expected: clean build (Task 6's `Terminal.RenderReflowFull` matches the new interface entry).
+
+- [ ] **Step 3: Run tests**
+
+```
+go test ./apps/texelterm/parser/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/texelterm/parser/main_screen.go
+git commit -m "MainScreen interface adds RenderReflowFull + RowOrigin alias
+
+Issue #224 plan, Task 7."
+```
+
+---
+
+## Phase 4: `VTerm` caches `mainScreenRowOrigin`
+
+### Task 8: Cache origin slice on every render
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Modify: `apps/texelterm/parser/vterm_main_screen.go`
+
+- [ ] **Step 1: Read the existing cache layout**
+
+Read `apps/texelterm/parser/vterm.go` to find the `lastRowGlobalIdx` field on `*VTerm` (or the equivalent stash if named differently). Confirm where the grid is built (`mainScreenGridWithRowIdx`).
+
+- [ ] **Step 2: Add the new cache field**
+
+In `apps/texelterm/parser/vterm.go`, near where the cached row-idx slice lives, add:
+
+```go
+// mainScreenRowOrigin caches the per-row cell-bearing (gid, col) emitted
+// by the sparse view's last render. Length matches the rendered grid;
+// Gid == -1 sentinel for blank rows / unwritten gaps. Read by
+// ContentToViewport / ViewportToContent under the same lock that gates
+// the existing grid cache. Issue #224.
+mainScreenRowOrigin []RowOrigin
+```
+
+- [ ] **Step 3: Capture origin in `mainScreenGridWithRowIdx`**
+
+In `apps/texelterm/parser/vterm_main_screen.go`, locate `mainScreenGridWithRowIdx` (~line 499). Change the implementation to call `RenderReflowFull` and stash all three results, then return the existing two:
+
+```go
+func (v *VTerm) mainScreenGridWithRowIdx() ([][]Cell, []int64) {
+    if v.mainScreen == nil {
+        return nil, nil
+    }
+    grid, rowIdx, rowOrigin := v.mainScreen.RenderReflowFull()
+    v.mainScreenRowOrigin = rowOrigin
+    return grid, rowIdx
+}
+```
+
+(Keep the existing function name — its callers don't change. The third value is captured into the cache as a side effect.)
+
+- [ ] **Step 4: Run tests**
+
+```
+go test ./apps/texelterm/parser/
+```
+
+Expected: PASS — no behaviour change for any caller of `mainScreenGridWithRowIdx`; the cache field is populated but not yet consumed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/vterm_main_screen.go
+git commit -m "VTerm caches mainScreenRowOrigin on every render
+
+The cache is populated but not yet consumed; ContentToViewport /
+ViewportToContent will read from it next. Issue #224 plan, Task 8."
+```
+
+---
+
+## Phase 5: Helper functions for origin-based mapping
+
+### Task 9: `advanceCells` helper
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Create: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/parser/viewport_mapping_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Tests for the origin-based viewport <-> content mapping.
+
+package parser
+
+import (
+	"testing"
+)
+
+// fillRowVTerm helper: write text to gid via the underlying main screen.
+// Existing tests use parser-level helpers; copy the pattern when needed.
+func TestAdvanceCells_StaysInGid(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	// Pre-fill gid 5 with 30 chars by writing through the main screen.
+	cells := make([]Cell, 30)
+	for i := range cells {
+		cells[i] = Cell{Rune: rune('a' + (i % 26))}
+	}
+	v.mainScreen.SetLine(5, cells)
+
+	gid, col := v.advanceCells(5, 0, 10)
+	if gid != 5 || col != 10 {
+		t.Errorf("advanceCells(5,0,10) = (%d,%d), want (5,10)", gid, col)
+	}
+}
+
+func TestAdvanceCells_CrossesGidBoundary(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	// gid 5 has 80 cells (last Wrapped); gid 6 has 60.
+	left := make([]Cell, 80)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	left[79].Wrapped = true
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 60)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	// From (5, 50), advance 40 cells: walks 30 cells of gid 5 (cols 50..79),
+	// then 10 cells of gid 6 (cols 0..9). Result: (6, 10).
+	gid, col := v.advanceCells(5, 50, 40)
+	if gid != 6 || col != 10 {
+		t.Errorf("advanceCells(5,50,40) = (%d,%d), want (6,10)", gid, col)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -run TestAdvanceCells ./apps/texelterm/parser/
+```
+
+Expected: FAIL — `advanceCells` undefined.
+
+- [ ] **Step 3: Implement `advanceCells`**
+
+Add to `apps/texelterm/parser/vterm.go` (in the same section as `ContentToViewport` / `ViewportToContent`):
+
+```go
+// advanceCells walks `n` cells forward from (originGid, originCol) through
+// the store, crossing gid boundaries when a row's cells are exhausted.
+// Returns the resulting (gid, col). Used by ViewportToContent to resolve
+// a viewport (y, x) given the row's origin.
+//
+// The walk is bounded by the caller (typically viewport width). Stops
+// at the first row beyond the store's content if `n` would take us past;
+// returns whatever (gid, col) the walk produced — past-content positions
+// are valid (selection there resolves to a zero-width selection).
+func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int) {
+    if v.mainScreen == nil {
+        return originGid, originCol
+    }
+    gid := originGid
+    col := originCol
+    remaining := n
+    for remaining > 0 {
+        cells := v.mainScreen.ReadLine(gid)
+        rowLen := len(cells)
+        available := rowLen - col
+        if remaining < available {
+            return gid, col + remaining
+        }
+        // Consume the rest of this gid; advance to the next.
+        if available < 0 {
+            available = 0
+        }
+        remaining -= available
+        gid++
+        col = 0
+    }
+    return gid, col
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+go test -run TestAdvanceCells ./apps/texelterm/parser/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "advanceCells: walk N cells from an origin, crossing gid boundaries
+
+Issue #224 plan, Task 9."
+```
+
+---
+
+### Task 10: `cellsBetween` helper
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/texelterm/parser/viewport_mapping_test.go`:
+
+```go
+func TestCellsBetween_StaysInGid(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 30)
+	for i := range cells {
+		cells[i] = Cell{Rune: 'a'}
+	}
+	v.mainScreen.SetLine(5, cells)
+
+	steps, ok := v.cellsBetween(5, 0, 5, 10, 80)
+	if !ok || steps != 10 {
+		t.Errorf("cellsBetween(5,0 -> 5,10) = (%d,%v), want (10,true)", steps, ok)
+	}
+}
+
+func TestCellsBetween_CrossesGidBoundary(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	left := make([]Cell, 80)
+	for i := range left {
+		left[i] = Cell{Rune: 'a'}
+	}
+	left[79].Wrapped = true
+	v.mainScreen.SetLine(5, left)
+	right := make([]Cell, 60)
+	for i := range right {
+		right[i] = Cell{Rune: 'b'}
+	}
+	v.mainScreen.SetLine(6, right)
+
+	// Origin (5, 50), target (6, 10), max 80 cells. Steps: 30 (rest of gid 5) + 10 = 40.
+	steps, ok := v.cellsBetween(5, 50, 6, 10, 80)
+	if !ok || steps != 40 {
+		t.Errorf("cellsBetween(5,50 -> 6,10) = (%d,%v), want (40,true)", steps, ok)
+	}
+}
+
+func TestCellsBetween_TargetOutOfRange(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 10)
+	v.mainScreen.SetLine(5, cells)
+
+	// Target too far; max 50 cells. Should return (_, false).
+	_, ok := v.cellsBetween(5, 0, 100, 0, 50)
+	if ok {
+		t.Errorf("cellsBetween(5,0 -> 100,0) returned ok=true; expected false")
+	}
+}
+
+func TestCellsBetween_TargetBeforeOrigin(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	cells := make([]Cell, 30)
+	v.mainScreen.SetLine(5, cells)
+
+	// Target is before origin in store order — not in this row.
+	_, ok := v.cellsBetween(5, 20, 5, 5, 80)
+	if ok {
+		t.Errorf("cellsBetween(5,20 -> 5,5) returned ok=true; expected false")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -run TestCellsBetween ./apps/texelterm/parser/
+```
+
+Expected: FAIL — `cellsBetween` undefined.
+
+- [ ] **Step 3: Implement `cellsBetween`**
+
+Add to `apps/texelterm/parser/vterm.go`:
+
+```go
+// cellsBetween counts cells from (originGid, originCol) forward to
+// (targetGid, targetCol), crossing gid boundaries. Returns
+// (stepsTaken, true) if the target is reached within maxCells steps,
+// or (0, false) if the walk runs past maxCells without finding the
+// target. Used by ContentToViewport to compute the visual x within a
+// row whose origin is known.
+//
+// "Before origin" cases (target is reachable only by going backward)
+// return (0, false) — the caller continues scanning to the next row.
+//
+// Safety: the loop is bounded both by step count AND by iteration
+// count. Walking through many consecutive empty gids contributes 0 to
+// `steps` per iteration; without an iteration bound the loop could
+// scan an arbitrarily distant target gid forever. Bound at
+// `maxCells*2` iterations — comfortably above the worst case of a
+// viewport-width walk through fully-populated rows (where each
+// iteration advances `steps` by at least 1 once we leave the origin
+// row).
+func (v *VTerm) cellsBetween(originGid int64, originCol int, targetGid int64, targetCol, maxCells int) (int, bool) {
+    if v.mainScreen == nil {
+        return 0, false
+    }
+    if targetGid < originGid || (targetGid == originGid && targetCol < originCol) {
+        return 0, false
+    }
+    gid := originGid
+    col := originCol
+    steps := 0
+    iterCap := maxCells*2 + 1
+    for i := 0; i < iterCap; i++ {
+        if gid == targetGid {
+            if targetCol < col {
+                return 0, false
+            }
+            delta := targetCol - col
+            if steps+delta > maxCells {
+                return 0, false
+            }
+            return steps + delta, true
+        }
+        cells := v.mainScreen.ReadLine(gid)
+        available := len(cells) - col
+        if available < 0 {
+            available = 0
+        }
+        steps += available
+        if steps > maxCells {
+            return 0, false
+        }
+        gid++
+        col = 0
+    }
+    return 0, false
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+go test -run TestCellsBetween ./apps/texelterm/parser/
+```
+
+Expected: PASS for all four sub-tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "cellsBetween: count cells from origin to target across gid boundaries
+
+Bounded by maxCells (typically viewport width). Returns (steps, false)
+when target is unreachable within the budget or before origin in
+store order. Issue #224 plan, Task 10."
+```
+
+---
+
+## Phase 6: Rewrite `ViewportToContent` and `ContentToViewport`
+
+### Task 11: Rewrite `ViewportToContent` to use `mainScreenRowOrigin` + `advanceCells`
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestViewportToContent_NonWrappedRow(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// Type a few non-wrapping lines.
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "hello" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	// Force a render so mainScreenRowOrigin is populated.
+	_, _ = v.GridWithRowIdx()
+
+	// Click at row 2, col 3. Origin should map straight through.
+	gid, col, _, ok := v.ViewportToContent(2, 3)
+	if !ok {
+		t.Fatalf("ViewportToContent(2, 3) ok=false")
+	}
+	// Validate against the rendered rowOrigin slice directly.
+	if int(gid) != int(v.mainScreenRowOrigin[2].Gid) {
+		t.Errorf("returned gid=%d, expected origin gid=%d", gid, v.mainScreenRowOrigin[2].Gid)
+	}
+	if col != v.mainScreenRowOrigin[2].Col+3 {
+		t.Errorf("returned col=%d, expected origin col + 3 = %d", col, v.mainScreenRowOrigin[2].Col+3)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -run TestViewportToContent_NonWrappedRow ./apps/texelterm/parser/
+```
+
+Expected: FAIL — current `ViewportToContent` uses naive math, not `mainScreenRowOrigin`. The check against `v.mainScreenRowOrigin[2]` will diverge for non-trivial cases (or compile-fail if that field isn't accessed yet).
+
+If naive math happens to match (gid 0 starts at row 0, etc.), the failure may be subtle; the wrapped tests in Task 12 will surface real mismatches.
+
+- [ ] **Step 3: Rewrite `ViewportToContent`**
+
+Replace the existing main-screen path:
+
+```go
+func (v *VTerm) ViewportToContent(y, x int) (logicalLine int64, charOffset int, isCurrentLine bool, ok bool) {
+    if v.inAltScreen {
+        // Alt screen: treat as current line equivalent.
+        charOffset = y*v.width + x
+        return -1, charOffset, true, true
+    }
+    if v.mainScreen == nil {
+        return 0, 0, false, false
+    }
+    cursorLine, _ := v.mainScreen.Cursor()
+
+    // Prefer the cached origin slice produced by the last render.
+    if y >= 0 && y < len(v.mainScreenRowOrigin) {
+        o := v.mainScreenRowOrigin[y]
+        if o.Gid != -1 {
+            gid, col := v.advanceCells(o.Gid, o.Col, x)
+            return gid, col, gid == cursorLine, true
+        }
+    }
+
+    // Fallback for rows outside the cached window or sentinel rows: use
+    // the naive (visibleTop + y, x) math, preserving pre-reflow behaviour
+    // for blank gaps and bottom padding.
+    visibleTop, _ := v.mainScreen.VisibleRange()
+    logicalLine = visibleTop + int64(y)
+    charOffset = x
+    isCurrentLine = logicalLine == cursorLine
+    ok = true
+    return
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+go test -run TestViewportToContent ./apps/texelterm/parser/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "ViewportToContent uses cached row origins
+
+Origin lookup + advanceCells walk gives correct (gid, col) even when
+a logical line wraps across multiple visual rows. Sentinel / out-of-
+window rows fall back to naive math. Issue #224 plan, Task 11."
+```
+
+---
+
+### Task 12: Rewrite `ContentToViewport` to use `mainScreenRowOrigin` + `cellsBetween`
+
+**Files:**
+- Modify: `apps/texelterm/parser/vterm.go`
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestContentToViewport_RoundTripNonWrapped(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "hello" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	_, _ = v.GridWithRowIdx()
+
+	for y := 0; y < 5; y++ {
+		for x := 0; x < 5; x++ {
+			gid, col, _, ok := v.ViewportToContent(y, x)
+			if !ok {
+				t.Fatalf("ViewportToContent(%d,%d) ok=false", y, x)
+			}
+			ry, rx, vis := v.ContentToViewport(gid, col)
+			if !vis {
+				t.Errorf("(%d,%d) → (%d,%d) → not visible", y, x, gid, col)
+				continue
+			}
+			if ry != y || rx != x {
+				t.Errorf("round-trip (%d,%d) → (gid=%d,col=%d) → (%d,%d)",
+					y, x, gid, col, ry, rx)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -run TestContentToViewport_RoundTripNonWrapped ./apps/texelterm/parser/
+```
+
+Expected: FAIL — ContentToViewport still uses naive math; round-trip won't match origin-based ViewportToContent for non-trivial cases.
+
+- [ ] **Step 3: Rewrite `ContentToViewport`**
+
+Replace the existing main-screen path:
+
+```go
+func (v *VTerm) ContentToViewport(logicalLine int64, charOffset int) (y, x int, visible bool) {
+    if v.inAltScreen {
+        if v.width <= 0 {
+            return 0, 0, false
+        }
+        y = charOffset / v.width
+        x = charOffset % v.width
+        visible = y >= 0 && y < v.height
+        return
+    }
+    if v.mainScreen == nil {
+        return 0, 0, false
+    }
+
+    // Scan the cached origin slice. For each row whose origin is set
+    // (Gid != -1), check whether (logicalLine, charOffset) falls within
+    // [origin, origin + viewportWidth) cell-walked through the chain.
+    for ry, o := range v.mainScreenRowOrigin {
+        if o.Gid == -1 {
+            continue
+        }
+        steps, ok := v.cellsBetween(o.Gid, o.Col, logicalLine, charOffset, v.width)
+        if !ok {
+            continue
+        }
+        if steps >= v.width {
+            // Target is past this row's visible cells; let a later row
+            // claim it (some other row's origin starts there).
+            continue
+        }
+        return ry, steps, true
+    }
+    return 0, 0, false
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+go test -run TestContentToViewport_RoundTripNonWrapped ./apps/texelterm/parser/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/texelterm/parser/vterm.go apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "ContentToViewport uses cached row origins
+
+Linear scan over rowOrigin + cellsBetween bounded by viewport width.
+Round-trip with ViewportToContent now consistent. Issue #224 plan,
+Task 12."
+```
+
+---
+
+## Phase 7: Wrapped-content tests + agreement against renderer
+
+### Task 13: Wrapped-content round-trip test
+
+**Files:**
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestContentToViewport_RoundTripWrappedChain(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// Single logical line of 100 chars, autowrap at 80.
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars total
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// Round-trip every (y, x) on the first two rows (the wrap chain).
+	for _, y := range []int{0, 1} {
+		for _, x := range []int{0, 5, 40, 79} {
+			gid, col, _, ok := v.ViewportToContent(y, x)
+			if !ok {
+				t.Fatalf("ViewportToContent(%d,%d) failed", y, x)
+			}
+			ry, rx, vis := v.ContentToViewport(gid, col)
+			if !vis {
+				t.Errorf("(%d,%d) → (%d,%d) → not visible", y, x, gid, col)
+				continue
+			}
+			if ry != y || rx != x {
+				t.Errorf("round-trip (%d,%d) → (gid=%d,col=%d) → (%d,%d)",
+					y, x, gid, col, ry, rx)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+go test -run TestContentToViewport_RoundTripWrappedChain ./apps/texelterm/parser/
+```
+
+Expected: PASS — Tasks 11 + 12 already handle wrapped chains via `mainScreenRowOrigin`.
+
+If it fails, the bug is in the origin slice or the helpers; debug there.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "Test: round-trip mapping for wrapped chain rows
+
+Issue #224 plan, Task 13."
+```
+
+---
+
+### Task 14: Agreement test (mapper matches renderer)
+
+**Files:**
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+This is the test that surfaced the bug in the reverted attempt. It confirms `ViewportToContent(y, 0)` returns the same `(gid, col)` that the renderer's `mainScreenRowOrigin[y]` reports for that row.
+
+```go
+func TestViewportToContent_AgreesWithRenderedRowOrigin(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// Mix of short non-wrapping lines, a long wrapped line, and more shorts.
+	p := NewParser(v)
+	for i := 0; i < 5; i++ {
+		for _, r := range "short" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	for i := 0; i < 5; i++ {
+		for _, r := range "after" {
+			p.Parse(r)
+		}
+		p.Parse('\r')
+		p.Parse('\n')
+	}
+	_, _ = v.GridWithRowIdx()
+
+	for y, o := range v.mainScreenRowOrigin {
+		if o.Gid == -1 {
+			continue
+		}
+		gid, col, _, ok := v.ViewportToContent(y, 0)
+		if !ok {
+			t.Errorf("row %d: ViewportToContent(%d, 0) failed", y, y)
+			continue
+		}
+		if gid != o.Gid || col != o.Col {
+			t.Errorf("row %d: ViewportToContent returned (%d,%d), origin says (%d,%d)",
+				y, gid, col, o.Gid, o.Col)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+go test -run TestViewportToContent_AgreesWithRenderedRowOrigin ./apps/texelterm/parser/
+```
+
+Expected: PASS — by definition `ViewportToContent(y, 0)` reads `mainScreenRowOrigin[y]` and applies a 0-cell `advanceCells`.
+
+If it fails, the path through `advanceCells(o.Gid, o.Col, 0)` isn't returning `(o.Gid, o.Col)` for some reason; debug `advanceCells`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "Test: ViewportToContent agrees with rendered row origin
+
+This is the invariant the reverted attempt violated — the mapper's
+chain walk must match what the renderer emitted. Issue #224 plan,
+Task 14."
+```
+
+---
+
+### Task 15: Sentinel / off-viewport handling tests
+
+**Files:**
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestViewportToContent_FallsBackToNaiveOnSentinel(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	// Type one short line, leaving rows 1..23 as bottom padding (-1 sentinel).
+	p := NewParser(v)
+	for _, r := range "only-line" {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// Find a sentinel row.
+	var sentY = -1
+	for y, o := range v.mainScreenRowOrigin {
+		if o.Gid == -1 {
+			sentY = y
+			break
+		}
+	}
+	if sentY < 0 {
+		t.Skip("no sentinel row to exercise")
+	}
+
+	// ViewportToContent on the sentinel row falls back to naive math
+	// — visibleTop + y, x — and reports ok=true so existing callers keep
+	// working.
+	gid, col, _, ok := v.ViewportToContent(sentY, 5)
+	if !ok {
+		t.Fatalf("ViewportToContent on sentinel row returned ok=false")
+	}
+	visibleTop, _ := v.mainScreen.VisibleRange()
+	wantGid := visibleTop + int64(sentY)
+	if gid != wantGid || col != 5 {
+		t.Errorf("sentinel fallback = (%d,%d), want (%d,5)", gid, col, wantGid)
+	}
+}
+
+func TestContentToViewport_OffViewportReturnsFalse(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+
+	p := NewParser(v)
+	for _, r := range "anchor-line" {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// (gid 9999, col 0) is past any rendered row; the scan finds no
+	// match and returns visible=false.
+	_, _, vis := v.ContentToViewport(9999, 0)
+	if vis {
+		t.Errorf("ContentToViewport(9999, 0) returned visible=true; expected false")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+go test -run "TestViewportToContent_FallsBackToNaiveOnSentinel|TestContentToViewport_OffViewportReturnsFalse" ./apps/texelterm/parser/
+```
+
+Expected: PASS — the sentinel/fallback paths in `ViewportToContent` and the no-match path in `ContentToViewport` are both already implemented from Task 11/12.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "Test: sentinel fallback + off-viewport visibility
+
+Issue #224 plan, Task 15."
+```
+
+---
+
+## Phase 8: Integration — selection survives resize
+
+### Task 16: Resize integration test
+
+**Files:**
+- Create: `apps/texelterm/selection_wrap_resize_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/texelterm/selection_wrap_resize_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Issue #224: selection highlight tracks the right cells across resize
+// that re-wraps a logical line. Test exercises the full path:
+// double-click → selection state in (gid, col) → resize → highlight
+// resolved via the new mapping.
+
+package texelterm
+
+import (
+	"testing"
+
+	"github.com/framegrace/texelation/apps/texelterm/parser"
+)
+
+func TestSelection_HighlightTracksWrappedContentAfterResize(t *testing.T) {
+	app := New("test")
+	app.Resize(80, 24)
+
+	v := app.vterm
+	v.EnableMemoryBuffer()
+	app.SetClipboardService(nil) // standalone-mode plumbing not needed
+
+	// Type a 100-char line that fits in one row at width 80 + 1 wrap row.
+	p := parser.NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// Pick a (y, x) on the second wrapped row — col 5 → logical char 85.
+	gid, col, _, ok := v.ViewportToContent(1, 5)
+	if !ok {
+		t.Fatalf("could not resolve (1, 5)")
+	}
+
+	// Sanity: confirm mapping back at width 80.
+	yPre, xPre, vis := v.ContentToViewport(gid, col)
+	if !vis || yPre != 1 || xPre != 5 {
+		t.Fatalf("pre-resize round-trip: got (%d,%d, vis=%v), want (1,5,true)", yPre, xPre, vis)
+	}
+
+	// Resize narrower so the same line wraps to more rows.
+	app.Resize(40, 24)
+	_, _ = v.GridWithRowIdx()
+
+	// The (gid, col) we captured pre-resize must still map to a visible
+	// row at the new width — somewhere in the multi-row reflow of the
+	// chain. We don't pin the exact row (that depends on chain layout),
+	// but it must be visible AND the round-trip must be consistent.
+	yPost, xPost, visPost := v.ContentToViewport(gid, col)
+	if !visPost {
+		t.Fatalf("post-resize: (%d,%d) not visible", gid, col)
+	}
+	gidR, colR, _, okR := v.ViewportToContent(yPost, xPost)
+	if !okR || gidR != gid || colR != col {
+		t.Errorf("post-resize round-trip: (gid=%d,col=%d) → (%d,%d) → (gid=%d,col=%d)",
+			gid, col, yPost, xPost, gidR, colR)
+	}
+}
+```
+
+(Adjust constructor / field access patterns to match the codebase — the test may need to use `NewTexelTerm()` or similar; see existing tests in `apps/texelterm/term_test.go` for the established pattern.)
+
+- [ ] **Step 2: Run the test**
+
+```
+go test -run TestSelection_HighlightTracksWrappedContentAfterResize ./apps/texelterm/
+```
+
+Expected: PASS.
+
+If it fails, the resize path may not be re-rendering the origin slice; check that `app.Resize` triggers a render or that `_, _ = v.GridWithRowIdx()` is being called.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/selection_wrap_resize_test.go
+git commit -m "Test: selection (gid,col) survives resize that re-wraps the line
+
+Issue #224 plan, Task 16."
+```
+
+---
+
+## Phase 9: Final verification
+
+### Task 17: Full test suite + race detector
+
+**Files:**
+- None (verification only).
+
+- [ ] **Step 1: Run the full texelterm parser suite**
+
+```
+go test ./apps/texelterm/parser/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the texelterm app suite**
+
+```
+go test ./apps/texelterm/
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run with race detector**
+
+```
+go test -race -count=1 ./apps/texelterm/parser/... ./apps/texelterm/
+```
+
+Expected: PASS, no data races.
+
+- [ ] **Step 4: Run the full repo test suite**
+
+```
+go test ./...
+```
+
+Expected: PASS — no consumer outside texelterm should be affected by the changes (publisher uses the discard-shim).
+
+- [ ] **Step 5: Confirm no commit needed**
+
+If everything passes, this verification phase needs no commit. If a regression surfaced, fix it inline and commit, then re-run.
+
+---
+
+## Summary
+
+| Phase | Tasks | Outcome |
+|---|---|---|
+| 1 | 1–4 | `reflowChain` consolidated to emit `(rows, origin)` with full case coverage. |
+| 2 | 5–6 | `view.Render` and `Terminal.RenderReflowFull` expose origin slice. |
+| 3 | 7 | `MainScreen` interface + parser-package `RowOrigin` alias. |
+| 4 | 8 | `VTerm` caches `mainScreenRowOrigin` on every render. |
+| 5 | 9–10 | `advanceCells` and `cellsBetween` helpers. |
+| 6 | 11–12 | `ViewportToContent` / `ContentToViewport` rewritten. |
+| 7 | 13–15 | Wrapped round-trip + agreement-with-renderer + sentinel tests. |
+| 8 | 16 | End-to-end resize integration test. |
+| 9 | 17 | Full-suite verification. |
+
+**Branch:** Continue on `feature/issue-224-wrap-highlight` (already created with the spec commit).

--- a/docs/superpowers/plans/2026-05-02-issue-224-wrap-highlight.md
+++ b/docs/superpowers/plans/2026-05-02-issue-224-wrap-highlight.md
@@ -86,7 +86,7 @@ type RowOrigin struct {
 }
 ```
 
-Then change the signature of `reflowChain` and the body to also build the origin slice:
+Then change the signature of `reflowChain` and the body to also build the origin slice. Critical: `logical` and `cellOrigin` must be trimmed in lockstep — call `trimTrailingPadding` once and use its return for both:
 
 ```go
 func reflowChain(s *Store, startGI, endGI int64, viewWidth int) (rows [][]parser.Cell, origin []RowOrigin) {
@@ -105,11 +105,12 @@ func reflowChain(s *Store, startGI, endGI int64, viewWidth int) (rows [][]parser
 			cellOrigin = append(cellOrigin, RowOrigin{Gid: gi, Col: col})
 		}
 	}
-	// trimTrailingPadding shortens logical; cellOrigin must shrink in lockstep
-	// so origin[i] still matches logical[i] after trimming.
-	trimmedLen := len(trimTrailingPadding(logical))
-	logical = logical[:trimmedLen]
-	cellOrigin = cellOrigin[:trimmedLen]
+	// Trim logical AND cellOrigin from the same length so origin[i] stays
+	// aligned with logical[i]. trimTrailingPadding returns a possibly-
+	// shorter slice (it does cells[:n]); reassign logical to it and shrink
+	// cellOrigin to match.
+	logical = trimTrailingPadding(logical)
+	cellOrigin = cellOrigin[:len(logical)]
 
 	trailing := trailingEmptyRows(s, startGI, endGI)
 	if len(logical) == 0 && trailing == 0 {
@@ -283,36 +284,143 @@ Issue #224 plan, Task 3."
 
 - [ ] **Step 1: Write the failing test**
 
-Append:
+Trailing empty rows in a chain are produced by `trailingEmptyRows` — that helper counts gids strictly after the start whose `len(s.GetLine(gid)) == 0`, **as long as `walkChain` reached them via `Wrapped=true` cells**. Setup that satisfies both: chain head has Wrapped=true, continuation gid is empty AND set with NoWrap=false (default), and `walkChain`'s exit condition `len(cells) == 0` returns early at the empty gid — so the trailing row count comes from chains where a continuation has cells but ends with Wrapped=true and the NEXT gid is empty. Use `SetLine` to write a fully-filled wrapped row at gid 6 (Wrapped=true) so `walkChain` advances to gid 6, then leave gid 7 empty so `trailingEmptyRows` counts it.
+
+Actually `walkChain` exits when the current row's last cell is not Wrapped, so the chain must end with a cell that has Wrapped=true. The cleanest setup that produces a trailing empty: gid 5 is filled with Wrapped=true, gid 6 also filled+Wrapped=true, gid 7 is in store but empty. `walkChain` loops: gid 5 (cells, last Wrapped → continue), gid 6 (cells, last Wrapped → check next), gid 7 (`s.GetLine(7) == nil` exits returning end=6). Result: `trailingEmptyRows(s, 5, 6)` returns 0 (only checks gid 6 which has cells). Hmm — that doesn't produce trailing empties either.
+
+Reading `trailingEmptyRows` again: it walks from `end` down to `start+1` counting empty rows. To get a non-zero count, an interior gid must be empty. That happens when a chain has been written, then the cursor advanced past the last Wrapped row by emitting a newline that creates a blank gid in the chain extension. Reproducing this without driving a parser is fragile.
+
+**Pragmatic test:** force the shape directly with `SetLine(gid, nil)` followed by `SetLine(gid+1, ...)` such that walkChain will visit both. Test the origin emission by stubbing the input directly:
 
 ```go
 func TestReflowChain_OriginTrailingEmptyRows(t *testing.T) {
 	s := NewStore(80)
-	// Chain with content in head, blank continuation rows that count
-	// via trailingEmptyRows.
-	fillRow(s, 5, "hello", true)
-	// Force trailing empties: gid 6 exists but has no cells.
-	s.SetLine(6, nil)
-	// Walk the chain to confirm shape (sanity).
-	end, _ := walkChain(s, 5, 100)
-	if end < 5 {
-		t.Skip("chain walk did not reach trailing empties; pattern unsupported")
-	}
+	// Two-gid chain head; both gids carry content + Wrapped=true. After
+	// reflow, with a trailing-empty path simulated by a chain whose
+	// trailingEmptyRows is non-zero, we'd want a setup where end > start
+	// and an interior gid in [start+1, end] is empty.
+	//
+	// Direct setup: gid 5 has 80 wrapped chars, gid 6 has 80 wrapped chars,
+	// gid 7 has empty cells but is in the store. walkChain will return
+	// end=6 (it bails when next is nil), so trailingEmptyRows returns 0.
+	// Fall back to confirming the absence-of-trailing-empties path
+	// emits all origins from the cell walk.
+	fillRow(s, 5, strings.Repeat("a", 80), true)
+	fillRow(s, 6, "bb", false)
 
-	rows, origin := reflowChain(s, 5, end, 80)
+	rows, origin := reflowChain(s, 5, 6, 80)
 	if len(rows) != len(origin) {
 		t.Fatalf("rows/origin length mismatch: %d vs %d", len(rows), len(origin))
 	}
-	if len(rows) < 1 {
-		t.Fatalf("expected at least 1 row")
+	// Two rows: one for gid 5 (80 a's), one for "bb".
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d, want 2", len(rows))
 	}
-	// The trailing empty rows (any rows past the head's content) must
-	// have origin (endGI, len(endGI's cells)).
-	for i := 1; i < len(rows); i++ {
-		want := RowOrigin{Gid: end, Col: len(s.GetLine(end))}
-		if origin[i] != want {
-			t.Errorf("trailing row %d origin=%+v, want %+v", i, origin[i], want)
-		}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if origin[1] != (RowOrigin{Gid: 6, Col: 0}) {
+		t.Errorf("origin[1]=%+v, want {Gid:6, Col:0}", origin[1])
+	}
+}
+```
+
+A second test directly verifies the trailing-empty origin sentinel via a synthetic setup that reaches the trailing-empty branch:
+
+```go
+func TestReflowChain_OriginTrailingEmptyBranch(t *testing.T) {
+	// Verify the trailing-empty branch by reflecting on the function
+	// directly. trailingEmptyRows's contract: counts rows in (start, end]
+	// whose len == 0. Pick a chain where end > start and the in-between
+	// gids are empty; this only happens when SetLine pre-creates an empty
+	// row in the middle of a chain — fragile but representative.
+	s := NewStore(80)
+	// Chain head fully filled, Wrapped=true.
+	cells := make([]parser.Cell, 80)
+	for i := range cells {
+		cells[i] = parser.Cell{Rune: 'a'}
+	}
+	cells[79].Wrapped = true
+	s.SetLine(5, cells)
+	// gid 6: pre-create an empty row. walkChain will see gid 6 has no
+	// cells via len(cells) == 0 and return end=5. So trailingEmptyRows
+	// runs over [5, 5] and returns 0. This means trailing branch isn't
+	// reachable from public APIs in a unit-testable way without a parser
+	// driving cursor moves. Skip the assert path; the trailing-empty
+	// branch is structurally tested via the integration tests in Phase 8.
+	end, _ := walkChain(s, 5, 100)
+	if end != 5 {
+		t.Fatalf("unexpected walkChain end=%d", end)
+	}
+	// Confirm the chain-head-only path still emits origins correctly.
+	rows, origin := reflowChain(s, 5, end, 80)
+	if len(rows) != 1 || len(origin) != 1 {
+		t.Fatalf("rows=%d origin=%d, want 1 each", len(rows), len(origin))
+	}
+}
+```
+
+The trailing-empty branch is genuinely hard to drive from a unit test without a parser; the integration test in Task 16 covers it via realistic parser input. Document this limitation rather than ship a `t.Skip` that asserts nothing.
+
+- [ ] **Step 2: Run tests to verify both pass**
+
+```
+go test -run "TestReflowChain_OriginTrailingEmptyRows|TestReflowChain_OriginTrailingEmptyBranch" ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "Test: reflowChain origin for trailing wrap-continuation rows
+
+Two tests: round-trip through the wrapped two-gid path, plus a
+documented limitation note that the trailing-empty-branch is
+covered structurally by Phase 8 integration. Issue #224 plan,
+Task 4."
+```
+
+---
+
+### Task 4a: Origin lockstep with trimTrailingPadding
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+This test directly exercises the lockstep bug class — `trimTrailingPadding` shortens `logical` and `cellOrigin` must shrink to match.
+
+```go
+func TestReflowChain_OriginWithTrailingPaddingTrimmed(t *testing.T) {
+	s := NewStore(80)
+	// 60 chars of content + 20 trailing padding cells (default-bg space).
+	// Chain head Wrapped=false so the chain is single-gid.
+	cells := make([]parser.Cell, 80)
+	for i := 0; i < 60; i++ {
+		cells[i] = parser.Cell{Rune: 'x'}
+	}
+	for i := 60; i < 80; i++ {
+		cells[i] = parser.Cell{Rune: ' '}
+	}
+	s.SetLine(5, cells)
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1", len(rows))
+	}
+	// After trim, logical has 60 cells; the row is 60 cells wide.
+	if len(rows[0]) != 60 {
+		t.Errorf("row width=%d, want 60 (trailing 20 padding cells trimmed)", len(rows[0]))
+	}
+	// origin[0] must point at gid 5 col 0 — trim is symmetric.
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+	if len(origin) != 1 {
+		t.Errorf("origin len=%d, want 1", len(origin))
 	}
 }
 ```
@@ -320,20 +428,74 @@ func TestReflowChain_OriginTrailingEmptyRows(t *testing.T) {
 - [ ] **Step 2: Run test to verify it passes**
 
 ```
-go test -run TestReflowChain_OriginTrailingEmptyRows ./apps/texelterm/parser/sparse/
+go test -run TestReflowChain_OriginWithTrailingPaddingTrimmed ./apps/texelterm/parser/sparse/
 ```
 
-Expected: PASS — Task 1's trailing-empty-rows loop already emits `RowOrigin{Gid: endGI, Col: len(s.GetLine(endGI))}`.
+Expected: PASS — Task 1's lockstep trim emits aligned `logical` and `cellOrigin`.
 
-If it fails, the trailing-empty-rows handling needs adjustment.
+If it fails, `cellOrigin` was not trimmed in lockstep with `logical`; revisit Task 1's trim block.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add apps/texelterm/parser/sparse/view_reflow_test.go
-git commit -m "Test: reflowChain origin for trailing empty wrap-continuation rows
+git commit -m "Test: reflowChain trim-padding lockstep on origin
 
-Issue #224 plan, Task 4."
+Issue #224 plan, Task 4a."
+```
+
+---
+
+### Task 4b: Origin emission for positional-gap one-row chain
+
+**Files:**
+- Modify: `apps/texelterm/parser/sparse/view_reflow_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```go
+func TestReflowChain_OriginPositionalGap(t *testing.T) {
+	s := NewStore(80)
+	// Powerline-style row: write at col 89 directly via WriteCell so the
+	// row carries unwritten cells before the last-written col.
+	for col := 0; col < 90; col++ {
+		if col == 89 {
+			s.WriteCell(5, col, parser.Cell{Rune: 'x'})
+		}
+	}
+	if !rowHasPositionalGap(s, 5) {
+		t.Fatalf("row 5 has no positional gap; setup invalid")
+	}
+
+	rows, origin := reflowChain(s, 5, 5, 80)
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1 (positional-gap path returns single row)", len(rows))
+	}
+	if origin[0] != (RowOrigin{Gid: 5, Col: 0}) {
+		t.Errorf("origin[0]=%+v, want {Gid:5, Col:0}", origin[0])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```
+go test -run TestReflowChain_OriginPositionalGap ./apps/texelterm/parser/sparse/
+```
+
+Expected: PASS — Task 1's `if startGI == endGI && rowHasPositionalGap` branch returns `[]RowOrigin{{Gid: startGI, Col: 0}}`.
+
+(If `WriteCell` isn't the right helper to populate without an autowrap, check the sparse package for the equivalent — `s.SetCell(gid, col, cell)` or similar. The test asserts `rowHasPositionalGap` upfront so a setup mismatch surfaces clearly.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/sparse/view_reflow_test.go
+git commit -m "Test: reflowChain origin for positional-gap one-row chain
+
+Issue #224 plan, Task 4b."
 ```
 
 ---
@@ -655,7 +817,11 @@ mainScreenRowOrigin []RowOrigin
 
 - [ ] **Step 3: Capture origin in `mainScreenGridWithRowIdx`**
 
-In `apps/texelterm/parser/vterm_main_screen.go`, locate `mainScreenGridWithRowIdx` (~line 499). Change the implementation to call `RenderReflowFull` and stash all three results, then return the existing two:
+`mainScreenGridWithRowIdx` is called from `Grid()` and `GridWithRowIdx()`, both of which hold `v.mu.RLock()`. Mutating `v.mainScreenRowOrigin` from inside that path would race with concurrent `RLock`-held readers — even if no production callers exist today, the race detector in Task 17 will flag it. The fix: take an exclusive lock around the cache mutation, or write to a slice-typed field via atomic-pointer swap.
+
+Simplest approach matching the existing codebase: drop the RLock for the duration of the render call (the caller's RLock is reacquired afterward), or — cleaner — change the field assignment to use a small dedicated mutex that's separate from `v.mu`. Pick the approach that matches existing patterns; if `lastRowGlobalIdx` (the parallel cache for `rowIdx`) is already protected somehow, follow that lead.
+
+In `apps/texelterm/parser/vterm_main_screen.go`, locate `mainScreenGridWithRowIdx` (~line 499). Change the implementation to call `RenderReflowFull` and stash all three results:
 
 ```go
 func (v *VTerm) mainScreenGridWithRowIdx() ([][]Cell, []int64) {
@@ -663,12 +829,46 @@ func (v *VTerm) mainScreenGridWithRowIdx() ([][]Cell, []int64) {
         return nil, nil
     }
     grid, rowIdx, rowOrigin := v.mainScreen.RenderReflowFull()
-    v.mainScreenRowOrigin = rowOrigin
+    // mainScreenRowOrigin is published under v.mu; readers in
+    // ContentToViewport / ViewportToContent must hold an RLock on
+    // v.mu while reading it.
+    //
+    // Lock-upgrade note: callers of mainScreenGridWithRowIdx hold an
+    // RLock today; switching here without releasing first would
+    // deadlock. The caller of Grid() / GridWithRowIdx() must promote
+    // to a write lock (or this function must be called only from
+    // contexts that already hold the write lock). See the calling
+    // path before changing this.
+    //
+    // Pragmatic option: store rowOrigin via a sync.RWMutex-protected
+    // field separate from v.mu, so this method can take its own write
+    // lock independently:
+    //
+    //   v.rowOriginMu.Lock()
+    //   v.mainScreenRowOrigin = rowOrigin
+    //   v.rowOriginMu.Unlock()
+    //
+    // and have the mappers RLock rowOriginMu when reading. Pick
+    // whichever pattern matches the codebase's existing rowIdx cache
+    // protection.
+    _ = rowOrigin // wired in Step 3a/3b below
     return grid, rowIdx
 }
 ```
 
-(Keep the existing function name — its callers don't change. The third value is captured into the cache as a side effect.)
+- [ ] **Step 3a: Read the existing rowIdx cache lock pattern**
+
+Look at how `lastRowGlobalIdx` (or wherever `rowIdx` gets cached) is currently protected. Match that pattern for `mainScreenRowOrigin` — same lock, same lifecycle.
+
+If there's no cache lock today (because no field gets written from `mainScreenGridWithRowIdx`), you have two choices:
+1. **Add a dedicated `sync.RWMutex` for the new cache** — write under `Lock()` here, read under `RLock()` in mappers. Cheapest.
+2. **Document mappers as not-thread-safe** — relies entirely on `a.mu` (texelterm's app lock) to serialize. Acceptable IF every external caller of `ViewportToContent` / `ContentToViewport` holds `a.mu`. Audit callers to confirm.
+
+- [ ] **Step 3b: Apply the chosen pattern**
+
+Edit `apps/texelterm/parser/vterm.go` to add the mutex (option 1) or document the contract (option 2). Update the field stash in `mainScreenGridWithRowIdx` accordingly. The mappers (Tasks 11/12) must consult the same mutex when reading.
+
+(Keep the existing `mainScreenGridWithRowIdx` name — its callers don't change. The third value is captured into the cache as a side effect.)
 
 - [ ] **Step 4: Run tests**
 
@@ -755,7 +955,33 @@ func TestAdvanceCells_CrossesGidBoundary(t *testing.T) {
 		t.Errorf("advanceCells(5,50,40) = (%d,%d), want (6,10)", gid, col)
 	}
 }
+
+func TestAdvanceCells_PastContentTerminates(t *testing.T) {
+	// Regression: walking past the store's last written gid must not
+	// loop indefinitely. Without the ReadLine == nil break, advanceCells
+	// would loop forever (available=0, gid++, no progress).
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	v.mainScreen.SetLine(5, []Cell{{Rune: 'a'}, {Rune: 'b'}})
+
+	// From (5, 5), try to advance 100 cells. Origin col is past the
+	// row's content (the row only has 2 cells), so available=0 first
+	// iter, then gid=6 which doesn't exist → break.
+	done := make(chan struct{})
+	go func() {
+		v.advanceCells(5, 5, 100)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Returned cleanly.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("advanceCells did not terminate within 100ms — likely infinite loop")
+	}
+}
 ```
+
+Add `import "time"` if not already imported (only for this test).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -775,10 +1001,15 @@ Add to `apps/texelterm/parser/vterm.go` (in the same section as `ContentToViewpo
 // Returns the resulting (gid, col). Used by ViewportToContent to resolve
 // a viewport (y, x) given the row's origin.
 //
-// The walk is bounded by the caller (typically viewport width). Stops
-// at the first row beyond the store's content if `n` would take us past;
-// returns whatever (gid, col) the walk produced — past-content positions
-// are valid (selection there resolves to a zero-width selection).
+// Bounded against runaway: when ReadLine returns nil (gid past the
+// store), break — the position is "past content" and further advancing
+// just walks empty space. Without this break, a click on a trailing-
+// empty wrap-continuation row could loop forever (each iteration:
+// available=0, gid++, no progress on `remaining`).
+//
+// The result for past-content positions is a (gid, col) just past the
+// store's max gid; selection callers handle that as a zero-width
+// selection (selectAtom finds no word; capture reads no cells).
 func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int) {
     if v.mainScreen == nil {
         return originGid, originCol
@@ -788,12 +1019,16 @@ func (v *VTerm) advanceCells(originGid int64, originCol int, n int) (int64, int)
     remaining := n
     for remaining > 0 {
         cells := v.mainScreen.ReadLine(gid)
+        if cells == nil {
+            // Past the store's last written gid. Stop here — further
+            // walking would loop without progress.
+            return gid, col
+        }
         rowLen := len(cells)
         available := rowLen - col
         if remaining < available {
             return gid, col + remaining
         }
-        // Consume the rest of this gid; advance to the next.
         if available < 0 {
             available = 0
         }
@@ -922,14 +1157,12 @@ Add to `apps/texelterm/parser/vterm.go`:
 // "Before origin" cases (target is reachable only by going backward)
 // return (0, false) — the caller continues scanning to the next row.
 //
-// Safety: the loop is bounded both by step count AND by iteration
-// count. Walking through many consecutive empty gids contributes 0 to
-// `steps` per iteration; without an iteration bound the loop could
-// scan an arbitrarily distant target gid forever. Bound at
-// `maxCells*2` iterations — comfortably above the worst case of a
-// viewport-width walk through fully-populated rows (where each
-// iteration advances `steps` by at least 1 once we leave the origin
-// row).
+// Safety: the loop is bounded both by step count AND by gid distance.
+// Walking through many consecutive empty gids contributes 0 to `steps`
+// per iteration; without a separate gid-based bound, a fixed iteration
+// cap can cut the walk short before reaching the target through gappy
+// stores. Bounding by (targetGid - originGid + 2) is provably tight —
+// the walk visits exactly the gids in [originGid, targetGid].
 func (v *VTerm) cellsBetween(originGid int64, originCol int, targetGid int64, targetCol, maxCells int) (int, bool) {
     if v.mainScreen == nil {
         return 0, false
@@ -940,7 +1173,9 @@ func (v *VTerm) cellsBetween(originGid int64, originCol int, targetGid int64, ta
     gid := originGid
     col := originCol
     steps := 0
-    iterCap := maxCells*2 + 1
+    // Tight bound: we visit at most (targetGid - originGid + 1) gids;
+    // +1 for the safety margin.
+    iterCap := int(targetGid-originGid) + 2
     for i := 0; i < iterCap; i++ {
         if gid == targetGid {
             if targetCol < col {
@@ -999,36 +1234,50 @@ store order. Issue #224 plan, Task 10."
 
 - [ ] **Step 1: Write the failing test**
 
-Append:
+Append. The test must use a wrap chain so naive `(visibleTop + y, x)` math diverges from origin-based math — otherwise the pre-rewrite implementation may pass by coincidence.
 
 ```go
-func TestViewportToContent_NonWrappedRow(t *testing.T) {
+func TestViewportToContent_WrappedContinuationRow(t *testing.T) {
 	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()
 
-	// Type a few non-wrapping lines.
+	// 100-char line wraps once at width 80 — row 0 displays gid 0
+	// (chain head); row 1 displays gid 1 (or stays in gid 0 with
+	// col offset, depending on chain layout).
 	p := NewParser(v)
-	for i := 0; i < 5; i++ {
-		for _, r := range "hello" {
-			p.Parse(r)
-		}
-		p.Parse('\r')
-		p.Parse('\n')
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
 	}
-	// Force a render so mainScreenRowOrigin is populated.
+	p.Parse('\r')
+	p.Parse('\n')
+	// Render so mainScreenRowOrigin is populated.
 	_, _ = v.GridWithRowIdx()
 
-	// Click at row 2, col 3. Origin should map straight through.
-	gid, col, _, ok := v.ViewportToContent(2, 3)
+	// Click at row 1, col 5. The naive implementation returns
+	// (visibleTop+1, 5). The origin-based implementation must return
+	// the cell-bearing (gid, col) — origin[1].Gid + col-walk-from-origin.
+	gid, col, _, ok := v.ViewportToContent(1, 5)
 	if !ok {
-		t.Fatalf("ViewportToContent(2, 3) ok=false")
+		t.Fatalf("ViewportToContent(1, 5) ok=false")
 	}
-	// Validate against the rendered rowOrigin slice directly.
-	if int(gid) != int(v.mainScreenRowOrigin[2].Gid) {
-		t.Errorf("returned gid=%d, expected origin gid=%d", gid, v.mainScreenRowOrigin[2].Gid)
+
+	// Independently re-derive what the answer should be from the cached
+	// origin slice — this gives a check that doesn't pre-suppose the
+	// implementation, but does require the origin slice to be built
+	// correctly (which Phase 1 covers).
+	o := v.mainScreenRowOrigin[1]
+	wantGid, wantCol := o.Gid, o.Col+5
+	// If +5 crosses a gid boundary in the chain, expand:
+	storeCells := v.mainScreen.ReadLine(o.Gid)
+	if wantCol >= len(storeCells) {
+		wantCol -= len(storeCells)
+		wantGid++
 	}
-	if col != v.mainScreenRowOrigin[2].Col+3 {
-		t.Errorf("returned col=%d, expected origin col + 3 = %d", col, v.mainScreenRowOrigin[2].Col+3)
+	if gid != wantGid || col != wantCol {
+		t.Errorf("ViewportToContent(1,5)=(gid=%d,col=%d), want (%d,%d)",
+			gid, col, wantGid, wantCol)
 	}
 }
 ```
@@ -1036,12 +1285,12 @@ func TestViewportToContent_NonWrappedRow(t *testing.T) {
 - [ ] **Step 2: Run test to verify it fails**
 
 ```
-go test -run TestViewportToContent_NonWrappedRow ./apps/texelterm/parser/
+go test -run TestViewportToContent_WrappedContinuationRow ./apps/texelterm/parser/
 ```
 
-Expected: FAIL — current `ViewportToContent` uses naive math, not `mainScreenRowOrigin`. The check against `v.mainScreenRowOrigin[2]` will diverge for non-trivial cases (or compile-fail if that field isn't accessed yet).
+Expected: FAIL — current `ViewportToContent` uses naive `(visibleTop + 1, 5)`. For a wrapped line, `visibleTop + 1` is the chain's second gid (or the same gid depending on store layout), but the col is wrong: 5 instead of `(origin col + 5)`. The naive math doesn't agree with what the renderer actually drew.
 
-If naive math happens to match (gid 0 starts at row 0, etc.), the failure may be subtle; the wrapped tests in Task 12 will surface real mismatches.
+If the test passes with naive math, the wrap setup didn't actually wrap; check with a longer line or verify `mainScreenRowOrigin[1].Col != 0`.
 
 - [ ] **Step 3: Rewrite `ViewportToContent`**
 
@@ -1285,21 +1534,24 @@ Issue #224 plan, Task 13."
 
 ---
 
-### Task 14: Agreement test (mapper matches renderer)
+### Task 14: Agreement test — origin matches rendered grid cells
 
 **Files:**
 - Modify: `apps/texelterm/parser/viewport_mapping_test.go`
 
 - [ ] **Step 1: Write the failing test**
 
-This is the test that surfaced the bug in the reverted attempt. It confirms `ViewportToContent(y, 0)` returns the same `(gid, col)` that the renderer's `mainScreenRowOrigin[y]` reports for that row.
+The reverted attempt failed because the mapper's chain walk disagreed with what `Render` actually drew. To catch that class of bug, the test must compare against **rendered grid cells**, not against the cache the mapper consults — otherwise it's tautological (mapper reads cache, test reads cache, they trivially agree).
+
+For each non-blank row `y` in the rendered grid, the cell at `(y, 0)` of the grid must equal the store's cell at `(origin[y].Gid, origin[y].Col)`.
 
 ```go
-func TestViewportToContent_AgreesWithRenderedRowOrigin(t *testing.T) {
+func TestRenderedGridAgreesWithRowOrigin(t *testing.T) {
 	v := NewVTerm(80, 24)
 	v.EnableMemoryBuffer()
 
-	// Mix of short non-wrapping lines, a long wrapped line, and more shorts.
+	// Mix of short non-wrapping lines and a long wrapped line so the
+	// origin slice has both per-gid and per-cell-offset entries.
 	p := NewParser(v)
 	for i := 0; i < 5; i++ {
 		for _, r := range "short" {
@@ -1322,20 +1574,29 @@ func TestViewportToContent_AgreesWithRenderedRowOrigin(t *testing.T) {
 		p.Parse('\r')
 		p.Parse('\n')
 	}
-	_, _ = v.GridWithRowIdx()
+	grid, _ := v.GridWithRowIdx()
 
 	for y, o := range v.mainScreenRowOrigin {
 		if o.Gid == -1 {
+			continue // blank / past-content sentinel
+		}
+		// Compare the rendered grid's first cell on row y with the
+		// store cell that origin[y] points to. This catches any
+		// divergence between what the renderer drew and what the
+		// origin slice claims about that row.
+		drewRune := grid[y][0].Rune
+		storeCells := v.mainScreen.ReadLine(o.Gid)
+		if o.Col >= len(storeCells) {
+			t.Errorf("row %d: origin (%d,%d) points past store row (len=%d)",
+				y, o.Gid, o.Col, len(storeCells))
 			continue
 		}
-		gid, col, _, ok := v.ViewportToContent(y, 0)
-		if !ok {
-			t.Errorf("row %d: ViewportToContent(%d, 0) failed", y, y)
-			continue
-		}
-		if gid != o.Gid || col != o.Col {
-			t.Errorf("row %d: ViewportToContent returned (%d,%d), origin says (%d,%d)",
-				y, gid, col, o.Gid, o.Col)
+		want := storeCells[o.Col].Rune
+		// Both might be zero (empty cell rendered, empty store cell)
+		// — that's fine. Mismatch is a real bug.
+		if drewRune != want {
+			t.Errorf("row %d col 0: drew rune=%q, but origin (%d,%d) says store rune=%q",
+				y, drewRune, o.Gid, o.Col, want)
 		}
 	}
 }
@@ -1344,22 +1605,75 @@ func TestViewportToContent_AgreesWithRenderedRowOrigin(t *testing.T) {
 - [ ] **Step 2: Run the test**
 
 ```
-go test -run TestViewportToContent_AgreesWithRenderedRowOrigin ./apps/texelterm/parser/
+go test -run TestRenderedGridAgreesWithRowOrigin ./apps/texelterm/parser/
 ```
 
-Expected: PASS — by definition `ViewportToContent(y, 0)` reads `mainScreenRowOrigin[y]` and applies a 0-cell `advanceCells`.
+Expected: PASS — `reflowChain` builds origin and rendered cells from the same concat walk, so they agree by construction.
 
-If it fails, the path through `advanceCells(o.Gid, o.Col, 0)` isn't returning `(o.Gid, o.Col)` for some reason; debug `advanceCells`.
+If it fails, the origin slice has drifted from the rendered output — that IS the failure mode of the previous attempt. Fix the trim or chain walk in Task 1 / Task 5.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Add a second agreement test that exercises columns past 0**
+
+To catch divergences in the *interior* of wrapped rows (not just first-cell), spot-check several `(y, x)` positions:
+
+```go
+func TestRenderedGridAgreesWithMapperInterior(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	// 100 chars wrap-into-two-rows at width 80.
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	grid, _ := v.GridWithRowIdx()
+
+	// Spot-check several (y, x) on the wrap chain.
+	cases := []struct{ y, x int }{
+		{0, 5}, {0, 79}, {1, 0}, {1, 15},
+	}
+	for _, c := range cases {
+		gid, col, _, ok := v.ViewportToContent(c.y, c.x)
+		if !ok {
+			t.Errorf("(%d,%d): ViewportToContent failed", c.y, c.x)
+			continue
+		}
+		drew := grid[c.y][c.x].Rune
+		storeCells := v.mainScreen.ReadLine(gid)
+		if col >= len(storeCells) {
+			t.Errorf("(%d,%d): mapped (%d,%d) past store len=%d",
+				c.y, c.x, gid, col, len(storeCells))
+			continue
+		}
+		want := storeCells[col].Rune
+		if drew != want {
+			t.Errorf("(%d,%d): drew %q, mapper says (%d,%d)→%q",
+				c.y, c.x, drew, gid, col, want)
+		}
+	}
+}
+```
+
+```
+go test -run TestRenderedGridAgreesWithMapperInterior ./apps/texelterm/parser/
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
 
 ```bash
 git add apps/texelterm/parser/viewport_mapping_test.go
-git commit -m "Test: ViewportToContent agrees with rendered row origin
+git commit -m "Test: rendered grid agrees with rowOrigin (catches reverted-attempt bug)
 
-This is the invariant the reverted attempt violated — the mapper's
-chain walk must match what the renderer emitted. Issue #224 plan,
-Task 14."
+Two tests compare the actual cells the renderer drew at (y, x)
+against what (gid, col) the mapper resolves to. The reverted
+attempt's failure was that the mapper's chain walk disagreed with
+what Render drew — these tests catch that class directly. Issue
+#224 plan, Task 14."
 ```
 
 ---
@@ -1455,12 +1769,81 @@ Issue #224 plan, Task 15."
 
 ## Phase 8: Integration — selection survives resize
 
-### Task 16: Resize integration test
+### Task 15a: Resize round-trip at vterm layer
+
+**Files:**
+- Modify: `apps/texelterm/parser/viewport_mapping_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+The vterm-level resize round-trip is distinct from the texelterm-app integration test in Task 16 — it pins the mapping math without involving selection state, click handlers, or paint code.
+
+```go
+func TestContentToViewport_AfterResize(t *testing.T) {
+	v := NewVTerm(80, 24)
+	v.EnableMemoryBuffer()
+	// 100-char line that wraps once at width 80.
+	p := NewParser(v)
+	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
+		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab"
+	for _, r := range long {
+		p.Parse(r)
+	}
+	p.Parse('\r')
+	p.Parse('\n')
+	_, _ = v.GridWithRowIdx()
+
+	// Capture (gid, col) for the rune at viewport (1, 0) — char 80 of
+	// the logical line — at width 80.
+	gid80, col80, _, ok := v.ViewportToContent(1, 0)
+	if !ok {
+		t.Fatalf("pre-resize ViewportToContent(1,0) failed")
+	}
+
+	// Resize to width 40. Same logical line now wraps to 3 rows; char 80
+	// lands on row 2.
+	v.Resize(40, 24)
+	_, _ = v.GridWithRowIdx()
+
+	y, x, vis := v.ContentToViewport(gid80, col80)
+	if !vis {
+		t.Fatalf("post-resize: (%d,%d) not visible", gid80, col80)
+	}
+	if y != 2 || x != 0 {
+		t.Errorf("post-resize: (gid=%d,col=%d) → (%d,%d), want (2,0)",
+			gid80, col80, y, x)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+go test -run TestContentToViewport_AfterResize ./apps/texelterm/parser/
+```
+
+Expected: PASS — the origin slice rebuilds on the post-resize render; mapper consults the new slice.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/texelterm/parser/viewport_mapping_test.go
+git commit -m "Test: ContentToViewport after resize at vterm layer
+
+Pins the mapping math through a resize that re-wraps a logical line.
+Issue #224 plan, Task 15a."
+```
+
+---
+
+### Task 16: Resize integration test driving the highlight paint
 
 **Files:**
 - Create: `apps/texelterm/selection_wrap_resize_test.go`
 
 - [ ] **Step 1: Write the failing test**
+
+The user-reported bug is "highlight visibly drifts after resize." The vterm round-trip test (Task 15a) covers the math; this test must exercise the actual paint path — drive `applySelectionHighlightLocked`, capture the painted buffer, and assert that the highlighted cells correspond to the cells the selection captured.
 
 Create `apps/texelterm/selection_wrap_resize_test.go`:
 
@@ -1469,9 +1852,8 @@ Create `apps/texelterm/selection_wrap_resize_test.go`:
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // Issue #224: selection highlight tracks the right cells across resize
-// that re-wraps a logical line. Test exercises the full path:
-// double-click → selection state in (gid, col) → resize → highlight
-// resolved via the new mapping.
+// that re-wraps a logical line. Drives the full paint path so a bug
+// in either the (gid, col) mapping OR the highlight paint surfaces.
 
 package texelterm
 
@@ -1481,15 +1863,17 @@ import (
 	"github.com/framegrace/texelation/apps/texelterm/parser"
 )
 
+// Match the constructor / public surface to existing tests in this
+// package. Look at apps/texelterm/term_test.go for the established
+// pattern; some tests use NewTexelTerm(), others use New(). Pick the
+// one that compiles and matches existing conventions.
 func TestSelection_HighlightTracksWrappedContentAfterResize(t *testing.T) {
-	app := New("test")
-	app.Resize(80, 24)
+	app := newTestTexelTerm(t, 80, 24) // helper following term_test.go's pattern
 
 	v := app.vterm
 	v.EnableMemoryBuffer()
-	app.SetClipboardService(nil) // standalone-mode plumbing not needed
 
-	// Type a 100-char line that fits in one row at width 80 + 1 wrap row.
+	// Type a 100-char line that wraps to two rows at width 80.
 	p := parser.NewParser(v)
 	const long = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" +
 		"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZab" // 100 chars
@@ -1498,41 +1882,100 @@ func TestSelection_HighlightTracksWrappedContentAfterResize(t *testing.T) {
 	}
 	p.Parse('\r')
 	p.Parse('\n')
-	_, _ = v.GridWithRowIdx()
 
-	// Pick a (y, x) on the second wrapped row — col 5 → logical char 85.
+	// Programmatically install a multi-row selection on the wrap chain.
+	// Use the public selection-state-machine entry point (StartMode +
+	// the existing ClickType-driven dispatch). See selection_state_test.go
+	// for the pattern. Specifically, target a word on the SECOND wrapped
+	// row so the highlight position depends on origin tracking.
 	gid, col, _, ok := v.ViewportToContent(1, 5)
 	if !ok {
-		t.Fatalf("could not resolve (1, 5)")
+		t.Fatalf("pre-resize ViewportToContent(1,5) failed")
+	}
+	// Drive double-click at (1, 5) so SelectionStateMachine resolves a
+	// SpaceWord selection rooted at (gid, col).
+	app.selectionMachine.Start(gid, col, 1, DoubleClick, 0)
+
+	// Render once so applySelectionHighlightLocked paints the highlight
+	// with the pre-resize layout.
+	bufPre := app.Render()
+	highlightedPre := highlightedCells(bufPre)
+	if len(highlightedPre) == 0 {
+		t.Fatal("pre-resize: no highlighted cells; selection didn't paint")
 	}
 
-	// Sanity: confirm mapping back at width 80.
-	yPre, xPre, vis := v.ContentToViewport(gid, col)
-	if !vis || yPre != 1 || xPre != 5 {
-		t.Fatalf("pre-resize round-trip: got (%d,%d, vis=%v), want (1,5,true)", yPre, xPre, vis)
+	// Capture the captured-text via SelectionStateMachine.Finish — this
+	// is the bytes the user would copy.
+	mime, data, finishOK := app.selectionMachine.Finish(gid, col, 1, 0)
+	_ = mime
+	if !finishOK {
+		t.Fatal("Finish returned !ok")
 	}
+	captured := string(data)
 
-	// Resize narrower so the same line wraps to more rows.
+	// Resize narrower; the same logical line now wraps to more rows.
 	app.Resize(40, 24)
-	_, _ = v.GridWithRowIdx()
 
-	// The (gid, col) we captured pre-resize must still map to a visible
-	// row at the new width — somewhere in the multi-row reflow of the
-	// chain. We don't pin the exact row (that depends on chain layout),
-	// but it must be visible AND the round-trip must be consistent.
-	yPost, xPost, visPost := v.ContentToViewport(gid, col)
-	if !visPost {
-		t.Fatalf("post-resize: (%d,%d) not visible", gid, col)
+	// Re-install the selection at the captured (gid, col) range and re-render.
+	// Because Finish was called, restart with the same anchors.
+	app.selectionMachine.Start(gid, col, 1, DoubleClick, 0)
+	bufPost := app.Render()
+	highlightedPost := highlightedCells(bufPost)
+	if len(highlightedPost) == 0 {
+		t.Fatal("post-resize: no highlighted cells; the regression is back")
 	}
-	gidR, colR, _, okR := v.ViewportToContent(yPost, xPost)
-	if !okR || gidR != gid || colR != col {
-		t.Errorf("post-resize round-trip: (gid=%d,col=%d) → (%d,%d) → (gid=%d,col=%d)",
-			gid, col, yPost, xPost, gidR, colR)
+
+	// Capture the post-resize text — must equal the pre-resize text.
+	_, dataPost, _ := app.selectionMachine.Finish(gid, col, 1, 0)
+	capturedPost := string(dataPost)
+	if capturedPost != captured {
+		t.Errorf("post-resize captured text differs:\npre:  %q\npost: %q", captured, capturedPost)
 	}
+
+	// Sanity: the rendered runes at the highlighted positions post-
+	// resize must equal the rendered runes at the highlighted positions
+	// pre-resize (modulo wrap layout). The text we captured ALSO lives
+	// in the highlighted cells at new positions.
+	highlightedRunesPost := runesAt(bufPost, highlightedPost)
+	if !containsSubstring(highlightedRunesPost, captured) {
+		t.Errorf("post-resize highlight cells %q do not contain captured text %q",
+			highlightedRunesPost, captured)
+	}
+}
+
+// Test helpers — implement based on the package's existing conventions.
+
+// newTestTexelTerm builds a TexelTerm for tests, sized cols x rows. See
+// term_test.go for the existing pattern (NewTexelTerm or New + Resize).
+func newTestTexelTerm(t *testing.T, cols, rows int) *TexelTerm {
+	t.Helper()
+	// Implementation: follow term_test.go.
+	panic("implement to match existing test pattern")
+}
+
+// highlightedCells returns the (y, x) of cells whose Style has the
+// selection-highlight background. Compare with the configured highlight
+// color from theming.ForApp("texelterm").GetColor("selection",
+// "highlight_bg", ...).
+func highlightedCells(buf [][]texelcoreCell) []struct{ Y, X int } {
+	// Implementation: walk buf, compare bg.
+	panic("implement based on the highlight bg color")
+}
+
+// runesAt extracts a string from buf at the given (y, x) positions in
+// reading order.
+func runesAt(buf [][]texelcoreCell, positions []struct{ Y, X int }) string {
+	panic("implement: read buf[y][x].Ch in order")
+}
+
+func containsSubstring(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
 }
 ```
 
-(Adjust constructor / field access patterns to match the codebase — the test may need to use `NewTexelTerm()` or similar; see existing tests in `apps/texelterm/term_test.go` for the established pattern.)
+(The helper implementations are left as panic stubs in the plan because the exact `texelcore.Cell` type, the `app.selectionMachine` field accessibility, and `Render()`'s return type need to be checked against the codebase. Use `term_test.go` as the template — there's already test infrastructure for driving render passes and inspecting buffer cells. If that infrastructure isn't sufficient, prefer extending it over duplicating it in this test file.)
+
+(Further adjust constructor / field access patterns to match the codebase. If `selectionMachine` is private and there's no exported method to start a selection programmatically, route through `mouseCoordinator.HandleMouse` with synthesized `tcell.EventMouse` events at the same `(y, x)` — that's the same path the click handler takes.)
 
 - [ ] **Step 2: Run the test**
 
@@ -1604,14 +2047,31 @@ If everything passes, this verification phase needs no commit. If a regression s
 
 | Phase | Tasks | Outcome |
 |---|---|---|
-| 1 | 1–4 | `reflowChain` consolidated to emit `(rows, origin)` with full case coverage. |
+| 1 | 1–4b | `reflowChain` consolidated to emit `(rows, origin)`; covers non-wrapped, wrapped same-gid, cross-gid mid-row, trailing wrap-continuation, trim-padding lockstep, positional-gap. |
 | 2 | 5–6 | `view.Render` and `Terminal.RenderReflowFull` expose origin slice. |
 | 3 | 7 | `MainScreen` interface + parser-package `RowOrigin` alias. |
-| 4 | 8 | `VTerm` caches `mainScreenRowOrigin` on every render. |
-| 5 | 9–10 | `advanceCells` and `cellsBetween` helpers. |
+| 4 | 8 | `VTerm` caches `mainScreenRowOrigin` on every render under the right lock. |
+| 5 | 9–10 | `advanceCells` (with past-content termination guard) and `cellsBetween` (with gid-distance bound) helpers. |
 | 6 | 11–12 | `ViewportToContent` / `ContentToViewport` rewritten. |
-| 7 | 13–15 | Wrapped round-trip + agreement-with-renderer + sentinel tests. |
-| 8 | 16 | End-to-end resize integration test. |
-| 9 | 17 | Full-suite verification. |
+| 7 | 13–15 | Wrapped round-trip + agreement-with-rendered-grid + sentinel tests. |
+| 8 | 15a | Resize round-trip at vterm layer (math-only). |
+| 9 | 16 | End-to-end resize integration test that drives the highlight paint. |
+| 10 | 17 | Full-suite verification. |
 
 **Branch:** Continue on `feature/issue-224-wrap-highlight` (already created with the spec commit).
+
+---
+
+## Deferred (consider after main plan lands)
+
+These came up during plan review. They're worth doing but aren't on the critical path for fixing the user-visible bug.
+
+1. **Demote `RenderReflow` and `RenderReflowWithRowIdx` shims off the `MainScreen` interface.** Keep them as concrete `Terminal` methods only. One canonical interface entry point (`RenderReflowFull`) is cleaner; the shims exist for source-code convenience, not interface contract. Audit publisher call sites first to confirm none reach through `MainScreen` for the shim methods.
+
+2. **Cache invalidation hooks.** `mainScreenRowOrigin` should be cleared (set to nil) on alt-screen entry/exit and on resize. Today the main-screen path checks `inAltScreen` upfront and falls back, so a stale cache is dormant. But a defensive `clear` keeps the invariant tighter and prevents a class of "post-resize, pre-render click" mishaps.
+
+3. **Length-equality assertion.** In `mainScreenGridFull`, after the render call, assert `len(rowIdx) == len(rowOrigin) == len(grid)`. Cheap defensive check that catches a class of slice-trimming bugs.
+
+4. **Concurrent store mutation during walk.** `advanceCells` and `cellsBetween` read `v.mainScreen.ReadLine` per iteration; the store is live and writes can interleave under a fine-grained lock. The cache slice is a snapshot from render time; the store walked during the helper is not. In practice `a.mu` serializes texterm app paths, but this hasn't been audited for non-texelterm callers (headless, server). Worth a `sparse.Store` snapshot that the helpers can walk without re-acquiring the store lock per cell — bigger refactor, file separately.
+
+5. **Selection state representation rework.** The plan keeps `(gid, col)` as the selection storage. A future cleanup could move to `(chain_head_gid, logical_col_within_chain)` which is reflow-independent — the current representation works but requires the origin-based mapper to translate at every render. Probably YAGNI unless the mapper becomes a hot path.

--- a/docs/superpowers/specs/2026-05-02-issue-224-wrap-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-224-wrap-highlight-design.md
@@ -1,0 +1,300 @@
+# Wrap-aware selection mapping (issue #224) — Design
+
+## Problem
+
+Selection highlights in a texelterm pane drift away from the cells they cover whenever a logical line wraps across multiple visual rows and the wrap boundary shifts. The most common trigger is resize, but any layout change between click and render exposes the same bug.
+
+The captured text remains correct because `GetContentText` reads cells directly from the sparse store by `(gid, col)`. What drifts is the *projection* — `ContentToViewport` (`(gid, col)` → visual `(y, x)`) and `ViewportToContent` (the inverse) use naive `y = gid - visibleTop` math, which assumes one logical line per visual row. With wrapping, a single logical line spans N visual rows and the assumption fails.
+
+## Why the previous attempt failed
+
+A first attempt at this fix (commits 73f9fd0 + 4d4d7cb, reverted in b60f7a3) routed both mappers through the view's existing reflow-aware `CursorToView` / `ViewToCursor`. Round-trip math passed in unit tests but production showed:
+
+- Non-wrapped lines: highlight several rows below the click. The unit-tested invariant wasn't the one the renderer actually depends on at runtime.
+- Wrapped lines: `ViewToCursor` returns the cell-bearing gid (e.g. `6` in a `5..6` chain) while the renderer's `rowIdx` tags every reflowed sub-row with the chain-head gid (`5`). The selection layer saw a gid the renderer never reports as "drawn here," so highlight and capture diverged in opposite directions.
+
+The fundamental lesson: the renderer at draw time *knows* exactly which cells it placed at each row — it builds rows by slicing a concatenated chain. Re-deriving that layout in a parallel function risks divergence. The fix must preserve the information the renderer already has.
+
+## Approach
+
+Add a per-row "origin" slice — `[]RowOrigin` where `RowOrigin{Gid, Col}` is the `(gid, col)` of the first cell on each visual row — to the render path. Cache it on `VTerm` parallel to the existing `lastRowGlobalIdx`. `ContentToViewport` and `ViewportToContent` consult this cache instead of computing.
+
+Selection state representation is unchanged — it still holds `(gid, col)` of the cell-bearing gid. Wire protocol is unchanged. Capture (`GetContentText`) is unchanged.
+
+The renderer's existing `rowIdx` (chain-head per row) keeps its current semantics for the publisher's clipping path. Origin is a separate, additive channel for selection.
+
+## Architecture
+
+```
+Render (every frame, under a.mu)
+ └─ vterm.GridFull
+     └─ mainScreen.RenderReflowFull
+         └─ Terminal.RenderReflowFull
+             ├─ RecomputeLiveAnchor
+             └─ view.Render
+                 └─ for each chain: reflowChain → (rows, origin)
+             returns (rows, rowGI, rowOrigin)
+     stashes lastRowGlobalIdx + mainScreenRowOrigin under v.mu
+
+Click (mouse press / drag, under a.mu)
+ └─ ViewportToContent(y, x)
+     ├─ origin := v.mainScreenRowOrigin[y]
+     ├─ if origin.Gid == -1 → naive fallback (blank/past-content rows)
+     └─ else: walk x cells from origin, crossing gid boundaries → (gid, col)
+
+Highlight (after render loop, same lock)
+ └─ ContentToViewport(gid, col)
+     ├─ scan v.mainScreenRowOrigin
+     ├─ find row y where origin[y] ≤ (gid, col) < origin[y+1]
+     └─ x := cell-distance from origin[y] to (gid, col)
+ └─ paint buf[startRow..endRow] as today
+
+Capture (mouse-up)
+ └─ GetContentText(startLine, startOffset, endLine, endOffset)
+     reads cells from store + PageStore fault — unchanged
+```
+
+## Components
+
+### `apps/texelterm/parser/sparse/view_reflow.go`
+
+`reflowChain` is consolidated to always emit origin alongside rows — there are no other callers, so no shim is needed:
+
+```go
+type RowOrigin struct {
+    Gid int64 // -1 sentinel for blank / past-content rows
+    Col int   // col within Gid; meaningless when Gid == -1
+}
+
+func reflowChain(s *Store, startGI, endGI int64, viewWidth int) (
+    rows [][]parser.Cell, origin []RowOrigin)
+```
+
+The concat phase tracks origin per cell:
+
+```go
+var logical []parser.Cell
+var cellOrigin []RowOrigin
+for gi := startGI; gi <= endGI; gi++ {
+    line := s.GetLine(gi)
+    for col := range line {
+        logical = append(logical, line[col])
+        cellOrigin = append(cellOrigin, RowOrigin{Gid: gi, Col: col})
+    }
+}
+```
+
+After `trimTrailingPadding`, slice by `viewWidth`. Each output row's origin = `cellOrigin[off]`. Trailing-empty-rows get `RowOrigin{Gid: endGI, Col: len(endGI_cells)}` ("past content"). The positional-gap and empty-chain edge cases set `Gid = -1`.
+
+### `apps/texelterm/parser/sparse/view_window.go`
+
+The single `Render` walker returns `([][]Cell, []int64, []RowOrigin)`. The unwrapped / nowrap branch fills `origin = (gi, 0)` per row. The wrapped branch unpacks `reflowChain`'s second return. Blank-row gaps and bottom padding fill `RowOrigin{Gid: -1}`. The `skip > 0` slice-trimming applies to all three slices in lockstep.
+
+### `apps/texelterm/parser/sparse/terminal.go`
+
+```go
+func (t *Terminal) RenderReflowFull() ([][]parser.Cell, []int64, []RowOrigin) {
+    cursorGI, cursorCol := t.write.Cursor()
+    t.view.RecomputeLiveAnchor(t.store, cursorGI, cursorCol, t.write.WriteTop())
+    return t.view.Render(t.store)
+}
+
+// Existing methods become discard-shims so the publisher path stays untouched.
+func (t *Terminal) RenderReflowWithRowIdx() ([][]parser.Cell, []int64) {
+    rows, gids, _ := t.RenderReflowFull()
+    return rows, gids
+}
+func (t *Terminal) RenderReflow() [][]parser.Cell {
+    rows, _, _ := t.RenderReflowFull()
+    return rows
+}
+```
+
+### `apps/texelterm/parser/main_screen.go`
+
+`MainScreen` interface adds `RenderReflowFull() ([][]Cell, []int64, []RowOrigin)`. Existing methods stay on the interface — they're the shapes the publisher already calls. Both delegate to the same view walker; no double-walk.
+
+`RowOrigin` is exported from the parser package as a type alias of `sparse.RowOrigin`:
+
+```go
+type RowOrigin = sparse.RowOrigin
+```
+
+### `apps/texelterm/parser/vterm.go` and `vterm_main_screen.go`
+
+A new cached slice on `VTerm`, set under `v.mu` at the end of every render — same lock and lifecycle as the existing `mainScreen` grid cache:
+
+```go
+mainScreenRowOrigin []RowOrigin // length matches the rendered grid; -1 sentinel for blank rows
+```
+
+`mainScreenGridWithRowIdx` is renamed to `mainScreenGridFull`, captures all three returns, stashes origin. The old name stays as a 2-return wrapper for any internal caller that doesn't want origin.
+
+`ViewportToContent(y, x)`:
+
+```go
+if y < 0 || y >= len(v.mainScreenRowOrigin) {
+    // Out of viewport — naive fallback.
+    return visibleTop + int64(y), x, gid == cursorLine, true
+}
+o := v.mainScreenRowOrigin[y]
+if o.Gid == -1 {
+    // Blank row / unwritten gap — naive fallback.
+    return visibleTop + int64(y), x, gid == cursorLine, true
+}
+gid, col := advanceCells(s, o.Gid, o.Col, x)
+return gid, col, gid == cursorLine, true
+```
+
+`ContentToViewport(gid, col)`:
+
+```go
+viewportWidth := v.width // viewport columns
+for y, o := range v.mainScreenRowOrigin {
+    if o.Gid == -1 { continue }
+    if x, ok := cellsBetween(s, o.Gid, o.Col, gid, col, viewportWidth); ok {
+        return y, x, true
+    }
+}
+return 0, 0, false
+```
+
+`cellsBetween(s, originGid, originCol, targetGid, targetCol, maxCells)` walks cells from origin advancing one at a time, crossing gid boundaries, returning `(stepsTaken, true)` if target is reached within `maxCells` steps, otherwise `(0, false)`. Bounded by viewport width per call. Using a row-bound rather than a `nextOrigin` lookup avoids special-casing the last row and keeps the predicate self-contained.
+
+`advanceCells(s, originGid, originCol, x)` is the dual used by `ViewportToContent`: walk `x` cells from origin, return the resulting `(gid, col)`. Same per-cell loop, bounded by viewport width.
+
+### `apps/texelterm/term.go`
+
+Unchanged. `applySelectionHighlightLocked` already calls `vterm.ContentToViewport`; the new origin-based math just produces correct results. Cached origin lives inside vterm; the app doesn't see it directly.
+
+### Publisher (`internal/runtime/server/desktop_publisher.go`)
+
+Unchanged. Continues to use `RowGlobalIdx` (chain head) for delta clipping. Origin is texelterm-internal.
+
+## Sentinel choices
+
+| Row condition | `rowGI[y]` | `rowOrigin[y]` |
+|---|---|---|
+| Normal unwrapped row | `gi` | `(gi, 0)` |
+| Wrapped chain head row | chain head `gi` | `(gi, 0)` |
+| Wrapped continuation row | chain head `gi` | cell-bearing `(g, c)` |
+| Blank row in chain walk gap | `-1` | `(Gid: -1)` |
+| Bottom padding (viewport > content) | `-1` | `(Gid: -1)` |
+| Trailing empty in chain | chain head `gi` | `(endGI, len(endGI_cells))` |
+| Positional-gap one-row chain | `gi` | `(gi, 0)` |
+
+`rowOrigin` and `rowGI` agree on `-1` for "no real content here" cases, so existing callers that already special-case `-1` keep working.
+
+## Lock model
+
+- `a.mu` (texelterm app) wraps both `Render` and `HandleMouse`. Origin slice is read & written under it.
+- `v.mu` (vterm RWLock) protects the cached origin slice itself. Render takes write; mappers take read.
+- `view.mu` is taken inside `Render` only; mappers don't touch it (they read the cached origin from vterm).
+
+No new lock acquisitions; no double-walk of chains.
+
+## Boundary semantics
+
+When a row's first cell is at `(gid_X, col_K)` because the row crosses a gid boundary mid-row, and a click at column `x` would resolve to the first cell of `gid_X+1`, the resolved gid is **`gid_X+1`** (cell-bearing). This matches what `selectAtom`, `GetContentText`, and the existing wrapped-chain copy logic expect.
+
+`Selection.AnchorOffset` / `CurrentOffset` follow the existing exclusive-end convention. A drag from row Y col 5 to row Y col 30 on a row whose cells span `(gid_5, 50)..(gid_5, 79), (gid_6, 0)..(gid_6, 19)` resolves to anchor `(gid_5, 55)`, head `(gid_6, 0)` — capture iterates `cells[55:80]` of gid 5 (the chain's `Wrapped=true` flag suppresses the `\n` join) plus `cells[0:0]` of gid 6, yielding 25 chars from gid 5 alone, which matches the 25 cells visually selected.
+
+## Testing
+
+Three layers, each independently meaningful.
+
+### Pure-function tests on `reflowChain`
+
+```go
+TestReflowChain_OriginNonWrapped
+// 1-gid chain with 50 chars at width 80. rows=1, origin[0]={gid, 0}.
+
+TestReflowChain_OriginWrappedTwoGids
+// gid 5 (80 chars) + gid 6 (60 chars), width 80. rows=2.
+// origin[0]={5, 0}, origin[1]={6, 0} (boundary aligned with width).
+
+TestReflowChain_OriginWrappedCrossingGidMidRow
+// gid 5 (80 chars) + gid 6 (60 chars), width 50. rows=3.
+// origin[0]={5, 0}, origin[1]={5, 50}, origin[2]={6, 20}.
+
+TestReflowChain_OriginWithTrailingPaddingTrimmed
+// Trim affects rows count but not origins of remaining rows.
+
+TestReflowChain_OriginPositionalGap
+// rowHasPositionalGap path: 1 row, origin={start, 0}.
+
+TestReflowChain_OriginTrailingEmptyRows
+// Cursor on blank wrap continuations. Trailing empties get
+// origin={endGI, len(endGI_cells)} ("past content").
+```
+
+### Round-trip tests on `vterm.ViewportToContent` ↔ `ContentToViewport`
+
+These tests verify *agreement with the renderer*, not just inverse-of-self — the failure mode of the previous attempt was that the mapper's walk produced different answers than what was drawn.
+
+```go
+TestViewportContent_AgreesWithRenderedRowOrigin
+// For each row y, ViewportToContent(y, 0) must return exactly origin[y].
+// ContentToViewport(origin[y]) must return exactly y.
+
+TestViewportContent_RoundTripNonWrapped
+// Click (y, x) → (gid, col) → (y, x). All cells in the viewport.
+
+TestViewportContent_RoundTripWrappedChain
+// Same, on continuation rows AND mid-row gid boundaries.
+
+TestViewportContent_BlankRowFallsBackToNaive
+// Click on a blank gap row. origin == -1 → naive math returns
+// (visibleTop+y, x), preserving today's behavior.
+
+TestViewportContent_SelectionScrolledOffViewport
+// Endpoint outside the rendered window → ContentToViewport returns
+// visible=false. Highlight clamp logic in term.go handles painting.
+
+TestContentToViewport_AfterResize
+// Type 100-char line at width 80 (1 wrap). Resize to width 40
+// (2 wraps). The (gid, col) of a known character maps to the
+// correct new visual row+col.
+```
+
+### Integration test in `apps/texelterm`
+
+```go
+TestSelection_HighlightTracksWrappedContentAfterResize
+// Build a 200-char wrapped line, double-click on the second
+// wrapped row to select a word. Resize narrower (more wraps).
+// SelectionRange unchanged. ContentToViewport of the start
+// returns the row that now displays that word.
+```
+
+### Regression coverage
+
+These tests stay green with no changes:
+
+- `TestGetContentText_WrappedChainJoinsWithoutNewline`
+- `TestGetContentText_FaultsEvictedRowsFromPageStore`
+- `TestSelectionStateMachine_*`
+- All `TestClickDetector_*`
+
+## Out of scope
+
+- Pixel-level visual rendering tests (manual via the visual diff harness when needed).
+- Concurrent click-during-render correctness (lock model serializes; Go's `sync.RWMutex` provides the guarantee).
+- Pane-level composition (border, statusbar) — origin stays in vterm coords; the pane already shifts by border offset.
+- Optimizing `ContentToViewport`'s O(rows) scan into O(log rows). Premature given viewport heights ≤ ~100 rows.
+- Selection state representation changes (e.g., chain-relative coords). The existing `(gid, col)` representation is not the source of the bug.
+
+## Risks
+
+- **Origin slice goes stale between render and mapper call**. Mitigated by the `a.mu` lock that wraps both `Render` and `HandleMouse` in texelterm — they serialize. New code does not introduce additional concurrency.
+- **Sentinel `-1` mishandling**. Every `ContentToViewport` / `ViewportToContent` path checks the sentinel and falls back to naive math. Tested directly.
+- **Off-viewport endpoints**. `ContentToViewport` returns `visible=false`; the existing clamp branch in `applySelectionHighlightLocked` handles painting. Tested.
+- **Performance**. One concat-walk per chain at render time (already paid by `reflowChain` today; the origin-tracking is a parallel slice append, no extra scan). Mapper calls are O(rows) ≤ ~100, run twice per render frame at most.
+
+## Acceptance
+
+- All three test layers above pass.
+- The dropped agreement test (`TestViewportContent_AgreesWithRenderedRowIdx` from the reverted attempt) is resurrected as `TestViewportContent_AgreesWithRenderedRowOrigin` and passes.
+- Manual: select content that includes a wrap boundary, capture the text, resize the pane (wider, narrower, both). Selection highlight remains on the same logical cells. Captured text stays unchanged.
+- No regression on click-row → highlight-row for non-wrapped content.
+- Publisher behavior unchanged (server-side delta clipping still uses `RowGlobalIdx` chain-head semantics).

--- a/docs/superpowers/specs/2026-05-02-issue-224-wrap-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-224-wrap-highlight-design.md
@@ -173,17 +173,40 @@ Unchanged. Continues to use `RowGlobalIdx` (chain head) for delta clipping. Orig
 
 ## Sentinel choices
 
-| Row condition | `rowGI[y]` | `rowOrigin[y]` |
-|---|---|---|
-| Normal unwrapped row | `gi` | `(gi, 0)` |
-| Wrapped chain head row | chain head `gi` | `(gi, 0)` |
-| Wrapped continuation row | chain head `gi` | cell-bearing `(g, c)` |
-| Blank row in chain walk gap | `-1` | `(Gid: -1)` |
-| Bottom padding (viewport > content) | `-1` | `(Gid: -1)` |
-| Trailing empty in chain | chain head `gi` | `(endGI, len(endGI_cells))` |
-| Positional-gap one-row chain | `gi` | `(gi, 0)` |
+The renderer emits two parallel per-row slices, each serving a different consumer:
 
-`rowOrigin` and `rowGI` agree on `-1` for "no real content here" cases, so existing callers that already special-case `-1` keep working.
+- `rowGI[y]` — **chain identity**. The publisher uses it to clip server→client deltas: every reflowed sub-row of one logical line clips together. So all rows that belong to the same wrapped chain share the chain-head gid here, regardless of which gid actually owns the cells they display.
+- `rowOrigin[y]` — **cell location**. Selection uses it to map between viewport coords and store coords. Tracks the cell-bearing `(gid, col)` of the first cell on each row, distinct per visual row even within a wrapped chain.
+
+The two slices are designed to be co-emittable from a single chain walk; nothing has to be re-derived. They agree on a `-1` sentinel for "no real content here" so existing `rowGI == -1` callers don't need new logic.
+
+| # | Row condition | `rowGI[y]` | `rowOrigin[y]` |
+|---|---|---|---|
+| 1 | Normal unwrapped row | `gi` | `(gi, 0)` |
+| 2 | Wrapped chain head row | chain head `gi` | `(gi, 0)` |
+| 3 | Wrapped continuation row | chain head `gi` | cell-bearing `(g, c)` |
+| 4 | Blank row in chain walk gap | `-1` | `(Gid: -1)` |
+| 5 | Bottom padding (viewport > content) | `-1` | `(Gid: -1)` |
+| 6 | Trailing empty in chain | chain head `gi` | `(endGI, len(endGI_cells))` |
+| 7 | Positional-gap one-row chain | `gi` | `(gi, 0)` |
+
+Walking each case:
+
+**1. Normal unwrapped row.** A logical line that fits in viewport width: one gid renders as one visual row. Chain length is 1, so chain head = cell-bearing gid. `rowGI = gi`, `rowOrigin = (gi, 0)` — the row starts at col 0 of the gid.
+
+**2. Wrapped chain head row.** First row of a multi-row wrapped chain. The chain head gid is `gi` and this row displays cells starting at col 0 of `gi`. Both slices reflect that.
+
+**3. Wrapped continuation row.** A subsequent row in the same chain. The publisher still tags it with the chain head `gi` for clipping (the chain is one delta unit). But the cells displayed here actually live somewhere else — either further into `gi` (`(gi, K)` where `K = row × width`), or in `gi+1`, `gi+2`, etc. if the chain spans multiple gids. `rowOrigin` carries that cell-bearing position. **This is the row type the reverted attempt got wrong** — it treated `rowGI`'s chain head as a cell location.
+
+**4. Blank row in chain walk gap.** Inside the live write window, the user can erase a line via EL/ED. The renderer sees an empty gid, emits a blank row, increments. Neither chain identity nor cell location applies here, so both slices use `-1`. `ViewportToContent` falls back to naive math `(visibleTop + y, x)` on `-1` rows, which is what the pre-reflow code already did.
+
+**5. Bottom padding.** Viewport taller than the content currently rendered. Renderer fills the remaining rows with blanks. Same `-1` treatment as case 4.
+
+**6. Trailing empty in chain.** Cursor sits on a blank wrap continuation row — the user just typed past the wrap boundary but hasn't written any cell yet. The row IS part of the chain (chain identity), so `rowGI` is the chain head. But there's no cell at this position to point to, so `rowOrigin` parks at "just past the chain's last cell": `(endGI, len(endGI_cells))`. A click here resolves to `(endGI, len(endGI_cells) + x)`, which is past content; `selectAtom` finds no word and degenerates to a zero-width selection. Same UX as today.
+
+**7. Positional-gap one-row chain.** A row with unwritten cells in the middle, typically a powerline prompt that jumped via `ESC[500C ESC[17D` and wrote at col 89 with cols 0..88 still unwritten. `reflowChain` has a special path that renders this as exactly one row regardless of width (the gap stays). `rowGI = gi`, `rowOrigin = (gi, 0)` — clicks within the row map directly to cells in `gi`; cells in the gap region read as blanks.
+
+The cases that the reverted attempt confused are #2 vs #3: the previous code returned `rowGI` from `ViewportToContent`, which was correct for #2 (head row, where chain head and cell location coincide) but wrong for #3 (continuation rows). With the new `rowOrigin` slice, `ViewportToContent` returns the cell-bearing gid in both cases.
 
 ## Lock model
 


### PR DESCRIPTION
## Summary

- **Issue #224**: selection highlights drifted away from cells after a resize that re-wrapped lines. Fixed by threading a per-row `RowOrigin` slice from `reflowChain` through `view.Render` to `VTerm`, and rewriting `ContentToViewport` / `ViewportToContent` to walk wrap chains via `advanceCells` / `cellsBetween` against the cached origins. Result: round-trip mapping is stable across narrow→wide→narrow resizes for both wrapped and non-wrapped lines.
- **Follow-up fixes from live testing**: line selection (quadruple-click) no longer extends to the viewport bottom on chain-end rows, and drag-select on non-wrapped lines no longer pulls in trailing blank padding (commit `eb0a39f`).
- **Multi-click clipboard storm**: triple/quadruple-click was firing one OSC52 event per release, so the host terminal (ghostty) toasted "Content copied" two or three times per gesture. Multi-click releases now defer the clipboard write by `DefaultMultiClickTimeout`; subsequent presses inside the window cancel the pending write, so an N-click chain produces a single SetClipboard call (commit `31c15b0`). Single-drag still copies synchronously.

## Test plan

- [x] `go test ./apps/texelterm/... -count=1 -race` — all packages green
- [x] New `viewport_mapping_test.go` (14 tests) covers `advanceCells` chain-end guard, `ContentToViewport` exclusive-end-of-row, and rendered-grid agreement with `RowOrigin`
- [x] New `selection_wrap_resize_test.go` integration test drives `applySelectionHighlightLocked` across resize
- [x] New `mouse_coordinator_test.go` cases: chain collapses to one clipboard write, new press cancels pending, single-drag stays immediate, right-click cancels pending
- [x] Manual: drag-select, double/triple/quadruple-click on ghostty — single "Content copied" toast per gesture

🤖 Generated with [Claude Code](https://claude.com/claude-code)