### PR TITLE
Client event-loop fairness: priority drain + render coalesce

### DIFF
--- a/docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md
+++ b/docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md
@@ -45,7 +45,6 @@ package clientruntime
 
 import (
 	"testing"
-	"time"
 )
 
 // TestCoalesceRenderCh_DrainsAllQueuedTicks verifies the helper
@@ -107,16 +106,30 @@ Add at the end of the file (after the `Run` function, before any existing helper
 // delta rate, the loop spent most of its time re-rendering against
 // transient intermediate state; coalescing makes render frequency
 // bounded by render duration itself.
+//
+// The function logs (at debuglog level) when it coalesces 2+ ticks
+// in one call. Pre-coalesce, the renderCh channel filling its 64
+// buffer was the de-facto canary that render() was lagging behind
+// readLoop. Coalescing collapses bursts before the buffer can fill,
+// so this log line preserves the same diagnostic signal — a tail
+// of the debug log shows post-hoc whether bursts were arriving.
 func coalesceRenderCh(ch <-chan struct{}) {
+	count := 0
 	for {
 		select {
 		case <-ch:
+			count++
 		default:
+			if count > 1 {
+				debuglog.Printf("event loop: coalesced %d renderCh ticks", count)
+			}
 			return
 		}
 	}
 }
 ```
+
+The `debuglog` import already exists in `app.go` (used by other code in the file); no new import needed.
 
 - [ ] **Step 2: Verify the failing test from Task 1 now passes**
 
@@ -126,7 +139,16 @@ Expected: PASS.
 
 - [ ] **Step 3: Append the second test to `event_loop_fairness_test.go`**
 
-Append at the end of the file (after the closing `}` of `TestCoalesceRenderCh_DrainsAllQueuedTicks`):
+This test uses `time.After`, so first add `"time"` to the import block at the top of the file:
+
+```go
+import (
+	"testing"
+	"time"
+)
+```
+
+Then append at the end of the file (after the closing `}` of `TestCoalesceRenderCh_DrainsAllQueuedTicks`):
 
 ```go
 // TestCoalesceRenderCh_NonBlockingOnEmpty verifies the helper
@@ -186,20 +208,21 @@ Append at the end of the file:
 // helper pulls every queued event and dispatches each via the
 // supplied callback in order, returning the total count and
 // ok=true for the empty-after-drain case.
