### PR TITLE
Boot splash for cold-start bootstrap window (protocol v4)

### DIFF
--- a/client/cmd/texel-headless/main.go
+++ b/client/cmd/texel-headless/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	// Handle resume if requested.
 	if *sessionStr != "" || *lastSeq > 0 {
-		hdr, payload, err := simple.RequestResume(conn, sessionID, *lastSeq, nil)
+		hdr, payload, err := simple.RequestResume(conn, sessionID, *lastSeq, nil, nil)
 		if err != nil {
 			logger.Fatalf("resume request failed: %v", err)
 		}

--- a/client/simple_client.go
+++ b/client/simple_client.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net"
 	"time"
 
@@ -98,7 +99,14 @@ func (c *SimpleClient) Connect(sessionID *[16]byte) (*protocol.ConnectAccept, ne
 // header/payload. paneViewports carries per-pane scrollback state so the
 // server can re-seat each pane's ViewWindow at the client's saved position
 // (#199 Plan B). Pass nil or an empty slice for fresh-connect semantics.
-func (c *SimpleClient) RequestResume(conn net.Conn, sessionID [16]byte, sequence uint64, paneViewports []protocol.PaneViewportState) (protocol.Header, []byte, error) {
+//
+// onProgress, when non-nil, is invoked synchronously for each
+// MsgBootProgress the server emits between the request and the
+// response. Server-side resume processing can take many seconds when
+// it reloads scrollback from the WAL; without a callback the client
+// would block silently the whole time. nil-safe — passing nil
+// preserves the legacy "block until response" behaviour.
+func (c *SimpleClient) RequestResume(conn net.Conn, sessionID [16]byte, sequence uint64, paneViewports []protocol.PaneViewportState, onProgress func(string)) (protocol.Header, []byte, error) {
 	req := protocol.ResumeRequest{SessionID: sessionID, LastSequence: sequence, PaneViewports: paneViewports}
 	payload, err := protocol.EncodeResumeRequest(req)
 	if err != nil {
@@ -107,7 +115,29 @@ func (c *SimpleClient) RequestResume(conn net.Conn, sessionID [16]byte, sequence
 	if err := protocol.WriteMessage(conn, protocol.Header{Version: protocol.Version, Type: protocol.MsgResumeRequest, Flags: protocol.FlagChecksum, SessionID: sessionID}, payload); err != nil {
 		return protocol.Header{}, nil, err
 	}
-	return protocol.ReadMessage(conn)
+	for {
+		hdr, body, err := protocol.ReadMessage(conn)
+		if err != nil {
+			return hdr, body, err
+		}
+		if hdr.Type != protocol.MsgBootProgress {
+			return hdr, body, nil
+		}
+		bp, decErr := protocol.DecodeBootProgress(body)
+		if decErr != nil {
+			// Decode failure after the type byte already matched
+			// MsgBootProgress signals wire-format drift (server/
+			// client version skew, transport corruption). Skip the
+			// frame so a cosmetic message doesn't tank an otherwise-
+			// healthy resume, but log the breadcrumb — without it,
+			// "splash never updates" has no traceable cause.
+			log.Printf("simple-client: malformed MsgBootProgress payload: %v", decErr)
+			continue
+		}
+		if onProgress != nil {
+			onProgress(bp.Message)
+		}
+	}
 }
 
 // SaveTree saves the tree data to the server

--- a/client/simple_client_resume_test.go
+++ b/client/simple_client_resume_test.go
@@ -38,7 +38,7 @@ func TestRequestResume_EncodesPaneViewports(t *testing.T) {
 	}
 	// RequestResume returns an error because Read returns ErrClosed after the
 	// write. We only care about the bytes written.
-	_, _, err := c.RequestResume(conn, sessionID, 7, viewports)
+	_, _, err := c.RequestResume(conn, sessionID, 7, viewports, nil)
 	if err == nil {
 		t.Fatalf("expected read error after write, got nil")
 	}
@@ -86,7 +86,7 @@ func TestRequestResume_EmptyPaneViewports(t *testing.T) {
 	c := &SimpleClient{}
 	conn := &captureConn{}
 	sessionID := [16]byte{5}
-	_, _, err := c.RequestResume(conn, sessionID, 0, nil)
+	_, _, err := c.RequestResume(conn, sessionID, 0, nil, nil)
 	if err == nil {
 		t.Fatalf("expected read error, got nil")
 	}
@@ -108,5 +108,130 @@ func TestRequestResume_EmptyPaneViewports(t *testing.T) {
 	}
 	if len(req.PaneViewports) != 0 {
 		t.Fatalf("empty viewports: got %d want 0", len(req.PaneViewports))
+	}
+}
+
+// scriptedConn delivers a pre-encoded sequence of frames on Read in
+// order, then returns io.EOF. Writes are buffered so tests can also
+// inspect what RequestResume sent. Used to drive the progress-loop
+// path: server emits N MsgBootProgress messages then a non-progress
+// reply (MsgTreeSnapshot here), and we verify (a) every progress
+// message reached onProgress in order and (b) the non-progress reply
+// is what RequestResume returns.
+type scriptedConn struct {
+	out      bytes.Buffer
+	readBuf  bytes.Buffer
+	deadline time.Time
+}
+
+func newScriptedConn(frames [][]byte) *scriptedConn {
+	c := &scriptedConn{}
+	for _, f := range frames {
+		c.readBuf.Write(f)
+	}
+	return c
+}
+
+func (c *scriptedConn) Read(p []byte) (int, error) {
+	if c.readBuf.Len() == 0 {
+		return 0, net.ErrClosed
+	}
+	return c.readBuf.Read(p)
+}
+func (c *scriptedConn) Write(p []byte) (int, error)        { return c.out.Write(p) }
+func (c *scriptedConn) Close() error                       { return nil }
+func (c *scriptedConn) LocalAddr() net.Addr                { return nil }
+func (c *scriptedConn) RemoteAddr() net.Addr               { return nil }
+func (c *scriptedConn) SetDeadline(t time.Time) error      { return nil }
+func (c *scriptedConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *scriptedConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// frameMessage encodes a header + payload in the framing protocol.WriteMessage uses.
+func frameMessage(t *testing.T, msgType protocol.MessageType, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	hdr := protocol.Header{Version: protocol.Version, Type: msgType, Flags: protocol.FlagChecksum}
+	if err := protocol.WriteMessage(&buf, hdr, payload); err != nil {
+		t.Fatalf("frameMessage: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestRequestResume_ProgressLoopForwardsAndReturnsResponse(t *testing.T) {
+	// Scripted server: two MsgBootProgress frames followed by a
+	// MsgTreeSnapshot. RequestResume must forward both progress
+	// messages to onProgress (in order) and return the tree
+	// snapshot as the response.
+	progPayload1, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: "Validating session…"})
+	if err != nil {
+		t.Fatalf("encode progress 1: %v", err)
+	}
+	progPayload2, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: "Restoring pane 1 of 3…"})
+	if err != nil {
+		t.Fatalf("encode progress 2: %v", err)
+	}
+	snapPayload, err := protocol.EncodeTreeSnapshot(protocol.TreeSnapshot{})
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+
+	frames := [][]byte{
+		frameMessage(t, protocol.MsgBootProgress, progPayload1),
+		frameMessage(t, protocol.MsgBootProgress, progPayload2),
+		frameMessage(t, protocol.MsgTreeSnapshot, snapPayload),
+	}
+	conn := newScriptedConn(frames)
+
+	c := &SimpleClient{}
+	var got []string
+	hdr, body, err := c.RequestResume(conn, [16]byte{1}, 0, nil, func(m string) {
+		got = append(got, m)
+	})
+	if err != nil {
+		t.Fatalf("RequestResume: %v", err)
+	}
+	if hdr.Type != protocol.MsgTreeSnapshot {
+		t.Fatalf("response type: got %v, want MsgTreeSnapshot", hdr.Type)
+	}
+	if len(body) == 0 {
+		t.Error("response body is empty")
+	}
+	want := []string{"Validating session…", "Restoring pane 1 of 3…"}
+	if len(got) != len(want) {
+		t.Fatalf("forwarded %d progress messages, want %d: %#v", len(got), len(want), got)
+	}
+	for i, m := range want {
+		if got[i] != m {
+			t.Errorf("progress[%d]: got %q want %q", i, got[i], m)
+		}
+	}
+}
+
+func TestRequestResume_ProgressLoopNilCallbackStillDrains(t *testing.T) {
+	// When onProgress is nil, RequestResume must still drain
+	// progress frames (otherwise the response would never be
+	// reached). The actual behaviour should be: skip the frame and
+	// keep reading.
+	progPayload, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: "Validating session…"})
+	if err != nil {
+		t.Fatalf("encode progress: %v", err)
+	}
+	snapPayload, err := protocol.EncodeTreeSnapshot(protocol.TreeSnapshot{})
+	if err != nil {
+		t.Fatalf("encode snapshot: %v", err)
+	}
+	frames := [][]byte{
+		frameMessage(t, protocol.MsgBootProgress, progPayload),
+		frameMessage(t, protocol.MsgTreeSnapshot, snapPayload),
+	}
+	conn := newScriptedConn(frames)
+
+	c := &SimpleClient{}
+	hdr, _, err := c.RequestResume(conn, [16]byte{1}, 0, nil, nil)
+	if err != nil {
+		t.Fatalf("RequestResume: %v", err)
+	}
+	if hdr.Type != protocol.MsgTreeSnapshot {
+		t.Errorf("response type: got %v, want MsgTreeSnapshot", hdr.Type)
 	}
 }

--- a/cmd/texel-stress/main.go
+++ b/cmd/texel-stress/main.go
@@ -181,7 +181,7 @@ func runSession(ctx context.Context, metrics *stressMetrics, socket string, mess
 		}
 		_ = accept
 
-		hdr, payload, err := simple.RequestResume(conn, sessionID, lastSeq, nil)
+		hdr, payload, err := simple.RequestResume(conn, sessionID, lastSeq, nil, nil)
 		if err != nil {
 			metrics.recordError(err)
 			_ = conn.Close()

--- a/cmd/texelation/boot/boot.go
+++ b/cmd/texelation/boot/boot.go
@@ -1,0 +1,309 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/boot.go
+// Summary: Pre-connect splash that owns the tcell screen during the
+// supervisor + handshake window.
+
+// Package boot renders a status splash on a pre-initialized tcell
+// screen while the texelation supervisor brings the server up and the
+// client runtime negotiates its handshake. The splash is intentionally
+// simple — no widget tree, no theming, no input handling — because
+// step 1 just needs to fill the dead air during a cold-start WAL
+// replay (10s+ in the wild) with something legible. Plan F will grow
+// this surface into a session picker; the runner already accepts an
+// externally-owned screen so the upgrade can swap the App without
+// touching the bootstrap.
+package boot
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	uicolor "github.com/framegrace/texelui/color"
+)
+
+// Stage names a step in the bootstrap pipeline. Stage strings are
+// rendered verbatim under the title, so keep them short and stable.
+type Stage string
+
+const (
+	StageStarting   Stage = "Starting server"
+	StageWaiting    Stage = "Waiting for server"
+	StageConnecting Stage = "Connecting"
+	StageResuming   Stage = "Loading session"
+	StageReady      Stage = "Ready"
+	StageError      Stage = "Error"
+)
+
+// App is the splash render model. It is safe for concurrent reads
+// (Render) and writes (SetStage / SetDetail) under its own mutex.
+//
+// App does not satisfy core.App from texelui — it is deliberately
+// lighter so we can avoid pulling in the widget machinery for the
+// pre-connect window. Plan F will likely promote this to a real
+// texelui App when the session-picker list widget comes online.
+type App struct {
+	mu        sync.RWMutex
+	title     string
+	stage     Stage
+	detail    string
+	startedAt time.Time
+	width     int
+	height    int
+}
+
+// New returns a splash app showing the given window title (used as the
+// box header). The first stage is rendered as soon as Render is called.
+func New(title string) *App {
+	return &App{
+		title:     title,
+		stage:     StageStarting,
+		startedAt: time.Now(),
+	}
+}
+
+// SetStage updates the headline status. It clears the detail line so a
+// stale "(connect failed)" from a previous stage does not leak into
+// the new one.
+func (a *App) SetStage(s Stage) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stage = s
+	a.detail = ""
+}
+
+// SetDetail attaches a sub-line to the current stage. Use it for
+// transient context that wouldn't earn its own Stage constant —
+// "(2/3 panes)" during resume, an error string, etc.
+func (a *App) SetDetail(detail string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.detail = detail
+}
+
+// Detail returns the current detail line. Exposed for tests.
+func (a *App) Detail() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.detail
+}
+
+// Stage returns the current stage. Exposed for tests + the runner so
+// the runner can decide when to stop without holding a render lock.
+func (a *App) Stage() Stage {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.stage
+}
+
+// SetSize updates the canvas dimensions. The runner calls this on
+// every resize event; tests call it directly.
+func (a *App) SetSize(w, h int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.width = w
+	a.height = h
+}
+
+// Frame holds a renderable splash frame: parallel rune + style grids,
+// always identical in shape (height rows × width cols). The runner
+// pushes them straight into screen.SetContent.
+type Frame struct {
+	Width  int
+	Height int
+	Runes  [][]rune
+	Styles [][]tcell.Style
+}
+
+// RenderFrame produces the current splash frame. Returns a zero-sized
+// Frame if the canvas is not yet sized (caller should skip the paint).
+func (a *App) RenderFrame() Frame {
+	a.mu.RLock()
+	w, h := a.width, a.height
+	title := a.title
+	stage := string(a.stage)
+	detail := a.detail
+	elapsed := time.Since(a.startedAt)
+	a.mu.RUnlock()
+
+	if w <= 0 || h <= 0 {
+		return Frame{}
+	}
+
+	frame := Frame{Width: w, Height: h}
+	frame.Runes = make([][]rune, h)
+	frame.Styles = make([][]tcell.Style, h)
+	bg := tcell.StyleDefault
+	for y := 0; y < h; y++ {
+		frame.Runes[y] = make([]rune, w)
+		frame.Styles[y] = make([]tcell.Style, w)
+		for x := 0; x < w; x++ {
+			frame.Runes[y][x] = ' '
+			frame.Styles[y][x] = bg
+		}
+	}
+
+	// Box geometry. The status text drives the inner width.
+	// minInnerW = 36 keeps the outer box ≥ 40 cols (4 cols of border +
+	// padding wrap the inner area), giving a padded title room to fit;
+	// the upper bound is the canvas minus 4 cols of outside margin.
+	const minInnerW = 36
+	innerW := minInnerW
+	if l := len(stage); l > innerW {
+		innerW = l
+	}
+	if l := len(detail); l > innerW {
+		innerW = l
+	}
+	if l := len(title); l > innerW {
+		innerW = l
+	}
+	if maxInner := w - 4; maxInner > 0 && innerW > maxInner {
+		innerW = maxInner
+	}
+	if innerW < 1 {
+		return frame
+	}
+
+	// 5 inner rows: title, blank, stage, detail, elapsed. Detail is
+	// always reserved (rendered blank when empty) so the layout doesn't
+	// jitter between stages with and without detail text.
+	innerH := 5
+	boxW := innerW + 4 // border + padding on each side
+	boxH := innerH + 2 // top/bottom border
+	if boxW > w {
+		boxW = w
+	}
+	if boxH > h {
+		boxH = h
+	}
+	x0 := (w - boxW) / 2
+	y0 := (h - boxH) / 2
+
+	boxStyle := tcell.StyleDefault
+	titleStyle := tcell.StyleDefault.Bold(true)
+	// Pulse the stage text to convey "this is alive, still working"
+	// during long waits like the cold-start WAL replay — see
+	// stagePulse for the rate / brightness range. Error and Ready
+	// stay static since they're terminal states and a breathing
+	// red/green would read agitated rather than steady.
+	stageStyle := tcell.StyleDefault.Foreground(stagePulse(elapsed)).Bold(true)
+	detailStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	elapsedStyle := tcell.StyleDefault.Foreground(tcell.ColorGray).Dim(true)
+	if stage == string(StageError) {
+		stageStyle = tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
+		detailStyle = tcell.StyleDefault.Foreground(tcell.ColorRed)
+	}
+	if stage == string(StageReady) {
+		stageStyle = tcell.StyleDefault.Foreground(tcell.ColorGreen).Bold(true)
+	}
+
+	// Box border. tcell line-drawing runes; Style() picks them up
+	// regardless of theme.
+	drawHLine := func(y, x1, x2 int, style tcell.Style) {
+		for x := x1; x <= x2; x++ {
+			if y < 0 || y >= h || x < 0 || x >= w {
+				continue
+			}
+			frame.Runes[y][x] = tcell.RuneHLine
+			frame.Styles[y][x] = style
+		}
+	}
+	drawVLine := func(x, y1, y2 int, style tcell.Style) {
+		for y := y1; y <= y2; y++ {
+			if y < 0 || y >= h || x < 0 || x >= w {
+				continue
+			}
+			frame.Runes[y][x] = tcell.RuneVLine
+			frame.Styles[y][x] = style
+		}
+	}
+	setRune := func(y, x int, r rune, style tcell.Style) {
+		if y < 0 || y >= h || x < 0 || x >= w {
+			return
+		}
+		frame.Runes[y][x] = r
+		frame.Styles[y][x] = style
+	}
+
+	x1 := x0 + boxW - 1
+	y1 := y0 + boxH - 1
+	drawHLine(y0, x0+1, x1-1, boxStyle)
+	drawHLine(y1, x0+1, x1-1, boxStyle)
+	drawVLine(x0, y0+1, y1-1, boxStyle)
+	drawVLine(x1, y0+1, y1-1, boxStyle)
+	setRune(y0, x0, tcell.RuneULCorner, boxStyle)
+	setRune(y0, x1, tcell.RuneURCorner, boxStyle)
+	setRune(y1, x0, tcell.RuneLLCorner, boxStyle)
+	setRune(y1, x1, tcell.RuneLRCorner, boxStyle)
+
+	contentLeft := x0 + 2
+	contentRight := x1 - 2
+
+	drawCenteredText := func(y int, text string, style tcell.Style) {
+		if y < 0 || y >= h {
+			return
+		}
+		runes := []rune(text)
+		room := contentRight - contentLeft + 1
+		if room <= 0 {
+			return
+		}
+		if len(runes) > room {
+			runes = runes[:room]
+		}
+		start := contentLeft + (room-len(runes))/2
+		for i, r := range runes {
+			setRune(y, start+i, r, style)
+		}
+	}
+
+	// Inner row layout (relative to y0+1):
+	//   0: title
+	//   1: blank
+	//   2: stage
+	//   3: detail
+	//   4: elapsed
+	drawCenteredText(y0+1, title, titleStyle)
+	drawCenteredText(y0+3, stage, stageStyle)
+	drawCenteredText(y0+4, detail, detailStyle)
+
+	elapsedText := formatElapsed(elapsed)
+	drawCenteredText(y0+5, elapsedText, elapsedStyle)
+
+	return frame
+}
+
+// stagePulse resolves the texelui Pulse DynamicColor at elapsed time,
+// returning a concrete tcell.Color the splash can paint. Base color
+// is a soft cyan; the brightness scales between 0.55 and 1.10 at
+// 3 Hz (~333ms cycle) — fast enough to read clearly as motion
+// without crossing the line into nervous flicker.
+func stagePulse(elapsed time.Duration) tcell.Color {
+	dc := uicolor.Pulse(tcell.NewRGBColor(140, 220, 250), 0.55, 1.10, 3.0)
+	return dc.Resolve(uicolor.ColorContext{T: float32(elapsed.Seconds())})
+}
+
+// formatElapsed renders a duration as "(0.4s)" / "(12s)" / "(1m 04s)"
+// — short enough to fit a 36-column box, precise enough to convey
+// "is the bootstrap actually progressing?" during a cold start.
+func formatElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Second:
+		tenths := int(d / (100 * time.Millisecond))
+		return fmt.Sprintf("(0.%ds)", tenths)
+	case d < time.Minute:
+		return fmt.Sprintf("(%ds)", int(d/time.Second))
+	default:
+		mins := int(d / time.Minute)
+		secs := int((d % time.Minute) / time.Second)
+		return fmt.Sprintf("(%dm %02ds)", mins, secs)
+	}
+}