+//
+// We tag events via NewEventInterrupt(int) and compare the int
+// payload (via .Data()) rather than pointer-equal the events
+// themselves — tcell.Event is an interface and pointer equality
+// would silently break if tcell ever pooled or copied events.
 func TestDrainScreenEvents_ReturnsCountAndDispatches(t *testing.T) {
 	ch := make(chan tcell.Event, 4)
-	events := []tcell.Event{
-		tcell.NewEventInterrupt(1),
-		tcell.NewEventInterrupt(2),
-		tcell.NewEventInterrupt(3),
-	}
-	for _, ev := range events {
-		ch <- ev
+	want := []int{10, 20, 30}
+	for _, id := range want {
+		ch <- tcell.NewEventInterrupt(id)
 	}
 
-	var dispatched []tcell.Event
+	var dispatched []int
 	handle := func(ev tcell.Event) bool {
-		dispatched = append(dispatched, ev)
+		dispatched = append(dispatched, ev.(*tcell.EventInterrupt).Data().(int))
 		return true
 	}
 
@@ -208,15 +231,15 @@ func TestDrainScreenEvents_ReturnsCountAndDispatches(t *testing.T) {
 	if !ok {
 		t.Errorf("ok = false, want true on clean drain")
 	}
-	if drained != len(events) {
-		t.Errorf("drained = %d, want %d", drained, len(events))
+	if drained != len(want) {
+		t.Errorf("drained = %d, want %d", drained, len(want))
 	}
-	if len(dispatched) != len(events) {
-		t.Fatalf("dispatched len = %d, want %d", len(dispatched), len(events))
+	if len(dispatched) != len(want) {
+		t.Fatalf("dispatched len = %d, want %d", len(dispatched), len(want))
 	}
-	for i, ev := range events {
-		if dispatched[i] != ev {
-			t.Errorf("dispatch[%d]: got %v, want %v", i, dispatched[i], ev)
+	for i, id := range want {
+		if dispatched[i] != id {
+			t.Errorf("dispatch[%d]: got %d, want %d", i, dispatched[i], id)
 		}
 	}
 }
@@ -287,7 +310,7 @@ Run: `go test ./internal/runtime/client/ -run TestDrainScreenEvents_ReturnsCount
 
 Expected: PASS.
 
-- [ ] **Step 3: Append two more tests to `event_loop_fairness_test.go`**
+- [ ] **Step 3: Append four more tests to `event_loop_fairness_test.go`**
 
 Append at the end:
 
@@ -347,13 +370,92 @@ func TestDrainScreenEvents_ChannelClosedReturnsNotOK(t *testing.T) {
 		t.Errorf("drained = %d, want 0 (channel closed before any event)", drained)
 	}
 }
+
+// TestDrainScreenEvents_DrainsThenChannelCloses covers the realistic
+// shutdown shape: events are queued, then the producer closes the
+// channel. The helper must drain the buffered events first and only
+// then observe the close. Without this case, a future regression
+// where the close-detection logic short-circuits before draining
+// the buffer would silently lose user input.
+func TestDrainScreenEvents_DrainsThenChannelCloses(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	want := []int{1, 2}
+	for _, id := range want {
+		ch <- tcell.NewEventInterrupt(id)
+	}
+	close(ch)
+
+	var dispatched []int
+	handle := func(ev tcell.Event) bool {
+		dispatched = append(dispatched, ev.(*tcell.EventInterrupt).Data().(int))
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false (channel closed after drain)")
+	}
+	if drained != len(want) {
+		t.Errorf("drained = %d, want %d", drained, len(want))
+	}
+	if len(dispatched) != len(want) {
+		t.Fatalf("dispatched %d events, want %d", len(dispatched), len(want))
+	}
+	for i, id := range want {
+		if dispatched[i] != id {
+			t.Errorf("dispatch[%d]: got %d, want %d", i, dispatched[i], id)
+		}
+	}
+}
+
+// TestDrainScreenEvents_HandleReturnsFalseStopsDrain covers the
+// production exit signal: handleScreenEvent returns false to mean
+// "the run loop should exit" (e.g. ctrl-Q, session disconnect).
+// The helper must propagate that immediately — drained must reflect
+// only events whose handler ran successfully (excluding the one
+// that returned false), and any remaining queued events stay in
+// the channel. Without this case, an off-by-one regression in the
+// helper (count++ before vs. after the handle check, or draining
+// one extra event after the false return) would silently leak
+// events past the exit signal.
+func TestDrainScreenEvents_HandleReturnsFalseStopsDrain(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	for _, id := range []int{1, 2, 3} {
+		ch <- tcell.NewEventInterrupt(id)
+	}
+
+	var dispatched []int
+	handle := func(ev tcell.Event) bool {
+		id := ev.(*tcell.EventInterrupt).Data().(int)
+		dispatched = append(dispatched, id)
+		return id != 2 // signal exit on the second event
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false when handle returned false")
+	}
+	if drained != 1 {
+		t.Errorf("drained = %d, want 1 (only the first successful event counts)", drained)
+	}
+	if len(dispatched) != 2 {
+		t.Errorf("dispatched %d events, want 2 (the handler ran for events 1 and 2)", len(dispatched))
+	}
+	// The third event must remain in the channel — exit-on-false
+	// means the helper stops AT the false event, not after it.
+	if got := len(ch); got != 1 {
+		t.Errorf("ch len after exit = %d, want 1 (third event should not have been drained)", got)
+	}
+}
 ```
 
-- [ ] **Step 4: Run all five tests**
+- [ ] **Step 4: Run all seven tests**
 
 Run: `go test ./internal/runtime/client/ -run "TestCoalesceRenderCh|TestDrainScreenEvents" -count=1 -v`
 
-Expected: 5/5 PASS.
+Expected: 7/7 PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -472,9 +574,11 @@ Expected: clean build.
 
 - [ ] **Step 3: Run the existing client-runtime tests for regression**
 
-Run: `go test ./internal/runtime/client/... -count=1 -race`
+Run: `go test ./internal/runtime/client/... -count=1 -race -v`
 
 Expected: PASS for everything that already passed on `main`. The loop-wiring change should not affect any existing test — the helpers are pure and the loop semantics are equivalent on idle / single-event paths.
+
+If any test fails, especially anything in `viewport_tracker_*_test.go`, `pane_cache_dispatch_test.go`, or `boot_handoff_test.go` (the suites that exercise channels and state mutations the loop interacts with), STOP and report — do not paper over by adjusting expectations. Compare the failing test against `main` to confirm the failure is introduced by the loop changes.
 
 - [ ] **Step 4: Commit**
 

--- a/docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md
+++ b/docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md
@@ -1,0 +1,553 @@
+# Client Event-Loop Fairness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the client's main event loop from making input lose select coin flips against `renderCh` ticks under heavy server traffic. Adds two pure helpers (`coalesceRenderCh`, `drainScreenEvents`) and wires them into the main loop so a delta storm collapses into one render and queued events always run before the next select.
+
+**Architecture:** Single-file change in `internal/runtime/client/app.go`. Two new package-level helpers — `coalesceRenderCh(ch <-chan struct{})` non-blocking-drains all queued ticks, and `drainScreenEvents(events <-chan tcell.Event, handle func(tcell.Event) bool) (int, bool)` pulls every queued event and dispatches via the supplied callback (the callback is a closure capturing state/screen/sessionID/writer at the call site, so the helper itself is pure and unit-testable). The loop body gets one new priority drain at the top and a `coalesceRenderCh(renderCh)` call inside the existing `case <-renderCh` arm.
+
+**Tech Stack:** Go 1.24.3, `github.com/gdamore/tcell/v2` for `tcell.Event`. No new imports.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-client-event-loop-fairness-design.md`
+
+---
+
+## File Structure
+
+| Path | Status | Responsibility |
+|------|--------|----------------|
+| `internal/runtime/client/app.go` | Modify | Add `coalesceRenderCh` + `drainScreenEvents` helpers; tweak main loop body to call them |
+| `internal/runtime/client/event_loop_fairness_test.go` | Create | Five unit tests covering both helpers' contracts |
+
+No other files touched. No protocol changes. No new exported APIs.
+
+---
+
+## Task 1: Failing test for `coalesceRenderCh`
+
+Establishes the TDD baseline — test references the helper that doesn't exist yet, fails to compile.
+
+**Files:**
+- Create: `internal/runtime/client/event_loop_fairness_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/event_loop_fairness_test.go
+// Summary: Tests for the priority-drain + coalesce helpers that
+// keep the client's main event loop fair under heavy server
+// traffic.
+
+package clientruntime
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCoalesceRenderCh_DrainsAllQueuedTicks verifies the helper
+// non-blocking-drains every queued tick on the channel. Without
+// this, a burst of N back-to-back signals would each trigger a
+// separate render call.
+func TestCoalesceRenderCh_DrainsAllQueuedTicks(t *testing.T) {
+	ch := make(chan struct{}, 8)
+	for i := 0; i < 5; i++ {
+		ch <- struct{}{}
+	}
+	if got := len(ch); got != 5 {
+		t.Fatalf("setup: ch len = %d, want 5", got)
+	}
+
+	coalesceRenderCh(ch)
+
+	if got := len(ch); got != 0 {
+		t.Errorf("after coalesce: ch len = %d, want 0", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/runtime/client/ -run TestCoalesceRenderCh_DrainsAllQueuedTicks -count=1 -v`
+
+Expected: FAIL with `undefined: coalesceRenderCh`. Test references the helper that doesn't exist yet — the next task adds it.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add internal/runtime/client/event_loop_fairness_test.go
+git commit -m "Test: failing coalesceRenderCh assertion"
+```
+
+The failing-test commit cleanly separates from the implementation that flips it to passing.
+
+---
+
+## Task 2: Implement `coalesceRenderCh` + add second test
+
+Adds the helper and the empty-channel non-blocking test (which passes immediately against the new implementation).
+
+**Files:**
+- Modify: `internal/runtime/client/app.go` (add helper before `Run` or at end of file — pick the cleaner spot near other top-level helpers)
+- Modify: `internal/runtime/client/event_loop_fairness_test.go` (append second test)
+
+- [ ] **Step 1: Add the helper to `app.go`**
+
+Add at the end of the file (after the `Run` function, before any existing helpers like `loadKeybindings`):
+
+```go
+// coalesceRenderCh non-blocks-drains every queued tick on ch. The
+// client's main event loop calls this after consuming a single
+// renderCh tick from its select so a burst of N signals (heavy
+// server traffic flooding readLoop's signalRender path) collapses
+// into one render call. With render frequency tracking incoming
+// delta rate, the loop spent most of its time re-rendering against
+// transient intermediate state; coalescing makes render frequency
+// bounded by render duration itself.
+func coalesceRenderCh(ch <-chan struct{}) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Verify the failing test from Task 1 now passes**
+
+Run: `go test ./internal/runtime/client/ -run TestCoalesceRenderCh_DrainsAllQueuedTicks -count=1 -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Append the second test to `event_loop_fairness_test.go`**
+
+Append at the end of the file (after the closing `}` of `TestCoalesceRenderCh_DrainsAllQueuedTicks`):
+
+```go
+// TestCoalesceRenderCh_NonBlockingOnEmpty verifies the helper
+// returns promptly when the channel is empty. A blocking call
+// here would freeze the main loop's renderCh case.
+func TestCoalesceRenderCh_NonBlockingOnEmpty(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		coalesceRenderCh(ch)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// returned promptly — good
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("coalesceRenderCh blocked on empty channel")
+	}
+}
+```
+
+- [ ] **Step 4: Run both coalesce tests**
+
+Run: `go test ./internal/runtime/client/ -run TestCoalesceRenderCh -count=1 -v`
+
+Expected: 2/2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/client/app.go internal/runtime/client/event_loop_fairness_test.go
+git commit -m "Add coalesceRenderCh helper for client main-loop fairness"
+```
+
+---
+
+## Task 3: Failing test for `drainScreenEvents`
+
+References the helper that doesn't exist yet — fails to compile.
+
+**Files:**
+- Modify: `internal/runtime/client/event_loop_fairness_test.go` (append)
+
+- [ ] **Step 1: Append the failing test**
+
+Append at the end of the file:
+
+```go
+// drainScreenEvents helper expectations
+//
+// The helper has the signature:
+//   func drainScreenEvents(events <-chan tcell.Event, handle func(tcell.Event) bool) (drained int, ok bool)
+// Pulled events are dispatched via handle. ok=false means either the
+// channel is closed OR handle returned false (signalling exit).
+
+// TestDrainScreenEvents_ReturnsCountAndDispatches verifies the
+// helper pulls every queued event and dispatches each via the
+// supplied callback in order, returning the total count and
+// ok=true for the empty-after-drain case.
+func TestDrainScreenEvents_ReturnsCountAndDispatches(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	events := []tcell.Event{
+		tcell.NewEventInterrupt(1),
+		tcell.NewEventInterrupt(2),
+		tcell.NewEventInterrupt(3),
+	}
+	for _, ev := range events {
+		ch <- ev
+	}
+
+	var dispatched []tcell.Event
+	handle := func(ev tcell.Event) bool {
+		dispatched = append(dispatched, ev)
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if !ok {
+		t.Errorf("ok = false, want true on clean drain")
+	}
+	if drained != len(events) {
+		t.Errorf("drained = %d, want %d", drained, len(events))
+	}
+	if len(dispatched) != len(events) {
+		t.Fatalf("dispatched len = %d, want %d", len(dispatched), len(events))
+	}
+	for i, ev := range events {
+		if dispatched[i] != ev {
+			t.Errorf("dispatch[%d]: got %v, want %v", i, dispatched[i], ev)
+		}
+	}
+}
+```
+
+The new test imports `tcell.Event` directly — add `"github.com/gdamore/tcell/v2"` to the existing import block at the top of `event_loop_fairness_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/runtime/client/ -run TestDrainScreenEvents_ReturnsCountAndDispatches -count=1 -v`
+
+Expected: FAIL with `undefined: drainScreenEvents`. Test references the helper that doesn't exist yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/runtime/client/event_loop_fairness_test.go
+git commit -m "Test: failing drainScreenEvents assertion"
+```
+
+---
+
+## Task 4: Implement `drainScreenEvents` + add remaining tests
+
+Adds the helper and the two remaining tests (empty channel, closed channel) which pass immediately against the new implementation.
+
+**Files:**
+- Modify: `internal/runtime/client/app.go` (append helper after `coalesceRenderCh`)
+- Modify: `internal/runtime/client/event_loop_fairness_test.go` (append two tests)
+
+- [ ] **Step 1: Add the helper to `app.go`**
+
+Add immediately after `coalesceRenderCh`:
+
+```go
+// drainScreenEvents pulls every queued tcell event from events and
+// dispatches each via handle. Returns the count drained and ok=false
+// if either the channel closed (run-loop exit signal) or the handle
+// returned false (also a run-loop exit signal). Non-blocking: empty
+// channel returns (0, true) immediately and the caller's select can
+// block on the next signal.
+//
+// The handle callback is the call site's closure over
+// handleScreenEvent + state/screen/sessionID/writer; passing it as
+// a parameter keeps this helper pure and unit-testable without a
+// full clientState fixture.
+func drainScreenEvents(events <-chan tcell.Event, handle func(tcell.Event) bool) (drained int, ok bool) {
+	for {
+		select {
+		case ev, chOK := <-events:
+			if !chOK {
+				return drained, false
+			}
+			if !handle(ev) {
+				return drained, false
+			}
+			drained++
+		default:
+			return drained, true
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Verify the failing test from Task 3 now passes**
+
+Run: `go test ./internal/runtime/client/ -run TestDrainScreenEvents_ReturnsCountAndDispatches -count=1 -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Append two more tests to `event_loop_fairness_test.go`**
+
+Append at the end:
+
+```go
+// TestDrainScreenEvents_EmptyChannelReturnsZero verifies the helper
+// is a fast no-op when nothing is queued. A blocking implementation
+// would freeze the main loop's per-iteration priority drain.
+func TestDrainScreenEvents_EmptyChannelReturnsZero(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	handle := func(ev tcell.Event) bool {
+		t.Errorf("handle should not be called on empty channel; got %v", ev)
+		return true
+	}
+
+	done := make(chan struct {
+		drained int
+		ok      bool
+	}, 1)
+	go func() {
+		drained, ok := drainScreenEvents(ch, handle)
+		done <- struct {
+			drained int
+			ok      bool
+		}{drained, ok}
+	}()
+
+	select {
+	case res := <-done:
+		if res.drained != 0 {
+			t.Errorf("drained = %d, want 0", res.drained)
+		}
+		if !res.ok {
+			t.Errorf("ok = false, want true on empty drain")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("drainScreenEvents blocked on empty channel")
+	}
+}
+
+// TestDrainScreenEvents_ChannelClosedReturnsNotOK verifies the
+// helper returns ok=false when the channel is closed, so the main
+// loop's caller can return nil and exit cleanly.
+func TestDrainScreenEvents_ChannelClosedReturnsNotOK(t *testing.T) {
+	ch := make(chan tcell.Event, 1)
+	close(ch)
+	handle := func(ev tcell.Event) bool {
+		t.Errorf("handle should not be called when channel closed; got %v", ev)
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false for closed channel")
+	}
+	if drained != 0 {
+		t.Errorf("drained = %d, want 0 (channel closed before any event)", drained)
+	}
+}
+```
+
+- [ ] **Step 4: Run all five tests**
+
+Run: `go test ./internal/runtime/client/ -run "TestCoalesceRenderCh|TestDrainScreenEvents" -count=1 -v`
+
+Expected: 5/5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/client/app.go internal/runtime/client/event_loop_fairness_test.go
+git commit -m "Add drainScreenEvents helper for client main-loop fairness"
+```
+
+---
+
+## Task 5: Wire helpers into the main loop
+
+Tweaks the loop body in `Run` to call the new helpers. This is the user-visible behaviour change.
+
+**Files:**
+- Modify: `internal/runtime/client/app.go` (the `for { ... }` body inside `Run`, currently around lines 403-492)
+
+- [ ] **Step 1: Apply the loop-body changes**
+
+Inside `Run`, locate the main `for { ... }` body that begins with `// Start or stop the unified ticker.` (around line 404). Make two changes:
+
+**Change A — add the priority drain before the main `select`.** Insert this block after the animation ticker setup (after the line `tickCh = ticker.C` block, before the line `select {`):
+
+```go
+		// PRIORITY DRAIN: process every queued tcell event before
+		// blocking on the main select. Without this, Go's uniform-
+		// random select pick lets renderCh win most rounds when
+		// it's saturated by heavy server traffic — input lags
+		// behind every queued render. drainScreenEvents is
+		// non-blocking when the events channel is empty, so the
+		// hot path is one default-case channel receive.
+		drained, ok := drainScreenEvents(events, func(ev tcell.Event) bool {
+			return handleScreenEvent(ev, state, screen, sessionID, writer)
+		})
+		if !ok {
+			return nil
+		}
+		if drained > 0 {
+			// Events advanced state; loop back so the next
+			// iteration re-evaluates the animation ticker
+			// condition before committing to a select. Removing
+			// this `continue` would let the loop block on a
+			// renderCh / tickCh tick that an event might have
+			// invalidated (e.g. a key toggling animations off).
+			continue
+		}
+```
+
+**Change B — coalesce queued renderCh ticks at the top of the `case <-renderCh:` arm.** Replace the existing `case <-renderCh:` block (currently at app.go ~line 443):
+
+```go
+		case <-renderCh:
+			// Data-driven render: delta/snapshot arrived. Render immediately, no time advance.
+			state.frameDT = 0
+			if state.effects != nil {
+				state.effects.Update(0)
+			}
+			render(state, screen)
+			// Splash handoff: stop only once a real TreeSnapshot has
+			// ... (large comment block)
+			if !firstContentRendered && state.bootHandoffReady() {
+				firstContentRendered = true
+				emitStatus(StageReady, "")
+			}
+```
+
+…with this version (one new line + an inline comment; the rest is unchanged):
+
+```go
+		case <-renderCh:
+			// Data-driven render: delta/snapshot arrived. Render immediately, no time advance.
+			// Coalesce any further renderCh ticks that readLoop has
+			// queued during the previous select round so a burst of
+			// N BufferDelta signals collapses into one render of
+			// the final state. Without this, render frequency
+			// tracks incoming delta rate.
+			coalesceRenderCh(renderCh)
+			state.frameDT = 0
+			if state.effects != nil {
+				state.effects.Update(0)
+			}
+			render(state, screen)
+			// Splash handoff: stop only once a real TreeSnapshot has
+			// been applied AND a content-bearing delta has landed.
+			//
+			// On rehydrated cold starts the server defers
+			// TreeSnapshot to handleClientReady (so it lands at the
+			// client's real dimensions), and that handler runs the
+			// slow SetViewportSize → Snapshot chain. Before that,
+			// the publisher emits decor-only BufferDeltas that fire
+			// renderCh while the panes are still hydrating.
+			//
+			// Without the treeSnapshotApplied gate the splash hands
+			// off to a workspace that has no real content yet. The
+			// race: on the first renderCh tick, ensureBuffers
+			// returns resized=true (so fullRender runs and
+			// fullRenderHappened flips) and a decor-only BufferDelta
+			// already in flight can flip firstContentDelta during
+			// render(). Both flags would pass, the splash would
+			// stop, and the user would see only borders while
+			// handleClientReady's slow SetViewportSize → Snapshot
+			// chain finished.
+			if !firstContentRendered && state.bootHandoffReady() {
+				firstContentRendered = true
+				emitStatus(StageReady, "")
+			}
+```
+
+Leave the existing `case ev, ok := <-events:`, `case <-doneCh:`, and the post-select clipboard sync block untouched. The `events` case in the main select is the fallback for events that arrive *after* the priority drain ran but before the loop blocks — without it, a fresh event arriving mid-block would have to wait for an unrelated wake-up.
+
+- [ ] **Step 2: Build the package**
+
+Run: `go build ./internal/runtime/client/...`
+
+Expected: clean build.
+
+- [ ] **Step 3: Run the existing client-runtime tests for regression**
+
+Run: `go test ./internal/runtime/client/... -count=1 -race`
+
+Expected: PASS for everything that already passed on `main`. The loop-wiring change should not affect any existing test — the helpers are pure and the loop semantics are equivalent on idle / single-event paths.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/runtime/client/app.go
+git commit -m "$(cat <<'EOF'
+Wire priority drain + render coalesce into client event loop
+
+The client's main loop in Run() previously used a flat 4-way select
+with Go's uniform-random pick. Heavy server traffic flooded
+renderCh, so events lost most select rounds and each render ran
+against transient intermediate state. Drain queued events before
+blocking on the main select (priority); coalesce remaining
+renderCh ticks before each data-driven render. Combined: render
+frequency is bounded by render duration itself, not delta rate;
+events always win when ready.
+EOF
+)"
+```
+
+---
+
+## Task 6: Race detector + final verification
+
+Confirms no goroutine races and the broader client suite still passes.
+
+- [ ] **Step 1: Race detector on the new tests**
+
+Run: `go test ./internal/runtime/client/ -run "TestCoalesceRenderCh|TestDrainScreenEvents" -count=10 -race`
+
+Expected: PASS, no race warnings.
+
+- [ ] **Step 2: Full client-runtime test suite under race**
+
+Run: `go test ./internal/runtime/client/... -count=1 -race`
+
+Expected: PASS.
+
+- [ ] **Step 3: Build the full repo**
+
+Run: `go build ./...`
+
+Expected: clean build, no warnings.
+
+- [ ] **Step 4: gofmt check**
+
+Run: `gofmt -l internal/runtime/client/app.go internal/runtime/client/event_loop_fairness_test.go`
+
+Expected: no output (no drift).
+
+If `gofmt` reports drift, run `gofmt -w` on the listed files and amend the previous commit:
+
+```bash
+gofmt -w internal/runtime/client/app.go internal/runtime/client/event_loop_fairness_test.go
+git add -u internal/runtime/client/
+git commit --amend --no-edit
+```
+
+- [ ] **Step 5: Manual cold-start test**
+
+This is the user-visible regression test the unit tests can't capture. Steps:
+
+```bash
+make build
+./bin/texelation --stop
+sleep 2
+./bin/texelation
+```
+
+In the running texelation, open two panes (`Ctrl-A` then split). In one pane, run `ls -lR /usr` (or any heavy-output command). While it's running, type into the other pane / select panes / toggle control mode. Input should remain responsive throughout — keystrokes should land within one render frame (~16–50 ms), not delayed by hundreds of milliseconds as before.
+
+Document the observed behaviour in the PR description.
+
+- [ ] **Step 6: No commit needed if everything is clean**
+
+If steps 1–4 pass with no edits, this task ships nothing new — it's a verification gate. Move on to opening the PR.

--- a/docs/superpowers/specs/2026-05-03-client-event-loop-fairness-design.md
+++ b/docs/superpowers/specs/2026-05-03-client-event-loop-fairness-design.md
@@ -1,0 +1,276 @@
+# Client Event-Loop Fairness — Design
+
+**Date:** 2026-05-03
+**Status:** Approved for plan
+**Scope:** Client-side `internal/runtime/client/app.go` main event loop
+
+## Problem
+
+When one pane has heavy output (`ls -lR`, build logs, `cat large_file`) the
+**entire client** becomes laggy — selecting panes, control-mode toggles, key
+input, mouse — every interactive action feels like it's stuck behind something.
+
+The server-side fix landed earlier (chunked `sendPending`) bounded how many
+diffs the server flushes per loop iteration; that's necessary but not
+sufficient. The visible lag is downstream in the **client's main event loop**.
+
+## Root cause
+
+The client's main loop in `internal/runtime/client/app.go`:
+
+```go
+for {
+    // ... animation ticker setup ...
+    select {
+    case <-tickCh:    /* render */
+    case <-renderCh:  /* render */
+    case ev := <-events: /* handle */
+    case <-doneCh:    return
+    }
+}
+```
+
+`readLoop` runs in a separate goroutine and signals `renderCh` on every
+applied `BufferDelta` (or other content message). Under heavy server traffic
+the `renderCh` channel (cap 64) stays full of fresh ticks. Two problems
+compound:
+
+1. **Render frequency tracks delta rate.** Each loop iteration consumes one
+   `renderCh` tick and runs a full `render()` (cache diff + `tcell.Show()`).
+   A burst of 50 `BufferDelta`s = 50 renders, even though one render covering
+   the final state would suffice.
+
+2. **Random `select` fairness.** Go's `select` picks uniformly at random when
+   multiple cases are ready. With renderCh constantly ready (refilling between
+   iterations) and events occasionally ready, the events case loses most of
+   the coin flips — an interactive keystroke is dispatched only after several
+   renders that didn't need to happen.
+
+The two failure modes together explain "the WHOLE client becomes laggy" — it
+isn't a network bottleneck, it's the main loop spending nearly all its time
+re-rendering against transient intermediate states while the user's input
+sits in the events buffer.
+
+## Out of scope
+
+- **60 Hz / wall-clock rate-limit on renders** (Option C from the brainstorm).
+  Worth adding only if measurement shows render itself is the bottleneck, not
+  the loop's pick discipline. The renderCh case is the only place data-driven
+  renders fire; adding a `lastRenderAt time.Time` guard there is local and
+  additive whenever we want it. Ship without it for now.
+- **Render in a separate goroutine.** Eliminates the in-flight-render-blocks-
+  events worst case, but doubles the rendering complexity (locking around
+  shared `state.cache`, double-buffer ownership, etc.). Out of scope until
+  measurement says it's needed.
+- **Server-side chunking** (already shipped on a sibling branch). Different
+  layer, complementary fix. This spec assumes nothing about the server's
+  flush behaviour — the client fix stands on its own.
+- **Animation tick coalescing.** The `tickCh` cadence is intentional — effects
+  expect a steady frame rate. Coalescing applies only to the data-driven
+  `renderCh` case.
+
+## Design
+
+### Component
+
+Two new helpers in `internal/runtime/client/app.go`, plus a small structural
+change to the main loop body. No new files, no new exported APIs.
+
+### Helpers
+
+```go
+// drainScreenEvents pulls every queued tcell event from `events` and
+// dispatches it via handleScreenEvent. Returns the number drained
+// and ok=false if the channel closed (signal that the run loop
+// should exit). Non-blocking: empty channel returns (0, true)
+// immediately and the caller falls through to the main select.
+func drainScreenEvents(
+    events <-chan tcell.Event,
+    state *clientState,
+    screen tcell.Screen,
+    sessionID [16]byte,
+    writer *messageWriter,
+) (drained int, ok bool) {
+    for {
+        select {
+        case ev, chOK := <-events:
+            if !chOK {
+                return drained, false
+            }
+            if !handleScreenEvent(ev, state, screen, sessionID, writer) {
+                return drained, false
+            }
+            drained++
+        default:
+            return drained, true
+        }
+    }
+}
+
+// coalesceRenderCh non-blocks-drains every queued tick on renderCh.
+// Used after a single tick is consumed by the main select so a
+// burst of N back-to-back signals (heavy server traffic) collapses
+// into one render call.
+func coalesceRenderCh(ch <-chan struct{}) {
+    for {
+        select {
+        case <-ch:
+        default:
+            return
+        }
+    }
+}
+```
+
+### Loop
+
+```go
+for {
+    // Animation ticker setup (unchanged) ...
+
+    // PRIORITY DRAIN: process every queued input event before
+    // waiting on anything else. User-driven event rates are well
+    // below the events channel cap (32), so this loop always
+    // exits in a handful of iterations.
+    drained, ok := drainScreenEvents(events, state, screen, sessionID, writer)
+    if !ok {
+        return nil
+    }
+    if drained > 0 {
+        // Events advanced state; loop back so the next iteration
+        // re-evaluates the animation ticker condition before
+        // committing to a select.
+        continue
+    }
+
+    select {
+    case <-tickCh:
+        // Animation tick (unchanged).
+        ...
+        render(state, screen)
+        state.frameDT = 0
+
+    case <-renderCh:
+        // Data-driven render. Coalesce remaining ticks so a
+        // delta storm collapses into a single render of the
+        // final state.
+        coalesceRenderCh(renderCh)
+        state.frameDT = 0
+        if state.effects != nil {
+            state.effects.Update(0)
+        }
+        render(state, screen)
+        // Splash handoff check (unchanged).
+        if !firstContentRendered && state.bootHandoffReady() {
+            firstContentRendered = true
+            emitStatus(StageReady, "")
+        }
+
+    case ev, ok := <-events:
+        if !ok {
+            return nil
+        }
+        if !handleScreenEvent(ev, state, screen, sessionID, writer) {
+            return nil
+        }
+
+    case <-doneCh:
+        fmt.Println("Connection closed")
+        return nil
+    }
+}
+```
+
+The events case in the main select stays — it handles the case where the
+loop blocked in `select` (no events drained at the top) and an event arrives
+mid-block. Without that fallback, an event arriving between the priority
+drain and the select would have to wait for a renderCh / tickCh / doneCh tick
+to wake the select.
+
+### Why this is sufficient
+
+- **Coalescing alone wouldn't fix events.** With `readLoop` faster than
+  `render()`, `renderCh` refills continuously between iterations. Random
+  `select` keeps picking renderCh as long as it's ready alongside events.
+
+- **Event-priority drain alone wouldn't slow renders.** It guarantees events
+  are handled when ready, but per-iteration we'd still call `render()` once
+  per renderCh tick — heavy `BufferDelta` storms still produce hundreds of
+  renders per second, each doing the diff + `tcell.Show()`.
+
+- **Combined**: render frequency is bounded by render duration itself (each
+  render covers all pending state; the next renderCh tick has to arrive after
+  render returns). Events are bounded by `handleScreenEvent` duration
+  (microseconds). Worst-case event latency = one in-flight render's duration
+  (~5–50 ms depending on workspace size), independent of incoming delta rate.
+
+### Forward-compat for Option C (60 Hz rate-limit)
+
+The renderCh case is the only place data-driven renders fire. Adding a
+`lastRenderAt time.Time` and a guard
+
+```go
+if since := time.Since(lastRenderAt); since < frameInterval {
+    // Re-arm renderCh and let timer fire next.
+    return
+}
+```
+
+is local and additive. We don't need to change anything in this spec to
+keep that door open.
+
+## Testing
+
+A new test file `internal/runtime/client/event_loop_fairness_test.go`. Helpers
+are pure functions, so unit tests can exercise them without a full
+`clientState` + `tcell.Screen` setup.
+
+1. **`TestCoalesceRenderCh_DrainsAllQueuedTicks`** — push 5 ticks into a
+   buffered chan, call `coalesceRenderCh`, assert `len(ch) == 0` after.
+
+2. **`TestCoalesceRenderCh_NonBlockingOnEmpty`** — call on empty chan inside
+   a goroutine with a 100 ms `time.After` deadline; assert it returns within
+   the deadline (proves the loop's `default` case is hit).
+
+3. **`TestDrainScreenEvents_ReturnsCountAndDispatches`** — build a mock
+   event channel and a hookable handler counter (via a test-only function
+   pointer or a wrapper), push 3 events, call `drainScreenEvents`, assert all
+   3 dispatched and returned count == 3, ok == true.
+
+4. **`TestDrainScreenEvents_EmptyChannelReturnsZero`** — empty chan returns
+   (0, true) without blocking.
+
+5. **`TestDrainScreenEvents_ChannelClosedReturnsNotOK`** — close the chan,
+   call `drainScreenEvents`, assert ok == false so the main loop exits.
+
+The integration behaviour ("events beat renderCh under heavy traffic") is
+hard to test without flakiness in a synchronous test — we rely on the
+manual `ls -lR` cold-start test the user runs, plus the helper-level unit
+tests pinning the contracts.
+
+## Risks
+
+- **Render starvation under pathological event rate.** A script
+  `xdotool`-spamming thousands of keys per second could keep the priority
+  drain busy and starve renders. Real human input rates are ≤100/sec and
+  each event dispatches in microseconds, so the drain returns in
+  microseconds. Not a real risk.
+
+- **Coalescing hides a backpressure signal.** Today, `signalRender` drops
+  signals when `renderCh` is full (non-blocking send). With coalescing the
+  buffer drains faster, so dropped signals decrease. That's a *good* side
+  effect — no actual risk.
+
+- **The events drain at the top of the loop runs even when no input is
+  pending.** Cost is one non-blocking channel receive (default case)
+  per iteration — single-digit nanoseconds. Negligible.
+
+- **`handleScreenEvent` returning false is the exit signal.** The drain
+  helper returns ok=false in that case, and the main loop returns nil.
+  Same as today's inline behaviour; just routed through the helper.
+
+- **Loop regression: someone removes `continue` after `drained > 0`.**
+  Without it, after draining events the loop falls into `select` and may
+  block on a renderCh tick that the drained events should have invalidated
+  (e.g. an animation toggled off by a key). The unit tests don't catch
+  this; a comment in the loop body marks it explicitly.

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -523,6 +523,36 @@ func formatPaneID(id [16]byte) string {
 	return fmt.Sprintf("%x", id[:4])
 }
 
+// coalesceRenderCh non-blocks-drains every queued tick on ch. The
+// client's main event loop calls this after consuming a single
+// renderCh tick from its select so a burst of N signals (heavy
+// server traffic flooding readLoop's signalRender path) collapses
+// into one render call. With render frequency tracking incoming
+// delta rate, the loop spent most of its time re-rendering against
+// transient intermediate state; coalescing makes render frequency
+// bounded by render duration itself.
+//
+// The function logs (at debuglog level) when it coalesces 2+ ticks
+// in one call. Pre-coalesce, the renderCh channel filling its 64
+// buffer was the de-facto canary that render() was lagging behind
+// readLoop. Coalescing collapses bursts before the buffer can fill,
+// so this log line preserves the same diagnostic signal — a tail
+// of the debug log shows post-hoc whether bursts were arriving.
+func coalesceRenderCh(ch <-chan struct{}) {
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		default:
+			if count > 1 {
+				debuglog.Printf("event loop: coalesced %d renderCh ticks", count)
+			}
+			return
+		}
+	}
+}
+
 func setupLogging() (*os.File, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -419,6 +419,29 @@ func Run(opts Options) error {
 			tickCh = ticker.C
 		}
 
+		// PRIORITY DRAIN: process every queued tcell event before
+		// blocking on the main select. Without this, Go's uniform-
+		// random select pick lets renderCh win most rounds when
+		// it's saturated by heavy server traffic — input lags
+		// behind every queued render. drainScreenEvents is
+		// non-blocking when the events channel is empty, so the
+		// hot path is one default-case channel receive.
+		drained, ok := drainScreenEvents(events, func(ev tcell.Event) bool {
+			return handleScreenEvent(ev, state, screen, sessionID, writer)
+		})
+		if !ok {
+			return nil
+		}
+		if drained > 0 {
+			// Events advanced state; loop back so the next
+			// iteration re-evaluates the animation ticker
+			// condition before committing to a select. Removing
+			// this `continue` would let the loop block on a
+			// renderCh / tickCh tick that an event might have
+			// invalidated (e.g. a key toggling animations off).
+			continue
+		}
+
 		select {
 		case <-tickCh:
 			// Fixed-timestep tick: advance time, update effects, render.
@@ -442,6 +465,12 @@ func Run(opts Options) error {
 
 		case <-renderCh:
 			// Data-driven render: delta/snapshot arrived. Render immediately, no time advance.
+			// Coalesce any further renderCh ticks that readLoop has
+			// queued during the previous select round so a burst of
+			// N BufferDelta signals collapses into one render of
+			// the final state. Without this, render frequency
+			// tracks incoming delta rate.
+			coalesceRenderCh(renderCh)
 			state.frameDT = 0
 			if state.effects != nil {
 				state.effects.Update(0)

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -553,6 +553,34 @@ func coalesceRenderCh(ch <-chan struct{}) {
 	}
 }
 
+// drainScreenEvents pulls every queued tcell event from events and
+// dispatches each via handle. Returns the count drained and ok=false
+// if either the channel closed (run-loop exit signal) or the handle
+// returned false (also a run-loop exit signal). Non-blocking: empty
+// channel returns (0, true) immediately and the caller's select can
+// block on the next signal.
+//
+// The handle callback is the call site's closure over
+// handleScreenEvent + state/screen/sessionID/writer; passing it as
+// a parameter keeps this helper pure and unit-testable without a
+// full clientState fixture.
+func drainScreenEvents(events <-chan tcell.Event, handle func(tcell.Event) bool) (drained int, ok bool) {
+	for {
+		select {
+		case ev, chOK := <-events:
+			if !chOK {
+				return drained, false
+			}
+			if !handle(ev) {
+				return drained, false
+			}
+			drained++
+		default:
+			return drained, true
+		}
+	}
+}
+
 func setupLogging() (*os.File, error) {
 	configDir, err := os.UserConfigDir()
 	if err != nil {

--- a/internal/runtime/client/event_loop_fairness_test.go
+++ b/internal/runtime/client/event_loop_fairness_test.go
@@ -1,0 +1,33 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/client/event_loop_fairness_test.go
+// Summary: Tests for the priority-drain + coalesce helpers that
+// keep the client's main event loop fair under heavy server
+// traffic.
+
+package clientruntime
+
+import (
+	"testing"
+)
+
+// TestCoalesceRenderCh_DrainsAllQueuedTicks verifies the helper
+// non-blocking-drains every queued tick on the channel. Without
+// this, a burst of N back-to-back signals would each trigger a
+// separate render call.
+func TestCoalesceRenderCh_DrainsAllQueuedTicks(t *testing.T) {
+	ch := make(chan struct{}, 8)
+	for i := 0; i < 5; i++ {
+		ch <- struct{}{}
+	}
+	if got := len(ch); got != 5 {
+		t.Fatalf("setup: ch len = %d, want 5", got)
+	}
+
+	coalesceRenderCh(ch)
+
+	if got := len(ch); got != 0 {
+		t.Errorf("after coalesce: ch len = %d, want 0", got)
+	}
+}

--- a/internal/runtime/client/event_loop_fairness_test.go
+++ b/internal/runtime/client/event_loop_fairness_test.go
@@ -10,6 +10,7 @@ package clientruntime
 
 import (
 	"testing"
+	"time"
 )
 
 // TestCoalesceRenderCh_DrainsAllQueuedTicks verifies the helper
@@ -29,5 +30,23 @@ func TestCoalesceRenderCh_DrainsAllQueuedTicks(t *testing.T) {
 
 	if got := len(ch); got != 0 {
 		t.Errorf("after coalesce: ch len = %d, want 0", got)
+	}
+}
+
+// TestCoalesceRenderCh_NonBlockingOnEmpty verifies the helper
+// returns promptly when the channel is empty. A blocking call
+// here would freeze the main loop's renderCh case.
+func TestCoalesceRenderCh_NonBlockingOnEmpty(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		coalesceRenderCh(ch)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// returned promptly — good
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("coalesceRenderCh blocked on empty channel")
 	}
 }

--- a/internal/runtime/client/event_loop_fairness_test.go
+++ b/internal/runtime/client/event_loop_fairness_test.go
@@ -11,6 +11,8 @@ package clientruntime
 import (
 	"testing"
 	"time"
+
+	"github.com/gdamore/tcell/v2"
 )
 
 // TestCoalesceRenderCh_DrainsAllQueuedTicks verifies the helper
@@ -48,5 +50,54 @@ func TestCoalesceRenderCh_NonBlockingOnEmpty(t *testing.T) {
 		// returned promptly — good
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("coalesceRenderCh blocked on empty channel")
+	}
+}
+
+// drainScreenEvents helper expectations
+//
+// The helper has the signature:
+//
+//	func drainScreenEvents(events <-chan tcell.Event, handle func(tcell.Event) bool) (drained int, ok bool)
+//
+// Pulled events are dispatched via handle. ok=false means either the
+// channel is closed OR handle returned false (signalling exit).
+
+// TestDrainScreenEvents_ReturnsCountAndDispatches verifies the
+// helper pulls every queued event and dispatches each via the
+// supplied callback in order, returning the total count and
+// ok=true for the empty-after-drain case.
+//
+// We tag events via NewEventInterrupt(int) and compare the int
+// payload (via .Data()) rather than pointer-equal the events
+// themselves — tcell.Event is an interface and pointer equality
+// would silently break if tcell ever pooled or copied events.
+func TestDrainScreenEvents_ReturnsCountAndDispatches(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	want := []int{10, 20, 30}
+	for _, id := range want {
+		ch <- tcell.NewEventInterrupt(id)
+	}
+
+	var dispatched []int
+	handle := func(ev tcell.Event) bool {
+		dispatched = append(dispatched, ev.(*tcell.EventInterrupt).Data().(int))
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if !ok {
+		t.Errorf("ok = false, want true on clean drain")
+	}
+	if drained != len(want) {
+		t.Errorf("drained = %d, want %d", drained, len(want))
+	}
+	if len(dispatched) != len(want) {
+		t.Fatalf("dispatched len = %d, want %d", len(dispatched), len(want))
+	}
+	for i, id := range want {
+		if dispatched[i] != id {
+			t.Errorf("dispatch[%d]: got %d, want %d", i, dispatched[i], id)
+		}
 	}
 }

--- a/internal/runtime/client/event_loop_fairness_test.go
+++ b/internal/runtime/client/event_loop_fairness_test.go
@@ -101,3 +101,138 @@ func TestDrainScreenEvents_ReturnsCountAndDispatches(t *testing.T) {
 		}
 	}
 }
+
+// TestDrainScreenEvents_EmptyChannelReturnsZero verifies the helper
+// is a fast no-op when nothing is queued. A blocking implementation
+// would freeze the main loop's per-iteration priority drain.
+func TestDrainScreenEvents_EmptyChannelReturnsZero(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	handle := func(ev tcell.Event) bool {
+		t.Errorf("handle should not be called on empty channel; got %v", ev)
+		return true
+	}
+
+	done := make(chan struct {
+		drained int
+		ok      bool
+	}, 1)
+	go func() {
+		drained, ok := drainScreenEvents(ch, handle)
+		done <- struct {
+			drained int
+			ok      bool
+		}{drained, ok}
+	}()
+
+	select {
+	case res := <-done:
+		if res.drained != 0 {
+			t.Errorf("drained = %d, want 0", res.drained)
+		}
+		if !res.ok {
+			t.Errorf("ok = false, want true on empty drain")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("drainScreenEvents blocked on empty channel")
+	}
+}
+
+// TestDrainScreenEvents_ChannelClosedReturnsNotOK verifies the
+// helper returns ok=false when the channel is closed, so the main
+// loop's caller can return nil and exit cleanly.
+func TestDrainScreenEvents_ChannelClosedReturnsNotOK(t *testing.T) {
+	ch := make(chan tcell.Event, 1)
+	close(ch)
+	handle := func(ev tcell.Event) bool {
+		t.Errorf("handle should not be called when channel closed; got %v", ev)
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false for closed channel")
+	}
+	if drained != 0 {
+		t.Errorf("drained = %d, want 0 (channel closed before any event)", drained)
+	}
+}
+
+// TestDrainScreenEvents_DrainsThenChannelCloses covers the realistic
+// shutdown shape: events are queued, then the producer closes the
+// channel. The helper must drain the buffered events first and only
+// then observe the close. Without this case, a future regression
+// where the close-detection logic short-circuits before draining
+// the buffer would silently lose user input.
+func TestDrainScreenEvents_DrainsThenChannelCloses(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	want := []int{1, 2}
+	for _, id := range want {
+		ch <- tcell.NewEventInterrupt(id)
+	}
+	close(ch)
+
+	var dispatched []int
+	handle := func(ev tcell.Event) bool {
+		dispatched = append(dispatched, ev.(*tcell.EventInterrupt).Data().(int))
+		return true
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false (channel closed after drain)")
+	}
+	if drained != len(want) {
+		t.Errorf("drained = %d, want %d", drained, len(want))
+	}
+	if len(dispatched) != len(want) {
+		t.Fatalf("dispatched %d events, want %d", len(dispatched), len(want))
+	}
+	for i, id := range want {
+		if dispatched[i] != id {
+			t.Errorf("dispatch[%d]: got %d, want %d", i, dispatched[i], id)
+		}
+	}
+}
+
+// TestDrainScreenEvents_HandleReturnsFalseStopsDrain covers the
+// production exit signal: handleScreenEvent returns false to mean
+// "the run loop should exit" (e.g. ctrl-Q, session disconnect).
+// The helper must propagate that immediately — drained must reflect
+// only events whose handler ran successfully (excluding the one
+// that returned false), and any remaining queued events stay in
+// the channel. Without this case, an off-by-one regression in the
+// helper (count++ before vs. after the handle check, or draining
+// one extra event after the false return) would silently leak
+// events past the exit signal.
+func TestDrainScreenEvents_HandleReturnsFalseStopsDrain(t *testing.T) {
+	ch := make(chan tcell.Event, 4)
+	for _, id := range []int{1, 2, 3} {
+		ch <- tcell.NewEventInterrupt(id)
+	}
+
+	var dispatched []int
+	handle := func(ev tcell.Event) bool {
+		id := ev.(*tcell.EventInterrupt).Data().(int)
+		dispatched = append(dispatched, id)
+		return id != 2 // signal exit on the second event
+	}
+
+	drained, ok := drainScreenEvents(ch, handle)
+
+	if ok {
+		t.Error("ok = true, want false when handle returned false")
+	}
+	if drained != 1 {
+		t.Errorf("drained = %d, want 1 (only the first successful event counts)", drained)
+	}
+	if len(dispatched) != 2 {
+		t.Errorf("dispatched %d events, want 2 (the handler ran for events 1 and 2)", len(dispatched))
+	}
+	// The third event must remain in the channel — exit-on-false
+	// means the helper stops AT the false event, not after it.
+	if got := len(ch); got != 1 {
+		t.Errorf("ch len after exit = %d, want 1 (third event should not have been drained)", got)
+	}
+}


### PR DESCRIPTION
## Summary

When one pane has heavy output (e.g. \`ls -lR\`), every pane's input lags — selecting panels, opening control mode, mouse, keys all feel stuck. A prior server-side fix ([feature/input-fairness-chunked-send](https://github.com/framegrace/texelation/tree/feature/input-fairness-chunked-send)) bounded how many diffs the server flushes per loop iteration, which was correct for its layer but didn't move the user-visible lag. The bottleneck is downstream, in the **client's main event loop**:

1. \`readLoop\` signals \`renderCh\` per applied \`BufferDelta\`. Heavy traffic keeps the channel saturated.
2. The main loop's flat 4-way \`select\` picks uniformly random when multiple cases are ready. Events lose most coin flips.
3. Each render runs against transient intermediate state, doing real work for nothing.

This PR adds two pure helpers and tweaks the loop body:

- **\`drainScreenEvents\`** — non-blocking-drains every queued tcell event before the main \`select\` blocks. Events always win when ready.
- **\`coalesceRenderCh\`** — non-blocking-drains every queued render tick after one was consumed by the select arm. A burst of 50 \`BufferDelta\` signals collapses into one render of the final state. Logs via debuglog when 2+ ticks coalesce so the (previously implicit) backpressure canary is preserved post-hoc.

Net effect: render frequency is bounded by render duration itself, not by incoming delta rate. Worst-case event latency is one in-flight render's duration (~5–50 ms depending on workspace), independent of server traffic.

## Diagnostic confirmation

Render-timing instrumentation gathered during a stress test showed sub-millisecond \`screen.Show()\` per frame on the user's terminal — render is fast. The main-loop fairness was the right fix; it landed cleanly.

The diagnostic also revealed a separate symptom: split / close animations stutter at ~15-20fps where 60fps was intended. That's an upstream / server-side issue (animation channel drops + heavy publish) and is filed as **#228** — out of scope here.

## What this branch does NOT include

- The server-side chunked-flush fix (separate branch \`feature/input-fairness-chunked-send\`)
- Render rate-limiting (option C from the brainstorm; deferred — the renderCh case is the only place it would land, additive change)
- Render in a separate goroutine
- Anything addressing #228

## Process notes

Spec → Plan → Subagent-driven execution → Two reviewer rounds (3 agents per round) → Two-stage final review.

- Spec: \`docs/superpowers/specs/2026-05-03-client-event-loop-fairness-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md\`

Round-1 review surfaced gaps that became commit \`Plan: address reviewer findings\`:
- TDD red→green flow was masked by an unused \`time\` import (code-reviewer)
- 2 missing test paths for \`drainScreenEvents\` exit signals (test-analyzer)
- Coalescing removed the de-facto backpressure observability (silent-failure-hunter)
- Brittle \`tcell.Event\` interface comparison (test-analyzer)
- Verification gate too vague (silent-failure-hunter)

Round-2 review confirmed all round-1 findings closed and no new gaps introduced.

## Test plan

- [x] \`go test -race ./internal/runtime/client/... -count=10\` — green, 7/7 new tests + 95 existing pass
- [x] \`go build ./...\` — clean
- [x] \`gofmt -l\` clean on touched files
- [x] Manual cold-start stress (\`./bin/texelation --stop && ./bin/texelation\`, then \`ls -lR /usr\` in one pane while typing in another) — input remains responsive throughout
- [ ] Race detector clean across the full test suite \`go test -race -count=1 ./...\` (run before merge)

## Files

| File | Change |
|------|--------|
| \`internal/runtime/client/app.go\` | Add \`coalesceRenderCh\`, \`drainScreenEvents\`; tweak main loop body to drain events at top + coalesce in renderCh arm |
| \`internal/runtime/client/event_loop_fairness_test.go\` | New file with 7 unit tests |
| \`docs/superpowers/specs/2026-05-03-client-event-loop-fairness-design.md\` | Design spec |
| \`docs/superpowers/plans/2026-05-03-client-event-loop-fairness.md\` | Implementation plan |

🤖 Generated with [Claude Code](https://claude.com/claude-code)