--- a/cmd/texelation/boot/boot_test.go
+++ b/cmd/texelation/boot/boot_test.go
@@ -1,0 +1,167 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// rowToString flattens a row of runes into a string for equality checks.
+func rowToString(row []rune) string {
+	return string(row)
+}
+
+// findCenteredText locates the first row that contains text. Used to
+// confirm the splash actually wrote our status string somewhere on the
+// canvas without baking specific row coordinates into the test (which
+// would couple to box geometry).
+func findCenteredText(frame Frame, needle string) (row int, ok bool) {
+	for y, runes := range frame.Runes {
+		if strings.Contains(rowToString(runes), needle) {
+			return y, true
+		}
+	}
+	return -1, false
+}
+
+func TestApp_RenderFrame_DimensionsMatch(t *testing.T) {
+	a := New("Texelation")
+	a.SetSize(80, 24)
+	frame := a.RenderFrame()
+
+	if frame.Width != 80 || frame.Height != 24 {
+		t.Fatalf("frame size mismatch: got %dx%d, want 80x24", frame.Width, frame.Height)
+	}
+	if len(frame.Runes) != 24 || len(frame.Styles) != 24 {
+		t.Fatalf("frame row counts mismatch: runes=%d styles=%d", len(frame.Runes), len(frame.Styles))
+	}
+	for y := 0; y < frame.Height; y++ {
+		if got := len(frame.Runes[y]); got != 80 {
+			t.Errorf("row %d rune width: got %d, want 80", y, got)
+		}
+		if got := len(frame.Styles[y]); got != 80 {
+			t.Errorf("row %d style width: got %d, want 80", y, got)
+		}
+	}
+}
+
+func TestApp_RenderFrame_ZeroSizeReturnsEmpty(t *testing.T) {
+	a := New("Texelation")
+	frame := a.RenderFrame()
+	if frame.Width != 0 || frame.Height != 0 {
+		t.Fatalf("expected zero-size frame, got %dx%d", frame.Width, frame.Height)
+	}
+	if frame.Runes != nil || frame.Styles != nil {
+		t.Errorf("expected nil grids on zero-size frame")
+	}
+}
+
+func TestApp_RenderFrame_TitleAndStageAppear(t *testing.T) {
+	a := New("Texelation")
+	a.SetSize(80, 24)
+	a.SetStage(StageStarting)
+	frame := a.RenderFrame()
+
+	if _, ok := findCenteredText(frame, "Texelation"); !ok {
+		t.Errorf("expected title 'Texelation' on canvas")
+	}
+	if _, ok := findCenteredText(frame, string(StageStarting)); !ok {
+		t.Errorf("expected stage %q on canvas", StageStarting)
+	}
+}
+
+func TestApp_RenderFrame_DetailAppearsBelowStage(t *testing.T) {
+	a := New("Texelation")
+	a.SetSize(80, 24)
+	a.SetStage(StageResuming)
+	a.SetDetail("2/3 panes")
+	frame := a.RenderFrame()
+
+	stageRow, ok := findCenteredText(frame, string(StageResuming))
+	if !ok {
+		t.Fatalf("stage missing")
+	}
+	detailRow, ok := findCenteredText(frame, "2/3 panes")
+	if !ok {
+		t.Fatalf("detail missing")
+	}
+	if detailRow != stageRow+1 {
+		t.Errorf("detail row %d should be directly below stage row %d", detailRow, stageRow)
+	}
+}
+
+func TestApp_SetStage_ClearsDetail(t *testing.T) {
+	a := New("Texelation")
+	a.SetSize(80, 24)
+	a.SetStage(StageStarting)
+	a.SetDetail("transient")
+	a.SetStage(StageConnecting)
+
+	frame := a.RenderFrame()
+	if _, ok := findCenteredText(frame, "transient"); ok {
+		t.Errorf("stale detail leaked into next stage")
+	}
+}
+
+func TestApp_RenderFrame_NarrowCanvasFitsInsideBox(t *testing.T) {
+	a := New("Texelation server")
+	a.SetSize(20, 10)
+	frame := a.RenderFrame()
+
+	if frame.Width != 20 || frame.Height != 10 {
+		t.Fatalf("frame %dx%d", frame.Width, frame.Height)
+	}
+	for y, row := range frame.Runes {
+		if len(row) != 20 {
+			t.Errorf("row %d width drift: %d", y, len(row))
+		}
+	}
+}
+
+func TestApp_RenderFrame_ErrorStageStyledRed(t *testing.T) {
+	a := New("Texelation")
+	a.SetSize(80, 24)
+	a.SetStage(StageError)
+	a.SetDetail("connect refused")
+	frame := a.RenderFrame()
+
+	row, ok := findCenteredText(frame, string(StageError))
+	if !ok {
+		t.Fatalf("error stage text missing")
+	}
+	rowText := rowToString(frame.Runes[row])
+	idx := strings.Index(rowText, string(StageError))
+	if idx < 0 {
+		t.Fatalf("could not locate stage text within row")
+	}
+	style := frame.Styles[row][idx]
+	fg, _, _ := style.Decompose()
+	// We don't assert the exact RGB triple, just confirm the error
+	// path picked a non-default foreground so the user can see
+	// something happened — exact values are an implementation
+	// detail of stagePulse / the error-stage style.
+	if fg == 0 {
+		t.Errorf("expected error stage to set a foreground color, got default")
+	}
+}
+
+func TestApp_FormatElapsed(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{0, "(0.0s)"},
+		{400 * time.Millisecond, "(0.4s)"},
+		{12 * time.Second, "(12s)"},
+		{75 * time.Second, "(1m 15s)"},
+		{63*time.Second + 500*time.Millisecond, "(1m 03s)"},
+	}
+	for _, tc := range cases {
+		if got := formatElapsed(tc.d); got != tc.want {
+			t.Errorf("formatElapsed(%v): got %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}

--- a/cmd/texelation/boot/runner.go
+++ b/cmd/texelation/boot/runner.go
@@ -1,0 +1,223 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/runner.go
+// Summary: Paints a boot.App to an externally-owned tcell screen.
+
+package boot
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// defaultRefreshInterval drives the splash repaint cadence. The splash
+// has no event polling of its own — resizes get noticed lazily on the
+// next tick and the elapsed-time line ticks once per second-ish — so a
+// short interval is required for the UI to feel alive without pegging
+// CPU. 100ms means at most ~10 frames per second of ANSI flushing
+// during the bootstrap window, well under what tcell can sustain.
+const defaultRefreshInterval = 100 * time.Millisecond
+
+// Runner drives a boot.App against an externally-managed tcell.Screen.
+// The screen MUST be initialized before Start is called and MUST NOT
+// be Fini'd while the runner is active. Stop() returns once the paint
+// goroutine has exited; the caller can then hand the screen off to
+// the production renderer without flicker.
+type Runner struct {
+	screen tcell.Screen
+	app    *App
+	tick   time.Duration
+
+	wakeMu  sync.Mutex
+	wakeCh  chan struct{} // buffered(1); coalesced wake-up signal
+	stopCh  chan struct{}
+	doneCh  chan struct{} // closed when the paint goroutine exits
+	pollCh  chan struct{} // closed when the event-drain goroutine exits
+	started bool
+
+	// paintMu serializes paint() against external readers (mainly
+	// tests). tcell SimulationScreen's GetContents is not safe to call
+	// concurrently with an in-flight Show, so we gate them here. The
+	// production path (Stop → handoff to clientrt) doesn't need this —
+	// after Stop returns there is no concurrent paint left to race —
+	// but tests legitimately want to read mid-flight.
+	paintMu sync.Mutex
+}
+
+// NewRunner constructs a runner. The screen must be initialized.
+func NewRunner(screen tcell.Screen, app *App) *Runner {
+	return &Runner{
+		screen: screen,
+		app:    app,
+		tick:   defaultRefreshInterval,
+		wakeCh: make(chan struct{}, 1),
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+		pollCh: make(chan struct{}),
+	}
+}
+
+// Start spins up the paint and event-drain goroutines. It is
+// idempotent; repeated calls after the first are no-ops, so callers
+// can defer Stop without worrying about double-Start.
+//
+// The event-drain goroutine is load-bearing: tcell's tscreen flushes
+// pending output via PostEvent / PollEvent cycles, so a screen that
+// nobody polls quietly stops repainting after the first frame. We
+// drop events during the splash window — the user has nothing
+// meaningful to do while the server hydrates, and any keystrokes
+// queued here would be lost on handoff anyway. clientrt.Run starts
+// its own poll loop after Stop returns.
+func (r *Runner) Start() {
+	r.wakeMu.Lock()
+	if r.started {
+		r.wakeMu.Unlock()
+		return
+	}
+	r.started = true
+	r.wakeMu.Unlock()
+
+	go r.loop()
+	go r.drainEvents()
+}
+
+// Wake nudges the paint goroutine to repaint immediately. Call after
+// SetStage / SetDetail so the user sees the new status without
+// waiting for the next tick. Wakes are coalesced — many calls between
+// two paints produce one paint.
+func (r *Runner) Wake() {
+	select {
+	case r.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+// Stop signals the paint and poll goroutines to exit and blocks
+// until they have. Safe to call multiple times AND from concurrent
+// goroutines — the close-once is gated by wakeMu, so two callers
+// hitting the racy "select default → close" pattern can't both
+// fire close on an already-closed channel. After Stop returns the
+// screen is no longer being touched by the runner; the caller may
+// hand it off.
+func (r *Runner) Stop() {
+	r.wakeMu.Lock()
+	if !r.started {
+		r.wakeMu.Unlock()
+		return
+	}
+	alreadyClosed := false
+	select {
+	case <-r.stopCh:
+		alreadyClosed = true
+	default:
+		close(r.stopCh)
+	}
+	r.wakeMu.Unlock()
+
+	// Wake the poll goroutine out of its blocking PollEvent call.
+	// PostEvent is non-blocking; on success the next PollEvent
+	// returns the interrupt and the goroutine notices stopCh closed.
+	if !alreadyClosed && r.screen != nil {
+		_ = r.screen.PostEvent(tcell.NewEventInterrupt(nil))
+	}
+	<-r.doneCh
+	<-r.pollCh
+}
+
+func (r *Runner) loop() {
+	defer close(r.doneCh)
+
+	ticker := time.NewTicker(r.tick)
+	defer ticker.Stop()
+
+	r.paint()
+
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ticker.C:
+			r.paint()
+		case <-r.wakeCh:
+			r.paint()
+		}
+	}
+}
+
+// drainEvents reads tcell events for the duration of the splash and
+// discards them. tcell needs PollEvent to be serviced for the screen
+// driver to keep flushing buffered output — without a reader the
+// driver stalls after the first frame. Resize events are absorbed
+// implicitly: paint() reads screen.Size() each tick, so the next
+// paint reflects the new dimensions even though we drop the event.
+func (r *Runner) drainEvents() {
+	defer close(r.pollCh)
+	for {
+		ev := r.screen.PollEvent()
+		if ev == nil {
+			// Screen was Fini'd. Should not happen during the splash
+			// — main keeps the screen alive across Stop — but if it
+			// ever does, log a breadcrumb. Without one the symptom
+			// (frozen splash on real terminals, since tscreen needs
+			// PollEvent to keep flushing) has no traceable cause.
+			log.Printf("boot.Runner: drainEvents got nil PollEvent (screen Fini'd?); splash will stop repainting")
+			return
+		}
+		select {
+		case <-r.stopCh:
+			return
+		default:
+		}
+	}
+}
+
+// paint reads the current canvas size, asks the App for a frame, and
+// flushes it to the screen. Skips the flush when the screen is not
+// yet sized (size=(0,0) right after Init on some terminals).
+//
+// We use Sync() rather than Show() for the splash repaint. Show()
+// emits a diff against tcell's last known cell buffer; the splash
+// has been observed to "stick" on the first frame on real terminals
+// (Ghostty in particular) — likely because the diff layer thinks
+// nothing meaningful changed even though the foreground colour did.
+// Sync() invalidates the cell cache and forces a full redraw, which
+// is fine here because the splash repaints at 10fps over a small
+// box and the cost is negligible compared to a TUI's full screen.
+func (r *Runner) paint() {
+	if r.screen == nil || r.app == nil {
+		return
+	}
+	r.paintMu.Lock()
+	defer r.paintMu.Unlock()
+	w, h := r.screen.Size()
+	if w <= 0 || h <= 0 {
+		return
+	}
+	r.app.SetSize(w, h)
+	frame := r.app.RenderFrame()
+	if frame.Width == 0 || frame.Height == 0 {
+		return
+	}
+	r.screen.Clear()
+	for y := 0; y < frame.Height; y++ {
+		row := frame.Runes[y]
+		styles := frame.Styles[y]
+		for x := 0; x < frame.Width; x++ {
+			r.screen.SetContent(x, y, row[x], nil, styles[x])
+		}
+	}
+	r.screen.Sync()
+}
+
+// withPaintLock runs fn with the paint mutex held, blocking any
+// concurrent in-flight paint. Tests use this to safely read the
+// simulation screen mid-run; production callers don't need it.
+func (r *Runner) withPaintLock(fn func()) {
+	r.paintMu.Lock()
+	defer r.paintMu.Unlock()
+	fn()
+}

--- a/cmd/texelation/boot/runner_test.go
+++ b/cmd/texelation/boot/runner_test.go
@@ -1,0 +1,164 @@
+// Copyright © 2025 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// newSimScreen returns an initialized tcell SimulationScreen sized for
+// the test. Caller must Fini() in cleanup. Sized at 80x24 to match
+// the splash's default geometry assumptions.
+func newSimScreen(t *testing.T) tcell.SimulationScreen {
+	t.Helper()
+	scr := tcell.NewSimulationScreen("UTF-8")
+	if err := scr.Init(); err != nil {
+		t.Fatalf("init sim screen: %v", err)
+	}
+	scr.SetSize(80, 24)
+	t.Cleanup(scr.Fini)
+	return scr
+}
+
+// readScreenAsText flattens the simulation screen's rendered cells
+// into row strings. Used to confirm Wake() actually drove a paint.
+// The runner argument is required so we can take its paint lock —
+// concurrent draw + GetContents on tcell.SimulationScreen is racy.
+// The cell slice returned by GetContents aliases the simscreen's
+// internal buffer, so the entire read MUST happen inside the lock —
+// releasing it and then iterating produces a use-after-mutate race.
+func readScreenAsText(t *testing.T, scr tcell.SimulationScreen, r *Runner) []string {
+	t.Helper()
+	var rows []string
+	r.withPaintLock(func() {
+		cells, w, h := scr.GetContents()
+		if len(cells) != w*h {
+			t.Fatalf("sim screen contents shape: got %d cells for %dx%d", len(cells), w, h)
+		}
+		rows = make([]string, h)
+		var b strings.Builder
+		for y := 0; y < h; y++ {
+			b.Reset()
+			for x := 0; x < w; x++ {
+				c := cells[y*w+x]
+				if len(c.Runes) == 0 {
+					b.WriteRune(' ')
+					continue
+				}
+				b.WriteRune(c.Runes[0])
+			}
+			rows[y] = b.String()
+		}
+	})
+	return rows
+}
+
+// containsRow reports whether any row contains needle. Used so tests
+// don't bake the box's exact y-coordinate into assertions.
+func containsRow(rows []string, needle string) bool {
+	for _, r := range rows {
+		if strings.Contains(r, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRunner_PaintsInitialFrameOnStart(t *testing.T) {
+	scr := newSimScreen(t)
+	app := New("Texelation")
+	app.SetStage(StageStarting)
+
+	r := NewRunner(scr, app)
+	r.Start()
+	defer r.Stop()
+
+	// The first paint runs synchronously from the loop goroutine; give
+	// it a beat to land on the simulated screen.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows := readScreenAsText(t, scr, r)
+		if containsRow(rows, "Texelation") && containsRow(rows, string(StageStarting)) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	rows := readScreenAsText(t, scr, r)
+	t.Fatalf("initial paint missing title or stage. rows:\n%s", strings.Join(rows, "\n"))
+}
+
+func TestRunner_WakeRepaintsAfterStageChange(t *testing.T) {
+	scr := newSimScreen(t)
+	app := New("Texelation")
+	app.SetStage(StageStarting)
+
+	r := NewRunner(scr, app)
+	r.Start()
+	defer r.Stop()
+
+	// Wait for initial paint.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if containsRow(readScreenAsText(t, scr, r), string(StageStarting)) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	app.SetStage(StageConnecting)
+	r.Wake()
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		rows := readScreenAsText(t, scr, r)
+		if containsRow(rows, string(StageConnecting)) && !containsRow(rows, string(StageStarting)) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	rows := readScreenAsText(t, scr, r)
+	t.Fatalf("Wake did not produce a stage update. rows:\n%s", strings.Join(rows, "\n"))
+}
+
+func TestRunner_StopReturnsCleanly(t *testing.T) {
+	scr := newSimScreen(t)
+	app := New("Texelation")
+	r := NewRunner(scr, app)
+	r.Start()
+
+	done := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return within 2s")
+	}
+}
+
+func TestRunner_StopIdempotent(t *testing.T) {
+	scr := newSimScreen(t)
+	app := New("Texelation")
+	r := NewRunner(scr, app)
+	r.Start()
+	r.Stop()
+	// Second Stop must not panic or block.
+	r.Stop()
+}
+
+func TestRunner_StartIdempotent(t *testing.T) {
+	scr := newSimScreen(t)
+	app := New("Texelation")
+	r := NewRunner(scr, app)
+	r.Start()
+	r.Start() // second call must not spawn a second goroutine
+	r.Stop()
+}

--- a/cmd/texelation/lifecycle/supervisor.go
+++ b/cmd/texelation/lifecycle/supervisor.go
@@ -28,12 +28,21 @@ type Supervisor struct {
 	pidFile       PIDFile
 	startupWait   time.Duration
 	healthTimeout time.Duration
+	reporter      func(message string)
 }
 
 // SupervisorConfig configures the supervisor
 type SupervisorConfig struct {
 	StartupWait   time.Duration // How long to wait for server to become healthy after start
 	HealthTimeout time.Duration // Timeout for health checks
+
+	// Reporter, when set, replaces the supervisor's default
+	// fmt.Println for human-readable progress messages ("Starting
+	// texelation server...", "Cleaning up stale PID file..."). The
+	// boot splash uses this to surface those messages inside the
+	// splash dialog instead of corrupting the tcell-owned screen.
+	// nil-safe: default behavior is fmt.Println on stdout.
+	Reporter func(message string)
 }
 
 // DefaultSupervisorConfig returns sensible defaults
@@ -52,12 +61,17 @@ func NewSupervisor(daemon DaemonManager, health HealthChecker, pidFile PIDFile, 
 	if config.HealthTimeout == 0 {
 		config.HealthTimeout = 2 * time.Second
 	}
+	reporter := config.Reporter
+	if reporter == nil {
+		reporter = func(msg string) { fmt.Println(msg) }
+	}
 	return &Supervisor{
 		daemon:        daemon,
 		health:        health,
 		pidFile:       pidFile,
 		startupWait:   config.StartupWait,
 		healthTimeout: config.HealthTimeout,
+		reporter:      reporter,
 	}
 }
 
@@ -82,7 +96,7 @@ func (s *Supervisor) EnsureRunning(ctx context.Context, opts ServerOptions) (*St
 
 	case StateUnresponsive:
 		// Server is hung - force restart
-		fmt.Printf("Server is unresponsive (PID %d), restarting...\n", s.daemon.GetPID())
+		s.reporter(fmt.Sprintf("Server is unresponsive (PID %d), restarting...", s.daemon.GetPID()))
 		if err := s.daemon.Restart(ctx, opts); err != nil {
 			return nil, fmt.Errorf("restart unresponsive server: %w", err)
 		}
@@ -91,13 +105,13 @@ func (s *Supervisor) EnsureRunning(ctx context.Context, opts ServerOptions) (*St
 
 	case StateStale:
 		// PID file exists but process is gone - clean up and start
-		fmt.Println("Cleaning up stale PID file...")
+		s.reporter("Cleaning up stale PID file...")
 		s.pidFile.Remove()
 		fallthrough
 
 	case StateStopped, StateUnknown:
 		// Server not running - start it
-		fmt.Println("Starting texelation server...")
+		s.reporter("Starting texelation server...")
 		if err := s.daemon.Start(ctx, opts); err != nil {
 			return nil, fmt.Errorf("start server: %w", err)
 		}

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -21,6 +21,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/cmd/texelation/boot"
 	"github.com/framegrace/texelation/cmd/texelation/lifecycle"
 	clientrt "github.com/framegrace/texelation/internal/runtime/client"
 )
@@ -113,7 +116,13 @@ func run() error {
 		return fmt.Errorf("create config directory: %w", err)
 	}
 
-	ctx := context.Background()
+	// Wire signal cancellation so Ctrl-C / SIGTERM collapse the
+	// supervisor's healthcheck wait, the splash error-display sleep,
+	// and any other ctx-aware path inside the bootstrap. Before this
+	// the unified-mode flow rooted at context.Background() couldn't
+	// be interrupted until the in-flight syscall returned.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	// Command dispatch
 	switch {
@@ -170,21 +179,88 @@ func handleUnifiedMode(ctx context.Context, paths *Paths, srvOpts lifecycle.Serv
 	if srvOpts.PIDFilePath == "" {
 		srvOpts.PIDFilePath = paths.PIDPath
 	}
+
+	// Boot splash takes the screen for the duration of the bootstrap
+	// (server health check + protocol handshake + first snapshot).
+	// Cold starts after a daemon stop currently spend 10+ seconds in
+	// WAL replay before the socket is healthy; without the splash the
+	// terminal looks frozen the whole time. The splash is a lightweight
+	// pre-connect harness that Plan F (#199 session recovery) will
+	// extend with a session picker.
+	screen, splashErr := tcell.NewScreen()
+	if splashErr != nil {
+		// Fall back to the legacy stdout-only path if we can't even
+		// allocate a screen — better the user sees the original
+		// "Starting texelation server..." prints than nothing. Log
+		// and surface to stderr so a misconfigured environment
+		// (missing TTY, unset $TERM, etc.) doesn't get hidden behind
+		// a downstream supervisor error.
+		log.Printf("boot splash unavailable (tcell.NewScreen: %v); falling back to text bootstrap", splashErr)
+		fmt.Fprintf(os.Stderr, "Note: boot splash unavailable (%v); using text mode\n", splashErr)
+		return runUnifiedWithoutSplash(ctx, paths, srvOpts, clientOpts)
+	}
+	if err := screen.Init(); err != nil {
+		log.Printf("boot splash unavailable (screen.Init: %v); falling back to text bootstrap", err)
+		fmt.Fprintf(os.Stderr, "Note: boot splash unavailable (%v); using text mode\n", err)
+		return runUnifiedWithoutSplash(ctx, paths, srvOpts, clientOpts)
+	}
+	defer screen.Fini()
+	// Hide the cursor immediately — without this, a blinking cursor
+	// shows in the top-left corner during the splash. clientrt.Run
+	// will re-assert HideCursor on handoff but doing it here removes
+	// the visible artifact in the bootstrap window.
+	screen.HideCursor()
+
+	splashApp := boot.New("Texelation")
+	splashApp.SetStage(boot.StageStarting)
+	splashRunner := boot.NewRunner(screen, splashApp)
+	splashRunner.Start()
+	splashStopped := false
+	stopSplash := func() {
+		if splashStopped {
+			return
+		}
+		splashStopped = true
+		splashRunner.Stop()
+	}
+	defer stopSplash()
+
+	// Supervisor messages flow into the splash's detail line. They are
+	// transient by design — the next stage transition clears them.
 	health := lifecycle.NewSocketHealthChecker(2 * time.Second)
 	pidFile := lifecycle.NewPIDFile(paths.PIDPath)
 	daemon := lifecycle.NewDaemonManager(pidFile, srvOpts.SocketPath, health)
-	supervisor := lifecycle.NewSupervisor(daemon, health, pidFile, lifecycle.DefaultSupervisorConfig())
+	supCfg := lifecycle.DefaultSupervisorConfig()
+	// Cold-start WAL replay can run 10+ seconds with deep scrollback;
+	// the default 5s ceiling fails the health check before the socket
+	// is reachable. With the splash now visible, an honest long wait
+	// is better UX than a false "failed to start" — bump the budget.
+	supCfg.StartupWait = 60 * time.Second
+	supCfg.Reporter = func(msg string) {
+		splashApp.SetDetail(msg)
+		splashRunner.Wake()
+	}
+	supervisor := lifecycle.NewSupervisor(daemon, health, pidFile, supCfg)
 
-	// Ensure server is running
 	result, err := supervisor.EnsureRunning(ctx, srvOpts)
 	if err != nil {
+		// Log the full error before squeezing it into the splash
+		// detail line — drawCenteredText truncates to the box's
+		// inner width (~32 cols), so wrapped/multi-line error
+		// chains get clipped on screen but stay legible in the log.
+		log.Printf("ensure server running failed: %v", err)
+		splashApp.SetStage(boot.StageError)
+		splashApp.SetDetail(err.Error())
+		splashRunner.Wake()
+		// Hold the error message on screen briefly so the user can
+		// read it before tcell's Fini wipes the dialog. ctx-aware
+		// so a Ctrl-C / context cancellation collapses the wait
+		// instead of forcing the user to sit through it.
+		select {
+		case <-time.After(1500 * time.Millisecond):
+		case <-ctx.Done():
+		}
 		return fmt.Errorf("ensure server running: %w", err)
-	}
-
-	if result.WasStarted {
-		fmt.Printf("Server started (PID %d)\n", result.PID)
-		fmt.Printf("  Socket: %s\n", srvOpts.SocketPath)
-		fmt.Printf("  Logs: %s\n", paths.ServerLogPath)
 	}
 
 	// If server was restarted due to being unresponsive, show notification
@@ -192,7 +268,60 @@ func handleUnifiedMode(ctx context.Context, paths *Paths, srvOpts lifecycle.Serv
 		clientOpts.ShowRestartNotification = true
 	}
 
-	// Run client
+	// Map clientrt's status callbacks onto the splash. Once StageReady
+	// fires the runtime has painted its first frame on the same screen
+	// and we can stop the splash without leaving blank cells.
+	clientOpts.Screen = screen
+	clientOpts.OnStatus = func(stage clientrt.Stage, detail string) {
+		switch stage {
+		case clientrt.StageConnecting:
+			splashApp.SetStage(boot.StageConnecting)
+		case clientrt.StageResuming:
+			splashApp.SetStage(boot.StageResuming)
+		case clientrt.StageReady:
+			stopSplash()
+			return
+		}
+		if detail != "" {
+			splashApp.SetDetail(detail)
+		}
+		splashRunner.Wake()
+	}
+
+	return clientrt.Run(clientOpts)
+}
+
+// runUnifiedWithoutSplash is the pre-splash bootstrap path, retained
+// as a fallback for environments where tcell.NewScreen / Init fails
+// (very rare — typically only when stdin/stdout aren't a tty). It
+// preserves the original behaviour: stdout messages from the
+// supervisor, then handing control to clientrt.Run with no pre-init
+// screen.
+func runUnifiedWithoutSplash(ctx context.Context, paths *Paths, srvOpts lifecycle.ServerOptions, clientOpts clientrt.Options) error {
+	health := lifecycle.NewSocketHealthChecker(2 * time.Second)
+	pidFile := lifecycle.NewPIDFile(paths.PIDPath)
+	daemon := lifecycle.NewDaemonManager(pidFile, srvOpts.SocketPath, health)
+	// Mirror the splash path's 60s startup ceiling. Cold-start WAL
+	// replay can run 10+ seconds with deep scrollback, and the
+	// fallback path shouldn't be a degraded mode where the same
+	// daemon spuriously fails to come up just because the splash
+	// couldn't initialise.
+	supCfg := lifecycle.DefaultSupervisorConfig()
+	supCfg.StartupWait = 60 * time.Second
+	supervisor := lifecycle.NewSupervisor(daemon, health, pidFile, supCfg)
+
+	result, err := supervisor.EnsureRunning(ctx, srvOpts)
+	if err != nil {
+		return fmt.Errorf("ensure server running: %w", err)
+	}
+	if result.WasStarted {
+		fmt.Printf("Server started (PID %d)\n", result.PID)
+		fmt.Printf("  Socket: %s\n", srvOpts.SocketPath)
+		fmt.Printf("  Logs: %s\n", paths.ServerLogPath)
+	}
+	if result.WasRestarted {
+		clientOpts.ShowRestartNotification = true
+	}
 	return clientrt.Run(clientOpts)
 }
 

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -30,6 +30,28 @@ import (
 
 const resizeDebounce = 10 * time.Millisecond
 
+// Stage names a milestone in client startup that an external splash
+// (texelation's boot package) renders to the user. Stage strings are
+// stable identifiers — the splash maps them to its own visual state.
+type Stage string
+
+const (
+	// StageConnecting fires before the protocol handshake.
+	StageConnecting Stage = "connecting"
+	// StageResuming fires before the resume request is sent. Skipped
+	// when no resume is needed (fresh start).
+	StageResuming Stage = "resuming"
+	// StageReady fires once the renderer is about to enter its main
+	// event loop. The splash should stop after seeing this.
+	StageReady Stage = "ready"
+)
+
+// StatusFn receives stage transitions during startup. The detail
+// string is optional context (e.g. "retrying after stale session").
+// The callback is invoked synchronously from Run's goroutine; keep
+// it cheap — defer expensive work to the splash's own paint loop.
+type StatusFn func(stage Stage, detail string)
+
 // Options configures the remote client runtime.
 type Options struct {
 	Socket                  string
@@ -37,6 +59,18 @@ type Options struct {
 	PanicLog                string
 	ShowRestartNotification bool   // Show notification that server was restarted
 	ClientName              string // --client-name slot for multi-client persistence (issue #199 Plan D)
+
+	// Screen, when set, is used in place of a freshly-created tcell
+	// screen. The caller owns its lifecycle: Init must already have
+	// been called and Fini is the caller's responsibility. This is
+	// how texelation hands off a screen that already showed a boot
+	// splash without forcing a Fini/Init flicker. When nil, Run
+	// creates and tears down a screen itself (the standalone path).
+	Screen tcell.Screen
+
+	// OnStatus, when set, is called at startup milestones (see Stage
+	// constants) so an external splash can update its display. nil-safe.
+	OnStatus StatusFn
 }
 
 func Run(opts Options) error {
@@ -74,6 +108,13 @@ func Run(opts Options) error {
 		sessionID = loadedState.SessionID
 	}
 
+	emitStatus := func(stage Stage, detail string) {
+		if opts.OnStatus != nil {
+			opts.OnStatus(stage, detail)
+		}
+	}
+
+	emitStatus(StageConnecting, "")
 	accept, conn, err := simple.Connect(&sessionID)
 	if err != nil && loadedState != nil {
 		// We sent a non-zero sessionID from disk and Connect failed.
@@ -94,6 +135,7 @@ func Run(opts Options) error {
 		}
 		loadedState = nil
 		sessionID = [16]byte{}
+		emitStatus(StageConnecting, "retrying with fresh session")
 		accept, conn, err = simple.Connect(&sessionID)
 	}
 	if err != nil {
@@ -185,7 +227,10 @@ func Run(opts Options) error {
 		}
 
 		state.resetOnNextSnapshot.Store(true)
-		hdr, payload, err := simple.RequestResume(conn, sessionID, lastSequence.Load(), viewports)
+		emitStatus(StageResuming, "")
+		hdr, payload, err := simple.RequestResume(conn, sessionID, lastSequence.Load(), viewports, func(msg string) {
+			emitStatus(StageResuming, msg)
+		})
 		if err != nil {
 			// Plan D2: a failed resume must NOT leave the flag armed — a later
 			// resume against a different sessionID (after Plan D's wipe-and-retry
@@ -241,6 +286,14 @@ func Run(opts Options) error {
 
 	renderCh := make(chan struct{}, 64) // Larger buffer for smooth animations
 	state.setRenderChannel(renderCh)
+	// Wire MsgBootProgress messages received via readLoop into the
+	// splash. RequestResume drains progress messages until its first
+	// non-progress response, so anything emitted by the server later
+	// (handleClientReady's per-pane progress on rehydrated cold
+	// starts) only arrives via the read pump.
+	state.setBootProgressFn(func(msg string) {
+		emitStatus(StageResuming, msg)
+	})
 	doneCh := make(chan struct{})
 	panicLogger.Go("readLoop", func() {
 		readLoop(conn, state, sessionID, &lastSequence, renderCh, doneCh, writer, &pendingAck, ackSignal)
@@ -253,18 +306,32 @@ func Run(opts Options) error {
 		ackLoop(sessionID, writer, doneCh, &pendingAck, &lastAck, ackSignal)
 	})
 
-	screen, err := tcell.NewScreen()
-	if err != nil {
-		return fmt.Errorf("create screen failed: %w", err)
-	}
-	if err := screen.Init(); err != nil {
-		return fmt.Errorf("init screen failed: %w", err)
+	// Screen ownership: if the caller passed in a pre-initialized
+	// screen via opts.Screen, use it as-is and let the caller Fini.
+	// This is the texelation boot-splash handoff path — the screen
+	// already has the splash painted on it, and we want the first
+	// production frame to land on the same surface without a
+	// Fini → Init flicker. Standalone callers (no opts.Screen) get
+	// the legacy behaviour where Run owns the lifecycle.
+	screen := opts.Screen
+	ownsScreen := screen == nil
+	if ownsScreen {
+		var err error
+		screen, err = tcell.NewScreen()
+		if err != nil {
+			return fmt.Errorf("create screen failed: %w", err)
+		}
+		if err := screen.Init(); err != nil {
+			return fmt.Errorf("init screen failed: %w", err)
+		}
 	}
 	screen.EnablePaste()
 	screen.EnableMouse()
 	defer screen.DisableMouse()
 	screen.HideCursor()
-	defer screen.Fini()
+	if ownsScreen {
+		defer screen.Fini()
+	}
 	defer close(pingStop)
 
 	// Initialize Kitty graphics output if the terminal supports it.
@@ -284,7 +351,16 @@ func Run(opts Options) error {
 	// Send ClientReady with our dimensions so server can send properly-sized snapshot
 	sendClientReady(writer, sessionID, screen)
 
-	render(state, screen)
+	// First render before any server content has arrived produces a
+	// blank frame — clearing it now would expose that blankness if a
+	// boot splash is still on the screen. Skip the empty render and
+	// let the first event-loop render (driven by the server's first
+	// snapshot/delta on renderCh) be what the splash hands off to.
+	// firstContentRendered tracks that handoff: it stays false until
+	// the first data-driven render lands actual cells, at which point
+	// we emit StageReady so the splash runner can stop without
+	// leaving blank cells between itself and live content.
+	firstContentRendered := false
 
 	events := make(chan tcell.Event, 32)
 	stopEvents := make(chan struct{})
@@ -371,6 +447,30 @@ func Run(opts Options) error {
 				state.effects.Update(0)
 			}
 			render(state, screen)
+			// Splash handoff: stop only once a real TreeSnapshot has
+			// been applied AND a content-bearing delta has landed.
+			//
+			// On rehydrated cold starts the server defers
+			// TreeSnapshot to handleClientReady (so it lands at the
+			// client's real dimensions), and that handler runs the
+			// slow SetViewportSize → Snapshot chain. Before that,
+			// the publisher emits decor-only BufferDeltas that fire
+			// renderCh while the panes are still hydrating.
+			//
+			// Without the treeSnapshotApplied gate the splash hands
+			// off to a workspace that has no real content yet. The
+			// race: on the first renderCh tick, ensureBuffers
+			// returns resized=true (so fullRender runs and
+			// fullRenderHappened flips) and a decor-only BufferDelta
+			// already in flight can flip firstContentDelta during
+			// render(). Both flags would pass, the splash would
+			// stop, and the user would see only borders while
+			// handleClientReady's slow SetViewportSize → Snapshot
+			// chain finished.
+			if !firstContentRendered && state.bootHandoffReady() {
+				firstContentRendered = true
+				emitStatus(StageReady, "")
+			}
 
 		case ev, ok := <-events:
 			if !ok {

--- a/internal/runtime/client/boot_handoff_test.go
+++ b/internal/runtime/client/boot_handoff_test.go
@@ -1,0 +1,207 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/boot_handoff_test.go
+// Summary: Tests for the three-flag boot-splash handoff predicate
+// and the BufferDelta / TreeSnapshot / BootProgress dispatch paths
+// in handleControlMessage that latch the gates.
+
+package clientruntime
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// TestBootHandoffReady_AllThreeGatesRequired verifies the predicate
+// returns true only when treeSnapshotApplied, firstContentDelta, and
+// fullRenderHappened are all set. Each single-flag drop must
+// suppress the handoff. This is the load-bearing splash deactivation
+// rule and the comment alongside the renderCh case spells out why
+// each gate matters on rehydrated cold starts.
+func TestBootHandoffReady_AllThreeGatesRequired(t *testing.T) {
+	cases := []struct {
+		name            string
+		tree, cnt, full bool
+		want            bool
+	}{
+		{"none", false, false, false, false},
+		{"only tree", true, false, false, false},
+		{"only content", false, true, false, false},
+		{"only full", false, false, true, false},
+		{"tree+content", true, true, false, false},
+		{"tree+full", true, false, true, false},
+		{"content+full", false, true, true, false},
+		{"all three", true, true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := makeTestState()
+			state.treeSnapshotApplied.Store(tc.tree)
+			state.firstContentDelta.Store(tc.cnt)
+			state.fullRenderHappened.Store(tc.full)
+			if got := state.bootHandoffReady(); got != tc.want {
+				t.Errorf("bootHandoffReady = %v, want %v (tree=%v cnt=%v full=%v)",
+					got, tc.want, tc.tree, tc.cnt, tc.full)
+			}
+		})
+	}
+}
+
+// TestFirstContentDelta_DecorOnlyDoesNotLatch verifies that a
+// BufferDelta carrying only DecorRows (pane borders, no actual
+// content) does NOT flip firstContentDelta. The publisher emits
+// decor-only deltas immediately after the resume snapshot — the
+// whole point of this gate is to ignore them so the splash stays
+// alive until real content arrives.
+func TestFirstContentDelta_DecorOnlyDoesNotLatch(t *testing.T) {
+	state := makeTestState()
+	var paneID [16]byte
+	paneID[0] = 1
+
+	// Encode a delta with no Rows but one DecorRow (a border row).
+	delta := protocol.BufferDelta{
+		PaneID:  paneID,
+		RowBase: 0,
+		Styles:  []protocol.StyleEntry{{AttrFlags: 0}},
+		DecorRows: []protocol.DecorRowDelta{
+			{
+				RowIdx: 0,
+				Spans:  []protocol.CellSpan{{StartCol: 0, Text: "─", StyleIndex: 0}},
+			},
+		},
+	}
+	payload, err := protocol.EncodeBufferDelta(delta)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+	hdr := protocol.Header{Type: protocol.MsgBufferDelta}
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+
+	if state.firstContentDelta.Load() {
+		t.Fatal("firstContentDelta latched on a decor-only delta; only Rows should count")
+	}
+}
+
+// TestFirstContentDelta_RowsDoesLatch is the positive counterpart:
+// a delta with at least one Row must flip firstContentDelta.
+func TestFirstContentDelta_RowsDoesLatch(t *testing.T) {
+	state := makeTestState()
+	var paneID [16]byte
+	paneID[0] = 2
+
+	delta := protocol.BufferDelta{
+		PaneID:  paneID,
+		RowBase: 0,
+		Styles:  []protocol.StyleEntry{{AttrFlags: 0}},
+		Rows: []protocol.RowDelta{
+			{Row: 0, Spans: []protocol.CellSpan{{StartCol: 0, Text: "$", StyleIndex: 0}}},
+		},
+	}
+	payload, err := protocol.EncodeBufferDelta(delta)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+	hdr := protocol.Header{Type: protocol.MsgBufferDelta}
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+
+	if !state.firstContentDelta.Load() {
+		t.Fatal("firstContentDelta did not latch on a delta with Rows")
+	}
+}
+
+// TestTreeSnapshot_LatchesGate verifies MsgTreeSnapshot processing
+// flips treeSnapshotApplied. Without this latch the splash hands off
+// before a real workspace snapshot has arrived (rehydrated cold
+// starts defer TreeSnapshot to handleClientReady).
+func TestTreeSnapshot_LatchesGate(t *testing.T) {
+	state := makeTestState()
+	if state.treeSnapshotApplied.Load() {
+		t.Fatal("treeSnapshotApplied should start false")
+	}
+
+	snap := protocol.TreeSnapshot{} // empty snapshot is valid for the latch
+	payload, err := protocol.EncodeTreeSnapshot(snap)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+	var lastSeq atomic.Uint64
+	hdr := protocol.Header{Type: protocol.MsgTreeSnapshot}
+	handleControlMessage(state, hdr, payload, [16]byte{}, &lastSeq, nil, &pendingAck, ackCh)
+
+	if !state.treeSnapshotApplied.Load() {
+		t.Fatal("treeSnapshotApplied did not latch on MsgTreeSnapshot")
+	}
+	if !state.fullRenderNeeded {
+		t.Error("fullRenderNeeded should also be set by the snapshot path")
+	}
+}
+
+// TestBootProgress_DispatchesToCallback verifies MsgBootProgress
+// payloads in handleControlMessage reach the registered
+// bootProgressFn. Without this dispatch the messages emitted by
+// handleClientReady's slow phase are silently dropped after
+// RequestResume returns, so the splash sits on whatever stage was
+// set before the resume.
+func TestBootProgress_DispatchesToCallback(t *testing.T) {
+	state := makeTestState()
+
+	var mu sync.Mutex
+	var got []string
+	state.setBootProgressFn(func(msg string) {
+		mu.Lock()
+		got = append(got, msg)
+		mu.Unlock()
+	})
+
+	for _, msg := range []string{"Validating session…", "Restoring pane 1 of 3…"} {
+		payload, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: msg})
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		var pendingAck atomic.Uint64
+		ackCh := make(chan struct{}, 1)
+		hdr := protocol.Header{Type: protocol.MsgBootProgress}
+		ret := handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+		if ret {
+			t.Errorf("handleControlMessage returned true for MsgBootProgress; should be false (cosmetic, no renderCh signal)")
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 || got[0] != "Validating session…" || got[1] != "Restoring pane 1 of 3…" {
+		t.Errorf("dispatched messages mismatch: got %#v", got)
+	}
+}
+
+// TestBootProgress_NilCallbackTolerated verifies the dispatch path
+// is a no-op when no bootProgressFn is registered (the splashless
+// path through clientrt.Run shouldn't crash on progress messages).
+func TestBootProgress_NilCallbackTolerated(t *testing.T) {
+	state := makeTestState()
+	// no setBootProgressFn call — fn stays nil
+
+	payload, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: "hi"})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var pendingAck atomic.Uint64
+	ackCh := make(chan struct{}, 1)
+	hdr := protocol.Header{Type: protocol.MsgBootProgress}
+
+	// Must not panic.
+	handleControlMessage(state, hdr, payload, [16]byte{}, nil, nil, &pendingAck, ackCh)
+}

--- a/internal/runtime/client/client_state.go
+++ b/internal/runtime/client/client_state.go
@@ -96,6 +96,45 @@ type clientState struct {
 	renderBuffer     [][]client.Cell
 	fullRenderNeeded bool
 
+	// firstContentDelta becomes true once a MsgBufferDelta carrying
+	// at least one Row (not just DecorRows) has been applied. The
+	// boot splash uses it as one of three handoff gates: the server
+	// flushes a Publish() with decor-only BufferDeltas (Rows empty,
+	// DecorRows populated with pane borders) as soon as the resume
+	// snapshot is sent, so a "first renderCh" trigger fires far too
+	// early on cold starts. Only a delta carrying actual Rows means
+	// at least one pane has hydrated content the renderer can paint
+	// on top of the splash.
+	firstContentDelta atomic.Bool
+
+	// fullRenderHappened becomes true the first time fullRender runs
+	// to completion. The boot splash needs this gate too: an
+	// incremental composite only writes the cells inside dirty pane
+	// regions, leaving the splash content intact in tcell's cell
+	// cache for everything outside those regions. fullRender fills
+	// the workspace buffer with default cells before drawing panes,
+	// so its diffAndShow actually overwrites the splash.
+	fullRenderHappened atomic.Bool
+
+	// treeSnapshotApplied becomes true once a MsgTreeSnapshot has
+	// landed in the cache. Gating splash handoff on this avoids the
+	// "first renderCh" trap on rehydrated cold starts: the publisher
+	// emits decor-only BufferDeltas immediately after the resume
+	// handler returns, which fire renderCh long before
+	// handleClientReady runs the slow SetViewportSize → Snapshot →
+	// Publish chain that produces the real first frame.
+	treeSnapshotApplied atomic.Bool
+
+	// bootProgressFn, when set, receives MsgBootProgress messages
+	// the server emits during slow startup phases (handleClientReady's
+	// SetViewportSize → Snapshot → Publish on rehydrated cold starts).
+	// RequestResume only consumes progress messages until the first
+	// non-progress reply; after that, readLoop is the only path and
+	// without this hook the messages would silently fall through
+	// handleControlMessage's default branch and never reach the splash.
+	bootProgressFnMu sync.Mutex
+	bootProgressFn   func(string)
+
 	// Pooled pane buffer for compositeInto (avoids per-frame allocations)
 	paneBuffer [][]client.Cell
 
@@ -179,6 +218,32 @@ func (s *clientState) setRenderChannel(ch chan<- struct{}) {
 	s.renderCh = ch
 	if s.effects != nil {
 		s.effects.SetWakeChannel(ch)
+	}
+}
+
+// bootHandoffReady reports whether all three splash-deactivation
+// gates are satisfied. Extracted from the renderCh case so the
+// predicate can be unit-tested without driving the full event loop;
+// the comment alongside the call site documents why each gate is
+// load-bearing on rehydrated cold starts.
+func (s *clientState) bootHandoffReady() bool {
+	return s.treeSnapshotApplied.Load() &&
+		s.firstContentDelta.Load() &&
+		s.fullRenderHappened.Load()
+}
+
+func (s *clientState) setBootProgressFn(fn func(string)) {
+	s.bootProgressFnMu.Lock()
+	s.bootProgressFn = fn
+	s.bootProgressFnMu.Unlock()
+}
+
+func (s *clientState) emitBootProgress(msg string) {
+	s.bootProgressFnMu.Lock()
+	fn := s.bootProgressFn
+	s.bootProgressFnMu.Unlock()
+	if fn != nil {
+		fn(msg)
 	}
 }
 

--- a/internal/runtime/client/protocol_handler.go
+++ b/internal/runtime/client/protocol_handler.go
@@ -50,6 +50,7 @@ func handleControlMessage(state *clientState, hdr protocol.Header, payload []byt
 		cache.ApplySnapshot(snap)
 		applyPostResumeReset(state, lastSequence) // Plan D2: one-shot reset on post-resume snapshot
 		state.fullRenderNeeded = true
+		state.treeSnapshotApplied.Store(true)
 		if state.effects != nil {
 			state.effects.ResetPaneStates(cache.SortedPanes())
 		}
@@ -78,6 +79,17 @@ func handleControlMessage(state *clientState, hdr protocol.Header, payload []byt
 		}
 		cache.ApplyDelta(delta)
 		state.paneCacheFor(delta.PaneID).ApplyDelta(delta)
+		// Boot splash handoff signal. The server publishes a flush
+		// of decor-only BufferDeltas (Rows empty, DecorRows populated
+		// with pane borders) right after the resume snapshot — those
+		// don't carry any content yet, so they must not trigger a
+		// handoff. Only Rows count: DecorRows are pane borders the
+		// publisher emits on every flush even before pane buffers
+		// have hydrated, so a decor-only delta is a false positive
+		// for "the panes have content."
+		if len(delta.Rows) > 0 && !state.firstContentDelta.Load() {
+			state.firstContentDelta.Store(true)
+		}
 		// Update viewport tracker: alt-screen transitions + AutoFollow advance.
 		if state.viewports != nil {
 			state.onBufferDelta(delta)
@@ -121,6 +133,21 @@ func handleControlMessage(state *clientState, hdr protocol.Header, payload []byt
 			}
 		}
 		return true
+	case protocol.MsgBootProgress:
+		bp, err := protocol.DecodeBootProgress(payload)
+		if err != nil {
+			log.Printf("decode boot progress failed: %v", err)
+			return false
+		}
+		// Forward to the splash via the pre-registered callback.
+		// RequestResume only loops until the first non-progress reply;
+		// any subsequent server-side progress (e.g. handleClientReady
+		// emissions during the slow SetViewportSize phase on rehydrated
+		// cold starts) lands here. Returning false suppresses the
+		// renderCh signal — progress messages are pure splash UI and
+		// shouldn't drive the production renderer.
+		state.emitBootProgress(bp.Message)
+		return false
 	case protocol.MsgPing:
 		pong, _ := protocol.EncodePong(protocol.Pong{Timestamp: time.Now().UnixNano()})
 		// Pong is on the read path: blocking on a full writer queue would

--- a/internal/runtime/client/renderer.go
+++ b/internal/runtime/client/renderer.go
@@ -396,6 +396,7 @@ func render(state *clientState, screen tcell.Screen) {
 	if needsFull {
 		fullRender(state, screen)
 		state.fullRenderNeeded = false
+		state.fullRenderHappened.Store(true)
 		// After first full render, switch effects to normal animation timestamps.
 		if state.effects != nil {
 			state.effects.FinishInitialization()

--- a/internal/runtime/server/connection.go
+++ b/internal/runtime/server/connection.go
@@ -211,6 +211,24 @@ func (c *connection) writeControlMessage(msgType protocol.MessageType, payload [
 	return c.writeMessage(header, payload)
 }
 
+// sendBootProgress emits a best-effort progress message to the client
+// during expensive resume operations. Write errors are deliberately
+// swallowed: progress is purely cosmetic and a write failure mid-
+// resume would mean the connection is doomed anyway, in which case
+// the actual resume response will surface the real error. Encode
+// errors are programmer-class signals (unbounded message string,
+// encoding regression) that won't surface anywhere else, so we log
+// them — without that breadcrumb a future regression silently drops
+// every progress message.
+func (c *connection) sendBootProgress(message string) {
+	payload, err := protocol.EncodeBootProgress(protocol.BootProgress{Message: message})
+	if err != nil {
+		log.Printf("server: sendBootProgress encode failed: %v", err)
+		return
+	}
+	_ = c.writeControlMessage(protocol.MsgBootProgress, payload)
+}
+
 func (c *connection) writeMessage(header protocol.Header, payload []byte) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -148,6 +148,7 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 			return errors.New("server: resume request session mismatch")
 		}
 		c.resumeProcessed = true
+		c.sendBootProgress("Validating session…")
 		// Plan D2: a rehydrated session (one reconstructed from disk
 		// after a daemon restart) has an empty diff queue and
 		// nextSequence == 0, so the client's claimed LastSequence is
@@ -221,16 +222,35 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 		// alt-screen guard in TexelTerm.RestoreViewport. Wrapped in a
 		// deferred recover so a panicking app cannot crash the connection.
 		if sinkOK && sink.Desktop() != nil {
+			// Count restorable panes for the progress dialog. Per-pane
+			// hydration is the dominant cost in this loop (sparse store
+			// loads scrollback rows from the on-disk page store), so
+			// "Restoring pane N/M" is the most useful breakdown the
+			// splash can show.
+			toRestore := 0
+			for _, ps := range viewportsToApply {
+				if !ps.AltScreen {
+					toRestore++
+				}
+			}
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
 						log.Printf("server: RestorePaneViewport panic: %v", r)
 					}
 				}()
+				done := 0
 				for _, ps := range viewportsToApply {
-					if !ps.AltScreen {
-						sink.Desktop().RestorePaneViewport(ps.PaneID, ps.ViewBottomIdx, ps.WrapSegmentIdx, ps.AutoFollow)
+					if ps.AltScreen {
+						continue
 					}
+					done++
+					if toRestore > 1 {
+						c.sendBootProgress(fmt.Sprintf("Restoring pane %d of %d…", done, toRestore))
+					} else {
+						c.sendBootProgress("Restoring pane viewport…")
+					}
+					sink.Desktop().RestorePaneViewport(ps.PaneID, ps.ViewBottomIdx, ps.WrapSegmentIdx, ps.AutoFollow)
 				}
 			}()
 		}
@@ -250,6 +270,7 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 		// the correct dims and ship a single coherent snapshot.
 		if !c.rehydrated {
 			if provider, ok := c.sink.(SnapshotProvider); ok {
+				c.sendBootProgress("Capturing snapshot…")
 				snapshot, err := provider.Snapshot()
 				if err != nil {
 					log.Printf("server: resume snapshot error: %v", err)
@@ -342,13 +363,29 @@ func (c *connection) handleClientReady(ready protocol.ClientReady) {
 		return
 	}
 
-	// Set viewport size with client's actual dimensions
+	// For rehydrated sessions handleClientReady is the heavy phase:
+	// SetViewportSize fires per-pane "Restoring pane…" via
+	// startPendingApps (which re-reflows each VTerm against its
+	// persisted scrollback) and sink.Snapshot() fires per-pane
+	// "Rendering pane…" via SnapshotForClient (which hits the WAL
+	// page store). Both routes hit disk-bound work, so per-pane
+	// progress is the honest granularity for the splash. Wire the
+	// reporter for the full duration here and clear it via defer
+	// so later runtime resizes don't ping a splash that no longer
+	// exists.
+	desktop.SetProgressReporter(func(msg string) {
+		c.sendBootProgress(msg)
+	})
+	defer desktop.SetProgressReporter(nil)
+
+	c.sendBootProgress(fmt.Sprintf("Resizing panes to %d×%d…", ready.Cols, ready.Rows))
 	desktop.SetViewportSize(int(ready.Cols), int(ready.Rows))
 
 	// Now send the snapshot with correct dimensions.
 	// Errors are logged so a frozen-looking client (no MsgTreeSnapshot
 	// after MsgClientReady ack) leaves a breadcrumb in the server log.
 	// Without this the symptom looks identical to a hang.
+	c.sendBootProgress("Capturing snapshot…")
 	snapshot, err := sink.Snapshot()
 	if err != nil {
 		log.Printf("server: handleClientReady snapshot error: %v", err)
@@ -357,6 +394,7 @@ func (c *connection) handleClientReady(ready protocol.ClientReady) {
 		return
 	}
 
+	c.sendBootProgress("Publishing initial frame…")
 	sink.Publish()
 
 	payload, err := protocol.EncodeTreeSnapshot(snapshot)

--- a/internal/runtime/server/connection_rehydrate_resume_test.go
+++ b/internal/runtime/server/connection_rehydrate_resume_test.go
@@ -21,6 +21,23 @@ import (
 	"github.com/framegrace/texelation/protocol"
 )
 
+// drainAllMessages reads every framed message available on conn until
+// it hits a read error (EOF / closed pipe / deadline), discarding the
+// payloads. Used by tests that talk to the server over a synchronous
+// net.Pipe — the resume handler now emits multiple unsolicited
+// MsgBootProgress frames ahead of any "real" response, and a writer
+// stuck on an undrained pipe would block before the handler finishes
+// setting state we want to assert on.
+func drainAllMessages(conn net.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	for {
+		if _, _, err := protocol.ReadMessage(conn); err != nil {
+			return
+		}
+	}
+}
+
 // driveResumeRequest writes a MsgResumeRequest with the given fields
 // onto clientConn, then closes clientConn so the connection's serve
 // loop sees EOF and returns. Returns the channel that will receive
@@ -104,11 +121,11 @@ func TestConnection_NonRehydratedResume_HonorsLastAcked(t *testing.T) {
 		LastSequence: 42,
 	})
 
-	// Drain whatever the resume branch writes (a TreeSnapshot for the
-	// non-rehydrated path) so the pipe doesn't block, then close.
-	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
-	_, _, _ = protocol.ReadMessage(clientConn)
-	_ = clientConn.SetReadDeadline(time.Time{})
+	// Drain whatever the resume branch writes — multiple
+	// MsgBootProgress messages plus a TreeSnapshot for the
+	// non-rehydrated path — so the synchronous net.Pipe doesn't
+	// block the handler before it finishes setting state.
+	drainAllMessages(clientConn)
 	_ = clientConn.Close()
 
 	select {
@@ -144,6 +161,9 @@ func TestConnection_RehydratedResume_LeavesInitialSnapshotSentFalse(t *testing.T
 		SessionID: sessionID,
 	})
 
+	// Drain any progress messages so the handler can finish setting
+	// state on the synchronous pipe before we close.
+	drainAllMessages(clientConn)
 	_ = clientConn.Close()
 
 	select {
@@ -176,10 +196,9 @@ func TestConnection_NonRehydratedResume_FlipsInitialSnapshotSent(t *testing.T) {
 		SessionID: sessionID,
 	})
 
-	// Drain the TreeSnapshot the non-rehydrated branch writes.
-	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
-	_, _, _ = protocol.ReadMessage(clientConn)
-	_ = clientConn.SetReadDeadline(time.Time{})
+	// Drain progress messages plus the TreeSnapshot the non-
+	// rehydrated branch writes.
+	drainAllMessages(clientConn)
 	_ = clientConn.Close()
 
 	select {
@@ -219,14 +238,22 @@ func TestConnection_RehydratedResume_SkipsEarlySnapshot(t *testing.T) {
 		SessionID: sessionID,
 	})
 
-	// Read with a short deadline. The rehydrated branch must NOT have
-	// written a TreeSnapshot in response to MsgResumeRequest, so we
-	// expect this read to time out / return io.EOF rather than yield
-	// a message.
+	// The rehydrated branch must NOT have written a TreeSnapshot in
+	// response to MsgResumeRequest. It MAY have written
+	// MsgBootProgress messages; those are cosmetic and we skip them.
+	// The first non-progress read should fail (io.EOF / timeout) —
+	// receiving a real payload here means the rehydrated path
+	// regressed and shipped an early snapshot.
 	_ = clientConn.SetReadDeadline(time.Now().Add(150 * time.Millisecond))
-	hdr, _, err := protocol.ReadMessage(clientConn)
-	if err == nil {
-		t.Fatalf("rehydrated resume wrote unexpected message type=%d; want no message before MsgClientReady", hdr.Type)
+	for {
+		hdr, _, err := protocol.ReadMessage(clientConn)
+		if err != nil {
+			break
+		}
+		if hdr.Type == protocol.MsgBootProgress {
+			continue
+		}
+		t.Fatalf("rehydrated resume wrote unexpected message type=%d; want no non-progress message before MsgClientReady", hdr.Type)
 	}
 }
 
@@ -250,13 +277,20 @@ func TestConnection_NonRehydratedResume_SendsEarlySnapshot(t *testing.T) {
 
 	// In-process resume: expect a MsgTreeSnapshot on the wire within
 	// the deadline. (nopSink.Snapshot returns an empty TreeSnapshot,
-	// so the message is short but present.)
+	// so the message is short but present.) Skip any cosmetic
+	// MsgBootProgress messages emitted ahead of it.
 	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	hdr, _, err := protocol.ReadMessage(clientConn)
-	if err != nil {
-		t.Fatalf("non-rehydrated resume: expected MsgTreeSnapshot, got read error: %v", err)
-	}
-	if hdr.Type != protocol.MsgTreeSnapshot {
-		t.Fatalf("non-rehydrated resume: wrote message type=%d, want MsgTreeSnapshot (%d)", hdr.Type, protocol.MsgTreeSnapshot)
+	for {
+		hdr, _, err := protocol.ReadMessage(clientConn)
+		if err != nil {
+			t.Fatalf("non-rehydrated resume: expected MsgTreeSnapshot, got read error: %v", err)
+		}
+		if hdr.Type == protocol.MsgBootProgress {
+			continue
+		}
+		if hdr.Type != protocol.MsgTreeSnapshot {
+			t.Fatalf("non-rehydrated resume: wrote message type=%d, want MsgTreeSnapshot (%d)", hdr.Type, protocol.MsgTreeSnapshot)
+		}
+		break
 	}
 }

--- a/protocol/messages.go
+++ b/protocol/messages.go
@@ -189,6 +189,15 @@ type ClientReady struct {
 	Rows uint16
 }
 
+// BootProgress is an unsolicited human-readable status string emitted
+// by the server during expensive resume operations so the client's
+// boot splash can render fine-grained progress instead of a static
+// "Loading session" stage. Payload is just the message — keep it
+// short (≤80 chars) so it fits the splash dialog without truncation.
+type BootProgress struct {
+	Message string
+}
+
 // PaneSnapshot describes the full buffer content for a single pane.
 type PaneSnapshot struct {
 	PaneID         [16]byte
@@ -957,6 +966,26 @@ func DecodeClientReady(b []byte) (ClientReady, error) {
 	r.Cols = binary.LittleEndian.Uint16(b[:2])
 	r.Rows = binary.LittleEndian.Uint16(b[2:4])
 	return r, nil
+}
+
+// EncodeBootProgress serialises a server-side boot progress message.
+// The payload is a single length-prefixed UTF-8 string; clients that
+// don't recognise the message type ignore it harmlessly.
+func EncodeBootProgress(p BootProgress) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, 4+len(p.Message)))
+	if err := encodeString(buf, p.Message); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeBootProgress parses a boot progress payload.
+func DecodeBootProgress(b []byte) (BootProgress, error) {
+	msg, _, err := decodeString(b)
+	if err != nil {
+		return BootProgress{}, err
+	}
+	return BootProgress{Message: msg}, nil
 }
 
 // EncodeTreeSnapshot serialises the tree snapshot for transport.

--- a/protocol/messages_test.go
+++ b/protocol/messages_test.go
@@ -450,3 +450,47 @@ func TestEncodeDecodeTreeSnapshot_ZeroContent(t *testing.T) {
 		t.Fatalf("zero-content mismatch: got top=%d num=%d", decoded.Panes[0].ContentTopRow, decoded.Panes[0].NumContentRows)
 	}
 }
+
+func TestBootProgressRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"typical", "Restoring pane 1 of 3 (Terminal)…"},
+		{"empty", ""},
+		{"unicode", "Loading session — élève à 100%"},
+		{"long", strings.Repeat("x", 200)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := EncodeBootProgress(BootProgress{Message: tc.msg})
+			if err != nil {
+				t.Fatalf("encode: %v", err)
+			}
+			decoded, err := DecodeBootProgress(payload)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if decoded.Message != tc.msg {
+				t.Fatalf("message mismatch: got %q want %q", decoded.Message, tc.msg)
+			}
+		})
+	}
+}
+
+func TestBootProgressDecode_TruncatedPayloadFails(t *testing.T) {
+	// Encode then truncate the body so the length prefix promises
+	// more bytes than the payload contains. Decode must error
+	// rather than panic — corrupted boot progress shouldn't tank
+	// the resume read loop.
+	payload, err := EncodeBootProgress(BootProgress{Message: "Restoring pane 1 of 3…"})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(payload) < 4 {
+		t.Fatalf("payload unexpectedly small: %d", len(payload))
+	}
+	if _, err := DecodeBootProgress(payload[:len(payload)-2]); err == nil {
+		t.Fatal("expected error on truncated payload, got nil")
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -32,7 +32,15 @@ const (
 // PaneViewportState records). Bumping the version lets pre-Plan-B clients
 // receive an explicit handshake rejection instead of a mysterious
 // ErrPayloadShort on the first resume attempt.
-const Version uint8 = 3
+//
+// v3 (PR #206): PaneSnapshot grew ContentTopRow / NumContentRows;
+// BufferDelta grew DecorRows.
+//
+// v4: MsgBootProgress added — server emits unsolicited string-payload
+// progress messages during expensive resume processing so the boot
+// splash can render fine-grained text instead of "Loading session…"
+// for the full WAL-replay window.
+const Version uint8 = 4
 
 // MessageType enumerates the canonical message categories exchanged between
 // client and server.
@@ -74,6 +82,12 @@ const (
 	MsgViewportUpdate
 	MsgFetchRange
 	MsgFetchRangeResponse
+	// MsgBootProgress carries a single human-readable progress string
+	// emitted by the server during expensive resume operations
+	// (per-pane WAL hydration etc). Clients display it in the boot
+	// splash; missing this message is harmless — the splash falls back
+	// to the static "Loading session" stage.
+	MsgBootProgress
 )
 
 // Header describes the fixed portion of every frame exchanged over the wire.

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -127,8 +127,8 @@ func TestReadMessage_PayloadTooLarge(t *testing.T) {
 	}
 }
 
-func TestProtocolVersionIs3(t *testing.T) {
-	if Version != 3 {
-		t.Fatalf("expected Version=3, got %d", Version)
+func TestProtocolVersionIs4(t *testing.T) {
+	if Version != 4 {
+		t.Fatalf("expected Version=4, got %d", Version)
 	}
 }

--- a/texel/desktop_engine_core.go
+++ b/texel/desktop_engine_core.go
@@ -139,6 +139,14 @@ type DesktopEngine struct {
 	pendingAppStartsMu sync.Mutex
 	pendingAppStarts   []*pane
 
+	// progressReporter, when set, receives short human-readable
+	// messages during slow boot phases (snapshot-restore app starts).
+	// The boot splash uses it to surface per-pane progress so a
+	// long SetViewportSize / StartPreparedApp loop doesn't sit on a
+	// single static message. Optional; nil-safe at call sites.
+	progressReporterMu sync.Mutex
+	progressReporter   func(string)
+
 	stateMu      sync.Mutex
 	hasLastState bool
 	lastState    StatePayload
@@ -911,6 +919,15 @@ func (d *DesktopEngine) PaneStates() []PaneStateSnapshot {
 	return states
 }
 
+// SetProgressReporter wires a callback that receives short
+// human-readable messages during slow boot phases. Pass nil to
+// detach. Safe to call from any goroutine.
+func (d *DesktopEngine) SetProgressReporter(fn func(string)) {
+	d.progressReporterMu.Lock()
+	d.progressReporter = fn
+	d.progressReporterMu.Unlock()
+}
+
 // SetViewportSize overrides the desktop viewport dimensions, typically used by
 // remote clients to dictate layout size.
 func (d *DesktopEngine) SetViewportSize(cols, rows int) {
@@ -946,8 +963,20 @@ func (d *DesktopEngine) startPendingApps() {
 		return
 	}
 
+	d.progressReporterMu.Lock()
+	report := d.progressReporter
+	d.progressReporterMu.Unlock()
+
 	debuglog.Printf("[RESTORE] Starting %d apps that were waiting for viewport dimensions", len(pending))
-	for _, p := range pending {
+	total := len(pending)
+	for i, p := range pending {
+		if report != nil {
+			title := p.getTitle()
+			if title == "" {
+				title = "untitled"
+			}
+			report(fmt.Sprintf("Restoring pane %d of %d (%s)…", i+1, total, title))
+		}
 		p.StartPreparedApp()
 	}
 

--- a/texel/progress_reporter_test.go
+++ b/texel/progress_reporter_test.go
@@ -1,0 +1,141 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: texel/progress_reporter_test.go
+// Summary: Tests for DesktopEngine.SetProgressReporter and the
+// per-pane progress emissions in SnapshotForClient. The boot splash
+// surfaces these messages during cold-start WAL replay; without
+// direct test coverage an off-by-one in the "N of M" denominator or
+// a mis-quoted title would ship silently.
+
+package texel
+
+import (
+	"sync"
+	"testing"
+)
+
+// snapshotProgressTestPane builds a minimal leaf pane suitable for a
+// snapshot walk. It only needs a non-nil app (so getTitle returns the
+// title) and the absolute rect fields; everything else can stay zero.
+func snapshotProgressTestPane(title string) *pane {
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = 20, 6
+	app := &snapshotTestApp{title: title, cols: 18, rows: 4}
+	p.setApp(app)
+	return p
+}
+
+// makeWorkspaceWithPanes builds a DesktopEngine whose active
+// workspace's tree consists of a flat split with one leaf per title.
+// Sufficient for SnapshotForClient's depth-first walk; we don't need
+// a real lifecycle / shell factory because capturePaneSnapshot reads
+// only the pane's own state.
+func makeWorkspaceWithPanes(t *testing.T, titles []string) *DesktopEngine {
+	t.Helper()
+	d := &DesktopEngine{
+		workspaces: make(map[int]*Workspace),
+	}
+	ws := &Workspace{id: 1, tree: &Tree{}}
+	if len(titles) == 1 {
+		// Single-leaf tree.
+		ws.tree.Root = &Node{Pane: snapshotProgressTestPane(titles[0])}
+	} else {
+		// Horizontal split with one leaf per title — keeps the walk
+		// order stable so we can assert message ordering.
+		root := &Node{Split: Horizontal}
+		for _, title := range titles {
+			leaf := &Node{Parent: root, Pane: snapshotProgressTestPane(title)}
+			root.Children = append(root.Children, leaf)
+		}
+		ws.tree.Root = root
+	}
+	d.workspaces[ws.id] = ws
+	d.activeWorkspace = ws
+	return d
+}
+
+func TestSetProgressReporter_StoresAndDetaches(t *testing.T) {
+	d := &DesktopEngine{}
+	if d.progressReporter != nil {
+		t.Fatal("default progressReporter should be nil")
+	}
+	d.SetProgressReporter(func(string) {})
+	if d.progressReporter == nil {
+		t.Fatal("SetProgressReporter did not store the callback")
+	}
+	d.SetProgressReporter(nil)
+	if d.progressReporter != nil {
+		t.Fatal("SetProgressReporter(nil) did not detach the callback")
+	}
+}
+
+func TestSnapshotForClient_PerPaneProgressMessages(t *testing.T) {
+	titles := []string{"shell", "editor", "logs"}
+	d := makeWorkspaceWithPanes(t, titles)
+
+	var mu sync.Mutex
+	var got []string
+	d.SetProgressReporter(func(msg string) {
+		mu.Lock()
+		got = append(got, msg)
+		mu.Unlock()
+	})
+
+	_ = d.SnapshotForClient()
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{
+		"Rendering pane 1 of 3 (shell)…",
+		"Rendering pane 2 of 3 (editor)…",
+		"Rendering pane 3 of 3 (logs)…",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d messages, want %d: %#v", len(got), len(want), got)
+	}
+	for i, msg := range want {
+		if got[i] != msg {
+			t.Errorf("message %d: got %q, want %q", i, got[i], msg)
+		}
+	}
+}
+
+func TestSnapshotForClient_NoReporterIsSilent(t *testing.T) {
+	// SnapshotForClient with progressReporter unset must not panic
+	// and must not invoke any callback (since none is registered).
+	d := makeWorkspaceWithPanes(t, []string{"only"})
+	// Don't call SetProgressReporter.
+
+	// Just verify it doesn't panic; capture.Panes population is
+	// already covered by other snapshot tests.
+	_ = d.SnapshotForClient()
+}
+
+func TestSnapshotForClient_UntitledPaneFallsBackGracefully(t *testing.T) {
+	// A pane with an empty title must not produce "Rendering pane 1
+	// of 1 ()…"; the format substitutes "untitled".
+	d := &DesktopEngine{
+		workspaces: make(map[int]*Workspace),
+	}
+	ws := &Workspace{id: 1, tree: &Tree{}}
+	p := newPane(nil)
+	p.absX0, p.absY0 = 0, 0
+	p.absX1, p.absY1 = 20, 6
+	app := &snapshotTestApp{title: "", cols: 18, rows: 4}
+	p.setApp(app)
+	ws.tree.Root = &Node{Pane: p}
+	d.workspaces[ws.id] = ws
+	d.activeWorkspace = ws
+
+	var got string
+	d.SetProgressReporter(func(msg string) { got = msg })
+
+	_ = d.SnapshotForClient()
+
+	want := "Rendering pane 1 of 1 (untitled)…"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/texel/snapshot.go
+++ b/texel/snapshot.go
@@ -8,6 +8,7 @@
 package texel
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/framegrace/texelui/theme"
@@ -130,28 +131,53 @@ func (d *DesktopEngine) SnapshotForClient() TreeCapture {
 	capture.Panes = make([]PaneSnapshot, 0)
 	capture.ActiveWorkspaceID = d.activeWorkspace.id
 
-	var collect func(*Node)
-	collect = func(n *Node) {
-		if n == nil {
-			return
-		}
-		if len(n.Children) == 0 {
-			if n.Pane != nil {
-				// Check if already captured
-				if _, exists := paneIndex[n.Pane]; !exists {
-					paneSnap := capturePaneSnapshot(n.Pane)
-					paneIndex[n.Pane] = len(capture.Panes)
-					capture.Panes = append(capture.Panes, paneSnap)
+	// Two-pass capture so per-pane progress reporting can give an
+	// "N of M" denominator. Each capturePaneSnapshot reads the pane's
+	// rendered buffer, which on rehydrated cold starts pulls WAL
+	// pages from disk — slow enough that without progress signals
+	// the boot splash sits on a single message for the duration.
+	d.progressReporterMu.Lock()
+	report := d.progressReporter
+	d.progressReporterMu.Unlock()
+
+	// seen dedups panes during the walk (a pane could appear in
+	// multiple subtrees in pathological cases). paneIndex itself is
+	// populated once per pane in the second pass so its value
+	// matches len(capture.Panes) — what buildTreeCapture reads.
+	seen := make(map[*pane]struct{})
+	var orderedPanes []*pane
+	if d.activeWorkspace.tree.Root != nil {
+		var walk func(*Node)
+		walk = func(n *Node) {
+			if n == nil {
+				return
+			}
+			if len(n.Children) == 0 && n.Pane != nil {
+				if _, exists := seen[n.Pane]; !exists {
+					seen[n.Pane] = struct{}{}
+					orderedPanes = append(orderedPanes, n.Pane)
 				}
 			}
+			for _, child := range n.Children {
+				walk(child)
+			}
 		}
-		for _, child := range n.Children {
-			collect(child)
-		}
-	}
+		walk(d.activeWorkspace.tree.Root)
 
-	if d.activeWorkspace.tree.Root != nil {
-		collect(d.activeWorkspace.tree.Root)
+		total := len(orderedPanes)
+		for i, p := range orderedPanes {
+			if report != nil {
+				title := p.getTitle()
+				if title == "" {
+					title = "untitled"
+				}
+				report(fmt.Sprintf("Rendering pane %d of %d (%s)…", i+1, total, title))
+			}
+			paneSnap := capturePaneSnapshot(p)
+			paneIndex[p] = len(capture.Panes)
+			capture.Panes = append(capture.Panes, paneSnap)
+		}
+
 		capture.Root = buildTreeCapture(d.activeWorkspace.tree.Root, paneIndex)
 		// For consistency, also set it in map
 		capture.WorkspaceRoots[d.activeWorkspace.id] = capture.Root


### PR DESCRIPTION
## Summary

Adds a boot splash that owns the tcell screen during the texelation cold-start window — supervisor health-check, protocol handshake, and the first WAL-replay-driven render. Without it, deep-history rehydrations spent 10–15s on a blank terminal with no signal that anything was happening; the supervisor's stdout messages got overwritten by tcell once the client took the screen.

The splash renders a centered status box with stage transitions (`Starting server` → `Connecting` → `Loading session`), a 3 Hz cyan pulse on the stage line, an elapsed-time counter, and a per-pane detail line populated by progress messages the server emits during `RestorePaneViewport` and `SnapshotForClient`. The runner paints to an externally-managed screen so handoff to `clientrt.Run` is flicker-free — the first production frame lands on the same surface, then the splash stops. This also drops the screen-handoff plumbing Plan F (#199 session recovery) will extend with a session picker.

The handoff itself is gated on three flags (`treeSnapshotApplied`, `firstContentDelta`, `fullRenderHappened`) extracted as `clientState.bootHandoffReady()` — an intermediate version had a race where `ensureBuffers`-on-first-call + a parallel decor-only `BufferDelta` would prematurely flip the splash to a workspace with only borders painted. The comment alongside the gate documents the race; tests cover all 8 combinations of the three flags.

3 commits, 25 files, +2007 / -73:
- `dcb1051` Protocol v4 + `MsgBootProgress` + `RequestResume` progress callback
- `f90f491` Boot splash package + `clientrt` screen handoff + the three-flag gate
- `57bd379` Server-side per-pane progress emission via `DesktopEngine.ProgressReporter`

Two rounds of multi-agent review (code, silent-failure, tests, comments) — all flagged items addressed.

## Test plan

- [x] `go test -race ./cmd/texelation/... ./internal/runtime/client/... ./internal/runtime/server/ ./protocol/ ./client/ ./texel/` — green
- [x] `gofmt -l` clean on branch files
- [x] Manual cold-start (\`./bin/texelation --stop && ./bin/texelation\`) — splash visibly progresses through `Starting server` → `Connecting` → `Loading session` with cyan-breathing stage text and per-pane "Restoring pane N of M (title)…" / "Rendering pane N of M (title)…" detail messages over the full WAL-replay window
- [x] Manual warm-start — splash flashes briefly and hands off cleanly with no visible transition artifact
- [x] Race detector clean on the splash runner (`paintMu` + `wakeMu`-gated `Stop` + `drainEvents` poll)
- [ ] Verify on non-rehydrated / fresh-session resume that the existing TreeSnapshot-during-resume path still ships its early snapshot and triggers handoff promptly
- [ ] Verify Ctrl-C during the splash error-display window collapses the wait (signal.NotifyContext + ctx-aware sleep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)