### PR TITLE
Issue #199 Plan F.1: stored-session recovery picker

### DIFF
--- a/cmd/texel-server/main.go
+++ b/cmd/texel-server/main.go
@@ -276,6 +276,12 @@ func main() {
 		publisher.SetObserver(publishLogger)
 		return publisher
 	})
+	// Plan F.1: wire the lifecycle thumbnail renderer. *DesktopSink
+	// satisfies the ThumbnailRenderer interface via its
+	// RenderSessionThumbnail method. Manager.Close /
+	// Manager.ShutdownSessions invoke it on the last-disconnect /
+	// graceful-shutdown paths.
+	srv.Manager().SetThumbnailRenderer(sink)
 
 	go func() {
 		if err := srv.Start(); err != nil {

--- a/cmd/texelation/boot/picker.go
+++ b/cmd/texelation/boot/picker.go
@@ -154,7 +154,18 @@ func (p *Picker) RefreshCatalog() {
 	}
 	p.errMsg = ""
 	p.response = resp
-	if p.selectedIdx >= len(p.response.Stored) {
+	// Pre-select the populated tab when only one has entries — the
+	// default `tabStored` would otherwise show empty when only Live
+	// has content (e.g. user runs --recover on a running daemon).
+	if len(p.response.Live) > 0 && len(p.response.Stored) == 0 {
+		p.activeTab = tabLive
+	} else if len(p.response.Stored) > 0 && len(p.response.Live) == 0 {
+		p.activeTab = tabStored
+	}
+	if p.selectedIdx >= len(p.response.Stored) && p.activeTab == tabStored {
+		p.selectedIdx = 0
+	}
+	if p.selectedIdx >= len(p.response.Live) && p.activeTab == tabLive {
 		p.selectedIdx = 0
 	}
 }

--- a/cmd/texelation/boot/picker.go
+++ b/cmd/texelation/boot/picker.go
@@ -1,0 +1,169 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker.go
+// Summary: Stored-session recovery picker UI (issue #199 Plan F.1).
+// Owns the tcell screen for the duration of the user's selection;
+// hands off to the splash + clientrt pipeline once a choice is made.
+
+package boot
+
+import (
+	"io"
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+	core "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/widgets"
+)
+
+// PickerClient is the network surface the picker needs. The boot
+// runner constructs a real implementation against the unix socket;
+// tests inject a fake.
+type PickerClient interface {
+	ListSessions() (protocol.ListSessionsResponse, error)
+	RecoverSession(id [16]byte, newLabel string) error
+	RenameSession(id [16]byte, newLabel string) error
+	DeleteSession(id [16]byte) error
+	FetchThumbnail(id [16]byte) ([]byte, error)
+	StartFreshSession()
+}
+
+type pickerMode int
+
+const (
+	modeBrowse pickerMode = iota
+	modeRename
+	modeDeleteConfirm
+)
+
+type pickerTab int
+
+const (
+	tabLive pickerTab = iota
+	tabStored
+)
+
+type pickerChoice int
+
+const (
+	choiceNone pickerChoice = iota
+	choiceRecover
+	choiceFresh
+	choiceQuit
+)
+
+// Public re-exports for the choice constants so main.go can
+// reference them.
+const (
+	PickerChoiceNone    = choiceNone
+	PickerChoiceRecover = choiceRecover
+	PickerChoiceFresh   = choiceFresh
+	PickerChoiceQuit    = choiceQuit
+)
+
+const maxFetchAttempts = 3
+
+// Picker holds the picker's runtime state.
+//
+// mu guards thumbCache + pending + imgCache + failedFetches against
+// concurrent access from the lazy fetch goroutines spawned in Task 17.
+type Picker struct {
+	screen tcell.Screen
+	client PickerClient
+
+	response    protocol.ListSessionsResponse
+	activeTab   pickerTab
+	selectedIdx int
+	mode        pickerMode
+
+	renameBuf []rune
+
+	// errMsg, when non-empty, is rendered as a red banner above the
+	// action bar. RefreshCatalog / Recover / Rename / Delete set it
+	// when their underlying op fails; user dismisses by pressing any
+	// navigation key. Sticky-until-dismissed because it's tied to a
+	// discrete user action.
+	errMsg string
+
+	// flushErrMsg is the per-frame variant set when the graphics
+	// provider's Flush fails during Render. Cleared on the next
+	// successful Flush so a single hiccup doesn't pin a stale banner.
+	flushErrMsg string
+
+	// gp drives image rendering through the texelui widgets.Image
+	// pipeline. nil = ASCII-only fallback.
+	gp core.GraphicsProvider
+
+	// gpFlush is where queued APC sequences (Kitty) are written.
+	gpFlush io.Writer
+
+	// cellBuf is the painter's destination, re-allocated on resize.
+	cellBuf [][]core.Cell
+
+	mu            sync.Mutex
+	thumbCache    map[[16]byte][]byte
+	pending       map[[16]byte]bool
+	imgCache      map[[16]byte]*widgets.Image
+	failedFetches map[[16]byte]int
+
+	done   bool
+	choice pickerChoice
+}
+
+// NewPicker returns a picker bound to screen + client.
+func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
+	return &Picker{
+		screen:        screen,
+		client:        client,
+		activeTab:     tabStored,
+		mode:          modeBrowse,
+		thumbCache:    make(map[[16]byte][]byte),
+		pending:       make(map[[16]byte]bool),
+		imgCache:      make(map[[16]byte]*widgets.Image),
+		failedFetches: make(map[[16]byte]int),
+	}
+}
+
+// SetGraphicsProvider wires the texelui GraphicsProvider used to render
+// thumbnails. flushTo is where queued APC sequences (Kitty) get written
+// after each Render — typically os.Stdout in production, io.Discard or
+// nil in tests.
+func (p *Picker) SetGraphicsProvider(gp core.GraphicsProvider, flushTo io.Writer) {
+	p.gp = gp
+	p.gpFlush = flushTo
+}
+
+// hasGraphics reports whether the wired provider can render images.
+// Used to gate fetch dispatch + the widgets.Image draw branch.
+func (p *Picker) hasGraphics() bool {
+	return p.gp != nil && p.gp.Capability() >= core.GraphicsHalfBlock
+}
+
+// RefreshCatalog fetches the catalog from the server. On error the
+// previous response is preserved (so a transient socket blip doesn't
+// wipe a freshly-shown list) and errMsg is set so the user sees a
+// banner rather than silently emptying.
+func (p *Picker) RefreshCatalog() {
+	resp, err := p.client.ListSessions()
+	if err != nil {
+		p.errMsg = "Could not load sessions: " + err.Error()
+		return
+	}
+	p.errMsg = ""
+	p.response = resp
+	if p.selectedIdx >= len(p.response.Stored) {
+		p.selectedIdx = 0
+	}
+}
+
+// SelectedIdx returns the currently highlighted index. Exposed for tests.
+func (p *Picker) SelectedIdx() int { return p.selectedIdx }
+
+// Done reports whether the picker has chosen an action.
+func (p *Picker) Done() bool { return p.done }
+
+// Choice returns what the user picked once Done() is true.
+func (p *Picker) Choice() pickerChoice { return p.choice }

--- a/cmd/texelation/boot/picker.go
+++ b/cmd/texelation/boot/picker.go
@@ -36,7 +36,6 @@ type pickerMode int
 const (
 	modeBrowse pickerMode = iota
 	modeRename
-	modeDeleteConfirm
 )
 
 type pickerTab int

--- a/cmd/texelation/boot/picker.go
+++ b/cmd/texelation/boot/picker.go
@@ -108,6 +108,11 @@ type Picker struct {
 	pending       map[[16]byte]bool
 	imgCache      map[[16]byte]*widgets.Image
 	failedFetches map[[16]byte]int
+	// liveIDs marks session IDs surfaced in the Live tab. Refreshed
+	// from RefreshCatalog. Used by the fetch path to bypass the
+	// thumbCache (live sessions change state continuously, so a
+	// cached PNG goes stale).
+	liveIDs map[[16]byte]bool
 
 	done   bool
 	choice pickerChoice
@@ -124,6 +129,7 @@ func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
 		pending:       make(map[[16]byte]bool),
 		imgCache:      make(map[[16]byte]*widgets.Image),
 		failedFetches: make(map[[16]byte]int),
+		liveIDs:       make(map[[16]byte]bool),
 	}
 }
 
@@ -154,6 +160,16 @@ func (p *Picker) RefreshCatalog() {
 	}
 	p.errMsg = ""
 	p.response = resp
+	// Mark which IDs are live so the fetch path can bypass the
+	// thumbCache (their state may have changed since last fetch).
+	p.mu.Lock()
+	for id := range p.liveIDs {
+		delete(p.liveIDs, id)
+	}
+	for _, l := range resp.Live {
+		p.liveIDs[l.SessionID] = true
+	}
+	p.mu.Unlock()
 	// Pre-select the populated tab when only one has entries — the
 	// default `tabStored` would otherwise show empty when only Live
 	// has content (e.g. user runs --recover on a running daemon).

--- a/cmd/texelation/boot/picker_ascii.go
+++ b/cmd/texelation/boot/picker_ascii.go
@@ -1,0 +1,153 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_ascii.go
+// Summary: Pure-function tree-snapshot to box-drawing characters.
+// Used as the fallback render path for thumbnails on terminals
+// without graphics support, and as the placeholder while a Kitty
+// thumbnail fetch is in flight.
+
+package boot
+
+import "github.com/framegrace/texelation/protocol"
+
+const (
+	asciiMinW = 8
+	asciiMinH = 4
+)
+
+// renderASCIILayoutGrid returns a (h × w) rune matrix containing the
+// box-drawing representation of root. Sub-minimum-size rects collapse
+// to a single bordered box; nil roots also fall back to a single box
+// so callers don't have to special-case missing layouts.
+func renderASCIILayoutGrid(w, h int, root *protocol.TreeNodeSnapshot) [][]rune {
+	grid := makeBlankGrid(w, h)
+	if root == nil || w < asciiMinW || h < asciiMinH {
+		drawSingleBox(grid, 0, 0, w, h)
+		return grid
+	}
+	drawNode(grid, 0, 0, w, h, root)
+	return grid
+}
+
+func makeBlankGrid(w, h int) [][]rune {
+	grid := make([][]rune, h)
+	for y := 0; y < h; y++ {
+		grid[y] = make([]rune, w)
+		for x := 0; x < w; x++ {
+			grid[y][x] = ' '
+		}
+	}
+	return grid
+}
+
+func drawNode(grid [][]rune, x, y, w, h int, n *protocol.TreeNodeSnapshot) {
+	if n.Split == protocol.SplitNone || len(n.Children) < 2 || w < asciiMinW || h < asciiMinH {
+		drawSingleBox(grid, x, y, w, h)
+		return
+	}
+	ratios := normaliseRatios(n.SplitRatios, len(n.Children))
+	if n.Split == protocol.SplitHorizontal {
+		// Walk children in order, allocating rows per ratio. Each
+		// child shares its bottom border with the next child's top
+		// border (the -1 / +1 dance), so the visual divider sits on
+		// a single row and shows '─' from each side's drawSingleBox.
+		cursorY := y
+		remaining := h
+		for i, child := range n.Children {
+			var sliceH int
+			if i == len(n.Children)-1 {
+				sliceH = remaining
+			} else {
+				sliceH = int(float32(h) * ratios[i])
+				if sliceH < asciiMinH {
+					sliceH = asciiMinH
+				}
+				if sliceH > remaining-asciiMinH*(len(n.Children)-i-1) {
+					sliceH = remaining - asciiMinH*(len(n.Children)-i-1)
+				}
+			}
+			drawNode(grid, x, cursorY, w, sliceH, &child)
+			cursorY += sliceH - 1
+			remaining -= sliceH - 1
+		}
+		return
+	}
+	// Vertical split: walk children left-to-right.
+	cursorX := x
+	remaining := w
+	for i, child := range n.Children {
+		var sliceW int
+		if i == len(n.Children)-1 {
+			sliceW = remaining
+		} else {
+			sliceW = int(float32(w) * ratios[i])
+			if sliceW < asciiMinW {
+				sliceW = asciiMinW
+			}
+			if sliceW > remaining-asciiMinW*(len(n.Children)-i-1) {
+				sliceW = remaining - asciiMinW*(len(n.Children)-i-1)
+			}
+		}
+		drawNode(grid, cursorX, y, sliceW, h, &child)
+		cursorX += sliceW - 1
+		remaining -= sliceW - 1
+	}
+}
+
+// normaliseRatios returns a slice of len(childCount) ratios summing to
+// ~1.0. If the input is missing/short or doesn't sum, it falls back to
+// equal allocation so n-way splits never produce zero-width children.
+func normaliseRatios(ratios []float32, count int) []float32 {
+	out := make([]float32, count)
+	if len(ratios) >= count {
+		var sum float32
+		for i := 0; i < count; i++ {
+			out[i] = ratios[i]
+			sum += ratios[i]
+		}
+		if sum > 0 {
+			for i := range out {
+				out[i] /= sum
+			}
+			return out
+		}
+	}
+	for i := range out {
+		out[i] = 1.0 / float32(count)
+	}
+	return out
+}
+
+func drawSingleBox(grid [][]rune, x, y, w, h int) {
+	if w < 2 || h < 2 {
+		return
+	}
+	maxY := y + h - 1
+	maxX := x + w - 1
+	for cy := y; cy <= maxY; cy++ {
+		for cx := x; cx <= maxX; cx++ {
+			if cy < 0 || cy >= len(grid) || cx < 0 || cx >= len(grid[cy]) {
+				continue
+			}
+			switch {
+			case cy == y && cx == x:
+				grid[cy][cx] = '┌'
+			case cy == y && cx == maxX:
+				grid[cy][cx] = '┐'
+			case cy == maxY && cx == x:
+				grid[cy][cx] = '└'
+			case cy == maxY && cx == maxX:
+				grid[cy][cx] = '┘'
+			case cy == y || cy == maxY:
+				if grid[cy][cx] == ' ' {
+					grid[cy][cx] = '─'
+				}
+			case cx == x || cx == maxX:
+				if grid[cy][cx] == ' ' {
+					grid[cy][cx] = '│'
+				}
+			}
+		}
+	}
+}

--- a/cmd/texelation/boot/picker_ascii_test.go
+++ b/cmd/texelation/boot/picker_ascii_test.go
@@ -1,0 +1,134 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestRenderASCIILayout_SinglePane(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	if len(grid) != 8 || len(grid[0]) != 20 {
+		t.Fatalf("dims = %dx%d, want 20x8", len(grid[0]), len(grid))
+	}
+	if grid[0][0] != '┌' {
+		t.Errorf("top-left = %q, want ┌", grid[0][0])
+	}
+	if grid[0][19] != '┐' {
+		t.Errorf("top-right = %q, want ┐", grid[0][19])
+	}
+	if grid[7][0] != '└' {
+		t.Errorf("bottom-left = %q, want └", grid[7][0])
+	}
+	if grid[7][19] != '┘' {
+		t.Errorf("bottom-right = %q, want ┘", grid[7][19])
+	}
+}
+
+func TestRenderASCIILayout_HorizontalSplit(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	dividerCount := 0
+	for y := 1; y < 7; y++ {
+		row := string(grid[y])
+		if strings.Count(row, "─") > 5 {
+			dividerCount++
+		}
+	}
+	if dividerCount == 0 {
+		t.Errorf("expected at least one horizontal divider row in:\n%s", debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_VerticalSplit(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitVertical,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	// With leftW = int(20 * 0.5) = 10, the right child draws starting
+	// at x=9 (border-sharing), so the divider column is 9, not 10.
+	dividerCol := 9
+	verticalAt := 0
+	for y := 1; y < 7; y++ {
+		if grid[y][dividerCol] == '│' {
+			verticalAt++
+		}
+	}
+	if verticalAt == 0 {
+		t.Errorf("expected vertical divider at col %d in:\n%s", dividerCol, debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_NWaySplit(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.34, 0.33, 0.33},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+			{PaneIndex: 2, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 12, root)
+	dividerRows := 0
+	for y := 1; y < 11; y++ {
+		if strings.Count(string(grid[y]), "─") > 5 {
+			dividerRows++
+		}
+	}
+	if dividerRows < 2 {
+		t.Errorf("expected ≥ 2 divider rows for 3-way split, got %d:\n%s", dividerRows, debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_NilRoot(t *testing.T) {
+	grid := renderASCIILayoutGrid(20, 8, nil)
+	if grid[0][0] != '┌' {
+		t.Errorf("nil root should fall back to single box; got %q at top-left", grid[0][0])
+	}
+}
+
+func TestRenderASCIILayout_BelowMinSize(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(6, 3, root)
+	if grid[0][0] != '┌' {
+		t.Errorf("expected single-box fallback")
+	}
+}
+
+func debugGrid(grid [][]rune) string {
+	var b strings.Builder
+	for _, row := range grid {
+		b.WriteString(string(row))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/cmd/texelation/boot/picker_client.go
+++ b/cmd/texelation/boot/picker_client.go
@@ -21,8 +21,13 @@ import (
 )
 
 // dialAndHandshake opens a unix socket connection to the texelation
-// daemon and runs the Hello/Welcome handshake. Returns the conn +
-// the assigned sessionID. The caller closes the conn.
+// daemon and runs the full Hello/Welcome/ConnectRequest/ConnectAccept
+// handshake. Returns the conn + the assigned sessionID. The caller
+// closes the conn.
+//
+// We complete the full handshake (not just Hello/Welcome) because the
+// server's handleHandshake expects MsgConnectRequest after Welcome —
+// anything else closes the connection with errUnexpectedMessage.
 func dialAndHandshake(socket string) (net.Conn, [16]byte, error) {
 	var sid [16]byte
 	conn, err := net.DialTimeout("unix", socket, 5*time.Second)
@@ -48,7 +53,7 @@ func dialAndHandshake(socket string) (net.Conn, [16]byte, error) {
 		conn.Close()
 		return nil, sid, fmt.Errorf("write hello: %w", err)
 	}
-	hdr, payload, err := protocol.ReadMessage(conn)
+	hdr, _, err := protocol.ReadMessage(conn)
 	if err != nil {
 		conn.Close()
 		return nil, sid, fmt.Errorf("read welcome: %w", err)
@@ -57,12 +62,39 @@ func dialAndHandshake(socket string) (net.Conn, [16]byte, error) {
 		conn.Close()
 		return nil, sid, fmt.Errorf("expected welcome, got message type %d", hdr.Type)
 	}
-	welcome, err := protocol.DecodeWelcome(payload)
+
+	// Send ConnectRequest with zero SessionID — the server creates a
+	// fresh ephemeral session for this picker connection. We never
+	// resume; the picker's role is to LIST sessions, not attach to one.
+	connectBody, err := protocol.EncodeConnectRequest(protocol.ConnectRequest{})
 	if err != nil {
 		conn.Close()
-		return nil, sid, fmt.Errorf("decode welcome: %w", err)
+		return nil, sid, fmt.Errorf("encode connect: %w", err)
 	}
-	return conn, welcome.SessionID, nil
+	connectHdr := protocol.Header{
+		Version: protocol.Version,
+		Type:    protocol.MsgConnectRequest,
+		Flags:   protocol.FlagChecksum,
+	}
+	if err := protocol.WriteMessage(conn, connectHdr, connectBody); err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("write connect: %w", err)
+	}
+	hdr, payload, err := protocol.ReadMessage(conn)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("read connect-accept: %w", err)
+	}
+	if hdr.Type != protocol.MsgConnectAccept {
+		conn.Close()
+		return nil, sid, fmt.Errorf("expected connect-accept, got message type %d", hdr.Type)
+	}
+	accept, err := protocol.DecodeConnectAccept(payload)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("decode connect-accept: %w", err)
+	}
+	return conn, accept.SessionID, nil
 }
 
 // ProbeStoredSessions performs Hello/Welcome + MsgListSessions and

--- a/cmd/texelation/boot/picker_client.go
+++ b/cmd/texelation/boot/picker_client.go
@@ -1,0 +1,244 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_client.go
+// Summary: Socket-backed PickerClient + ProbeStoredSessions. Performs
+// the protocol Hello/Welcome handshake and round-trips picker
+// messages over a unix socket. Modelled on client/simple_client.go's
+// dial-and-handshake helper.
+
+package boot
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// dialAndHandshake opens a unix socket connection to the texelation
+// daemon and runs the Hello/Welcome handshake. Returns the conn +
+// the assigned sessionID. The caller closes the conn.
+func dialAndHandshake(socket string) (net.Conn, [16]byte, error) {
+	var sid [16]byte
+	conn, err := net.DialTimeout("unix", socket, 5*time.Second)
+	if err != nil {
+		return nil, sid, fmt.Errorf("dial %s: %w", socket, err)
+	}
+	var clientID [16]byte
+	if _, err := rand.Read(clientID[:]); err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("rand client id: %w", err)
+	}
+	helloBody, err := protocol.EncodeHello(protocol.Hello{ClientID: clientID, ClientName: "texelation-picker"})
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("encode hello: %w", err)
+	}
+	helloHdr := protocol.Header{
+		Version: protocol.Version,
+		Type:    protocol.MsgHello,
+		Flags:   protocol.FlagChecksum,
+	}
+	if err := protocol.WriteMessage(conn, helloHdr, helloBody); err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("write hello: %w", err)
+	}
+	hdr, payload, err := protocol.ReadMessage(conn)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("read welcome: %w", err)
+	}
+	if hdr.Type != protocol.MsgWelcome {
+		conn.Close()
+		return nil, sid, fmt.Errorf("expected welcome, got message type %d", hdr.Type)
+	}
+	welcome, err := protocol.DecodeWelcome(payload)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("decode welcome: %w", err)
+	}
+	return conn, welcome.SessionID, nil
+}
+
+// ProbeStoredSessions performs Hello/Welcome + MsgListSessions and
+// returns the count of stored sessions. The ephemeral session created
+// by the handshake is left dangling on the server's side and gets
+// reaped via the daemon's normal idle-session cleanup.
+func ProbeStoredSessions(socket string) (int, error) {
+	conn, _, err := dialAndHandshake(socket)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	body, _ := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	hdr := protocol.Header{
+		Version: protocol.Version,
+		Type:    protocol.MsgListSessions,
+		Flags:   protocol.FlagChecksum,
+	}
+	if err := protocol.WriteMessage(conn, hdr, body); err != nil {
+		return 0, fmt.Errorf("write list-sessions: %w", err)
+	}
+	respHdr, respPayload, err := protocol.ReadMessage(conn)
+	if err != nil {
+		return 0, fmt.Errorf("read list-sessions: %w", err)
+	}
+	if respHdr.Type != protocol.MsgListSessionsResponse {
+		return 0, fmt.Errorf("expected list-sessions response, got %d", respHdr.Type)
+	}
+	resp, err := protocol.DecodeListSessionsResponse(respPayload)
+	if err != nil {
+		return 0, fmt.Errorf("decode list-sessions: %w", err)
+	}
+	return len(resp.Stored), nil
+}
+
+// SocketPickerClient implements PickerClient against a live socket
+// for the duration of the picker's UI session. One connection per
+// picker invocation; closed when the picker exits.
+type SocketPickerClient struct {
+	conn      net.Conn
+	sessionID [16]byte
+
+	mu        sync.Mutex
+	closeOnce sync.Once
+}
+
+// NewSocketPickerClient dials the socket and runs the handshake.
+// Returns a client ready for use; caller must Close() when done.
+func NewSocketPickerClient(socket string) (*SocketPickerClient, error) {
+	conn, sid, err := dialAndHandshake(socket)
+	if err != nil {
+		return nil, err
+	}
+	return &SocketPickerClient{conn: conn, sessionID: sid}, nil
+}
+
+func (s *SocketPickerClient) roundTrip(reqType protocol.MessageType, body []byte) (protocol.Header, []byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      reqType,
+		Flags:     protocol.FlagChecksum,
+		SessionID: s.sessionID,
+	}
+	if err := protocol.WriteMessage(s.conn, hdr, body); err != nil {
+		return protocol.Header{}, nil, fmt.Errorf("write %d: %w", reqType, err)
+	}
+	respHdr, respPayload, err := protocol.ReadMessage(s.conn)
+	if err != nil {
+		return protocol.Header{}, nil, fmt.Errorf("read response: %w", err)
+	}
+	return respHdr, respPayload, nil
+}
+
+func (s *SocketPickerClient) ListSessions() (protocol.ListSessionsResponse, error) {
+	body, _ := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	hdr, payload, err := s.roundTrip(protocol.MsgListSessions, body)
+	if err != nil {
+		return protocol.ListSessionsResponse{}, err
+	}
+	if hdr.Type != protocol.MsgListSessionsResponse {
+		return protocol.ListSessionsResponse{}, fmt.Errorf("unexpected response type %d", hdr.Type)
+	}
+	return protocol.DecodeListSessionsResponse(payload)
+}
+
+func (s *SocketPickerClient) RecoverSession(id [16]byte, newLabel string) error {
+	body, err := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: id, NewLabel: newLabel})
+	if err != nil {
+		return err
+	}
+	hdr, payload, err := s.roundTrip(protocol.MsgRecoverSession, body)
+	if err != nil {
+		return err
+	}
+	switch hdr.Type {
+	case protocol.MsgConnectAccept:
+		return nil
+	case protocol.MsgError:
+		ef, _ := protocol.DecodeErrorFrame(payload)
+		return errors.New(ef.Message)
+	default:
+		return fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+}
+
+func (s *SocketPickerClient) RenameSession(id [16]byte, newLabel string) error {
+	body, err := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: id, NewLabel: newLabel})
+	if err != nil {
+		return err
+	}
+	return s.opRoundTrip(protocol.MsgRenameSession, body, protocol.OpRename)
+}
+
+func (s *SocketPickerClient) DeleteSession(id [16]byte) error {
+	body, err := protocol.EncodeDeleteSessionRequest(protocol.DeleteSessionRequest{SessionID: id})
+	if err != nil {
+		return err
+	}
+	return s.opRoundTrip(protocol.MsgDeleteSession, body, protocol.OpDelete)
+}
+
+func (s *SocketPickerClient) opRoundTrip(reqType protocol.MessageType, body []byte, expectOp protocol.SessionOpKind) error {
+	hdr, payload, err := s.roundTrip(reqType, body)
+	if err != nil {
+		return err
+	}
+	if hdr.Type != protocol.MsgSessionOpResponse {
+		return fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+	resp, err := protocol.DecodeSessionOpResponse(payload)
+	if err != nil {
+		return err
+	}
+	if resp.OpType != expectOp {
+		return fmt.Errorf("op mismatch: got %d, want %d", resp.OpType, expectOp)
+	}
+	if !resp.OK {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+func (s *SocketPickerClient) FetchThumbnail(id [16]byte) ([]byte, error) {
+	body, err := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	if err != nil {
+		return nil, err
+	}
+	hdr, payload, err := s.roundTrip(protocol.MsgFetchThumbnail, body)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.Type != protocol.MsgFetchThumbnailResponse {
+		return nil, fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+	resp, err := protocol.DecodeFetchThumbnailResponse(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.PNG, nil
+}
+
+// StartFreshSession is a no-op for the socket client — the picker
+// simply exits with choiceFresh and main.go takes the ordinary
+// connect path (zero sessionID).
+func (s *SocketPickerClient) StartFreshSession() {}
+
+// Close shuts down the underlying socket. Safe to call multiple times.
+func (s *SocketPickerClient) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		err = s.conn.Close()
+	})
+	return err
+}

--- a/cmd/texelation/boot/picker_client.go
+++ b/cmd/texelation/boot/picker_client.go
@@ -116,18 +116,25 @@ func ProbeStoredSessions(socket string) (int, error) {
 	if err := protocol.WriteMessage(conn, hdr, body); err != nil {
 		return 0, fmt.Errorf("write list-sessions: %w", err)
 	}
-	respHdr, respPayload, err := protocol.ReadMessage(conn)
-	if err != nil {
-		return 0, fmt.Errorf("read list-sessions: %w", err)
+	// Skip unsolicited state-push frames the same way SocketPickerClient
+	// does; the connection has the desktop listeners attached.
+	for {
+		respHdr, respPayload, err := protocol.ReadMessage(conn)
+		if err != nil {
+			return 0, fmt.Errorf("read list-sessions: %w", err)
+		}
+		if !isPickerResponseType(respHdr.Type) {
+			continue
+		}
+		if respHdr.Type != protocol.MsgListSessionsResponse {
+			return 0, fmt.Errorf("expected list-sessions response, got %d", respHdr.Type)
+		}
+		resp, err := protocol.DecodeListSessionsResponse(respPayload)
+		if err != nil {
+			return 0, fmt.Errorf("decode list-sessions: %w", err)
+		}
+		return len(resp.Stored), nil
 	}
-	if respHdr.Type != protocol.MsgListSessionsResponse {
-		return 0, fmt.Errorf("expected list-sessions response, got %d", respHdr.Type)
-	}
-	resp, err := protocol.DecodeListSessionsResponse(respPayload)
-	if err != nil {
-		return 0, fmt.Errorf("decode list-sessions: %w", err)
-	}
-	return len(resp.Stored), nil
 }
 
 // SocketPickerClient implements PickerClient against a live socket
@@ -151,6 +158,25 @@ func NewSocketPickerClient(socket string) (*SocketPickerClient, error) {
 	return &SocketPickerClient{conn: conn, sessionID: sid}, nil
 }
 
+// pickerResponseTypes is the set of message types we consider valid
+// responses to a picker request. The server's connection.serve()
+// pushes unsolicited state updates (MsgPaneFocus, MsgStateUpdate,
+// MsgPaneState, MsgBufferDelta, MsgClipboardData, etc.) over the
+// same wire — the picker is uninterested in any of those, so
+// roundTrip discards anything that isn't in this set.
+func isPickerResponseType(t protocol.MessageType) bool {
+	switch t {
+	case protocol.MsgListSessionsResponse,
+		protocol.MsgSessionOpResponse,
+		protocol.MsgFetchThumbnailResponse,
+		protocol.MsgConnectAccept, // recover-session uses the connect-accept envelope
+		protocol.MsgError:
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *SocketPickerClient) roundTrip(reqType protocol.MessageType, body []byte) (protocol.Header, []byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -163,11 +189,22 @@ func (s *SocketPickerClient) roundTrip(reqType protocol.MessageType, body []byte
 	if err := protocol.WriteMessage(s.conn, hdr, body); err != nil {
 		return protocol.Header{}, nil, fmt.Errorf("write %d: %w", reqType, err)
 	}
-	respHdr, respPayload, err := protocol.ReadMessage(s.conn)
-	if err != nil {
-		return protocol.Header{}, nil, fmt.Errorf("read response: %w", err)
+	// Skip unsolicited state pushes from the server (MsgPaneFocus,
+	// MsgStateUpdate, etc.) until we see a picker-relevant response.
+	// The connection still has the desktop's focus/state/pane listeners
+	// attached because handleHandshake → newConnection wires them
+	// unconditionally; we live with the noise on this side rather than
+	// adding a new "headless connection" mode server-side.
+	for {
+		respHdr, respPayload, err := protocol.ReadMessage(s.conn)
+		if err != nil {
+			return protocol.Header{}, nil, fmt.Errorf("read response: %w", err)
+		}
+		if isPickerResponseType(respHdr.Type) {
+			return respHdr, respPayload, nil
+		}
+		// Drop the frame and keep reading.
 	}
-	return respHdr, respPayload, nil
 }
 
 func (s *SocketPickerClient) ListSessions() (protocol.ListSessionsResponse, error) {

--- a/cmd/texelation/boot/picker_client_test.go
+++ b/cmd/texelation/boot/picker_client_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// TestSocketPickerClient_ListSessions wires a fake server-side
+// listener that speaks just enough protocol to validate the picker
+// client's round-trip.
+func TestSocketPickerClient_ListSessions(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		hdr, _, err := protocol.ReadMessage(conn)
+		if err != nil || hdr.Type != protocol.MsgHello {
+			return
+		}
+		welBody, _ := protocol.EncodeWelcome(protocol.Welcome{SessionID: [16]byte{0xAA}, ServerName: "test"})
+		welHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgWelcome, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
+		_ = protocol.WriteMessage(conn, welHdr, welBody)
+
+		_, _, _ = protocol.ReadMessage(conn)
+		respBody, _ := protocol.EncodeListSessionsResponse(protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0xBB}, Label: "test", LastActive: 1, PaneCount: 1}},
+		})
+		respHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgListSessionsResponse, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
+		_ = protocol.WriteMessage(conn, respHdr, respBody)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	c, err := NewSocketPickerClient(socket)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+
+	resp, err := c.ListSessions()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(resp.Stored) != 1 || resp.Stored[0].Label != "test" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}

--- a/cmd/texelation/boot/picker_client_test.go
+++ b/cmd/texelation/boot/picker_client_test.go
@@ -30,6 +30,7 @@ func TestSocketPickerClient_ListSessions(t *testing.T) {
 			return
 		}
 		defer conn.Close()
+		// Hello → Welcome
 		hdr, _, err := protocol.ReadMessage(conn)
 		if err != nil || hdr.Type != protocol.MsgHello {
 			return
@@ -37,7 +38,15 @@ func TestSocketPickerClient_ListSessions(t *testing.T) {
 		welBody, _ := protocol.EncodeWelcome(protocol.Welcome{SessionID: [16]byte{0xAA}, ServerName: "test"})
 		welHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgWelcome, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
 		_ = protocol.WriteMessage(conn, welHdr, welBody)
-
+		// ConnectRequest → ConnectAccept
+		hdr, _, err = protocol.ReadMessage(conn)
+		if err != nil || hdr.Type != protocol.MsgConnectRequest {
+			return
+		}
+		acceptBody, _ := protocol.EncodeConnectAccept(protocol.ConnectAccept{SessionID: [16]byte{0xAA}, ResumeSupported: true})
+		acceptHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgConnectAccept, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
+		_ = protocol.WriteMessage(conn, acceptHdr, acceptBody)
+		// MsgListSessions → MsgListSessionsResponse
 		_, _, _ = protocol.ReadMessage(conn)
 		respBody, _ := protocol.EncodeListSessionsResponse(protocol.ListSessionsResponse{
 			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0xBB}, Label: "test", LastActive: 1, PaneCount: 1}},

--- a/cmd/texelation/boot/picker_input.go
+++ b/cmd/texelation/boot/picker_input.go
@@ -91,10 +91,6 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 		if p.selectedIdx > 0 {
 			p.selectedIdx--
 		}
-	case 'n':
-		p.client.StartFreshSession()
-		p.done = true
-		p.choice = choiceFresh
 	case 'r':
 		// Rename only operates on stored sessions. Live sessions
 		// don't have a sensible rename target in F.1.

--- a/cmd/texelation/boot/picker_input.go
+++ b/cmd/texelation/boot/picker_input.go
@@ -38,10 +38,6 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 		p.handleRenameKey(key, ch)
 		return
 	}
-	if p.mode == modeDeleteConfirm {
-		p.handleDeleteConfirmKey(key, ch)
-		return
-	}
 	// Any key dismisses a sticky error banner, even if it doesn't
 	// otherwise navigate.
 	p.errMsg = ""
@@ -98,12 +94,6 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 			p.mode = modeRename
 			p.renameBuf = []rune(p.response.Stored[p.selectedIdx].Label)
 		}
-	case 'd':
-		// Delete only operates on stored sessions; the server refuses
-		// to delete a live session anyway.
-		if p.activeTab == tabStored && len(p.response.Stored) > 0 {
-			p.mode = modeDeleteConfirm
-		}
 	case 'q':
 		p.done = true
 		p.choice = choiceQuit
@@ -142,27 +132,3 @@ func (p *Picker) handleRenameKey(key tcell.Key, ch rune) {
 	}
 }
 
-func (p *Picker) handleDeleteConfirmKey(key tcell.Key, ch rune) {
-	switch ch {
-	case 'y', 'Y':
-		if len(p.response.Stored) > 0 {
-			id := p.response.Stored[p.selectedIdx].SessionID
-			if err := p.client.DeleteSession(id); err != nil {
-				p.errMsg = "Delete failed: " + err.Error()
-			} else {
-				// Drop the entry locally so the cursor position
-				// stays meaningful even if we don't refresh.
-				p.response.Stored = append(p.response.Stored[:p.selectedIdx], p.response.Stored[p.selectedIdx+1:]...)
-				if p.selectedIdx >= len(p.response.Stored) && p.selectedIdx > 0 {
-					p.selectedIdx--
-				}
-			}
-		}
-		p.mode = modeBrowse
-	case 'n', 'N':
-		p.mode = modeBrowse
-	}
-	if key == tcell.KeyEsc {
-		p.mode = modeBrowse
-	}
-}

--- a/cmd/texelation/boot/picker_input.go
+++ b/cmd/texelation/boot/picker_input.go
@@ -1,0 +1,142 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import "github.com/gdamore/tcell/v2"
+
+// HandleKey routes a tcell key event through the picker's mode-aware
+// state machine. Tests call this directly; the run loop wraps real
+// EventKey events.
+func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
+	if p.mode == modeRename {
+		p.handleRenameKey(key, ch)
+		return
+	}
+	if p.mode == modeDeleteConfirm {
+		p.handleDeleteConfirmKey(key, ch)
+		return
+	}
+	// Any key dismisses a sticky error banner, even if it doesn't
+	// otherwise navigate.
+	p.errMsg = ""
+	switch key {
+	case tcell.KeyUp:
+		if p.selectedIdx > 0 {
+			p.selectedIdx--
+		}
+	case tcell.KeyDown:
+		if p.selectedIdx < len(p.response.Stored)-1 {
+			p.selectedIdx++
+		}
+	case tcell.KeyEnter:
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			if err := p.client.RecoverSession(id, ""); err != nil {
+				// Keep the picker open and surface the error so the
+				// user can pick a different session or retry. Don't
+				// signal Done — recovery hasn't actually happened.
+				p.errMsg = "Recover failed: " + err.Error()
+				return
+			}
+			p.done = true
+			p.choice = choiceRecover
+		}
+		return
+	case tcell.KeyTab:
+		if p.activeTab == tabStored {
+			p.activeTab = tabLive
+		} else {
+			p.activeTab = tabStored
+		}
+		return
+	case tcell.KeyEsc:
+		p.done = true
+		p.choice = choiceQuit
+		return
+	default:
+	}
+	switch ch {
+	case 'j':
+		if p.selectedIdx < len(p.response.Stored)-1 {
+			p.selectedIdx++
+		}
+	case 'k':
+		if p.selectedIdx > 0 {
+			p.selectedIdx--
+		}
+	case 'n':
+		p.client.StartFreshSession()
+		p.done = true
+		p.choice = choiceFresh
+	case 'r':
+		if len(p.response.Stored) > 0 {
+			p.mode = modeRename
+			p.renameBuf = []rune(p.response.Stored[p.selectedIdx].Label)
+		}
+	case 'd':
+		if len(p.response.Stored) > 0 {
+			p.mode = modeDeleteConfirm
+		}
+	case 'q':
+		p.done = true
+		p.choice = choiceQuit
+	}
+}
+
+func (p *Picker) handleRenameKey(key tcell.Key, ch rune) {
+	switch key {
+	case tcell.KeyEsc:
+		p.mode = modeBrowse
+		p.renameBuf = nil
+		return
+	case tcell.KeyEnter:
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			newLabel := string(p.renameBuf)
+			if err := p.client.RenameSession(id, newLabel); err != nil {
+				p.errMsg = "Rename failed: " + err.Error()
+				p.mode = modeBrowse
+				p.renameBuf = nil
+				return
+			}
+			p.response.Stored[p.selectedIdx].Label = newLabel
+		}
+		p.mode = modeBrowse
+		p.renameBuf = nil
+		return
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if len(p.renameBuf) > 0 {
+			p.renameBuf = p.renameBuf[:len(p.renameBuf)-1]
+		}
+		return
+	}
+	if ch != 0 {
+		p.renameBuf = append(p.renameBuf, ch)
+	}
+}
+
+func (p *Picker) handleDeleteConfirmKey(key tcell.Key, ch rune) {
+	switch ch {
+	case 'y', 'Y':
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			if err := p.client.DeleteSession(id); err != nil {
+				p.errMsg = "Delete failed: " + err.Error()
+			} else {
+				// Drop the entry locally so the cursor position
+				// stays meaningful even if we don't refresh.
+				p.response.Stored = append(p.response.Stored[:p.selectedIdx], p.response.Stored[p.selectedIdx+1:]...)
+				if p.selectedIdx >= len(p.response.Stored) && p.selectedIdx > 0 {
+					p.selectedIdx--
+				}
+			}
+		}
+		p.mode = modeBrowse
+	case 'n', 'N':
+		p.mode = modeBrowse
+	}
+	if key == tcell.KeyEsc {
+		p.mode = modeBrowse
+	}
+}

--- a/cmd/texelation/boot/picker_input.go
+++ b/cmd/texelation/boot/picker_input.go
@@ -5,6 +5,31 @@ package boot
 
 import "github.com/gdamore/tcell/v2"
 
+// activeListLen returns the entry count of whichever tab is currently
+// active. Used to clamp navigation indices.
+func (p *Picker) activeListLen() int {
+	if p.activeTab == tabLive {
+		return len(p.response.Live)
+	}
+	return len(p.response.Stored)
+}
+
+// activeSelectedID returns the session ID at p.selectedIdx in the
+// currently-active tab. Returns ([16]byte{}, false) if the active list
+// is empty.
+func (p *Picker) activeSelectedID() ([16]byte, bool) {
+	if p.activeTab == tabLive {
+		if p.selectedIdx >= len(p.response.Live) {
+			return [16]byte{}, false
+		}
+		return p.response.Live[p.selectedIdx].SessionID, true
+	}
+	if p.selectedIdx >= len(p.response.Stored) {
+		return [16]byte{}, false
+	}
+	return p.response.Stored[p.selectedIdx].SessionID, true
+}
+
 // HandleKey routes a tcell key event through the picker's mode-aware
 // state machine. Tests call this directly; the run loop wraps real
 // EventKey events.
@@ -26,16 +51,12 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 			p.selectedIdx--
 		}
 	case tcell.KeyDown:
-		if p.selectedIdx < len(p.response.Stored)-1 {
+		if p.selectedIdx < p.activeListLen()-1 {
 			p.selectedIdx++
 		}
 	case tcell.KeyEnter:
-		if len(p.response.Stored) > 0 {
-			id := p.response.Stored[p.selectedIdx].SessionID
+		if id, ok := p.activeSelectedID(); ok {
 			if err := p.client.RecoverSession(id, ""); err != nil {
-				// Keep the picker open and surface the error so the
-				// user can pick a different session or retry. Don't
-				// signal Done — recovery hasn't actually happened.
 				p.errMsg = "Recover failed: " + err.Error()
 				return
 			}
@@ -49,6 +70,11 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 		} else {
 			p.activeTab = tabStored
 		}
+		// Clamp selection so the new tab's smaller list doesn't
+		// leave selectedIdx pointing past the end.
+		if p.selectedIdx >= p.activeListLen() {
+			p.selectedIdx = 0
+		}
 		return
 	case tcell.KeyEsc:
 		p.done = true
@@ -58,7 +84,7 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 	}
 	switch ch {
 	case 'j':
-		if p.selectedIdx < len(p.response.Stored)-1 {
+		if p.selectedIdx < p.activeListLen()-1 {
 			p.selectedIdx++
 		}
 	case 'k':
@@ -70,12 +96,16 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 		p.done = true
 		p.choice = choiceFresh
 	case 'r':
-		if len(p.response.Stored) > 0 {
+		// Rename only operates on stored sessions. Live sessions
+		// don't have a sensible rename target in F.1.
+		if p.activeTab == tabStored && len(p.response.Stored) > 0 {
 			p.mode = modeRename
 			p.renameBuf = []rune(p.response.Stored[p.selectedIdx].Label)
 		}
 	case 'd':
-		if len(p.response.Stored) > 0 {
+		// Delete only operates on stored sessions; the server refuses
+		// to delete a live session anyway.
+		if p.activeTab == tabStored && len(p.response.Stored) > 0 {
 			p.mode = modeDeleteConfirm
 		}
 	case 'q':

--- a/cmd/texelation/boot/picker_render.go
+++ b/cmd/texelation/boot/picker_render.go
@@ -98,9 +98,6 @@ func (p *Picker) Render() {
 	p.drawActionBar(painter, styles, w, h)
 	// Rename mode renders inline on the selected card via drawCard; no
 	// separate overlay needed.
-	if p.mode == modeDeleteConfirm {
-		p.drawDeleteConfirmOverlay(painter, styles, w, h)
-	}
 
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
@@ -250,7 +247,7 @@ func (p *Picker) drawASCIILayoutAt(painter *core.Painter, rect core.Rect, layout
 }
 
 func (p *Picker) drawActionBar(painter *core.Painter, styles pickerStyles, w, h int) {
-	bar := "[Enter] recover   [r] rename   [d] delete   [q] quit"
+	bar := "[Enter] recover   [r] rename   [q] quit"
 	startX := (w - len(bar)) / 2
 	if startX < 0 {
 		startX = 0
@@ -258,22 +255,6 @@ func (p *Picker) drawActionBar(painter *core.Painter, styles pickerStyles, w, h 
 	painter.DrawText(startX, h-2, bar, styles.secondary)
 }
 
-func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, styles pickerStyles, w, h int) {
-	if len(p.response.Stored) == 0 {
-		return
-	}
-	// F.1 limitation: deleting only removes per-session metadata
-	// (the JSON sidecar + thumbnail). The daemon's snapshot.json holds
-	// the workspace tree separately, so the recovered desktop content
-	// can re-appear on the next start. Use `texelation --reset-state`
-	// for a full wipe. The hint here keeps the user from being
-	// surprised; we don't auto-wipe snapshot.json from the picker
-	// because it's shared across all sessions in a single-desktop
-	// architecture.
-	label := labelOrUntitled(p.response.Stored[p.selectedIdx].Label)
-	prompt := fmt.Sprintf("Delete '%s'? [y/N]   (metadata only — workspace persists; --reset-state for full wipe)", label)
-	painter.DrawText(2, h-4, prompt, styles.danger)
-}
 
 func labelOrUntitled(s string) string {
 	if s == "" {

--- a/cmd/texelation/boot/picker_render.go
+++ b/cmd/texelation/boot/picker_render.go
@@ -133,10 +133,26 @@ func (p *Picker) drawTabs(painter *core.Painter, w int) {
 }
 
 func (p *Picker) drawCards(painter *core.Painter, w, h int) {
-	if p.activeTab != tabStored {
+	startY := 4
+	if p.activeTab == tabLive {
+		// F.1: render live sessions as lightweight cards. We synthesize
+		// a SessionSummary from each LiveSummary so drawCard can stay
+		// uniform. No layout/thumbnail data — that belongs to Stored.
+		for i, live := range p.response.Live {
+			cardY := startY + i*(cardThumbH+cardGap)
+			if cardY+cardThumbH+cardGap > h-2 {
+				break
+			}
+			summary := protocol.SessionSummary{
+				SessionID:  live.SessionID,
+				Label:      live.Label,
+				LastActive: live.LastInputAt,
+				PaneCount:  live.PaneCount,
+			}
+			p.drawCard(painter, 2, cardY, summary, i == p.selectedIdx)
+		}
 		return
 	}
-	startY := 4
 	for i, summary := range p.response.Stored {
 		cardY := startY + i*(cardThumbH+cardGap)
 		if cardY+cardThumbH+cardGap > h-2 {

--- a/cmd/texelation/boot/picker_render.go
+++ b/cmd/texelation/boot/picker_render.go
@@ -96,9 +96,8 @@ func (p *Picker) Render() {
 	p.drawCards(painter, styles, w, h)
 	p.drawErrorBanner(painter, styles, w, h)
 	p.drawActionBar(painter, styles, w, h)
-	if p.mode == modeRename {
-		p.drawRenameOverlay(painter, styles, w, h)
-	}
+	// Rename mode renders inline on the selected card via drawCard; no
+	// separate overlay needed.
 	if p.mode == modeDeleteConfirm {
 		p.drawDeleteConfirmOverlay(painter, styles, w, h)
 	}
@@ -221,7 +220,14 @@ func (p *Picker) drawCard(painter *core.Painter, styles pickerStyles, x, y int, 
 			painter.SetCell(col, y+row, ' ', cardStyle)
 		}
 	}
-	painter.DrawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), cardStyle.Bold(true))
+	// Selected card + rename mode → show the edit buffer inline on
+	// the Label line instead of the static label. Cursor indicator is
+	// a trailing block char so the user knows it's an active input.
+	labelLine := fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label))
+	if selected && p.mode == modeRename {
+		labelLine = fmt.Sprintf("Rename:  %s▏", string(p.renameBuf))
+	}
+	painter.DrawText(metaX, y, labelLine, cardStyle.Bold(true))
 	painter.DrawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), cardStyle)
 	painter.DrawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), cardStyle)
 	painter.DrawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), cardStyle)
@@ -244,7 +250,7 @@ func (p *Picker) drawASCIILayoutAt(painter *core.Painter, rect core.Rect, layout
 }
 
 func (p *Picker) drawActionBar(painter *core.Painter, styles pickerStyles, w, h int) {
-	bar := "[Enter] recover   [n] new   [r] rename   [d] delete   [q] quit"
+	bar := "[Enter] recover   [r] rename   [d] delete   [q] quit"
 	startX := (w - len(bar)) / 2
 	if startX < 0 {
 		startX = 0
@@ -252,16 +258,20 @@ func (p *Picker) drawActionBar(painter *core.Painter, styles pickerStyles, w, h 
 	painter.DrawText(startX, h-2, bar, styles.secondary)
 }
 
-func (p *Picker) drawRenameOverlay(painter *core.Painter, styles pickerStyles, w, h int) {
-	prompt := fmt.Sprintf("Rename: %s", string(p.renameBuf))
-	painter.DrawText(2, h-4, prompt, styles.primary)
-}
-
 func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, styles pickerStyles, w, h int) {
 	if len(p.response.Stored) == 0 {
 		return
 	}
-	prompt := fmt.Sprintf("Delete '%s'? [y/N]", labelOrUntitled(p.response.Stored[p.selectedIdx].Label))
+	// F.1 limitation: deleting only removes per-session metadata
+	// (the JSON sidecar + thumbnail). The daemon's snapshot.json holds
+	// the workspace tree separately, so the recovered desktop content
+	// can re-appear on the next start. Use `texelation --reset-state`
+	// for a full wipe. The hint here keeps the user from being
+	// surprised; we don't auto-wipe snapshot.json from the picker
+	// because it's shared across all sessions in a single-desktop
+	// architecture.
+	label := labelOrUntitled(p.response.Stored[p.selectedIdx].Label)
+	prompt := fmt.Sprintf("Delete '%s'? [y/N]   (metadata only — workspace persists; --reset-state for full wipe)", label)
 	painter.DrawText(2, h-4, prompt, styles.danger)
 }
 

--- a/cmd/texelation/boot/picker_render.go
+++ b/cmd/texelation/boot/picker_render.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/framegrace/texelation/protocol"
 	core "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/theme"
 )
 
 const (
@@ -20,6 +21,41 @@ const (
 	cardThumbH = 8
 	cardGap    = 1
 )
+
+// pickerStyles centralises the theme-resolved styles for the picker
+// so we look them up once per Render rather than per-cell. Build is
+// cheap (theme.Get is map lookups) but caching keeps draw helpers
+// uncluttered.
+type pickerStyles struct {
+	base     tcell.Style // overall background
+	surface  tcell.Style // cards
+	primary  tcell.Style // active/bold text
+	secondary tcell.Style // action bar
+	muted    tcell.Style // inactive tab labels
+	accent   tcell.Style // selected card highlight
+	danger   tcell.Style // error banner
+}
+
+func loadPickerStyles() pickerStyles {
+	tm := theme.Get()
+	bg := tm.GetSemanticColor("bg.base")
+	surfaceBG := tm.GetSemanticColor("bg.surface")
+	primaryFG := tm.GetSemanticColor("text.primary")
+	secondaryFG := tm.GetSemanticColor("text.secondary")
+	mutedFG := tm.GetSemanticColor("text.muted")
+	accentFG := tm.GetSemanticColor("text.inverse")
+	accentBG := tm.GetSemanticColor("action.primary")
+	dangerFG := tm.GetSemanticColor("action.danger")
+	return pickerStyles{
+		base:      tcell.StyleDefault.Background(bg).Foreground(primaryFG),
+		surface:   tcell.StyleDefault.Background(surfaceBG).Foreground(primaryFG),
+		primary:   tcell.StyleDefault.Background(bg).Foreground(primaryFG).Bold(true),
+		secondary: tcell.StyleDefault.Background(bg).Foreground(secondaryFG),
+		muted:     tcell.StyleDefault.Background(bg).Foreground(mutedFG),
+		accent:    tcell.StyleDefault.Background(accentBG).Foreground(accentFG).Bold(true),
+		danger:    tcell.StyleDefault.Background(bg).Foreground(dangerFG).Bold(true),
+	}
+}
 
 // Render paints the picker. Builds a fresh cell buffer per frame,
 // runs the widget tree (cards + tabs + banner + action-bar) through
@@ -30,16 +66,18 @@ func (p *Picker) Render() {
 	if w <= 0 || h <= 0 {
 		return
 	}
+	styles := loadPickerStyles()
 	if len(p.cellBuf) != h || (len(p.cellBuf) > 0 && len(p.cellBuf[0]) != w) {
 		p.cellBuf = make([][]core.Cell, h)
 		for y := range p.cellBuf {
 			p.cellBuf[y] = make([]core.Cell, w)
 		}
-	} else {
-		for y := range p.cellBuf {
-			for x := range p.cellBuf[y] {
-				p.cellBuf[y][x] = core.Cell{Ch: ' ', Style: tcell.StyleDefault}
-			}
+	}
+	// Fill with theme background each frame regardless of size match
+	// so a previous-frame styled cell doesn't bleed through.
+	for y := range p.cellBuf {
+		for x := range p.cellBuf[y] {
+			p.cellBuf[y][x] = core.Cell{Ch: ' ', Style: styles.base}
 		}
 	}
 	clip := core.Rect{X: 0, Y: 0, W: w, H: h}
@@ -53,16 +91,16 @@ func (p *Picker) Render() {
 		p.gp.Reset()
 	}
 
-	p.drawHeader(painter, w)
-	p.drawTabs(painter, w)
-	p.drawCards(painter, w, h)
-	p.drawErrorBanner(painter, w, h)
-	p.drawActionBar(painter, w, h)
+	p.drawHeader(painter, styles, w)
+	p.drawTabs(painter, styles, w)
+	p.drawCards(painter, styles, w, h)
+	p.drawErrorBanner(painter, styles, w, h)
+	p.drawActionBar(painter, styles, w, h)
 	if p.mode == modeRename {
-		p.drawRenameOverlay(painter, w, h)
+		p.drawRenameOverlay(painter, styles, w, h)
 	}
 	if p.mode == modeDeleteConfirm {
-		p.drawDeleteConfirmOverlay(painter, w, h)
+		p.drawDeleteConfirmOverlay(painter, styles, w, h)
 	}
 
 	for y := 0; y < h; y++ {
@@ -92,7 +130,7 @@ func (p *Picker) Render() {
 	p.screen.Show()
 }
 
-func (p *Picker) drawErrorBanner(painter *core.Painter, w, h int) {
+func (p *Picker) drawErrorBanner(painter *core.Painter, styles pickerStyles, w, h int) {
 	msg := p.errMsg
 	if msg == "" {
 		msg = p.flushErrMsg
@@ -100,39 +138,37 @@ func (p *Picker) drawErrorBanner(painter *core.Painter, w, h int) {
 	if msg == "" {
 		return
 	}
-	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
 	if len(msg) > w-4 {
 		msg = msg[:w-5] + "…"
 	}
-	painter.DrawText(2, h-3, msg, style)
+	painter.DrawText(2, h-3, msg, styles.danger)
 }
 
-func (p *Picker) drawHeader(painter *core.Painter, w int) {
-	style := tcell.StyleDefault.Bold(true)
+func (p *Picker) drawHeader(painter *core.Painter, styles pickerStyles, w int) {
 	title := "texelation — recover session"
 	startX := (w - len(title)) / 2
 	if startX < 0 {
 		startX = 0
 	}
-	painter.DrawText(startX, 0, title, style)
+	painter.DrawText(startX, 0, title, styles.primary)
 }
 
-func (p *Picker) drawTabs(painter *core.Painter, w int) {
+func (p *Picker) drawTabs(painter *core.Painter, styles pickerStyles, w int) {
 	live := fmt.Sprintf("[ Live (%d) ]", len(p.response.Live))
 	stored := fmt.Sprintf("[ Stored (%d) ]", len(p.response.Stored))
-	liveStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	liveStyle := styles.muted
 	if p.activeTab == tabLive {
-		liveStyle = tcell.StyleDefault.Bold(true)
+		liveStyle = styles.primary
 	}
-	storedStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	storedStyle := styles.muted
 	if p.activeTab == tabStored {
-		storedStyle = tcell.StyleDefault.Bold(true)
+		storedStyle = styles.primary
 	}
 	painter.DrawText(2, 2, live, liveStyle)
 	painter.DrawText(2+len(live)+2, 2, stored, storedStyle)
 }
 
-func (p *Picker) drawCards(painter *core.Painter, w, h int) {
+func (p *Picker) drawCards(painter *core.Painter, styles pickerStyles, w, h int) {
 	startY := 4
 	if p.activeTab == tabLive {
 		// F.1: render live sessions as lightweight cards. We synthesize
@@ -148,8 +184,13 @@ func (p *Picker) drawCards(painter *core.Painter, w, h int) {
 				Label:      live.Label,
 				LastActive: live.LastInputAt,
 				PaneCount:  live.PaneCount,
+				// HasThumbnail=true so the picker fetches a thumbnail
+				// for live sessions (the server renders it on demand
+				// from the publisher's prevBuffers when the file
+				// doesn't exist yet).
+				HasThumbnail: true,
 			}
-			p.drawCard(painter, 2, cardY, summary, i == p.selectedIdx)
+			p.drawCard(painter, styles, 2, cardY, summary, i == p.selectedIdx)
 		}
 		return
 	}
@@ -158,25 +199,34 @@ func (p *Picker) drawCards(painter *core.Painter, w, h int) {
 		if cardY+cardThumbH+cardGap > h-2 {
 			break
 		}
-		p.drawCard(painter, 2, cardY, summary, i == p.selectedIdx)
+		p.drawCard(painter, styles, 2, cardY, summary, i == p.selectedIdx)
 	}
 }
 
-func (p *Picker) drawCard(painter *core.Painter, x, y int, s protocol.SessionSummary, selected bool) {
-	bgStyle := tcell.StyleDefault
+func (p *Picker) drawCard(painter *core.Painter, styles pickerStyles, x, y int, s protocol.SessionSummary, selected bool) {
+	cardStyle := styles.surface
 	if selected {
-		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
+		cardStyle = styles.accent
 	}
 	thumbRect := core.Rect{X: x, Y: y, W: cardThumbW, H: cardThumbH}
-	p.drawThumbnail(painter, thumbRect, s, bgStyle)
+	p.drawThumbnail(painter, thumbRect, s, cardStyle)
 
+	// Paint the metadata column background up-front so trailing
+	// whitespace (after labels shorter than the column) still picks
+	// up the card style.
 	metaX := x + cardThumbW + 2
-	painter.DrawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
-	painter.DrawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
-	painter.DrawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
-	painter.DrawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
+	pw, _ := painter.Size()
+	for row := 0; row < cardThumbH; row++ {
+		for col := metaX; col < metaX+50 && col < pw; col++ {
+			painter.SetCell(col, y+row, ' ', cardStyle)
+		}
+	}
+	painter.DrawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), cardStyle.Bold(true))
+	painter.DrawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), cardStyle)
+	painter.DrawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), cardStyle)
+	painter.DrawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), cardStyle)
 	if s.Pinned {
-		painter.DrawText(metaX, y+4, "Pinned:  ★", bgStyle)
+		painter.DrawText(metaX, y+4, "Pinned:  ★", cardStyle)
 	}
 }
 
@@ -193,27 +243,26 @@ func (p *Picker) drawASCIILayoutAt(painter *core.Painter, rect core.Rect, layout
 	}
 }
 
-func (p *Picker) drawActionBar(painter *core.Painter, w, h int) {
+func (p *Picker) drawActionBar(painter *core.Painter, styles pickerStyles, w, h int) {
 	bar := "[Enter] recover   [n] new   [r] rename   [d] delete   [q] quit"
-	style := tcell.StyleDefault.Foreground(tcell.ColorGray)
 	startX := (w - len(bar)) / 2
 	if startX < 0 {
 		startX = 0
 	}
-	painter.DrawText(startX, h-2, bar, style)
+	painter.DrawText(startX, h-2, bar, styles.secondary)
 }
 
-func (p *Picker) drawRenameOverlay(painter *core.Painter, w, h int) {
+func (p *Picker) drawRenameOverlay(painter *core.Painter, styles pickerStyles, w, h int) {
 	prompt := fmt.Sprintf("Rename: %s", string(p.renameBuf))
-	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Bold(true))
+	painter.DrawText(2, h-4, prompt, styles.primary)
 }
 
-func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, w, h int) {
+func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, styles pickerStyles, w, h int) {
 	if len(p.response.Stored) == 0 {
 		return
 	}
 	prompt := fmt.Sprintf("Delete '%s'? [y/N]", labelOrUntitled(p.response.Stored[p.selectedIdx].Label))
-	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true))
+	painter.DrawText(2, h-4, prompt, styles.danger)
 }
 
 func labelOrUntitled(s string) string {

--- a/cmd/texelation/boot/picker_render.go
+++ b/cmd/texelation/boot/picker_render.go
@@ -1,0 +1,232 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+	core "github.com/framegrace/texelui/core"
+)
+
+const (
+	cardThumbW = 22
+	cardThumbH = 8
+	cardGap    = 1
+)
+
+// Render paints the picker. Builds a fresh cell buffer per frame,
+// runs the widget tree (cards + tabs + banner + action-bar) through
+// a Painter wired to the graphics provider, copies the buffer cells
+// to the tcell.Screen, and flushes any queued APC sequences.
+func (p *Picker) Render() {
+	w, h := p.screen.Size()
+	if w <= 0 || h <= 0 {
+		return
+	}
+	if len(p.cellBuf) != h || (len(p.cellBuf) > 0 && len(p.cellBuf[0]) != w) {
+		p.cellBuf = make([][]core.Cell, h)
+		for y := range p.cellBuf {
+			p.cellBuf[y] = make([]core.Cell, w)
+		}
+	} else {
+		for y := range p.cellBuf {
+			for x := range p.cellBuf[y] {
+				p.cellBuf[y][x] = core.Cell{Ch: ' ', Style: tcell.StyleDefault}
+			}
+		}
+	}
+	clip := core.Rect{X: 0, Y: 0, W: w, H: h}
+	painter := core.NewPainterWithGraphics(p.cellBuf, clip, p.gp)
+	painter.SetScreenSize(w, h)
+
+	// Reset graphics provider's placement set each frame so stale
+	// images from the previous frame don't linger when scrolled away
+	// or replaced by an upgrade.
+	if p.gp != nil {
+		p.gp.Reset()
+	}
+
+	p.drawHeader(painter, w)
+	p.drawTabs(painter, w)
+	p.drawCards(painter, w, h)
+	p.drawErrorBanner(painter, w, h)
+	p.drawActionBar(painter, w, h)
+	if p.mode == modeRename {
+		p.drawRenameOverlay(painter, w, h)
+	}
+	if p.mode == modeDeleteConfirm {
+		p.drawDeleteConfirmOverlay(painter, w, h)
+	}
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := p.cellBuf[y][x]
+			ch := c.Ch
+			if ch == 0 {
+				ch = ' '
+			}
+			p.screen.SetContent(x, y, ch, nil, c.Style)
+		}
+	}
+	// Flush queued graphics commands. KittyProvider has Flush; the
+	// HalfBlockProvider does not (its writes already landed in
+	// cellBuf via Place→SetCell), so the type assertion is
+	// intentionally Kitty-only — when it fails, no flush is needed.
+	if p.gp != nil && p.gpFlush != nil {
+		if flusher, ok := p.gp.(interface{ Flush(io.Writer) error }); ok {
+			if err := flusher.Flush(p.gpFlush); err != nil {
+				log.Printf("picker: graphics flush failed: %v", err)
+				p.flushErrMsg = "Thumbnails unavailable: " + err.Error()
+			} else {
+				p.flushErrMsg = ""
+			}
+		}
+	}
+	p.screen.Show()
+}
+
+func (p *Picker) drawErrorBanner(painter *core.Painter, w, h int) {
+	msg := p.errMsg
+	if msg == "" {
+		msg = p.flushErrMsg
+	}
+	if msg == "" {
+		return
+	}
+	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
+	if len(msg) > w-4 {
+		msg = msg[:w-5] + "…"
+	}
+	painter.DrawText(2, h-3, msg, style)
+}
+
+func (p *Picker) drawHeader(painter *core.Painter, w int) {
+	style := tcell.StyleDefault.Bold(true)
+	title := "texelation — recover session"
+	startX := (w - len(title)) / 2
+	if startX < 0 {
+		startX = 0
+	}
+	painter.DrawText(startX, 0, title, style)
+}
+
+func (p *Picker) drawTabs(painter *core.Painter, w int) {
+	live := fmt.Sprintf("[ Live (%d) ]", len(p.response.Live))
+	stored := fmt.Sprintf("[ Stored (%d) ]", len(p.response.Stored))
+	liveStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	if p.activeTab == tabLive {
+		liveStyle = tcell.StyleDefault.Bold(true)
+	}
+	storedStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	if p.activeTab == tabStored {
+		storedStyle = tcell.StyleDefault.Bold(true)
+	}
+	painter.DrawText(2, 2, live, liveStyle)
+	painter.DrawText(2+len(live)+2, 2, stored, storedStyle)
+}
+
+func (p *Picker) drawCards(painter *core.Painter, w, h int) {
+	if p.activeTab != tabStored {
+		return
+	}
+	startY := 4
+	for i, summary := range p.response.Stored {
+		cardY := startY + i*(cardThumbH+cardGap)
+		if cardY+cardThumbH+cardGap > h-2 {
+			break
+		}
+		p.drawCard(painter, 2, cardY, summary, i == p.selectedIdx)
+	}
+}
+
+func (p *Picker) drawCard(painter *core.Painter, x, y int, s protocol.SessionSummary, selected bool) {
+	bgStyle := tcell.StyleDefault
+	if selected {
+		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
+	}
+	thumbRect := core.Rect{X: x, Y: y, W: cardThumbW, H: cardThumbH}
+	p.drawThumbnail(painter, thumbRect, s, bgStyle)
+
+	metaX := x + cardThumbW + 2
+	painter.DrawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
+	painter.DrawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
+	painter.DrawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
+	painter.DrawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
+	if s.Pinned {
+		painter.DrawText(metaX, y+4, "Pinned:  ★", bgStyle)
+	}
+}
+
+// drawASCIILayoutAt paints the box-drawing tree for s.Layout into the
+// rect via the Painter. Shared between Task 16 (no-graphics or no-
+// cached-thumbnail path) and Task 17 (called when the widget isn't
+// cached yet).
+func (p *Picker) drawASCIILayoutAt(painter *core.Painter, rect core.Rect, layout *protocol.TreeNodeSnapshot, bgStyle tcell.Style) {
+	grid := renderASCIILayoutGrid(rect.W, rect.H, layout)
+	for cy := 0; cy < rect.H && cy < len(grid); cy++ {
+		for cx := 0; cx < rect.W && cx < len(grid[cy]); cx++ {
+			painter.SetCell(rect.X+cx, rect.Y+cy, grid[cy][cx], bgStyle)
+		}
+	}
+}
+
+func (p *Picker) drawActionBar(painter *core.Painter, w, h int) {
+	bar := "[Enter] recover   [n] new   [r] rename   [d] delete   [q] quit"
+	style := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	startX := (w - len(bar)) / 2
+	if startX < 0 {
+		startX = 0
+	}
+	painter.DrawText(startX, h-2, bar, style)
+}
+
+func (p *Picker) drawRenameOverlay(painter *core.Painter, w, h int) {
+	prompt := fmt.Sprintf("Rename: %s", string(p.renameBuf))
+	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Bold(true))
+}
+
+func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, w, h int) {
+	if len(p.response.Stored) == 0 {
+		return
+	}
+	prompt := fmt.Sprintf("Delete '%s'? [y/N]", labelOrUntitled(p.response.Stored[p.selectedIdx].Label))
+	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true))
+}
+
+func labelOrUntitled(s string) string {
+	if s == "" {
+		return "Untitled"
+	}
+	return s
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}
+
+func relativeTime(unixSec int64) string {
+	if unixSec == 0 {
+		return "—"
+	}
+	d := time.Since(time.Unix(unixSec, 0))
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%d min ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%d h ago", int(d/time.Hour))
+	default:
+		return fmt.Sprintf("%d days ago", int(d/(24*time.Hour)))
+	}
+}

--- a/cmd/texelation/boot/picker_runner.go
+++ b/cmd/texelation/boot/picker_runner.go
@@ -1,0 +1,55 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_runner.go
+// Summary: Drives the picker's event loop until the user makes a
+// selection. Returns a PickerOutcome the caller translates into a
+// connect path.
+
+package boot
+
+import (
+	"io"
+
+	"github.com/gdamore/tcell/v2"
+
+	core "github.com/framegrace/texelui/core"
+)
+
+// PickerOutcome captures what the user picked.
+type PickerOutcome struct {
+	Choice    pickerChoice
+	SessionID [16]byte // populated when Choice == choiceRecover
+}
+
+// RunPicker drives the picker against client until the user makes a
+// selection. The screen is shared with the splash and clientrt; this
+// function does not call Init/Fini.
+//
+// gp is the texelui graphics provider used for thumbnail rendering.
+// Pass nil for ASCII-only mode. flushTo is where Kitty APC sequences
+// are written after each Render — typically os.Stdout in production.
+func RunPicker(screen tcell.Screen, client PickerClient, gp core.GraphicsProvider, flushTo io.Writer) (PickerOutcome, error) {
+	p := NewPicker(screen, client)
+	p.SetGraphicsProvider(gp, flushTo)
+	p.RefreshCatalog()
+
+	for !p.Done() {
+		p.Render()
+		ev := screen.PollEvent()
+		switch e := ev.(type) {
+		case *tcell.EventKey:
+			p.HandleKey(e.Key(), e.Rune(), e.Modifiers())
+		case *tcell.EventResize:
+			screen.Sync()
+		case *tcell.EventInterrupt:
+			return PickerOutcome{Choice: choiceQuit}, nil
+		}
+	}
+
+	out := PickerOutcome{Choice: p.choice}
+	if p.choice == choiceRecover && len(p.response.Stored) > 0 {
+		out.SessionID = p.response.Stored[p.selectedIdx].SessionID
+	}
+	return out, nil
+}

--- a/cmd/texelation/boot/picker_runner.go
+++ b/cmd/texelation/boot/picker_runner.go
@@ -43,7 +43,10 @@ func RunPicker(screen tcell.Screen, client PickerClient, gp core.GraphicsProvide
 		case *tcell.EventResize:
 			screen.Sync()
 		case *tcell.EventInterrupt:
-			return PickerOutcome{Choice: choiceQuit}, nil
+			// Interrupt is the picker's wake-up signal — fired by the
+			// thumbnail-fetch goroutine when the cache populates. Just
+			// fall through; the next Render at the top of the loop
+			// will pick up the new thumbnail.
 		}
 	}
 

--- a/cmd/texelation/boot/picker_test.go
+++ b/cmd/texelation/boot/picker_test.go
@@ -167,15 +167,21 @@ func TestPicker_EnterDispatchesRecover(t *testing.T) {
 	}
 }
 
-func TestPicker_NewKeyDispatchesNew(t *testing.T) {
+// 'n' was removed from the picker — pressing it is a no-op now (the
+// shared-desktop architecture made "new session" misleading; users
+// quit with q/Esc and run texelation normally for a fresh slot).
+func TestPicker_NewKeyIsNoop(t *testing.T) {
 	screen := newPickerScreen(t)
 	defer screen.Fini()
 	fc := &fakeClient{response: protocol.ListSessionsResponse{}}
 	p := NewPicker(screen, fc)
 	p.RefreshCatalog()
 	p.HandleKey(0, 'n', 0)
-	if !fc.newCalled {
-		t.Errorf("expected fresh-session dispatch on 'n'")
+	if fc.newCalled {
+		t.Errorf("expected 'n' to be a no-op, but StartFreshSession was called")
+	}
+	if p.Done() {
+		t.Errorf("expected picker to stay open on 'n'")
 	}
 }
 

--- a/cmd/texelation/boot/picker_test.go
+++ b/cmd/texelation/boot/picker_test.go
@@ -1,0 +1,344 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelui/graphics"
+)
+
+// fakeClient stubs the picker's network transport for tests. Fields
+// cover both Task 16 (basic ops) and Task 17 (thumbnail fetch).
+type fakeClient struct {
+	response      protocol.ListSessionsResponse
+	listErr       error
+	recoverCalled bool
+	recoverID     [16]byte
+	recoverErr    error
+	newCalled     bool
+	renameErr     error
+	deleteErr     error
+	fetchCalled   bool
+	thumbBytes    []byte
+	thumbErr      error
+}
+
+func (f *fakeClient) ListSessions() (protocol.ListSessionsResponse, error) {
+	if f.listErr != nil {
+		return protocol.ListSessionsResponse{}, f.listErr
+	}
+	return f.response, nil
+}
+func (f *fakeClient) RecoverSession(id [16]byte, newLabel string) error {
+	f.recoverCalled = true
+	f.recoverID = id
+	return f.recoverErr
+}
+func (f *fakeClient) RenameSession(id [16]byte, newLabel string) error { return f.renameErr }
+func (f *fakeClient) DeleteSession(id [16]byte) error                  { return f.deleteErr }
+func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
+	f.fetchCalled = true
+	if f.thumbErr != nil {
+		return nil, f.thumbErr
+	}
+	return f.thumbBytes, nil
+}
+func (f *fakeClient) StartFreshSession() {
+	f.newCalled = true
+}
+
+func newPickerScreen(t *testing.T) tcell.Screen {
+	t.Helper()
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	screen.SetSize(80, 24)
+	return screen
+}
+
+func screenContents(s tcell.Screen) string {
+	sim, ok := s.(tcell.SimulationScreen)
+	if !ok {
+		return ""
+	}
+	cells, w, h := sim.GetContents()
+	var b []byte
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := cells[y*w+x]
+			if len(c.Runes) > 0 {
+				b = append(b, []byte(string(c.Runes[0]))...)
+			} else {
+				b = append(b, ' ')
+			}
+		}
+		b = append(b, '\n')
+	}
+	return string(b)
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPicker_RendersStoredCards(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	p := NewPicker(screen, &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "alpha", LastActive: 100, PaneCount: 1},
+				{SessionID: [16]byte{0x02}, Label: "beta", LastActive: 50, PaneCount: 2},
+			},
+		},
+	})
+	p.RefreshCatalog()
+	p.Render()
+	body := screenContents(screen)
+	if !contains(body, "alpha") {
+		t.Errorf("expected 'alpha' in render:\n%s", body)
+	}
+	if !contains(body, "beta") {
+		t.Errorf("expected 'beta' in render:\n%s", body)
+	}
+}
+
+func TestPicker_NavigationDown(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	p := NewPicker(screen, &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "first"},
+				{SessionID: [16]byte{0x02}, Label: "second"},
+			},
+		},
+	})
+	p.RefreshCatalog()
+	if got := p.SelectedIdx(); got != 0 {
+		t.Fatalf("initial selectedIdx = %d, want 0", got)
+	}
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if got := p.SelectedIdx(); got != 1 {
+		t.Fatalf("after down: selectedIdx = %d, want 1", got)
+	}
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if got := p.SelectedIdx(); got != 1 {
+		t.Errorf("clamp: selectedIdx = %d, want 1", got)
+	}
+}
+
+func TestPicker_EnterDispatchesRecover(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0xCC}, Label: "pickme"},
+			},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(tcell.KeyEnter, 0, 0)
+	if !fc.recoverCalled {
+		t.Errorf("expected RecoverSession dispatch on Enter")
+	}
+	if fc.recoverID != ([16]byte{0xCC}) {
+		t.Errorf("recoverID = %x, want CC", fc.recoverID)
+	}
+}
+
+func TestPicker_NewKeyDispatchesNew(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{response: protocol.ListSessionsResponse{}}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(0, 'n', 0)
+	if !fc.newCalled {
+		t.Errorf("expected fresh-session dispatch on 'n'")
+	}
+}
+
+func TestPicker_RecoverError_StaysOpen(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0xCC}, Label: "broken"}},
+		},
+		recoverErr: errors.New("session evicted"),
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(tcell.KeyEnter, 0, 0)
+	if p.Done() {
+		t.Errorf("picker exited despite Recover error")
+	}
+	if p.errMsg == "" {
+		t.Errorf("expected errMsg set after Recover failure")
+	}
+}
+
+func TestPicker_RefreshCatalogError_PreservesPriorList(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0x01}, Label: "alpha"}},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	if len(p.response.Stored) != 1 {
+		t.Fatalf("setup: expected 1 stored, got %d", len(p.response.Stored))
+	}
+	fc.listErr = errors.New("socket dropped")
+	p.RefreshCatalog()
+	if len(p.response.Stored) != 1 {
+		t.Errorf("expected prior list preserved on error, got %d", len(p.response.Stored))
+	}
+	if p.errMsg == "" {
+		t.Errorf("expected errMsg set on RefreshCatalog error")
+	}
+}
+
+// makeValidPNG produces minimal valid PNG bytes the picker's
+// DecodeConfig + full Decode + widgets.Image will accept.
+func makeValidPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0x40, A: 0xFF})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestPicker_FetchThumbnailDispatchedWhenGraphicsCapable(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	id := [16]byte{0xEE}
+	pngBytes := makeValidPNG(t, 100, 60)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: id, Label: "graphics", HasThumbnail: true},
+			},
+		},
+		thumbBytes: pngBytes,
+	}
+	p := NewPicker(screen, fc)
+	p.SetGraphicsProvider(graphics.NewHalfBlockProvider(), io.Discard)
+	p.RefreshCatalog()
+	p.Render()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if p.ThumbCached(id) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !p.ThumbCached(id) {
+		t.Fatalf("expected thumbnail cached within 500ms")
+	}
+	if !fc.fetchCalled {
+		t.Errorf("expected FetchThumbnail dispatch")
+	}
+}
+
+func TestPicker_NoFetchWhenGraphicsAbsent(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0x10}, HasThumbnail: true}},
+		},
+		thumbBytes: []byte("nope"),
+	}
+	p := NewPicker(screen, fc)
+	// gp left nil — picker stays in ASCII-only mode.
+	p.RefreshCatalog()
+	p.Render()
+	time.Sleep(20 * time.Millisecond)
+	if fc.fetchCalled {
+		t.Errorf("did not expect FetchThumbnail dispatch on text-only terminal")
+	}
+}
+
+func TestPicker_FetchThumbnailErrorClearsPending(t *testing.T) {
+	// Regression test: a failed fetch must not leave pending[id]=true
+	// forever (would prevent retry). After the goroutine returns,
+	// pending must be cleared and failedFetches incremented so
+	// successive renders don't re-spawn the goroutine.
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	id := [16]byte{0xAB}
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: id, HasThumbnail: true}},
+		},
+		thumbErr: errors.New("transient"),
+	}
+	p := NewPicker(screen, fc)
+	p.SetGraphicsProvider(graphics.NewHalfBlockProvider(), io.Discard)
+	p.RefreshCatalog()
+	p.Render()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !p.IsPending(id) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if p.IsPending(id) {
+		t.Fatalf("expected pending cleared after fetch error within 500ms")
+	}
+	if p.ThumbCached(id) {
+		t.Errorf("expected thumbCache empty on fetch error")
+	}
+}
+
+func TestPicker_NavigationDismissesError(t *testing.T) {
+	screen := newPickerScreen(t)
+	defer screen.Fini()
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "first"},
+				{SessionID: [16]byte{0x02}, Label: "second"},
+			},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.errMsg = "stale error"
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if p.errMsg != "" {
+		t.Errorf("expected errMsg cleared after navigation, got %q", p.errMsg)
+	}
+}

--- a/cmd/texelation/boot/picker_thumbnail.go
+++ b/cmd/texelation/boot/picker_thumbnail.go
@@ -152,6 +152,13 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		p.mu.Lock()
 		p.thumbCache[targetID] = data
 		p.mu.Unlock()
+		// Wake the picker's run loop so the new thumbnail renders
+		// without waiting for the user to press a key. PostEvent is
+		// non-blocking; on a contested screen it returns an error
+		// we can safely ignore.
+		if p.screen != nil {
+			_ = p.screen.PostEvent(tcell.NewEventInterrupt(nil))
+		}
 	}(id)
 }
 

--- a/cmd/texelation/boot/picker_thumbnail.go
+++ b/cmd/texelation/boot/picker_thumbnail.go
@@ -1,0 +1,177 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_thumbnail.go
+// Summary: Lazy thumbnail fetch + widgets.Image instantiation for the
+// picker. Rendering is delegated to texelui/widgets.Image which
+// handles Kitty + half-block + alt-text fallback internally.
+
+package boot
+
+import (
+	"bytes"
+	"image/png"
+	"log"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+	core "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/widgets"
+)
+
+// maxThumbnailDim caps PNG dimensions on the decode path. A 480×270
+// PNG is well within this; anything larger is either corrupt or
+// hostile (the 16 MiB protocol cap leaves room for adversarial
+// dimension declarations within a small payload). Decoding without
+// this check can OOM the picker on corrupted inputs.
+const maxThumbnailDim = 4096
+
+// ThumbCached returns true iff a PNG for id is in the local cache.
+// Locked accessor for tests; production read sites also take p.mu.
+func (p *Picker) ThumbCached(id [16]byte) bool {
+	p.mu.Lock()
+	_, ok := p.thumbCache[id]
+	p.mu.Unlock()
+	return ok
+}
+
+// IsPending reports whether a fetch is in flight for id. Locked
+// accessor for tests.
+func (p *Picker) IsPending(id [16]byte) bool {
+	p.mu.Lock()
+	v := p.pending[id]
+	p.mu.Unlock()
+	return v
+}
+
+// markFetchFailed bumps the failure counter for id. Called from the
+// goroutine's error branches and the panic recover so a deterministic
+// failure exhausts attempts after maxFetchAttempts.
+func (p *Picker) markFetchFailed(id [16]byte) {
+	p.mu.Lock()
+	p.failedFetches[id]++
+	p.mu.Unlock()
+}
+
+// imageWidgetFor returns the widgets.Image bound to id's cached PNG,
+// constructing one on first use. nil if no PNG cached.
+func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	data, ok := p.thumbCache[id]
+	if !ok {
+		return nil
+	}
+	if w, exists := p.imgCache[id]; exists {
+		return w
+	}
+	w := widgets.NewImage(data, "session-thumbnail")
+	p.imgCache[id] = w
+	return w
+}
+
+// maybeFetchThumbnail kicks off a non-blocking fetch for id if we
+// haven't cached or pending one already, and haven't already failed
+// maxFetchAttempts times for that id.
+func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
+	if !p.hasGraphics() || !hasThumb {
+		return
+	}
+	p.mu.Lock()
+	if _, cached := p.thumbCache[id]; cached {
+		p.mu.Unlock()
+		return
+	}
+	if p.pending[id] {
+		p.mu.Unlock()
+		return
+	}
+	if p.failedFetches[id] >= maxFetchAttempts {
+		p.mu.Unlock()
+		return
+	}
+	p.pending[id] = true
+	p.mu.Unlock()
+
+	go func(targetID [16]byte) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("picker: thumbnail fetch panic: %v", rec)
+				p.markFetchFailed(targetID)
+			}
+			p.mu.Lock()
+			delete(p.pending, targetID)
+			p.mu.Unlock()
+		}()
+		data, err := p.client.FetchThumbnail(targetID)
+		if err != nil {
+			// All four server-side OK=false branches (path empty,
+			// file missing, oversize, IO error) collapse into err
+			// here. Any of those is permanent — the file will not
+			// magically appear next render — so we count toward the
+			// limiter. A purely transient socket blip would also
+			// count, but maxFetchAttempts=3 means three blips in a
+			// row to give up, which is acceptable and prevents a
+			// render-storm against a hopeless ID.
+			log.Printf("picker: thumbnail fetch %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
+			return
+		}
+		if len(data) == 0 {
+			log.Printf("picker: thumbnail fetch %x: empty response", targetID[:4])
+			p.markFetchFailed(targetID)
+			return
+		}
+		// First-pass: header check + dimension cap. Cheap and
+		// catches non-PNG / huge-canvas attacks before full decode.
+		// Decode-stage errors are bytes-permanent (the same bytes
+		// will fail the same way next time), so they count toward
+		// failedFetches.
+		cfg, err := png.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			log.Printf("picker: thumbnail decode-config %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
+			return
+		}
+		if cfg.Width > maxThumbnailDim || cfg.Height > maxThumbnailDim {
+			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)",
+				targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
+			p.markFetchFailed(targetID)
+			return
+		}
+		// Second-pass: full decode. Catches truncated IDAT, bad
+		// CRCs, etc. that DecodeConfig accepts. Required because
+		// widgets.Image silently falls back to alt text on decode
+		// failure, and the picker has no retry signal.
+		if _, err := png.Decode(bytes.NewReader(data)); err != nil {
+			log.Printf("picker: thumbnail decode %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
+			return
+		}
+		p.mu.Lock()
+		p.thumbCache[targetID] = data
+		p.mu.Unlock()
+	}(id)
+}
+
+// drawThumbnail paints the thumbnail rect for a session card. Branches:
+//   - Graphics-capable + cached PNG  → widgets.Image (Kitty or half-block)
+//   - Otherwise                       → ASCII tree from TreeNodeSnapshot
+//
+// We never half-block-render the structural layout because at thumbnail
+// resolution it produces noise; the box-drawing characters convey
+// structure cleanly even at 22×8.
+func (p *Picker) drawThumbnail(painter *core.Painter, rect core.Rect, s protocol.SessionSummary, bgStyle tcell.Style) {
+	if p.hasGraphics() {
+		if w := p.imageWidgetFor(s.SessionID); w != nil {
+			w.SetPosition(rect.X, rect.Y)
+			w.Resize(rect.W, rect.H)
+			w.Draw(painter)
+			p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
+			return
+		}
+	}
+	p.drawASCIILayoutAt(painter, rect, s.Layout, bgStyle)
+	p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
+}

--- a/cmd/texelation/boot/picker_thumbnail.go
+++ b/cmd/texelation/boot/picker_thumbnail.go
@@ -55,7 +55,11 @@ func (p *Picker) markFetchFailed(id [16]byte) {
 }
 
 // imageWidgetFor returns the widgets.Image bound to id's cached PNG,
-// constructing one on first use. nil if no PNG cached.
+// constructing one on first use. nil if no PNG cached. The widget is
+// keyed not just by id but also by the byte length of the cached PNG —
+// for live sessions the bytes change between renders, so a stale
+// widget would keep showing the old surface; we discard the old
+// widget when the bytes change.
 func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -64,6 +68,18 @@ func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 		return nil
 	}
 	if w, exists := p.imgCache[id]; exists {
+		// For live sessions the bytes may differ between fetches.
+		// Cheap signal: byte-length mismatch → rebuild. PNG bytes
+		// are not deterministic for the same image (timestamps,
+		// compression order) so a length match is "probably same"
+		// and a mismatch is "definitely different." Good enough.
+		if len(data) > 0 && p.liveIDs[id] {
+			// Always rebuild for live IDs so even same-length re-renders
+			// land. Cost: re-decode per render frame, negligible at
+			// thumbnail dims.
+			w = widgets.NewImage(data, "session-thumbnail")
+			p.imgCache[id] = w
+		}
 		return w
 	}
 	w := widgets.NewImage(data, "session-thumbnail")
@@ -74,14 +90,22 @@ func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 // maybeFetchThumbnail kicks off a non-blocking fetch for id if we
 // haven't cached or pending one already, and haven't already failed
 // maxFetchAttempts times for that id.
+//
+// Live sessions bypass the cache check — their state changes
+// continuously, so we always re-fetch. The pending guard still
+// prevents in-flight duplicates, so each render only spawns one
+// goroutine per visible card.
 func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 	if !p.hasGraphics() || !hasThumb {
 		return
 	}
 	p.mu.Lock()
-	if _, cached := p.thumbCache[id]; cached {
-		p.mu.Unlock()
-		return
+	isLive := p.liveIDs[id]
+	if !isLive {
+		if _, cached := p.thumbCache[id]; cached {
+			p.mu.Unlock()
+			return
+		}
 	}
 	if p.pending[id] {
 		p.mu.Unlock()

--- a/cmd/texelation/boot/picker_thumbnail.go
+++ b/cmd/texelation/boot/picker_thumbnail.go
@@ -55,11 +55,9 @@ func (p *Picker) markFetchFailed(id [16]byte) {
 }
 
 // imageWidgetFor returns the widgets.Image bound to id's cached PNG,
-// constructing one on first use. nil if no PNG cached. The widget is
-// keyed not just by id but also by the byte length of the cached PNG —
-// for live sessions the bytes change between renders, so a stale
-// widget would keep showing the old surface; we discard the old
-// widget when the bytes change.
+// constructing one on first use. nil if no PNG cached. Within a
+// single picker session the widget is constructed once and reused
+// — re-decoding/re-uploading every render flashes the Kitty surface.
 func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -68,18 +66,6 @@ func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 		return nil
 	}
 	if w, exists := p.imgCache[id]; exists {
-		// For live sessions the bytes may differ between fetches.
-		// Cheap signal: byte-length mismatch → rebuild. PNG bytes
-		// are not deterministic for the same image (timestamps,
-		// compression order) so a length match is "probably same"
-		// and a mismatch is "definitely different." Good enough.
-		if len(data) > 0 && p.liveIDs[id] {
-			// Always rebuild for live IDs so even same-length re-renders
-			// land. Cost: re-decode per render frame, negligible at
-			// thumbnail dims.
-			w = widgets.NewImage(data, "session-thumbnail")
-			p.imgCache[id] = w
-		}
 		return w
 	}
 	w := widgets.NewImage(data, "session-thumbnail")
@@ -91,21 +77,21 @@ func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 // haven't cached or pending one already, and haven't already failed
 // maxFetchAttempts times for that id.
 //
-// Live sessions bypass the cache check — their state changes
-// continuously, so we always re-fetch. The pending guard still
-// prevents in-flight duplicates, so each render only spawns one
-// goroutine per visible card.
+// Note on live sessions: the server's RenderLiveThumbnailBytes
+// returns fresh state on every fetch, so each --recover invocation
+// gets an up-to-date thumbnail. Within a single picker session we
+// keep the cached PNG — re-fetching every render flashes the Kitty
+// surface (Reset → re-Place gap) and provides no value the user can
+// notice during a brief picker visit. If continuous refresh is ever
+// needed, gate it on a TTL or an explicit "r"-to-refresh keybinding.
 func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 	if !p.hasGraphics() || !hasThumb {
 		return
 	}
 	p.mu.Lock()
-	isLive := p.liveIDs[id]
-	if !isLive {
-		if _, cached := p.thumbCache[id]; cached {
-			p.mu.Unlock()
-			return
-		}
+	if _, cached := p.thumbCache[id]; cached {
+		p.mu.Unlock()
+		return
 	}
 	if p.pending[id] {
 		p.mu.Unlock()

--- a/cmd/texelation/main.go
+++ b/cmd/texelation/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -26,6 +27,8 @@ import (
 	"github.com/framegrace/texelation/cmd/texelation/boot"
 	"github.com/framegrace/texelation/cmd/texelation/lifecycle"
 	clientrt "github.com/framegrace/texelation/internal/runtime/client"
+	texelcore "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/graphics"
 )
 
 func main() {
@@ -63,6 +66,7 @@ func run() error {
 	reconnect := fs.Bool("reconnect", false, "Attempt to resume previous session")
 	panicLog := fs.String("panic-log", "", "File to append panic stack traces")
 	clientName := fs.String("client-name", "", "Client identity slot for persistence (default: $TEXELATION_CLIENT_NAME or \"default\")")
+	recoverFlag := fs.Bool("recover", false, "Show the session-recovery picker even if client state is intact (issue #199 Plan F.1)")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if err == flag.ErrHelp {
@@ -164,10 +168,11 @@ func run() error {
 			LogFilePath:  paths.ServerLogPath,
 			Title:        *title,
 		}, clientrt.Options{
-			Socket:     *socketPath,
-			Reconnect:  *reconnect,
-			PanicLog:   *panicLog,
-			ClientName: *clientName,
+			Socket:            *socketPath,
+			Reconnect:         *reconnect,
+			PanicLog:          *panicLog,
+			ClientName:        *clientName,
+			ShowRecoverPicker: *recoverFlag,
 		})
 	}
 }
@@ -268,6 +273,72 @@ func handleUnifiedMode(ctx context.Context, paths *Paths, srvOpts lifecycle.Serv
 		clientOpts.ShowRestartNotification = true
 	}
 
+	// Plan F.1: show the recovery picker when (a) the user passed
+	// --recover, OR (b) we have no persisted client state AND the
+	// server has stored sessions to offer.
+	shouldShowPicker := clientOpts.ShowRecoverPicker
+	if !shouldShowPicker && !clientStateExists(clientOpts) {
+		probe, perr := boot.ProbeStoredSessions(clientOpts.Socket)
+		if perr == nil && probe > 0 {
+			shouldShowPicker = true
+		}
+	}
+	if shouldShowPicker {
+		splashApp.SetDetail("Loading session list…")
+		splashRunner.Wake()
+		pickerClient, perr := boot.NewSocketPickerClient(clientOpts.Socket)
+		if perr != nil {
+			log.Printf("picker: socket client setup failed: %v; skipping picker", perr)
+			if clientOpts.ShowRecoverPicker {
+				splashApp.SetDetail("Could not connect to daemon: " + perr.Error())
+				splashRunner.Wake()
+			}
+		} else {
+			stopSplash()
+			var gp texelcore.GraphicsProvider
+			switch graphics.DetectCapability() {
+			case texelcore.GraphicsKitty:
+				gp = graphics.NewKittyProvider()
+			case texelcore.GraphicsHalfBlock:
+				gp = graphics.NewHalfBlockProvider()
+			}
+			outcome, runErr := boot.RunPicker(screen, pickerClient, gp, os.Stdout)
+			if cerr := pickerClient.Close(); cerr != nil {
+				log.Printf("picker: close socket: %v", cerr)
+			}
+			if gp != nil {
+				gp.Reset()
+				if flusher, ok := gp.(interface{ Flush(io.Writer) error }); ok {
+					if err := flusher.Flush(os.Stdout); err != nil {
+						log.Printf("picker: clear graphics before splash handoff: %v", err)
+					}
+				}
+			}
+			if runErr != nil {
+				log.Printf("picker: %v; falling back to fresh session", runErr)
+			} else {
+				switch outcome.Choice {
+				case boot.PickerChoiceRecover:
+					clientOpts.RecoverSessionID = outcome.SessionID
+				case boot.PickerChoiceFresh:
+					// fall through to ordinary connect path
+				case boot.PickerChoiceQuit:
+					return nil
+				}
+			}
+			// Restart the splash so clientrt's status callbacks have
+			// somewhere to render after the picker handoff.
+			splashApp = boot.New("Texelation")
+			splashRunner = boot.NewRunner(screen, splashApp)
+			splashRunner.Start()
+			splashStopped = false
+			if runErr != nil {
+				splashApp.SetDetail("Recovery failed; starting fresh session")
+				splashRunner.Wake()
+			}
+		}
+	}
+
 	// Map clientrt's status callbacks onto the splash. Once StageReady
 	// fires the runtime has painted its first frame on the same screen
 	// and we can stop the splash without leaving blank cells.
@@ -289,6 +360,28 @@ func handleUnifiedMode(ctx context.Context, paths *Paths, srvOpts lifecycle.Serv
 	}
 
 	return clientrt.Run(clientOpts)
+}
+
+// clientStateExists is a thin wrapper: if Plan D's persistence path
+// resolves AND the file is present and non-empty, return true.
+func clientStateExists(opts clientrt.Options) bool {
+	path, err := clientrt.ResolvePath(opts.Socket, opts.ClientName)
+	if err != nil || path == "" {
+		return false
+	}
+	info, statErr := os.Stat(path)
+	// Only treat ENOENT as "no state"; permission errors etc. are
+	// surfaced upstream — for the picker trigger we conservatively
+	// say "state exists" to avoid showing the picker over an unrelated
+	// filesystem problem.
+	if os.IsNotExist(statErr) {
+		return false
+	}
+	if statErr != nil {
+		log.Printf("picker: clientStateExists stat %s: %v", path, statErr)
+		return true
+	}
+	return info.Size() > 0
 }
 
 // runUnifiedWithoutSplash is the pre-splash bootstrap path, retained

--- a/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
+++ b/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
@@ -1,4 +1,4 @@
-# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v2)
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v3)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -14,6 +14,11 @@
 - Protocol uses strict version equality (`protocol/protocol.go:178`). v4 ↔ v5 cross-talk is impossible by design — `ErrUnsupportedVer` rejects mismatched headers. Plan ships v5 as a hard cutover; the spec's "v4 fallback UX" risk does not materialize because old clients see a connect error and cannot reach the picker code path. Documented but not implemented as graceful fallback.
 - The wire-level layout type is `protocol.TreeNodeSnapshot` (already exists in `protocol/messages.go`), not `TreeNodeCapture`. Tasks reference `TreeNodeSnapshot`.
 - `StoredSession` JSON shape gains a Layout field as an additive change. No `SchemaVersion` bump (existing files unmarshal cleanly with Layout=nil; old daemons reading new files ignore the unknown JSON field).
+
+**v3 revisions vs v2:**
+- **Picker uses `texelui/widgets.Image` + `texelui/graphics` providers** for thumbnail rendering instead of hand-rolled Kitty escape sequences (Task 17). Picker also gets half-block fallback "for free" on terminals that support it but not Kitty.
+- **Picker switches to a `[][]core.Cell` buffer + `core.Painter` rendering pipeline** (Task 16). After painting, the buffer is copied to the tcell.Screen and the graphics provider's `Flush` emits queued APC sequences. Tests run with provider=nil (ASCII fallback) and don't need to model the Kitty protocol.
+- **`SetGraphicsProvider(gp)` replaces `SetGraphicsCapable(b bool)`** — the picker stores the provider and derives `hasGraphics` from `gp.Capability() >= core.GraphicsHalfBlock`. Production wiring uses `graphics.DetectCapability()` to choose `KittyProvider` / `HalfBlockProvider`.
 
 **v2 revisions vs v1 (incorporates review findings):**
 - **New `internal/thumbnail/` package** (Task 9) shared by server lifecycle capture and client user-screenshot. Eliminates duplicate textrender wiring; client `screenshot.go` is refactored in Task 19 to use it.
@@ -68,7 +73,7 @@
 
 ---
 
-## Tasks Overview (v2)
+## Tasks Overview (v3)
 
 1. Protocol: bump version + add MessageType constants (incl. SessionOpResponse)
 2. Protocol: SessionSummary + LiveSummary wire types (with off-by-16 fix)
@@ -85,9 +90,9 @@
 13. Connection handlers: list + recover
 14. Connection handlers: rename + delete + fetch-thumbnail (size + dim caps; uses SessionOpResponse)
 15. Picker: ASCII layout algorithm (n-way splits, divider-column-correct)
-16. Picker: state machine, navigation, render (mu, error banner, RefreshCatalog error visible)
-17. Picker: Kitty thumbnail rendering + lazy fetch (locked, defer-clear pending)
-18. boot.Run integration: real ProbeStoredSessions + SocketPickerClient + handoff
+16. Picker: cell-buffer + Painter render pipeline, state machine, navigation (mu, error banner)
+17. Picker: thumbnails via `widgets.Image` + `graphics` providers (Kitty + half-block, lazy fetch with locked map + defer-clear pending)
+18. boot.Run integration: real ProbeStoredSessions + SocketPickerClient + handoff (graphics provider wired)
 19. Client screenshot: refactor to use shared `internal/thumbnail` primitive
 
 ---
@@ -3866,7 +3871,7 @@ git commit -m "Picker: ASCII tree-layout fallback render"
 
 ---
 
-### Task 16: Picker — state machine, navigation, render (with error surfacing)
+### Task 16: Picker — cell-buffer + Painter render pipeline, state machine, navigation
 
 **Files:**
 - Create: `cmd/texelation/boot/picker.go`
@@ -3874,7 +3879,9 @@ git commit -m "Picker: ASCII tree-layout fallback render"
 - Create: `cmd/texelation/boot/picker_render.go`
 - Test: `cmd/texelation/boot/picker_test.go`
 
-This task wires the Picker with `mu sync.Mutex` declared up-front (used in Task 17 for thumbnail fetches), an `errMsg` field for surfacing operation failures, and modal behavior that does NOT close the picker when Recover/Rename/Delete errors. The user sees a banner and can retry.
+The picker uses the texelui rendering pipeline so Task 17's thumbnails can drop in `widgets.Image` directly. Specifically: each `Render()` builds a `[][]core.Cell` buffer, constructs a `core.Painter` with a graphics provider, paints all cards/tabs/banner/action-bar via Painter calls, copies the buffer cells to tcell.Screen, and flushes the graphics provider so any queued Kitty/half-block APC sequences hit the terminal.
+
+Wires Picker with `mu sync.Mutex` declared up-front (used in Task 17 for thumbnail fetches), an `errMsg` field for surfacing operation failures, and modal behavior that does NOT close the picker when Recover/Rename/Delete errors. The user sees a banner and can retry.
 
 - [ ] **Step 1: Write failing tests**
 
@@ -4143,11 +4150,14 @@ Create `cmd/texelation/boot/picker.go`:
 package boot
 
 import (
+	"io"
 	"sync"
 
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/framegrace/texelation/protocol"
+	core "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/widgets"
 )
 
 // PickerClient is the network surface the picker needs. The boot
@@ -4199,10 +4209,26 @@ type Picker struct {
 	// navigation key.
 	errMsg string
 
-	mu          sync.Mutex
-	thumbCache  map[[16]byte][]byte
-	pending     map[[16]byte]bool
-	hasGraphics bool
+	// gp drives image rendering through the texelui widgets.Image
+	// pipeline. nil = ASCII-only fallback (tests). Production wires
+	// graphics.NewKittyProvider() or graphics.NewHalfBlockProvider()
+	// based on graphics.DetectCapability().
+	gp core.GraphicsProvider
+
+	// gpFlush is the writer the provider's queued APC sequences are
+	// flushed to. Production passes os.Stdout; tests pass io.Discard
+	// (or leave nil to skip the flush).
+	gpFlush io.Writer
+
+	// cellBuf is the painter's destination. Re-allocated to match the
+	// screen size on each Render() so the picker handles resizes
+	// without explicit handling.
+	cellBuf [][]core.Cell
+
+	mu         sync.Mutex
+	thumbCache map[[16]byte][]byte
+	pending    map[[16]byte]bool
+	imgCache   map[[16]byte]*widgets.Image // one widget per cached thumbnail
 
 	done   bool
 	choice pickerChoice
@@ -4218,7 +4244,10 @@ const (
 )
 
 // NewPicker returns a picker bound to screen + client. Call
-// RefreshCatalog before Render so the response is populated.
+// RefreshCatalog before Render so the response is populated. The
+// graphics provider is optional — pass nil for ASCII-only mode (tests
+// + non-graphics terminals); production passes a KittyProvider /
+// HalfBlockProvider from texelui/graphics.
 func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
 	return &Picker{
 		screen:     screen,
@@ -4227,7 +4256,24 @@ func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
 		mode:       modeBrowse,
 		thumbCache: make(map[[16]byte][]byte),
 		pending:    make(map[[16]byte]bool),
+		imgCache:   make(map[[16]byte]*widgets.Image),
 	}
+}
+
+// SetGraphicsProvider wires the texelui GraphicsProvider used to render
+// thumbnails. flushTo is where queued APC sequences (Kitty) get written
+// after each Render — typically os.Stdout in production, io.Discard or
+// nil in tests.
+func (p *Picker) SetGraphicsProvider(gp core.GraphicsProvider, flushTo io.Writer) {
+	p.gp = gp
+	p.gpFlush = flushTo
+}
+
+// hasGraphics reports whether the wired provider can render images at
+// all (Kitty or half-block). Used to gate fetch dispatch + the
+// widgets.Image draw branch.
+func (p *Picker) hasGraphics() bool {
+	return p.gp != nil && p.gp.Capability() >= core.GraphicsHalfBlock
 }
 
 // RefreshCatalog fetches the catalog from the server. On error the
@@ -4416,11 +4462,13 @@ package boot
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/framegrace/texelation/protocol"
+	core "github.com/framegrace/texelui/core"
 )
 
 const (
@@ -4429,26 +4477,75 @@ const (
 	cardGap    = 1
 )
 
-// Render paints the picker to the screen. The caller is responsible
-// for calling screen.Show() / screen.Sync() afterwards.
+// Render paints the picker. Builds a fresh cell buffer per frame,
+// runs the widget tree (cards + tabs + banner + action-bar) through
+// a Painter wired to the graphics provider, copies the buffer cells
+// to the tcell.Screen, and flushes any queued APC sequences.
 func (p *Picker) Render() {
 	w, h := p.screen.Size()
-	p.clear(w, h)
-	p.drawHeader(w)
-	p.drawTabs(w)
-	p.drawCards(w, h)
-	p.drawErrorBanner(w, h)
-	p.drawActionBar(w, h)
+	if w <= 0 || h <= 0 {
+		return
+	}
+	// Re-allocate the cell buffer if size changed. Cheap on steady
+	// state; a fresh allocation per frame is fine — the buffer is
+	// at most ~80x24 cells.
+	if len(p.cellBuf) != h || len(p.cellBuf) > 0 && len(p.cellBuf[0]) != w {
+		p.cellBuf = make([][]core.Cell, h)
+		for y := range p.cellBuf {
+			p.cellBuf[y] = make([]core.Cell, w)
+		}
+	} else {
+		for y := range p.cellBuf {
+			for x := range p.cellBuf[y] {
+				p.cellBuf[y][x] = core.Cell{Ch: ' ', Style: tcell.StyleDefault}
+			}
+		}
+	}
+	clip := core.Rect{X: 0, Y: 0, W: w, H: h}
+	painter := core.NewPainterWithGraphics(p.cellBuf, clip, p.gp)
+	painter.SetScreenSize(w, h)
+
+	// Reset graphics provider's placement set each frame so stale
+	// images from the previous frame don't linger when scrolled away
+	// or replaced by an upgrade.
+	if p.gp != nil {
+		p.gp.Reset()
+	}
+
+	p.drawHeader(painter, w)
+	p.drawTabs(painter, w)
+	p.drawCards(painter, w, h)
+	p.drawErrorBanner(painter, w, h)
+	p.drawActionBar(painter, w, h)
 	if p.mode == modeRename {
-		p.drawRenameOverlay(w, h)
+		p.drawRenameOverlay(painter, w, h)
 	}
 	if p.mode == modeDeleteConfirm {
-		p.drawDeleteConfirmOverlay(w, h)
+		p.drawDeleteConfirmOverlay(painter, w, h)
+	}
+
+	// Copy cell buffer into the tcell.Screen.
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := p.cellBuf[y][x]
+			ch := c.Ch
+			if ch == 0 {
+				ch = ' '
+			}
+			p.screen.SetContent(x, y, ch, nil, c.Style)
+		}
+	}
+	// Flush queued graphics commands (APC sequences for Kitty,
+	// half-block cell writes already landed via the painter).
+	if p.gp != nil && p.gpFlush != nil {
+		if flusher, ok := p.gp.(interface{ Flush(io.Writer) error }); ok {
+			_ = flusher.Flush(p.gpFlush)
+		}
 	}
 	p.screen.Show()
 }
 
-func (p *Picker) drawErrorBanner(w, h int) {
+func (p *Picker) drawErrorBanner(painter *core.Painter, w, h int) {
 	if p.errMsg == "" {
 		return
 	}
@@ -4457,54 +4554,35 @@ func (p *Picker) drawErrorBanner(w, h int) {
 	if len(msg) > w-4 {
 		msg = msg[:w-5] + "…"
 	}
-	for i, r := range msg {
-		p.screen.SetContent(2+i, h-3, r, nil, style)
-	}
+	painter.DrawText(2, h-3, msg, style)
 }
 
-func (p *Picker) clear(w, h int) {
-	bg := tcell.StyleDefault
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			p.screen.SetContent(x, y, ' ', nil, bg)
-		}
-	}
-}
-
-func (p *Picker) drawHeader(w int) {
+func (p *Picker) drawHeader(painter *core.Painter, w int) {
 	style := tcell.StyleDefault.Bold(true)
 	title := "texelation — recover session"
 	startX := (w - len(title)) / 2
 	if startX < 0 {
 		startX = 0
 	}
-	for i, r := range title {
-		p.screen.SetContent(startX+i, 0, r, nil, style)
-	}
+	painter.DrawText(startX, 0, title, style)
 }
 
-func (p *Picker) drawTabs(w int) {
+func (p *Picker) drawTabs(painter *core.Painter, w int) {
 	live := fmt.Sprintf("[ Live (%d) ]", len(p.response.Live))
 	stored := fmt.Sprintf("[ Stored (%d) ]", len(p.response.Stored))
-	x := 2
-	for i, r := range live {
-		style := tcell.StyleDefault.Foreground(tcell.ColorGray)
-		if p.activeTab == tabLive {
-			style = tcell.StyleDefault.Bold(true)
-		}
-		p.screen.SetContent(x+i, 2, r, nil, style)
+	liveStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	if p.activeTab == tabLive {
+		liveStyle = tcell.StyleDefault.Bold(true)
 	}
-	x += len(live) + 2
-	for i, r := range stored {
-		style := tcell.StyleDefault.Foreground(tcell.ColorGray)
-		if p.activeTab == tabStored {
-			style = tcell.StyleDefault.Bold(true)
-		}
-		p.screen.SetContent(x+i, 2, r, nil, style)
+	storedStyle := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	if p.activeTab == tabStored {
+		storedStyle = tcell.StyleDefault.Bold(true)
 	}
+	painter.DrawText(2, 2, live, liveStyle)
+	painter.DrawText(2+len(live)+2, 2, stored, storedStyle)
 }
 
-func (p *Picker) drawCards(w, h int) {
+func (p *Picker) drawCards(painter *core.Painter, w, h int) {
 	if p.activeTab != tabStored {
 		return // Live tab empty in F.1
 	}
@@ -4514,68 +4592,69 @@ func (p *Picker) drawCards(w, h int) {
 		if cardY+cardThumbH+cardGap > h-2 {
 			break
 		}
-		p.drawCard(2, cardY, summary, i == p.selectedIdx)
+		p.drawCard(painter, 2, cardY, summary, i == p.selectedIdx)
 	}
 }
 
-func (p *Picker) drawCard(x, y int, s protocol.SessionSummary, selected bool) {
+func (p *Picker) drawCard(painter *core.Painter, x, y int, s protocol.SessionSummary, selected bool) {
 	bgStyle := tcell.StyleDefault
 	if selected {
 		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
 	}
-	// Thumbnail box (ASCII fallback for now; Kitty render added in Task 17)
-	grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
-	for cy := 0; cy < cardThumbH; cy++ {
-		for cx := 0; cx < cardThumbW; cx++ {
-			p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
-		}
-	}
-	// Metadata column
+	// Thumbnail box: ASCII layout from TreeNodeSnapshot is the
+	// authoritative fallback (it stays legible at 22×8). The
+	// widgets.Image branch (Task 17) overrides this only when (a)
+	// the user is on a graphics-capable terminal AND (b) we have a
+	// real cached PNG screenshot — we never half-block-render the
+	// structural layout tree, since that produces visual noise.
+	thumbRect := core.Rect{X: x, Y: y, W: cardThumbW, H: cardThumbH}
+	p.drawThumbnail(painter, thumbRect, s, bgStyle)
+
+	// Metadata column.
 	metaX := x + cardThumbW + 2
-	p.drawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
-	p.drawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
-	p.drawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
-	p.drawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
+	painter.DrawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
+	painter.DrawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
+	painter.DrawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
+	painter.DrawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
 	if s.Pinned {
-		p.drawText(metaX, y+4, "Pinned:  ★", bgStyle)
+		painter.DrawText(metaX, y+4, "Pinned:  ★", bgStyle)
 	}
 }
 
-func (p *Picker) drawActionBar(w, h int) {
+// drawASCIILayoutAt paints the box-drawing tree for s.Layout into the
+// rect via the Painter. Replaces direct tcell.Screen writes — the
+// algorithm in picker_ascii.go still produces the [][]rune grid; this
+// helper just dispatches the runes through the painter.
+func (p *Picker) drawASCIILayoutAt(painter *core.Painter, rect core.Rect, layout *protocol.TreeNodeSnapshot, bgStyle tcell.Style) {
+	grid := renderASCIILayoutGrid(rect.W, rect.H, layout)
+	for cy := 0; cy < rect.H && cy < len(grid); cy++ {
+		for cx := 0; cx < rect.W && cx < len(grid[cy]); cx++ {
+			painter.SetCell(rect.X+cx, rect.Y+cy, grid[cy][cx], bgStyle)
+		}
+	}
+}
+
+func (p *Picker) drawActionBar(painter *core.Painter, w, h int) {
 	bar := "[Enter] recover   [n] new   [r] rename   [d] delete   [q] quit"
 	style := tcell.StyleDefault.Foreground(tcell.ColorGray)
 	startX := (w - len(bar)) / 2
 	if startX < 0 {
 		startX = 0
 	}
-	for i, r := range bar {
-		p.screen.SetContent(startX+i, h-2, r, nil, style)
-	}
+	painter.DrawText(startX, h-2, bar, style)
 }
 
-func (p *Picker) drawRenameOverlay(w, h int) {
+func (p *Picker) drawRenameOverlay(painter *core.Painter, w, h int) {
 	prompt := fmt.Sprintf("Rename: %s", string(p.renameBuf))
-	style := tcell.StyleDefault.Bold(true)
-	for i, r := range prompt {
-		p.screen.SetContent(2+i, h-4, r, nil, style)
-	}
+	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Bold(true))
 }
 
-func (p *Picker) drawDeleteConfirmOverlay(w, h int) {
+func (p *Picker) drawDeleteConfirmOverlay(painter *core.Painter, w, h int) {
 	if len(p.response.Stored) == 0 {
 		return
 	}
 	prompt := fmt.Sprintf("Delete '%s'? [y/N]", labelOrUntitled(p.response.Stored[p.selectedIdx].Label))
-	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
-	for i, r := range prompt {
-		p.screen.SetContent(2+i, h-4, r, nil, style)
-	}
-}
-
-func (p *Picker) drawText(x, y int, s string, style tcell.Style) {
-	for i, r := range s {
-		p.screen.SetContent(x+i, y, r, nil, style)
-	}
+	painter.DrawText(2, h-4, prompt, tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true))
 }
 
 func labelOrUntitled(s string) string {
@@ -4624,31 +4703,38 @@ git commit -m "Picker: state machine, navigation, render"
 
 ---
 
-### Task 17: Picker — Kitty thumbnail rendering + lazy fetch (locked, defer-clear pending, dimension cap)
+### Task 17: Picker — thumbnails via `widgets.Image` + lazy fetch
 
 **Files:**
 - Create: `cmd/texelation/boot/picker_thumbnail.go`
-- Modify: `cmd/texelation/boot/picker_render.go` (route through `renderThumbnail`)
-- Modify: `cmd/texelation/boot/picker_test.go` (test the upgrade path + locked accessor)
+- Modify: `cmd/texelation/boot/picker_render.go` (`drawThumbnail` chooses widget vs ASCII)
+- Modify: `cmd/texelation/boot/picker_test.go` (locked accessors + provider injection)
 
-The Picker struct already has `mu` and `hasGraphics` fields from Task 16. This task adds the fetch coordinator and the render hook. **Critical correctness fixes vs v1:**
-- Reads of `thumbCache` and `pending` happen under `mu` (was: unlocked, raced with the goroutine's writes).
-- The fetch goroutine clears `pending[id]` in a `defer`, so a failed fetch doesn't strand the entry forever (was: only cleared on success → ASCII-forever bug).
-- Test uses a `ThumbCached` accessor that takes the lock instead of poking the map directly under `-race`.
-- Decoded PNG dimensions are capped via `png.DecodeConfig` before `png.Decode` to defend against pathological inputs (corrupt sidecar, hostile file at the predictable on-disk path).
+We delegate the actual image rendering to `texelui/widgets.Image`. The widget already handles PNG/JPEG/GIF decode, surface upload, Kitty placement *and* half-block fallback — wiring it requires only a `core.GraphicsProvider` injected at picker construction time. Production wires `graphics.NewKittyProvider()` or `graphics.NewHalfBlockProvider()` per `graphics.DetectCapability()`. Tests pass `gp=nil` so the picker stays in ASCII mode.
 
-- [ ] **Step 1: Write failing test**
+The structural ASCII layout (`renderASCIILayoutGrid` from Task 15) remains the fallback for two distinct cases:
+1. Graphics-capable terminal but no cached PNG yet (still fetching, or `HasThumbnail=false`).
+2. Non-graphics terminal (gp=nil OR Capability < HalfBlock).
+
+We deliberately do NOT half-block-render the structural `TreeNodeSnapshot` layout: at 22×8 cells the box-drawing diagram is legible and conveys structure, while half-block of the same diagram would look like noise.
+
+**Correctness invariants preserved from v2:**
+- `thumbCache` + `pending` reads/writes happen under `p.mu`.
+- The fetch goroutine clears `pending[id]` in a `defer`, so a failed fetch doesn't strand the entry forever.
+- `png.DecodeConfig` validates dimensions before caching, defending against corrupt or hostile PNG bytes.
+
+- [ ] **Step 1: Write failing tests**
 
 Append to `cmd/texelation/boot/picker_test.go`:
 
 ```go
-func TestPicker_FetchThumbnailUpgradesCard(t *testing.T) {
+func TestPicker_FetchThumbnailDispatchedWhenGraphicsCapable(t *testing.T) {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	screen.Init()
 	defer screen.Fini()
 	screen.SetSize(80, 24)
 	id := [16]byte{0xEE}
-	pngBytes := []byte("fake-png-bytes")
+	pngBytes := makeValidPNG(t, 100, 60) // helper: returns real PNG bytes
 	fc := &fakeClient{
 		response: protocol.ListSessionsResponse{
 			Stored: []protocol.SessionSummary{
@@ -4658,7 +4744,7 @@ func TestPicker_FetchThumbnailUpgradesCard(t *testing.T) {
 		thumbBytes: pngBytes,
 	}
 	p := NewPicker(screen, fc)
-	p.SetGraphicsCapable(true)
+	p.SetGraphicsProvider(graphics.NewHalfBlockProvider(), io.Discard)
 	p.RefreshCatalog()
 	p.Render() // triggers the lazy fetch
 	deadline := time.Now().Add(500 * time.Millisecond)
@@ -4688,7 +4774,7 @@ func TestPicker_NoFetchWhenGraphicsAbsent(t *testing.T) {
 		thumbBytes: []byte("nope"),
 	}
 	p := NewPicker(screen, fc)
-	p.SetGraphicsCapable(false)
+	// gp left nil — picker stays in ASCII-only mode.
 	p.RefreshCatalog()
 	p.Render()
 	time.Sleep(20 * time.Millisecond)
@@ -4698,11 +4784,8 @@ func TestPicker_NoFetchWhenGraphicsAbsent(t *testing.T) {
 }
 
 func TestPicker_FetchThumbnailErrorClearsPending(t *testing.T) {
-	// Critical regression test for the v1 bug where a failed fetch
-	// left pending[id]=true forever, preventing retry. After the
-	// goroutine returns, pending must be cleared regardless of
-	// outcome so a future Render can re-attempt (e.g., user toggles
-	// tabs and back).
+	// Regression test for the v1 bug where a failed fetch left
+	// pending[id]=true forever, preventing retry.
 	screen := tcell.NewSimulationScreen("UTF-8")
 	screen.Init()
 	defer screen.Fini()
@@ -4715,7 +4798,7 @@ func TestPicker_FetchThumbnailErrorClearsPending(t *testing.T) {
 		thumbErr: errors.New("transient"),
 	}
 	p := NewPicker(screen, fc)
-	p.SetGraphicsCapable(true)
+	p.SetGraphicsProvider(graphics.NewHalfBlockProvider(), io.Discard)
 	p.RefreshCatalog()
 	p.Render()
 	deadline := time.Now().Add(500 * time.Millisecond)
@@ -4732,6 +4815,44 @@ func TestPicker_FetchThumbnailErrorClearsPending(t *testing.T) {
 		t.Errorf("expected thumbCache empty on fetch error")
 	}
 }
+
+// makeValidPNG produces a minimal PNG with the given dimensions for
+// tests that need bytes the picker's DecodeConfig + widgets.Image
+// will accept.
+func makeValidPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0x40, A: 0xFF})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	return buf.Bytes()
+}
+```
+
+Add the necessary imports to the test file:
+
+```go
+import (
+	"bytes"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelui/graphics"
+)
 ```
 
 Update the `fakeClient` definition to support fetch error injection:
@@ -4751,8 +4872,6 @@ type fakeClient struct {
 	thumbErr      error
 }
 
-// ... existing methods ...
-
 func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
 	f.fetchCalled = true
 	if f.thumbErr != nil {
@@ -4766,8 +4885,8 @@ func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
 
 - [ ] **Step 2: Run tests, verify failure**
 
-Run: `go test ./cmd/texelation/boot/ -run "TestPicker_FetchThumbnailUpgradesCard|TestPicker_NoFetchWhenGraphicsAbsent|TestPicker_FetchThumbnailErrorClearsPending" -count=1`
-Expected: FAIL — `SetGraphicsCapable`, `ThumbCached`, `IsPending` not exposed.
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_FetchThumbnailDispatchedWhenGraphicsCapable|TestPicker_NoFetchWhenGraphicsAbsent|TestPicker_FetchThumbnailErrorClearsPending" -count=1`
+Expected: FAIL — `ThumbCached`, `IsPending`, `maybeFetchThumbnail` not yet defined.
 
 - [ ] **Step 3: Implement the thumbnail dispatcher**
 
@@ -4778,17 +4897,18 @@ Create `cmd/texelation/boot/picker_thumbnail.go`:
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // File: cmd/texelation/boot/picker_thumbnail.go
-// Summary: Kitty thumbnail rendering + lazy fetch for the picker.
-// Falls back to the ASCII layout when graphics are unavailable or
-// the fetch is still in flight.
+// Summary: Lazy thumbnail fetch + widgets.Image instantiation for the
+// picker. Rendering is delegated to texelui/widgets.Image which
+// handles Kitty + half-block + alt-text fallback internally.
 
 package boot
 
 import (
 	"bytes"
-	"image"
 	"image/png"
 	"log"
+
+	"github.com/framegrace/texelui/widgets"
 )
 
 // maxThumbnailDim caps PNG dimensions on the decode path. A 480×270
@@ -4797,13 +4917,6 @@ import (
 // dimension declarations within a small payload). Decoding without
 // this check can OOM the picker on corrupted inputs.
 const maxThumbnailDim = 4096
-
-// SetGraphicsCapable tells the picker whether to dispatch
-// FetchThumbnail requests + render Kitty images. False keeps the
-// ASCII fallback exclusively (no network traffic for thumbnails).
-func (p *Picker) SetGraphicsCapable(b bool) {
-	p.hasGraphics = b
-}
 
 // ThumbCached returns true iff a PNG for id is in the local cache.
 // Locked accessor for tests; production read sites in drawCard also
@@ -4824,23 +4937,30 @@ func (p *Picker) IsPending(id [16]byte) bool {
 	return v
 }
 
-// thumbnailFor returns the cached PNG bytes for id, or nil if not
-// cached. Caller does not need to hold p.mu — this method takes it.
-func (p *Picker) thumbnailFor(id [16]byte) []byte {
+// imageWidgetFor returns the widgets.Image bound to id's cached PNG,
+// constructing one on first use. nil if no PNG cached. Held under
+// p.mu since imgCache and thumbCache must be observed atomically.
+func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 	p.mu.Lock()
-	data := p.thumbCache[id]
-	p.mu.Unlock()
-	return data
+	defer p.mu.Unlock()
+	data, ok := p.thumbCache[id]
+	if !ok {
+		return nil
+	}
+	if w, exists := p.imgCache[id]; exists {
+		return w
+	}
+	w := widgets.NewImage(data, "session-thumbnail")
+	p.imgCache[id] = w
+	return w
 }
 
 // maybeFetchThumbnail kicks off a non-blocking fetch for id if we
-// haven't cached or pending one already. Called from the render
-// loop's per-card pass. All map access is under p.mu; the goroutine
-// always clears pending[id] in defer so a failed fetch doesn't
-// strand the entry permanently (previously a "card stays ASCII
-// forever" bug — see Task 17 in the plan).
+// haven't cached or pending one already. All map access is under
+// p.mu; the goroutine always clears pending[id] in defer so a failed
+// fetch doesn't strand the entry permanently.
 func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
-	if !p.hasGraphics || !hasThumb {
+	if !p.hasGraphics() || !hasThumb {
 		return
 	}
 	p.mu.Lock()
@@ -4857,12 +4977,6 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 
 	go func(targetID [16]byte) {
 		defer func() {
-			// Clear pending unconditionally so subsequent renders
-			// can retry. Without this defer, an error path leaves
-			// pending[id]=true forever — a real bug we exorcised
-			// in v2. Recover from any panic in the client (the
-			// transport could trip a runtime fault on a dropped
-			// socket) so we don't crash the picker.
 			if rec := recover(); rec != nil {
 				log.Printf("picker: thumbnail fetch panic: %v", rec)
 			}
@@ -4878,15 +4992,14 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		if len(data) == 0 {
 			return
 		}
-		// Validate dimensions before storing. A png.DecodeConfig
-		// failure means corrupt/non-PNG bytes; refuse to cache.
 		cfg, err := png.DecodeConfig(bytes.NewReader(data))
 		if err != nil {
 			log.Printf("picker: thumbnail decode-config %x: %v", targetID[:4], err)
 			return
 		}
 		if cfg.Width > maxThumbnailDim || cfg.Height > maxThumbnailDim {
-			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)", targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
+			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)",
+				targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
 			return
 		}
 		p.mu.Lock()
@@ -4894,72 +5007,46 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		p.mu.Unlock()
 	}(id)
 }
-
-// decodeCachedThumb decodes the PNG bytes for id into an image.Image,
-// or returns nil if the bytes can't be decoded. The dimension check
-// happens at fetch time (above), so this is purely the costlier
-// full decode for paint use. Currently only used by the (future)
-// Kitty emission path; the SimulationScreen unit tests don't exercise
-// it.
-func decodeCachedThumb(data []byte) image.Image {
-	img, err := png.Decode(bytes.NewReader(data))
-	if err != nil {
-		return nil
-	}
-	return img
-}
 ```
 
-In `picker_render.go`, replace the thumbnail-drawing block at the top of `drawCard` with the locked-read version:
+In `picker_render.go`, add the `drawThumbnail` helper that `drawCard` already calls:
 
 ```go
-func (p *Picker) drawCard(x, y int, s protocol.SessionSummary, selected bool) {
-	bgStyle := tcell.StyleDefault
-	if selected {
-		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
-	}
-	cached := p.thumbnailFor(s.SessionID)
-	if cached != nil && p.hasGraphics {
-		// Cached thumbnail available. The full Kitty escape-sequence
-		// emission is out of scope for SimulationScreen; tests detect
-		// the upgrade by checking the placeholder block char.
-		for cy := 0; cy < cardThumbH; cy++ {
-			for cx := 0; cx < cardThumbW; cx++ {
-				p.screen.SetContent(x+cx, y+cy, '▓', nil, bgStyle)
-			}
-		}
-	} else {
-		grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
-		for cy := 0; cy < cardThumbH; cy++ {
-			for cx := 0; cx < cardThumbW; cx++ {
-				p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
-			}
+// drawThumbnail paints the thumbnail rect for a session card. Branches:
+//   - Graphics-capable + cached PNG  → widgets.Image (Kitty or half-block)
+//   - Otherwise                       → ASCII tree from TreeNodeSnapshot
+//
+// We never half-block-render the structural layout because at thumbnail
+// resolution it produces noise; the box-drawing characters convey
+// structure cleanly even at 22×8.
+func (p *Picker) drawThumbnail(painter *core.Painter, rect core.Rect, s protocol.SessionSummary, bgStyle tcell.Style) {
+	if p.hasGraphics() {
+		if w := p.imageWidgetFor(s.SessionID); w != nil {
+			// widgets.Image expects a raw rect in screen coords.
+			// SetRect is on the embedded BaseWidget.
+			w.SetRect(rect)
+			w.Draw(painter)
+			p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
+			return
 		}
 	}
+	p.drawASCIILayoutAt(painter, rect, s.Layout, bgStyle)
 	p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
-
-	// Metadata column (unchanged).
-	metaX := x + cardThumbW + 2
-	p.drawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
-	p.drawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
-	p.drawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
-	p.drawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
-	if s.Pinned {
-		p.drawText(metaX, y+4, "Pinned:  ★", bgStyle)
-	}
 }
 ```
+
+(`drawASCIILayoutAt` was added to `picker_render.go` in Task 16.)
 
 - [ ] **Step 4: Run tests, verify pass**
 
 Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1 -race`
-Expected: PASS — including under `-race`. The locked accessors are critical here.
+Expected: PASS, including under `-race`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add cmd/texelation/boot/picker_thumbnail.go cmd/texelation/boot/picker_render.go cmd/texelation/boot/picker_test.go
-git commit -m "Picker: lazy thumbnail fetch with locked cache + deferred pending clear"
+git commit -m "Picker: thumbnails via widgets.Image (Kitty + half-block) with locked cache"
 ```
 
 ---
@@ -5007,7 +5094,11 @@ Create `cmd/texelation/boot/picker_runner.go`:
 package boot
 
 import (
+	"io"
+
 	"github.com/gdamore/tcell/v2"
+
+	core "github.com/framegrace/texelui/core"
 )
 
 // PickerOutcome captures what the user picked.
@@ -5020,9 +5111,13 @@ type PickerOutcome struct {
 // selection. Returns the outcome; callers translate it to a connect
 // path. The screen is shared with the splash and clientrt; this
 // function does not call Init/Fini.
-func RunPicker(screen tcell.Screen, client PickerClient, hasGraphics bool) (PickerOutcome, error) {
+//
+// gp is the texelui graphics provider used for thumbnail rendering.
+// Pass nil for ASCII-only mode. flushTo is where Kitty APC sequences
+// are written after each Render — typically os.Stdout in production.
+func RunPicker(screen tcell.Screen, client PickerClient, gp core.GraphicsProvider, flushTo io.Writer) (PickerOutcome, error) {
 	p := NewPicker(screen, client)
-	p.SetGraphicsCapable(hasGraphics)
+	p.SetGraphicsProvider(gp, flushTo)
 	p.RefreshCatalog()
 
 	for !p.Done() {
@@ -5079,8 +5174,27 @@ if shouldShowPicker {
 		log.Printf("picker: socket client setup failed: %v; skipping picker", err)
 	} else {
 		stopSplash()
-		outcome, err := boot.RunPicker(screen, pickerClient, graphics.DetectCapability() == texelcore.GraphicsKitty)
+		// Build the graphics provider that matches the terminal's
+		// capability. Falling all the way down to nil is correct
+		// when the terminal supports neither — the picker stays in
+		// ASCII-only mode.
+		var gp texelcore.GraphicsProvider
+		switch graphics.DetectCapability() {
+		case texelcore.GraphicsKitty:
+			gp = graphics.NewKittyProvider()
+		case texelcore.GraphicsHalfBlock:
+			gp = graphics.NewHalfBlockProvider()
+		}
+		outcome, err := boot.RunPicker(screen, pickerClient, gp, os.Stdout)
 		_ = pickerClient.Close()
+		if gp != nil {
+			// Clear any image placements before splash takes the
+			// screen back so we don't leave Kitty images stranded.
+			gp.Reset()
+			if flusher, ok := gp.(interface{ Flush(io.Writer) error }); ok {
+				_ = flusher.Flush(os.Stdout)
+			}
+		}
 		if err != nil {
 			log.Printf("picker: %v; falling back to fresh session", err)
 		} else {
@@ -5678,8 +5792,8 @@ gh pr create --title "Issue #199 Plan F.1: stored-session recovery picker" --bod
 - Adds protocol v5 with six new picker messages (list, recover, rename, delete, fetch-thumbnail, op-response) and SessionSummary/LiveSummary wire types.
 - New shared `internal/thumbnail/` rendering primitive used by both server-side lifecycle capture and client-side user screenshots.
 - Server-side: manager helpers (StoredSummaries, LiveSummaries, RenameStored, DeleteStored), connection handlers (with thumbnail size cap), lifecycle thumbnail capture (graceful shutdown + last-disconnect), pane-buffer composition adapter on DesktopSink.
-- Client-side: picker UI in `cmd/texelation/boot/` reusing the splash screen; ASCII fallback (n-way splits) + lazy Kitty thumbnail fetch with locked map access and deferred pending clear; in-picker error banners on Recover/Rename/Delete/RefreshCatalog failures.
-- Trigger logic in `boot.Run` activates picker when client state is missing AND server has stored sessions, or when `--recover` is passed.
+- Client-side: picker UI in `cmd/texelation/boot/` reusing the splash screen with a Painter-based render pipeline. Real-screenshot thumbnails delegate to `texelui/widgets.Image` (Kitty + half-block + alt-text fallback handled inside the widget); structural layout previews stay as ASCII box-drawing tree from `TreeNodeSnapshot` (legible at 22×8). Lazy fetch with locked map access and deferred pending clear; in-picker error banners on Recover/Rename/Delete/RefreshCatalog failures.
+- Trigger logic in `boot.Run` activates picker when client state is missing AND server has stored sessions, or when `--recover` is passed. Picker receives a `texelui/graphics` provider chosen by `graphics.DetectCapability()`.
 - Client `takeScreenshot` refactored to use the shared primitive (dedup).
 - Spec: `docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md`
 

--- a/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
+++ b/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
@@ -1,0 +1,4283 @@
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a client-side stored-session recovery picker so users with lost client state can discover and rejoin sessions the daemon persisted to disk.
+
+**Architecture:** Bumps protocol v4 → v5 with five new messages (list, recover, rename, delete, fetch-thumbnail) and two wire types (SessionSummary, LiveSummary). Server-side persisted-session map (Plan D2) is exposed via new manager helpers and connection handlers; lifecycle-only thumbnail capture writes PNG sidecars next to each session JSON. Client-side picker UI lives in `cmd/texelation/boot/`, reusing the splash's tcell screen so handoff to the existing connect path is flicker-free.
+
+**Tech Stack:** Go 1.24, tcell/v2 for picker UI, `texelui/graphics/textrender` for thumbnail rendering, `texelui/widgets` Image upload for Kitty graphics, existing `internal/persistence/atomicjson` for atomic writes.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md`
+
+**Reality adjustments from the spec (locked in here):**
+- Protocol uses strict version equality (`protocol/protocol.go:178`). v4 ↔ v5 cross-talk is impossible by design — `ErrUnsupportedVer` rejects mismatched headers. Plan ships v5 as a hard cutover; the spec's "v4 fallback UX" risk does not materialize because old clients see a connect error and cannot reach the picker code path. Documented but not implemented as graceful fallback.
+- The wire-level layout type is `protocol.TreeNodeSnapshot` (already exists in `protocol/messages.go`), not `TreeNodeCapture`. Tasks reference `TreeNodeSnapshot`.
+- `StoredSession` JSON shape gains a Layout field as an additive change. No `SchemaVersion` bump (existing files unmarshal cleanly with Layout=nil; old daemons reading new files ignore the unknown JSON field).
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Responsibility |
+|---|---|
+| `protocol/session_picker.go` | Wire types (SessionSummary, LiveSummary) and encoders/decoders for ListSessions, RecoverSession, Rename, Delete, FetchThumbnail messages |
+| `protocol/session_picker_test.go` | Round-trip encode/decode tests for all new wire types |
+| `internal/runtime/server/manager_session_picker.go` | `StoredSummaries`, `LiveSummaries`, `RenameStored`, `DeleteStored` methods on Manager |
+| `internal/runtime/server/manager_session_picker_test.go` | Manager helper unit tests |
+| `internal/runtime/server/thumbnail.go` | `captureThumbnail`, `writePNGAtomic`, downscale helper |
+| `internal/runtime/server/thumbnail_test.go` | Thumbnail capture + atomic-write tests |
+| `internal/runtime/server/connection_session_picker.go` | Connection handlers: `handleListSessions`, `handleRecoverSession`, `handleRenameSession`, `handleDeleteSession`, `handleFetchThumbnail` |
+| `internal/runtime/server/connection_session_picker_test.go` | Handler unit tests via memconn |
+| `cmd/texelation/boot/picker.go` | `Picker` struct, run loop, dispatch |
+| `cmd/texelation/boot/picker_input.go` | Key handling, navigation, mode transitions |
+| `cmd/texelation/boot/picker_render.go` | Card layout, tabs, action bar |
+| `cmd/texelation/boot/picker_thumbnail.go` | Kitty image rendering, lazy fetch coordinator |
+| `cmd/texelation/boot/picker_ascii.go` | TreeNodeSnapshot → box-drawing chars |
+| `cmd/texelation/boot/picker_ascii_test.go` | Pure ASCII algorithm tests |
+| `cmd/texelation/boot/picker_test.go` | Picker render + navigation tests |
+
+**Modified files:**
+
+| File | Change |
+|---|---|
+| `protocol/protocol.go` | Bump `Version` to 5; add 7 new `MessageType` constants |
+| `internal/runtime/server/session_persistence.go` | Add `Layout *protocol.TreeNodeSnapshot` field to `StoredSession` and JSON shape |
+| `internal/runtime/server/connection_handler.go` | Dispatch new message types to `connection_session_picker.go` handlers |
+| `internal/runtime/server/manager.go` | Extend boot scan with HasThumbnail flag + orphan PNG cleanup; thumbnail capture in `ShutdownSessions` and `Close(id)` |
+| `cmd/texelation/main.go` | Add `--recover` flag; wire picker activation between supervisor and `clientrt.Run` |
+
+---
+
+## Tasks Overview
+
+1. Protocol: bump version + add MessageType constants
+2. Protocol: SessionSummary + LiveSummary wire types
+3. Protocol: ListSessions request/response
+4. Protocol: RecoverSession + Rename + Delete + FetchThumbnail messages
+5. StoredSession: add Layout field
+6. Manager: StoredSummaries + LiveSummaries
+7. Manager: RenameStored + DeleteStored
+8. Manager: HasThumbnail flag + orphan PNG cleanup at boot scan
+9. Thumbnail: writePNGAtomic + downscale + captureThumbnail core
+10. Thumbnail: capture trigger on last-disconnect + graceful shutdown
+11. Connection handlers: list + recover
+12. Connection handlers: rename + delete + fetch-thumbnail
+13. Picker: ASCII layout algorithm (pure functions)
+14. Picker: state machine, navigation, render
+15. Picker: Kitty thumbnail rendering + lazy fetch
+16. boot.Run integration: trigger logic + handoff
+
+---
+
+### Task 1: Protocol version bump + MessageType constants
+
+**Files:**
+- Modify: `protocol/protocol.go:43` (Version constant) and `protocol/protocol.go:50-91` (MessageType iota block)
+- Test: `protocol/protocol_test.go` (existing — just needs the constant assertion updated if any)
+
+- [ ] **Step 1: Read existing version test**
+
+Run: `grep -n "Version" protocol/protocol_test.go`
+Expected: locate any test that pins the version constant.
+
+- [ ] **Step 2: Write a failing test pinning v5 + new constants**
+
+Create or extend `protocol/protocol_test.go` with:
+
+```go
+func TestVersionIsV5(t *testing.T) {
+	if protocol.Version != 5 {
+		t.Fatalf("Version = %d, want 5 (Plan F.1 picker bump)", protocol.Version)
+	}
+}
+
+func TestSessionPickerMessageTypes(t *testing.T) {
+	// Pinning the iota positions guards against accidental reorder
+	// of preceding entries (which would silently shift these to a
+	// MsgType already on the wire).
+	cases := []struct {
+		name string
+		got  protocol.MessageType
+		want protocol.MessageType
+	}{
+		{"MsgListSessions", protocol.MsgListSessions, 35},
+		{"MsgListSessionsResponse", protocol.MsgListSessionsResponse, 36},
+		{"MsgRecoverSession", protocol.MsgRecoverSession, 37},
+		{"MsgRenameSession", protocol.MsgRenameSession, 38},
+		{"MsgDeleteSession", protocol.MsgDeleteSession, 39},
+		{"MsgFetchThumbnail", protocol.MsgFetchThumbnail, 40},
+		{"MsgFetchThumbnailResponse", protocol.MsgFetchThumbnailResponse, 41},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Fatalf("%s = %d, want %d", c.name, c.got, c.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `go test ./protocol/ -run "TestVersionIsV5|TestSessionPickerMessageTypes" -count=1`
+Expected: FAIL — undefined identifiers `MsgListSessions` etc., and `Version != 5`.
+
+- [ ] **Step 4: Bump version**
+
+In `protocol/protocol.go`, update the version block to:
+
+```go
+// v5 (issue #199 Plan F.1): adds MsgListSessions, MsgListSessionsResponse,
+// MsgRecoverSession, MsgRenameSession, MsgDeleteSession, MsgFetchThumbnail,
+// MsgFetchThumbnailResponse plus SessionSummary / LiveSummary wire types.
+// Strict version equality means old (v4) clients fail at the header check
+// — there is no in-band fallback path; users on the old client see a
+// generic connect error and must upgrade. Single-binary deployment makes
+// this acceptable; revisit if a multi-version client population emerges.
+const Version uint8 = 5
+```
+
+- [ ] **Step 5: Add MessageType constants**
+
+Append at the end of the iota block in `protocol/protocol.go` (after `MsgBootProgress`):
+
+```go
+	// MsgListSessions / MsgListSessionsResponse drive the F.1 stored-
+	// session recovery picker. Request has no payload; response carries
+	// Live and Stored slices.
+	MsgListSessions
+	MsgListSessionsResponse
+	// MsgRecoverSession: client picks a stored session to hydrate.
+	// Server replies with the ordinary MsgConnectAccept + MsgTreeSnapshot
+	// flow; picker hands off to the existing connect path.
+	MsgRecoverSession
+	// MsgRenameSession: edit a stored session's label without recovering.
+	MsgRenameSession
+	// MsgDeleteSession: remove a stored session's JSON + PNG sidecar.
+	// Refused with error if the session is currently live.
+	MsgDeleteSession
+	// MsgFetchThumbnail / MsgFetchThumbnailResponse: lazy pull of a
+	// stored session's PNG thumbnail. Only fires for graphics-capable
+	// terminals; non-graphics clients render an ASCII fallback instead.
+	MsgFetchThumbnail
+	MsgFetchThumbnailResponse
+```
+
+- [ ] **Step 6: Run test to verify pass**
+
+Run: `go test ./protocol/ -run "TestVersionIsV5|TestSessionPickerMessageTypes" -count=1`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full protocol suite to catch any version-coupled regressions**
+
+Run: `go test ./protocol/ -count=1`
+Expected: PASS. The strict version check means existing tests that construct headers via `protocol.Version` automatically use v5.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add protocol/protocol.go protocol/protocol_test.go
+git commit -m "Protocol v5: bump version + add session-picker message constants"
+```
+
+---
+
+### Task 2: SessionSummary + LiveSummary wire types
+
+**Files:**
+- Create: `protocol/session_picker.go`
+- Test: `protocol/session_picker_test.go`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Create `protocol/session_picker_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+	"reflect"
+	"testing"
+)
+
+func makeID(b byte) [16]byte {
+	var id [16]byte
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+func TestSessionSummary_RoundTrip(t *testing.T) {
+	in := SessionSummary{
+		SessionID:      makeID(0xAB),
+		Label:          "work-laptop",
+		LastActive:     1714752000,
+		PaneCount:      4,
+		FirstPaneTitle: "nvim · texelation/cmd/texelation",
+		Pinned:         true,
+		HasThumbnail:   true,
+		Layout: &TreeNodeSnapshot{
+			PaneIndex:   -1,
+			Split:       SplitHorizontal,
+			SplitRatios: []float32{0.5, 0.5},
+			Children: []TreeNodeSnapshot{
+				{PaneIndex: 0, Split: SplitNone},
+				{PaneIndex: 1, Split: SplitNone},
+			},
+		},
+	}
+	encoded, err := EncodeSessionSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, consumed, err := DecodeSessionSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if consumed != len(encoded) {
+		t.Fatalf("consumed=%d, len=%d", consumed, len(encoded))
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestSessionSummary_NilLayout(t *testing.T) {
+	in := SessionSummary{
+		SessionID:    makeID(0x01),
+		Label:        "untitled",
+		LastActive:   100,
+		PaneCount:    1,
+		HasThumbnail: false,
+		Layout:       nil,
+	}
+	encoded, err := EncodeSessionSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, _, err := DecodeSessionSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Layout != nil {
+		t.Fatalf("expected nil Layout after round-trip, got %#v", out.Layout)
+	}
+}
+
+func TestLiveSummary_RoundTrip(t *testing.T) {
+	in := LiveSummary{
+		SessionID:       makeID(0xCD),
+		Label:           "debug-cluster",
+		AttachedClients: 2,
+		PaneCount:       3,
+		LastInputAt:     1714752100,
+	}
+	encoded, err := EncodeLiveSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, consumed, err := DecodeLiveSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if consumed != len(encoded) {
+		t.Fatalf("consumed=%d, len=%d", consumed, len(encoded))
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `go test ./protocol/ -run "TestSessionSummary|TestLiveSummary" -count=1`
+Expected: FAIL — undefined `SessionSummary`, `LiveSummary`, `EncodeSessionSummary`, etc.
+
+- [ ] **Step 3: Implement the wire types and encoders**
+
+Create `protocol/session_picker.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: protocol/session_picker.go
+// Summary: Wire types and encoders for the F.1 session-recovery picker.
+// Usage: Used by the server's connection handler to advertise stored
+//   sessions and by the client's boot-package picker to consume them.
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// SessionSummary describes a stored (fossilized) session on disk.
+// HasThumbnail indicates whether <sessionID>.png exists alongside the
+// JSON sidecar; the client fetches the PNG lazily via MsgFetchThumbnail.
+// Layout is optional — nil when the StoredSession was written before
+// Plan F.1 added the Layout field, in which case the picker falls back
+// to a single-box ASCII placeholder.
+type SessionSummary struct {
+	SessionID      [16]byte
+	Label          string
+	LastActive     int64 // unix seconds
+	PaneCount      int32
+	FirstPaneTitle string
+	Pinned         bool
+	HasThumbnail   bool
+	Layout         *TreeNodeSnapshot
+}
+
+// LiveSummary describes a hydrated (in-memory) session. Populated only
+// by F.2; F.1 always sends an empty slice.
+type LiveSummary struct {
+	SessionID       [16]byte
+	Label           string
+	AttachedClients int32
+	PaneCount       int32
+	LastInputAt     int64
+}
+
+// EncodeSessionSummary writes a SessionSummary in the picker wire format.
+// Layout is preceded by a uint8 flag (1 = present, 0 = nil) to handle
+// the optional case without needing a sentinel TreeNodeSnapshot.
+func EncodeSessionSummary(s SessionSummary) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(s.SessionID[:])
+	if err := encodeString(buf, s.Label); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.LastActive); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.PaneCount); err != nil {
+		return nil, err
+	}
+	if err := encodeString(buf, s.FirstPaneTitle); err != nil {
+		return nil, err
+	}
+	flags := byte(0)
+	if s.Pinned {
+		flags |= 0x01
+	}
+	if s.HasThumbnail {
+		flags |= 0x02
+	}
+	buf.WriteByte(flags)
+	if s.Layout == nil {
+		buf.WriteByte(0)
+	} else {
+		buf.WriteByte(1)
+		if err := encodeTreeNode(buf, *s.Layout); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeSessionSummary reads a SessionSummary and returns the number of
+// bytes consumed so callers parsing slices of summaries can advance.
+func DecodeSessionSummary(b []byte) (SessionSummary, int, error) {
+	var s SessionSummary
+	start := len(b)
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	copy(s.SessionID[:], b[:16])
+	b = b[16:]
+	label, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.Label = label
+	b = rest
+	if len(b) < 8 {
+		return s, 0, ErrPayloadShort
+	}
+	s.LastActive = int64(binary.LittleEndian.Uint64(b[:8]))
+	b = b[8:]
+	if len(b) < 4 {
+		return s, 0, ErrPayloadShort
+	}
+	s.PaneCount = int32(binary.LittleEndian.Uint32(b[:4]))
+	b = b[4:]
+	title, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.FirstPaneTitle = title
+	b = rest
+	if len(b) < 1 {
+		return s, 0, ErrPayloadShort
+	}
+	flags := b[0]
+	s.Pinned = flags&0x01 != 0
+	s.HasThumbnail = flags&0x02 != 0
+	b = b[1:]
+	if len(b) < 1 {
+		return s, 0, ErrPayloadShort
+	}
+	hasLayout := b[0]
+	b = b[1:]
+	if hasLayout != 0 {
+		node, rest, err := decodeTreeNode(b)
+		if err != nil {
+			return s, 0, err
+		}
+		s.Layout = &node
+		b = rest
+	}
+	return s, start - len(b), nil
+}
+
+// EncodeLiveSummary writes a LiveSummary in the picker wire format.
+func EncodeLiveSummary(s LiveSummary) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(s.SessionID[:])
+	if err := encodeString(buf, s.Label); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.AttachedClients); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.PaneCount); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.LastInputAt); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeLiveSummary reads a LiveSummary and returns bytes consumed.
+func DecodeLiveSummary(b []byte) (LiveSummary, int, error) {
+	var s LiveSummary
+	start := len(b)
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	copy(s.SessionID[:], b[:16])
+	b = b[16:]
+	label, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.Label = label
+	b = rest
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	s.AttachedClients = int32(binary.LittleEndian.Uint32(b[:4]))
+	s.PaneCount = int32(binary.LittleEndian.Uint32(b[4:8]))
+	s.LastInputAt = int64(binary.LittleEndian.Uint64(b[8:16]))
+	return s, start - (len(b) - 16), nil
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `go test ./protocol/ -run "TestSessionSummary|TestLiveSummary" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/session_picker.go protocol/session_picker_test.go
+git commit -m "Protocol: SessionSummary and LiveSummary wire types"
+```
+
+---
+
+### Task 3: ListSessions request/response messages
+
+**Files:**
+- Modify: `protocol/session_picker.go` (extend with request/response types)
+- Modify: `protocol/session_picker_test.go` (add round-trip tests)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `protocol/session_picker_test.go`:
+
+```go
+func TestListSessionsRequest_RoundTrip(t *testing.T) {
+	in := ListSessionsRequest{}
+	encoded, err := EncodeListSessionsRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(encoded) != 0 {
+		t.Fatalf("expected empty payload for v5 request, got %d bytes", len(encoded))
+	}
+	out, err := DecodeListSessionsRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestListSessionsResponse_RoundTrip(t *testing.T) {
+	in := ListSessionsResponse{
+		Live: []LiveSummary{
+			{SessionID: makeID(0xAA), Label: "live-1", PaneCount: 2, LastInputAt: 200},
+		},
+		Stored: []SessionSummary{
+			{SessionID: makeID(0xBB), Label: "stored-1", LastActive: 100, PaneCount: 1},
+			{SessionID: makeID(0xCC), Label: "stored-2", LastActive: 50, PaneCount: 4, Pinned: true, HasThumbnail: true},
+		},
+	}
+	encoded, err := EncodeListSessionsResponse(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeListSessionsResponse(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestListSessionsResponse_EmptyBoth(t *testing.T) {
+	in := ListSessionsResponse{}
+	encoded, err := EncodeListSessionsResponse(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeListSessionsResponse(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Live) != 0 || len(out.Stored) != 0 {
+		t.Fatalf("expected empty slices, got Live=%d Stored=%d", len(out.Live), len(out.Stored))
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `go test ./protocol/ -run "TestListSessions" -count=1`
+Expected: FAIL — undefined types.
+
+- [ ] **Step 3: Implement request/response encoders**
+
+Append to `protocol/session_picker.go`:
+
+```go
+// ListSessionsRequest is the client-side trigger for the recovery
+// picker's catalog. Empty payload in v5; reserved for filters in F.2.
+type ListSessionsRequest struct{}
+
+// EncodeListSessionsRequest returns an empty payload (no fields in v5).
+func EncodeListSessionsRequest(r ListSessionsRequest) ([]byte, error) {
+	return nil, nil
+}
+
+// DecodeListSessionsRequest tolerates trailing bytes for forward-compat
+// with future filter additions.
+func DecodeListSessionsRequest(b []byte) (ListSessionsRequest, error) {
+	return ListSessionsRequest{}, nil
+}
+
+// ListSessionsResponse carries the catalog of recoverable sessions.
+// Live is empty in F.1; populated by F.2.
+type ListSessionsResponse struct {
+	Live   []LiveSummary
+	Stored []SessionSummary
+}
+
+// EncodeListSessionsResponse writes Live and Stored slices.
+func EncodeListSessionsResponse(r ListSessionsResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if len(r.Live) > 0xFFFF {
+		return nil, ErrStringTooLong
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Live))); err != nil {
+		return nil, err
+	}
+	for _, l := range r.Live {
+		raw, err := EncodeLiveSummary(l)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(raw)
+	}
+	if len(r.Stored) > 0xFFFF {
+		return nil, ErrStringTooLong
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Stored))); err != nil {
+		return nil, err
+	}
+	for _, s := range r.Stored {
+		raw, err := EncodeSessionSummary(s)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(raw)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeListSessionsResponse parses Live then Stored slices in order.
+func DecodeListSessionsResponse(b []byte) (ListSessionsResponse, error) {
+	var r ListSessionsResponse
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	liveCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if liveCount > 0 {
+		r.Live = make([]LiveSummary, 0, liveCount)
+		for i := uint16(0); i < liveCount; i++ {
+			l, consumed, err := DecodeLiveSummary(b)
+			if err != nil {
+				return ListSessionsResponse{}, err
+			}
+			r.Live = append(r.Live, l)
+			b = b[consumed:]
+		}
+	}
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	storedCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if storedCount > 0 {
+		r.Stored = make([]SessionSummary, 0, storedCount)
+		for i := uint16(0); i < storedCount; i++ {
+			s, consumed, err := DecodeSessionSummary(b)
+			if err != nil {
+				return ListSessionsResponse{}, err
+			}
+			r.Stored = append(r.Stored, s)
+			b = b[consumed:]
+		}
+	}
+	return r, nil
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `go test ./protocol/ -run "TestListSessions" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/session_picker.go protocol/session_picker_test.go
+git commit -m "Protocol: ListSessions request/response messages"
+```
+
+---
+
+### Task 4: RecoverSession + Rename + Delete + FetchThumbnail messages
+
+**Files:**
+- Modify: `protocol/session_picker.go`
+- Modify: `protocol/session_picker_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `protocol/session_picker_test.go`:
+
+```go
+func TestRecoverSessionRequest_RoundTrip(t *testing.T) {
+	in := RecoverSessionRequest{
+		SessionID: makeID(0xFF),
+		NewLabel:  "renamed-on-recover",
+	}
+	encoded, err := EncodeRecoverSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeRecoverSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestRenameSessionRequest_RoundTrip(t *testing.T) {
+	in := RenameSessionRequest{SessionID: makeID(0x11), NewLabel: "edit"}
+	encoded, err := EncodeRenameSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeRenameSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestSessionOpResponse_RoundTrip(t *testing.T) {
+	cases := []SessionOpResponse{
+		{OK: true},
+		{OK: false, Error: "session is live"},
+	}
+	for i, in := range cases {
+		encoded, err := EncodeSessionOpResponse(in)
+		if err != nil {
+			t.Fatalf("[%d] encode: %v", i, err)
+		}
+		out, err := DecodeSessionOpResponse(encoded)
+		if err != nil {
+			t.Fatalf("[%d] decode: %v", i, err)
+		}
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("[%d] round-trip mismatch: in=%#v out=%#v", i, in, out)
+		}
+	}
+}
+
+func TestDeleteSessionRequest_RoundTrip(t *testing.T) {
+	in := DeleteSessionRequest{SessionID: makeID(0x22)}
+	encoded, err := EncodeDeleteSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeDeleteSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestFetchThumbnailRequest_RoundTrip(t *testing.T) {
+	in := FetchThumbnailRequest{SessionID: makeID(0x33)}
+	encoded, err := EncodeFetchThumbnailRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeFetchThumbnailRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestFetchThumbnailResponse_RoundTrip(t *testing.T) {
+	cases := []FetchThumbnailResponse{
+		{OK: true, PNG: []byte{0x89, 0x50, 0x4E, 0x47}},
+		{OK: false, Error: "missing"},
+		{OK: true, PNG: nil},
+	}
+	for i, in := range cases {
+		encoded, err := EncodeFetchThumbnailResponse(in)
+		if err != nil {
+			t.Fatalf("[%d] encode: %v", i, err)
+		}
+		out, err := DecodeFetchThumbnailResponse(encoded)
+		if err != nil {
+			t.Fatalf("[%d] decode: %v", i, err)
+		}
+		// Treat nil and empty PNG as equal — the wire never preserves
+		// the distinction.
+		if !bytesEqual(in.PNG, out.PNG) || in.OK != out.OK || in.Error != out.Error {
+			t.Fatalf("[%d] round-trip mismatch: in=%#v out=%#v", i, in, out)
+		}
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./protocol/ -run "TestRecoverSession|TestRenameSession|TestSessionOpResponse|TestDeleteSession|TestFetchThumbnail" -count=1`
+Expected: FAIL — undefined types/encoders.
+
+- [ ] **Step 3: Implement the messages**
+
+Append to `protocol/session_picker.go`:
+
+```go
+// RecoverSessionRequest hydrates a stored session and connects to it.
+// NewLabel is optional — empty string means leave the label unchanged.
+type RecoverSessionRequest struct {
+	SessionID [16]byte
+	NewLabel  string
+}
+
+func EncodeRecoverSessionRequest(r RecoverSessionRequest) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(r.SessionID[:])
+	if err := encodeString(buf, r.NewLabel); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeRecoverSessionRequest(b []byte) (RecoverSessionRequest, error) {
+	var r RecoverSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	label, _, err := decodeString(b[16:])
+	if err != nil {
+		return r, err
+	}
+	r.NewLabel = label
+	return r, nil
+}
+
+// RenameSessionRequest edits a stored session's label without recovering.
+type RenameSessionRequest struct {
+	SessionID [16]byte
+	NewLabel  string
+}
+
+func EncodeRenameSessionRequest(r RenameSessionRequest) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(r.SessionID[:])
+	if err := encodeString(buf, r.NewLabel); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeRenameSessionRequest(b []byte) (RenameSessionRequest, error) {
+	var r RenameSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	label, _, err := decodeString(b[16:])
+	if err != nil {
+		return r, err
+	}
+	r.NewLabel = label
+	return r, nil
+}
+
+// DeleteSessionRequest removes a stored session's JSON + PNG sidecar.
+type DeleteSessionRequest struct {
+	SessionID [16]byte
+}
+
+func EncodeDeleteSessionRequest(r DeleteSessionRequest) ([]byte, error) {
+	out := make([]byte, 16)
+	copy(out, r.SessionID[:])
+	return out, nil
+}
+
+func DecodeDeleteSessionRequest(b []byte) (DeleteSessionRequest, error) {
+	var r DeleteSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	return r, nil
+}
+
+// SessionOpResponse is the shared shape for rename + delete responses.
+// OK=false implies a non-empty Error explaining the refusal (live
+// session, not found, IO failure).
+type SessionOpResponse struct {
+	OK    bool
+	Error string
+}
+
+func EncodeSessionOpResponse(r SessionOpResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if r.OK {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	if err := encodeString(buf, r.Error); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeSessionOpResponse(b []byte) (SessionOpResponse, error) {
+	var r SessionOpResponse
+	if len(b) < 1 {
+		return r, ErrPayloadShort
+	}
+	r.OK = b[0] != 0
+	msg, _, err := decodeString(b[1:])
+	if err != nil {
+		return r, err
+	}
+	r.Error = msg
+	return r, nil
+}
+
+// FetchThumbnailRequest pulls a stored session's PNG sidecar.
+type FetchThumbnailRequest struct {
+	SessionID [16]byte
+}
+
+func EncodeFetchThumbnailRequest(r FetchThumbnailRequest) ([]byte, error) {
+	out := make([]byte, 16)
+	copy(out, r.SessionID[:])
+	return out, nil
+}
+
+func DecodeFetchThumbnailRequest(b []byte) (FetchThumbnailRequest, error) {
+	var r FetchThumbnailRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	return r, nil
+}
+
+// FetchThumbnailResponse carries the PNG bytes (or an error explanation
+// if OK=false). PNGs over 16MiB are rejected at the framing layer
+// (MaxPayloadLen); typical sidecars are tens of KB.
+type FetchThumbnailResponse struct {
+	OK    bool
+	Error string
+	PNG   []byte
+}
+
+func EncodeFetchThumbnailResponse(r FetchThumbnailResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if r.OK {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	if err := encodeString(buf, r.Error); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint32(len(r.PNG))); err != nil {
+		return nil, err
+	}
+	if len(r.PNG) > 0 {
+		if _, err := buf.Write(r.PNG); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func DecodeFetchThumbnailResponse(b []byte) (FetchThumbnailResponse, error) {
+	var r FetchThumbnailResponse
+	if len(b) < 1 {
+		return r, ErrPayloadShort
+	}
+	r.OK = b[0] != 0
+	b = b[1:]
+	msg, rest, err := decodeString(b)
+	if err != nil {
+		return r, err
+	}
+	r.Error = msg
+	if len(rest) < 4 {
+		return r, ErrPayloadShort
+	}
+	pngLen := binary.LittleEndian.Uint32(rest[:4])
+	rest = rest[4:]
+	if uint32(len(rest)) < pngLen {
+		return r, ErrPayloadShort
+	}
+	if pngLen > 0 {
+		r.PNG = append([]byte(nil), rest[:pngLen]...)
+	}
+	return r, nil
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./protocol/ -run "TestRecoverSession|TestRenameSession|TestSessionOpResponse|TestDeleteSession|TestFetchThumbnail" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add protocol/session_picker.go protocol/session_picker_test.go
+git commit -m "Protocol: recover/rename/delete/fetch-thumbnail messages"
+```
+
+---
+
+### Task 5: Extend StoredSession with Layout field
+
+**Files:**
+- Modify: `internal/runtime/server/session_persistence.go:34-78` (struct + JSON shape)
+- Test: `internal/runtime/server/session_persistence_test.go` (existing) — add round-trip + missing-field tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/runtime/server/session_persistence_test.go` (create the file structure if it doesn't already define a package import for protocol):
+
+```go
+func TestStoredSession_LayoutRoundTrip(t *testing.T) {
+	in := StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     [16]byte{0xAA, 0xBB, 0xCC},
+		LastActive:    time.Unix(1714752000, 0).UTC(),
+		Pinned:        true,
+		Label:         "with-layout",
+		PaneCount:     2,
+		Layout: &protocol.TreeNodeSnapshot{
+			PaneIndex:   -1,
+			Split:       protocol.SplitHorizontal,
+			SplitRatios: []float32{0.5, 0.5},
+			Children: []protocol.TreeNodeSnapshot{
+				{PaneIndex: 0, Split: protocol.SplitNone},
+				{PaneIndex: 1, Split: protocol.SplitNone},
+			},
+		},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out StoredSession
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Layout == nil {
+		t.Fatalf("expected Layout populated, got nil")
+	}
+	if !reflect.DeepEqual(in.Layout, out.Layout) {
+		t.Fatalf("layout round-trip mismatch:\n in=%#v\nout=%#v", in.Layout, out.Layout)
+	}
+}
+
+func TestStoredSession_LayoutAbsentInOlderJSON(t *testing.T) {
+	// Older Plan D2 JSONs have no "layout" field. Unmarshal must
+	// leave the field nil rather than failing — the picker falls
+	// back to a single-box ASCII placeholder.
+	older := []byte(`{
+		"schemaVersion": 1,
+		"sessionID": "aabbccddeeff00112233445566778899",
+		"lastActive": "2026-04-26T00:00:00Z",
+		"pinned": false,
+		"paneViewports": [],
+		"label": "legacy",
+		"paneCount": 1,
+		"firstPaneTitle": ""
+	}`)
+	var out StoredSession
+	if err := json.Unmarshal(older, &out); err != nil {
+		t.Fatalf("unmarshal pre-F.1 JSON: %v", err)
+	}
+	if out.Layout != nil {
+		t.Fatalf("expected Layout=nil for legacy JSON, got %#v", out.Layout)
+	}
+	if out.Label != "legacy" {
+		t.Fatalf("expected Label preserved, got %q", out.Label)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestStoredSession_Layout" -count=1`
+Expected: FAIL — `Layout` not a field on StoredSession.
+
+- [ ] **Step 3: Add the Layout field**
+
+In `internal/runtime/server/session_persistence.go`, modify the struct (around line 34) and the JSON shape (line 59):
+
+```go
+type StoredSession struct {
+	SchemaVersion int
+	SessionID     [16]byte
+	LastActive    time.Time
+	Pinned        bool
+	PaneViewports []StoredPaneViewport
+	// Plan F metadata (populated at write time):
+	Label          string
+	PaneCount      int
+	FirstPaneTitle string
+	// Plan F.1: pane-tree layout for the recovery picker's ASCII
+	// fallback render. Nil for sessions written before F.1 — the
+	// picker handles that as a single-box placeholder.
+	Layout *protocol.TreeNodeSnapshot
+}
+```
+
+```go
+type sessionJSONShape struct {
+	SchemaVersion  int                       `json:"schemaVersion"`
+	SessionID      string                    `json:"sessionID"`
+	LastActive     time.Time                 `json:"lastActive"`
+	Pinned         bool                      `json:"pinned"`
+	PaneViewports  []paneViewportJSONShape   `json:"paneViewports"`
+	Label          string                    `json:"label"`
+	PaneCount      int                       `json:"paneCount"`
+	FirstPaneTitle string                    `json:"firstPaneTitle"`
+	Layout         *protocol.TreeNodeSnapshot `json:"layout,omitempty"`
+}
+```
+
+Update `MarshalJSON` to copy the Layout pointer:
+
+```go
+func (s StoredSession) MarshalJSON() ([]byte, error) {
+	out := sessionJSONShape{
+		SchemaVersion:  s.SchemaVersion,
+		SessionID:      hex.EncodeToString(s.SessionID[:]),
+		LastActive:     s.LastActive,
+		Pinned:         s.Pinned,
+		Label:          s.Label,
+		PaneCount:      s.PaneCount,
+		FirstPaneTitle: s.FirstPaneTitle,
+		Layout:         s.Layout,
+	}
+	out.PaneViewports = make([]paneViewportJSONShape, len(s.PaneViewports))
+	for i, p := range s.PaneViewports {
+		out.PaneViewports[i] = paneViewportJSONShape{
+			PaneID:         hex.EncodeToString(p.PaneID[:]),
+			AltScreen:      p.AltScreen,
+			AutoFollow:     p.AutoFollow,
+			ViewBottomIdx:  p.ViewBottomIdx,
+			WrapSegmentIdx: p.WrapSegmentIdx,
+			Rows:           p.Rows,
+			Cols:           p.Cols,
+		}
+	}
+	return json.Marshal(&out)
+}
+```
+
+Update `UnmarshalJSON` to read it back:
+
+```go
+func (s *StoredSession) UnmarshalJSON(data []byte) error {
+	var in sessionJSONShape
+	if err := json.Unmarshal(data, &in); err != nil {
+		return err
+	}
+	s.SchemaVersion = in.SchemaVersion
+	if err := decodeHex16Session(in.SessionID, &s.SessionID); err != nil {
+		return fmt.Errorf("sessionID: %w", err)
+	}
+	s.LastActive = in.LastActive
+	s.Pinned = in.Pinned
+	s.Label = in.Label
+	s.PaneCount = in.PaneCount
+	s.FirstPaneTitle = in.FirstPaneTitle
+	s.Layout = in.Layout
+	s.PaneViewports = make([]StoredPaneViewport, len(in.PaneViewports))
+	for i, p := range in.PaneViewports {
+		var pid [16]byte
+		if err := decodeHex16Session(p.PaneID, &pid); err != nil {
+			return fmt.Errorf("paneViewports[%d].paneID: %w", i, err)
+		}
+		s.PaneViewports[i] = StoredPaneViewport{
+			PaneID:         pid,
+			AltScreen:      p.AltScreen,
+			AutoFollow:     p.AutoFollow,
+			ViewBottomIdx:  p.ViewBottomIdx,
+			WrapSegmentIdx: p.WrapSegmentIdx,
+			Rows:           p.Rows,
+			Cols:           p.Cols,
+		}
+	}
+	return nil
+}
+```
+
+Add `"github.com/framegrace/texelation/protocol"` to the imports if not already present.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestStoredSession" -count=1`
+Expected: PASS — both the new tests and any existing StoredSession tests.
+
+- [ ] **Step 5: Run full server test suite to catch regressions**
+
+Run: `go test ./internal/runtime/server/ -count=1`
+Expected: PASS. Existing tests construct StoredSession without Layout — Go zero-values it to nil.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/server/session_persistence.go internal/runtime/server/session_persistence_test.go
+git commit -m "StoredSession: add optional Layout field for picker render"
+```
+
+---
+
+### Task 6: Manager.StoredSummaries + Manager.LiveSummaries
+
+**Files:**
+- Create: `internal/runtime/server/manager_session_picker.go`
+- Test: `internal/runtime/server/manager_session_picker_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/runtime/server/manager_session_picker_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestStoredSummaries_EmptyOnFreshManager(t *testing.T) {
+	m := NewManager()
+	got := m.StoredSummaries()
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d entries", len(got))
+	}
+}
+
+func TestStoredSummaries_OrderedPinnedThenLastActive(t *testing.T) {
+	m := NewManager()
+	m.SetPersistedSessions(map[[16]byte]*StoredSession{
+		{0x01}: {SessionID: [16]byte{0x01}, Label: "old-pinned", LastActive: time.Unix(100, 0), Pinned: true, PaneCount: 1},
+		{0x02}: {SessionID: [16]byte{0x02}, Label: "newest", LastActive: time.Unix(300, 0), PaneCount: 2},
+		{0x03}: {SessionID: [16]byte{0x03}, Label: "middle", LastActive: time.Unix(200, 0), PaneCount: 3},
+	})
+	got := m.StoredSummaries()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 summaries, got %d", len(got))
+	}
+	// Pinned first, then LastActive desc.
+	if got[0].Label != "old-pinned" {
+		t.Fatalf("[0] expected pinned first, got %q", got[0].Label)
+	}
+	if got[1].Label != "newest" {
+		t.Fatalf("[1] expected newest second, got %q", got[1].Label)
+	}
+	if got[2].Label != "middle" {
+		t.Fatalf("[2] expected middle third, got %q", got[2].Label)
+	}
+}
+
+func TestStoredSummaries_HasThumbnailFlag(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := filepath.Join(dir, SessionsDirName)
+	if err := mkdirAll(sessionsDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	withPNG := [16]byte{0x10}
+	withoutPNG := [16]byte{0x20}
+	if err := writeFile(filepath.Join(sessionsDir, hexID(withPNG)+".png"), []byte("fake")); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	m := NewManager()
+	m.persistBasedir = dir
+	m.SetPersistedSessions(map[[16]byte]*StoredSession{
+		withPNG:    {SessionID: withPNG, LastActive: time.Unix(200, 0), PaneCount: 1},
+		withoutPNG: {SessionID: withoutPNG, LastActive: time.Unix(100, 0), PaneCount: 1},
+	})
+	got := m.StoredSummaries()
+	bySID := make(map[[16]byte]protocol.SessionSummary)
+	for _, s := range got {
+		bySID[s.SessionID] = s
+	}
+	if !bySID[withPNG].HasThumbnail {
+		t.Errorf("expected HasThumbnail=true for %x", withPNG)
+	}
+	if bySID[withoutPNG].HasThumbnail {
+		t.Errorf("expected HasThumbnail=false for %x", withoutPNG)
+	}
+	_ = sort.IntSlice(nil) // keep sort import live for future tests
+}
+
+func TestLiveSummaries_EmptyInF1(t *testing.T) {
+	m := NewManager()
+	if got := m.LiveSummaries(); got != nil {
+		t.Fatalf("expected nil (F.2 will populate), got %#v", got)
+	}
+}
+```
+
+Helpers (declare once at the top of the test file or in a shared `_test.go` if they don't already exist — note that `mkdirAll`, `writeFile`, `hexID` may already be present from other test files in the package):
+
+```go
+func mkdirAll(p string) error {
+	return os.MkdirAll(p, 0o755)
+}
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0o644)
+}
+
+func hexID(id [16]byte) string {
+	return hex.EncodeToString(id[:])
+}
+```
+
+If those names collide with existing helpers, use them as-is (the package is small enough that helper sharing is acceptable). The `os` and `encoding/hex` imports must be added to the test file.
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestStoredSummaries|TestLiveSummaries" -count=1`
+Expected: FAIL — `StoredSummaries` and `LiveSummaries` undefined.
+
+- [ ] **Step 3: Implement the methods**
+
+Create `internal/runtime/server/manager_session_picker.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/manager_session_picker.go
+// Summary: Session-picker helpers on Manager — list / rename / delete
+// stored sessions for the F.1 recovery flow.
+
+package server
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/framegrace/texelation/internal/persistence/atomicjson"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// StoredSummaries returns a slice of SessionSummary records for every
+// known persisted session, sorted pinned-first then LastActive desc.
+// HasThumbnail is set per record by stat-ing the on-disk PNG sidecar
+// when persistence is enabled; without persistence the flag is always
+// false.
+//
+// Reads the in-memory persistedSessions map; no JSON parsing or disk
+// IO except the per-record PNG stat. Safe to call from request paths.
+func (m *Manager) StoredSummaries() []protocol.SessionSummary {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.persistedSessions) == 0 {
+		return nil
+	}
+	summaries := make([]protocol.SessionSummary, 0, len(m.persistedSessions))
+	for id, s := range m.persistedSessions {
+		summary := protocol.SessionSummary{
+			SessionID:      id,
+			Label:          s.Label,
+			LastActive:     s.LastActive.Unix(),
+			PaneCount:      int32(s.PaneCount),
+			FirstPaneTitle: s.FirstPaneTitle,
+			Pinned:         s.Pinned,
+			Layout:         s.Layout,
+		}
+		if m.persistBasedir != "" {
+			pngPath := filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+			if info, err := os.Stat(pngPath); err == nil && !info.IsDir() {
+				summary.HasThumbnail = true
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].Pinned != summaries[j].Pinned {
+			return summaries[i].Pinned
+		}
+		return summaries[i].LastActive > summaries[j].LastActive
+	})
+	return summaries
+}
+
+// LiveSummaries returns the live (in-memory, attached or detached)
+// session catalog. F.1 always returns nil — F.2 will populate this
+// from m.sessions and per-session attached-client counts.
+func (m *Manager) LiveSummaries() []protocol.LiveSummary {
+	return nil
+}
+
+// sessionPNGPath is a small helper so other Plan F code paths
+// (delete, fetch-thumbnail) can build the same PNG sidecar path.
+// Returns empty string if persistence is disabled.
+func (m *Manager) sessionPNGPath(id [16]byte) string {
+	if m.persistBasedir == "" {
+		return ""
+	}
+	return filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+}
+
+// loadStoredFromDisk reads <id>.json off disk for rename/delete paths
+// that need to mutate persisted state outside the in-memory index.
+// Returns ErrSessionNotFound if the file is missing.
+func (m *Manager) loadStoredFromDisk(id [16]byte) (*StoredSession, error) {
+	if m.persistBasedir == "" {
+		return nil, fmt.Errorf("manager: persistence disabled")
+	}
+	path := SessionFilePath(m.persistBasedir, id)
+	s, err := atomicjson.Load[StoredSession](path)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil {
+		return nil, ErrSessionNotFound
+	}
+	return s, nil
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestStoredSummaries|TestLiveSummaries" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/manager_session_picker.go internal/runtime/server/manager_session_picker_test.go
+git commit -m "Manager: StoredSummaries + LiveSummaries for picker"
+```
+
+---
+
+### Task 7: Manager.RenameStored + Manager.DeleteStored
+
+**Files:**
+- Modify: `internal/runtime/server/manager_session_picker.go` (append methods)
+- Modify: `internal/runtime/server/manager_session_picker_test.go` (append tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/runtime/server/manager_session_picker_test.go`:
+
+```go
+func TestRenameStored_UpdatesInMemoryAndDisk(t *testing.T) {
+	dir := t.TempDir()
+	if err := mkdirAll(filepath.Join(dir, SessionsDirName)); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xAA}
+	original := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "before",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(original)
+	if err := writeFile(SessionFilePath(dir, id), data); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable persistence: %v", err)
+	}
+	if err := m.RenameStored(id, "after"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	got := m.StoredSummaries()
+	if len(got) != 1 || got[0].Label != "after" {
+		t.Fatalf("in-memory rename failed; got %#v", got)
+	}
+	// Disk side: re-load and confirm.
+	reloaded, err := atomicjson.Load[StoredSession](SessionFilePath(dir, id))
+	if err != nil || reloaded == nil {
+		t.Fatalf("reload: err=%v reloaded=%v", err, reloaded)
+	}
+	if reloaded.Label != "after" {
+		t.Fatalf("on-disk Label=%q, want %q", reloaded.Label, "after")
+	}
+}
+
+func TestRenameStored_UnknownID(t *testing.T) {
+	m := NewManager()
+	if err := m.EnablePersistence(t.TempDir(), 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.RenameStored([16]byte{0xFF}, "nope"); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestDeleteStored_RemovesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := mkdirAll(filepath.Join(dir, SessionsDirName)); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xBB}
+	jsonPath := SessionFilePath(dir, id)
+	pngPath := filepath.Join(dir, SessionsDirName, hexID(id)+".png")
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	writeFile(jsonPath, data)
+	writeFile(pngPath, []byte("fake-png"))
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.DeleteStored(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Errorf("expected JSON gone, stat err=%v", err)
+	}
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected PNG gone, stat err=%v", err)
+	}
+	if got := m.StoredSummaries(); len(got) != 0 {
+		t.Errorf("expected empty after delete, got %d entries", len(got))
+	}
+}
+
+func TestDeleteStored_PNGMissingStillSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	if err := mkdirAll(filepath.Join(dir, SessionsDirName)); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xCC}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	writeFile(SessionFilePath(dir, id), data)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.DeleteStored(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestDeleteStored_RefusesLive(t *testing.T) {
+	id := [16]byte{0xDD}
+	m := NewManager()
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	err := m.DeleteStored(id)
+	if err == nil {
+		t.Fatalf("expected error refusing live session, got nil")
+	}
+}
+```
+
+Add `"encoding/json"` and `"github.com/framegrace/texelation/internal/persistence/atomicjson"` to the test file imports.
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestRenameStored|TestDeleteStored" -count=1`
+Expected: FAIL — methods undefined.
+
+- [ ] **Step 3: Implement RenameStored + DeleteStored**
+
+Append to `internal/runtime/server/manager_session_picker.go`:
+
+```go
+// RenameStored updates the persisted session's Label both in-memory
+// and on disk. Acquires m.mu so concurrent StoredSummaries / Recover
+// calls observe a consistent state. The disk write goes through
+// atomicjson.Save to retain the existing crash-safety guarantees.
+//
+// Returns ErrSessionNotFound when the ID is unknown to the in-memory
+// index. On disk-write failures, in-memory state is rolled back so a
+// subsequent retry sees the original Label rather than a half-applied
+// rename.
+func (m *Manager) RenameStored(id [16]byte, newLabel string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	stored, ok := m.persistedSessions[id]
+	if !ok {
+		return ErrSessionNotFound
+	}
+	prev := stored.Label
+	stored.Label = newLabel
+	if m.persistBasedir == "" {
+		return nil
+	}
+	if err := atomicjson.Save(SessionFilePath(m.persistBasedir, id), stored); err != nil {
+		stored.Label = prev
+		return fmt.Errorf("manager: rename %x: %w", id[:4], err)
+	}
+	return nil
+}
+
+// DeleteStored removes the session's JSON sidecar, PNG sidecar (if
+// present), and the in-memory persisted entry. Refuses with an error
+// when the session is currently live — the user must detach all
+// clients first.
+//
+// PNG removal is best-effort (a missing PNG is not an error); JSON
+// removal is authoritative — if the JSON unlink fails we leave the
+// in-memory entry alone and surface the error so the caller can
+// retry. The PNG-then-JSON order avoids leaving a JSON with stale
+// HasThumbnail expectations across a partial delete.
+func (m *Manager) DeleteStored(id [16]byte) error {
+	m.mu.Lock()
+	if _, live := m.sessions[id]; live {
+		m.mu.Unlock()
+		return fmt.Errorf("manager: session %x is live; detach all clients first", id[:4])
+	}
+	if _, ok := m.persistedSessions[id]; !ok && m.persistBasedir == "" {
+		m.mu.Unlock()
+		return ErrSessionNotFound
+	}
+	persistDir := m.persistBasedir
+	m.mu.Unlock()
+
+	if persistDir != "" {
+		pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+		if err := os.Remove(pngPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("manager: remove %s: %w", pngPath, err)
+		}
+		jsonPath := SessionFilePath(persistDir, id)
+		if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("manager: remove %s: %w", jsonPath, err)
+		}
+	}
+
+	m.mu.Lock()
+	delete(m.persistedSessions, id)
+	m.mu.Unlock()
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestRenameStored|TestDeleteStored" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/manager_session_picker.go internal/runtime/server/manager_session_picker_test.go
+git commit -m "Manager: RenameStored + DeleteStored for picker"
+```
+
+---
+
+### Task 8: Boot scan extension — orphan PNG cleanup
+
+**Files:**
+- Modify: `internal/runtime/server/session_persistence.go` (extend `ScanSessionsDir`)
+- Test: `internal/runtime/server/session_persistence_test.go` (existing)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/runtime/server/session_persistence_test.go`:
+
+```go
+func TestScanSessionsDir_RemovesOrphanPNGs(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	keepID := [16]byte{0x01}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     keepID,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	if err := os.WriteFile(filepath.Join(sessions, hex.EncodeToString(keepID[:])+".json"), data, 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessions, hex.EncodeToString(keepID[:])+".png"), []byte("matched"), 0o644); err != nil {
+		t.Fatalf("write keep png: %v", err)
+	}
+	orphanID := [16]byte{0xDE}
+	orphanPath := filepath.Join(sessions, hex.EncodeToString(orphanID[:])+".png")
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan png: %v", err)
+	}
+	if _, err := ScanSessionsDir(dir); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Errorf("expected orphan PNG removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessions, hex.EncodeToString(keepID[:])+".png")); err != nil {
+		t.Errorf("expected matched PNG retained, stat err=%v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestScanSessionsDir_RemovesOrphanPNGs" -count=1`
+Expected: FAIL — orphan PNG still present after scan.
+
+- [ ] **Step 3: Extend ScanSessionsDir**
+
+In `internal/runtime/server/session_persistence.go`, after the existing `for _, e := range entries` loop in `ScanSessionsDir`, add a second pass that walks `*.png` entries and removes ones without a matching JSON:
+
+```go
+// ... existing loop populating `out` ...
+
+// Plan F.1: clean up orphaned PNG sidecars (a PNG whose matching
+// JSON was deleted, or whose JSON failed to load above). Keeping
+// them would silently inflate the picker's HasThumbnail flag for
+// nonexistent entries and leak disk space across restarts.
+for _, e := range entries {
+	if e.IsDir() {
+		continue
+	}
+	name := e.Name()
+	if !strings.HasSuffix(name, ".png") {
+		continue
+	}
+	hexPart := strings.TrimSuffix(name, ".png")
+	var id [16]byte
+	if err := decodeHex16Session(hexPart, &id); err != nil {
+		continue // unrecognised filename; leave alone
+	}
+	if _, ok := out[id]; ok {
+		continue // matched a loaded JSON; keep
+	}
+	pngPath := filepath.Join(dir, name)
+	if err := os.Remove(pngPath); err != nil {
+		log.Printf("server: orphan PNG cleanup: %s: %v", pngPath, err)
+	}
+}
+
+return out, nil
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestScanSessionsDir" -count=1`
+Expected: PASS — both the new orphan-removal test and any existing scan tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/session_persistence.go internal/runtime/server/session_persistence_test.go
+git commit -m "Boot scan: remove orphaned PNG thumbnails"
+```
+
+---
+
+### Task 9: Thumbnail core — writePNGAtomic + downscale + capture skeleton
+
+**Files:**
+- Create: `internal/runtime/server/thumbnail.go`
+- Test: `internal/runtime/server/thumbnail_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/runtime/server/thumbnail_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func makeTestImage(w, h int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0x80, A: 0xFF})
+		}
+	}
+	return img
+}
+
+func TestWritePNGAtomic_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thumb.png")
+	if err := writePNGAtomic(path, makeTestImage(40, 30)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// Tmp file should be gone.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("tmp file not cleaned: stat err=%v", err)
+	}
+	// Decoded image should be the same dimensions.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	img, err := png.Decode(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if img.Bounds().Dx() != 40 || img.Bounds().Dy() != 30 {
+		t.Fatalf("decoded dims = %dx%d, want 40x30", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestWritePNGAtomic_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thumb.png")
+	if err := writePNGAtomic(path, makeTestImage(20, 20)); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writePNGAtomic(path, makeTestImage(40, 40)); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	f, _ := os.Open(path)
+	defer f.Close()
+	img, _ := png.Decode(f)
+	if img.Bounds().Dx() != 40 {
+		t.Fatalf("expected overwrite to 40x40, got %dx%d", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_Wider(t *testing.T) {
+	src := makeTestImage(800, 200) // 4:1 — wider than 16:9 (480x270)
+	out := downscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_Taller(t *testing.T) {
+	src := makeTestImage(200, 800) // narrow + tall
+	out := downscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_AlreadySmall(t *testing.T) {
+	src := makeTestImage(100, 80)
+	out := downscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestWritePNGAtomic|TestDownscaleAspectFit" -count=1`
+Expected: FAIL — undefined `writePNGAtomic`, `downscaleAspectFit`.
+
+- [ ] **Step 3: Implement helpers**
+
+Create `internal/runtime/server/thumbnail.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/thumbnail.go
+// Summary: Lifecycle thumbnail capture for the F.1 session picker.
+// Usage: Called from Manager.ShutdownSessions and Manager.Close on
+//   the last-disconnect transition. Writes <basedir>/sessions/<id>.png.
+
+package server
+
+import (
+	"fmt"
+	"image"
+	"image/draw"
+	"image/png"
+	"os"
+
+	"golang.org/x/image/draw" // golang.org/x/image is already a transitive dep via texelui
+)
+
+// writePNGAtomic encodes img to path via a temp-file-then-rename so a
+// crash mid-write doesn't leave a half-PNG (which the client would
+// then fail to decode and silently fall back to ASCII forever).
+func writePNGAtomic(path string, img image.Image) error {
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("thumbnail: create %s: %w", tmp, err)
+	}
+	encErr := png.Encode(f, img)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if encErr != nil || syncErr != nil || closeErr != nil {
+		_ = os.Remove(tmp)
+		if encErr != nil {
+			return fmt.Errorf("thumbnail: encode: %w", encErr)
+		}
+		if syncErr != nil {
+			return fmt.Errorf("thumbnail: sync: %w", syncErr)
+		}
+		return fmt.Errorf("thumbnail: close: %w", closeErr)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("thumbnail: rename %s: %w", path, err)
+	}
+	return nil
+}
+
+// downscaleAspectFit returns a (targetW × targetH) RGBA image with src
+// drawn into the centred subrect that preserves src's aspect ratio.
+// The remainder is filled with theme-neutral black (zero pixels). Used
+// to standardise picker thumbnail dimensions regardless of the source
+// workspace size.
+func downscaleAspectFit(src image.Image, targetW, targetH int) *image.RGBA {
+	dst := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
+	srcW := src.Bounds().Dx()
+	srcH := src.Bounds().Dy()
+	if srcW == 0 || srcH == 0 {
+		return dst
+	}
+	srcRatio := float64(srcW) / float64(srcH)
+	dstRatio := float64(targetW) / float64(targetH)
+	var scaledW, scaledH int
+	if srcRatio > dstRatio {
+		scaledW = targetW
+		scaledH = int(float64(targetW) / srcRatio)
+	} else {
+		scaledH = targetH
+		scaledW = int(float64(targetH) * srcRatio)
+	}
+	if scaledW < 1 {
+		scaledW = 1
+	}
+	if scaledH < 1 {
+		scaledH = 1
+	}
+	offsetX := (targetW - scaledW) / 2
+	offsetY := (targetH - scaledH) / 2
+	dstRect := image.Rect(offsetX, offsetY, offsetX+scaledW, offsetY+scaledH)
+	xdraw.ApproxBiLinear.Scale(dst, dstRect, src, src.Bounds(), draw.Over, nil)
+	return dst
+}
+```
+
+Note: the scaling import is named `xdraw "golang.org/x/image/draw"` (rename to avoid collision with stdlib `image/draw`). Adjust the import block accordingly:
+
+```go
+import (
+	"fmt"
+	"image"
+	stddraw "image/draw"
+	"image/png"
+	"os"
+
+	xdraw "golang.org/x/image/draw"
+)
+```
+
+…and replace `draw.Over` in the call site with `stddraw.Over`.
+
+If `golang.org/x/image` is not yet a direct dependency, add it via `go get golang.org/x/image/draw` before running the tests; it's already pulled in transitively by texelui's text rendering, so `go mod tidy` will resolve it without surprises.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestWritePNGAtomic|TestDownscaleAspectFit" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/thumbnail.go internal/runtime/server/thumbnail_test.go go.mod go.sum
+git commit -m "Server: writePNGAtomic + downscaleAspectFit helpers for picker thumbnails"
+```
+
+---
+
+### Task 10: Capture trigger — wire shutdown + last-disconnect
+
+**Files:**
+- Modify: `internal/runtime/server/thumbnail.go` (add captureThumbnail + ThumbnailRenderer interface)
+- Modify: `internal/runtime/server/manager.go` (call from `Close` and `ShutdownSessions`)
+- Modify: `internal/runtime/server/thumbnail_test.go` (test the trigger paths)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/runtime/server/thumbnail_test.go`:
+
+```go
+// fakeRenderer is a stub ThumbnailRenderer used by trigger tests so we
+// don't drag textrender + a real font into the unit harness.
+type fakeRenderer struct {
+	calls int
+}
+
+func (f *fakeRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	f.calls++
+	return makeTestImage(80, 24), true
+}
+
+func TestCaptureThumbnail_WritesPNG(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0x77}
+	r := &fakeRenderer{}
+	if err := captureThumbnail(dir, id, r); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Fatalf("stat png: %v", err)
+	}
+}
+
+func TestCaptureThumbnail_RendererSkip(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0x88}
+	r := skipRenderer{}
+	if err := captureThumbnail(dir, id, r); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected no PNG when renderer skips, stat err=%v", err)
+	}
+}
+
+type skipRenderer struct{}
+
+func (skipRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	return nil, false
+}
+
+func TestManager_CaptureOnShutdown(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0x55}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	r := &fakeRenderer{}
+	m.SetThumbnailRenderer(r)
+	sess, err := m.NewSessionWithID(id)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	_ = sess
+	m.ShutdownSessions()
+	if r.calls < 1 {
+		t.Errorf("expected at least 1 thumbnail render, got %d", r.calls)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Errorf("expected PNG after shutdown, stat err=%v", err)
+	}
+}
+
+func TestManager_CaptureOnLastDisconnect(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0x66}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	r := &fakeRenderer{}
+	m.SetThumbnailRenderer(r)
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	m.Close(id)
+	if r.calls < 1 {
+		t.Errorf("expected thumbnail render on Close, got %d", r.calls)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Errorf("expected PNG after Close, stat err=%v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail|TestManager_Capture" -count=1`
+Expected: FAIL — `captureThumbnail`, `SetThumbnailRenderer` undefined.
+
+- [ ] **Step 3: Implement renderer interface + captureThumbnail**
+
+Append to `internal/runtime/server/thumbnail.go`:
+
+```go
+// ThumbnailRenderer produces a PNG-suitable image for a given session.
+// Implemented by the desktop publisher in production; tests inject a
+// stub. Returns ok=false when the session has nothing meaningful to
+// capture (empty workspace, no live buffer) so the caller can skip the
+// disk write rather than store an all-black PNG.
+type ThumbnailRenderer interface {
+	RenderSessionThumbnail(id [16]byte) (image.Image, bool)
+}
+
+// captureThumbnail renders id via the renderer (if present), downscales
+// to 480x270, and writes the result to <basedir>/sessions/<id>.png.
+// All errors are returned; callers are expected to log + continue —
+// thumbnail capture is a hint, not authoritative state.
+func captureThumbnail(basedir string, id [16]byte, r ThumbnailRenderer) error {
+	if r == nil || basedir == "" {
+		return nil
+	}
+	img, ok := r.RenderSessionThumbnail(id)
+	if !ok {
+		return nil
+	}
+	scaled := downscaleAspectFit(img, 480, 270)
+	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	return writePNGAtomic(pngPath, scaled)
+}
+```
+
+Add `"path/filepath"` and `"encoding/hex"` to the imports.
+
+In `internal/runtime/server/manager.go`, add a renderer field and setter:
+
+```go
+// On the Manager struct, add:
+//   thumbRenderer ThumbnailRenderer
+
+// SetThumbnailRenderer wires the production renderer (DesktopSink in
+// the texel-server harness, nil/stub in tests). nil renderers skip
+// capture silently — no error, no log spam.
+func (m *Manager) SetThumbnailRenderer(r ThumbnailRenderer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.thumbRenderer = r
+}
+```
+
+Then extend `ShutdownSessions` and `Close` to fire capture *before* the per-session Close:
+
+```go
+// ShutdownSessions: inside the per-session loop, before session.Close():
+if m.persistBasedir != "" && m.thumbRenderer != nil {
+	if err := captureThumbnail(m.persistBasedir, id, m.thumbRenderer); err != nil {
+		log.Printf("server: shutdown thumbnail %x: %v", id[:4], err)
+	}
+}
+// (Note: m.thumbRenderer is read after m.mu was released in the
+// existing flow; capture the renderer pointer before the unlock to
+// avoid a race with SetThumbnailRenderer. Add to the locked section.)
+```
+
+For `Close(id)`:
+
+```go
+// Close(id): immediately after `delete(m.sessions, id)` and before
+// the markClosing/unlock block, capture the renderer pointer:
+basedir := m.persistBasedir
+renderer := m.thumbRenderer
+m.mu.Unlock()
+
+if basedir != "" && renderer != nil {
+	if err := captureThumbnail(basedir, id, renderer); err != nil {
+		log.Printf("server: close thumbnail %x: %v", id[:4], err)
+	}
+}
+// Then continue with markClosing + session.Close() as before.
+```
+
+Take care to preserve the existing `markClosing` / `unmarkClosing` ordering. The full revised `Close`:
+
+```go
+func (m *Manager) Close(id [16]byte) {
+	m.mu.Lock()
+	session, ok := m.sessions[id]
+	if ok {
+		delete(m.sessions, id)
+	}
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	basedir := m.persistBasedir
+	renderer := m.thumbRenderer
+	m.markClosing(id)
+	m.mu.Unlock()
+	defer m.unmarkClosing(id)
+
+	if basedir != "" && renderer != nil {
+		if err := captureThumbnail(basedir, id, renderer); err != nil {
+			log.Printf("server: close thumbnail %x: %v", id[:4], err)
+		}
+	}
+	session.Close()
+}
+```
+
+Apply the analogous adjustment to `ShutdownSessions`: capture `basedir` and `renderer` once under m.mu, then loop with both available.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail|TestManager_Capture" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full server suite**
+
+Run: `go test -race ./internal/runtime/server/ -count=1`
+Expected: PASS — no races introduced by the new field access.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/runtime/server/thumbnail.go internal/runtime/server/thumbnail_test.go internal/runtime/server/manager.go
+git commit -m "Server: capture thumbnails on shutdown + last-disconnect"
+```
+
+---
+
+### Task 11: Connection handlers — list + recover
+
+**Files:**
+- Create: `internal/runtime/server/connection_session_picker.go`
+- Modify: `internal/runtime/server/connection_handler.go` (dispatch new types)
+- Test: `internal/runtime/server/connection_session_picker_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/runtime/server/connection_session_picker_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// roundTripPicker is a small helper that drives a request through
+// handleMessage and decodes the response. The test harness uses a
+// memconn-backed connection; existing pattern from
+// connection_rehydrate_resume_test.go.
+//
+// We use the same nopSink defined in test_helpers_test.go (or
+// equivalent) to bypass the desktop wiring — picker handlers don't
+// touch the desktop.
+
+func TestHandleListSessions_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, sink := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	got, err := protocol.DecodeListSessionsResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Stored) != 0 || len(got.Live) != 0 {
+		t.Fatalf("expected empty, got Stored=%d Live=%d", len(got.Stored), len(got.Live))
+	}
+	_ = sink
+}
+
+func TestHandleListSessions_StoredPopulated(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id1 := [16]byte{0x01}
+	id2 := [16]byte{0x02}
+	for i, fixture := range []*StoredSession{
+		{SchemaVersion: StoredSessionSchemaVersion, SessionID: id1, LastActive: time.Unix(100, 0), Label: "older", PaneCount: 1},
+		{SchemaVersion: StoredSessionSchemaVersion, SessionID: id2, LastActive: time.Unix(200, 0), Label: "newer", PaneCount: 2},
+	} {
+		data, _ := json.Marshal(fixture)
+		path := filepath.Join(sessions, hex.EncodeToString(fixture.SessionID[:])+".json")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	got, err := protocol.DecodeListSessionsResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Stored) != 2 {
+		t.Fatalf("expected 2 stored, got %d", len(got.Stored))
+	}
+	if got.Stored[0].Label != "newer" {
+		t.Errorf("expected newer first, got %q", got.Stored[0].Label)
+	}
+}
+
+func TestHandleRecoverSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xAA}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "rec-me",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	if err := os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, err := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: id})
+	if err != nil {
+		t.Fatalf("encode req: %v", err)
+	}
+	conn.send(protocol.MsgRecoverSession, body)
+	// Response should be a ConnectAccept with the recovered session ID.
+	resp := conn.expectResponse(t, protocol.MsgConnectAccept)
+	accept, err := protocol.DecodeConnectAccept(resp)
+	if err != nil {
+		t.Fatalf("decode accept: %v", err)
+	}
+	if accept.SessionID != id {
+		t.Fatalf("accept SessionID = %x, want %x", accept.SessionID, id)
+	}
+}
+
+func TestHandleRecoverSession_UnknownID(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: [16]byte{0xFF}})
+	conn.send(protocol.MsgRecoverSession, body)
+	// Server should respond with MsgError.
+	resp := conn.expectResponse(t, protocol.MsgError)
+	got, err := protocol.DecodeErrorFrame(resp)
+	if err != nil {
+		t.Fatalf("decode error frame: %v", err)
+	}
+	if got.Message == "" {
+		t.Errorf("expected non-empty error message")
+	}
+}
+
+func mustEncodeListSessionsRequest(t *testing.T) []byte {
+	t.Helper()
+	out, err := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return out
+}
+```
+
+`newPickerTestConn` is a helper to model after the existing memconn patterns. Inspect `internal/runtime/server/connection_rehydrate_resume_test.go` and `internal/runtime/server/testutil/memconn.go` and adapt the harness to drive the connection handler with arbitrary message types. If a similar helper already exists in the test corpus, reuse it. Otherwise, write a minimal helper here:
+
+```go
+// pickerTestConn wires a connection's writer half to a buffer the test
+// reads from. The connection runs handleMessage synchronously per
+// send.
+
+type pickerTestConn struct {
+	conn      *connection
+	clientEnd interface{ /* memconn-style read interface */ }
+	cleanupFn func()
+}
+
+func newPickerTestConn(t *testing.T, m *Manager) (*pickerTestConn, *nopSink) {
+	t.Helper()
+	// ... wire memconn pair, construct a connection bound to m,
+	// run a session via NewSession or attach one for testing
+	// ... return wrapper
+	return nil, nil
+}
+
+func (p *pickerTestConn) send(typ protocol.MessageType, payload []byte)        { /* ... */ }
+func (p *pickerTestConn) expectResponse(t *testing.T, want protocol.MessageType) []byte { /* ... */; return nil }
+func (p *pickerTestConn) cleanup()                                                  {}
+```
+
+When implementing this helper, refer to `connection_rehydrate_resume_test.go` lines that construct a connection with a memconn pair. Reuse the existing `nopSink` type already in the test files.
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestHandleListSessions|TestHandleRecoverSession" -count=1`
+Expected: FAIL — `MsgListSessions` not dispatched, no handler returns response.
+
+- [ ] **Step 3: Implement the handlers**
+
+Create `internal/runtime/server/connection_session_picker.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/connection_session_picker.go
+// Summary: Picker request handlers (Plan F.1) — listing, recovery,
+//   rename, delete, and lazy thumbnail fetch.
+
+package server
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func (c *connection) handleListSessions(payload []byte) error {
+	if _, err := protocol.DecodeListSessionsRequest(payload); err != nil {
+		return fmt.Errorf("decode list-sessions: %w", err)
+	}
+	resp := protocol.ListSessionsResponse{
+		Live:   c.manager.LiveSummaries(),
+		Stored: c.manager.StoredSummaries(),
+	}
+	body, err := protocol.EncodeListSessionsResponse(resp)
+	if err != nil {
+		return fmt.Errorf("encode list-sessions: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgListSessionsResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+func (c *connection) handleRecoverSession(payload []byte) error {
+	req, err := protocol.DecodeRecoverSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode recover-session: %w", err)
+	}
+	if req.NewLabel != "" {
+		if rerr := c.manager.RenameStored(req.SessionID, req.NewLabel); rerr != nil && !errors.Is(rerr, ErrSessionNotFound) {
+			return c.sendErrorFrame(rerr)
+		}
+	}
+	sess, _, err := c.manager.LookupOrRehydrate(req.SessionID)
+	if err != nil {
+		return c.sendErrorFrame(err)
+	}
+	c.session = sess
+	accept := protocol.ConnectAccept{
+		SessionID:       sess.ID(),
+		ResumeSupported: true,
+	}
+	body, err := protocol.EncodeConnectAccept(accept)
+	if err != nil {
+		return fmt.Errorf("encode accept: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgConnectAccept,
+		Flags:     protocol.FlagChecksum,
+		SessionID: sess.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+// sendErrorFrame is a small helper so picker handlers can surface an
+// error to the client without aborting the connection.
+func (c *connection) sendErrorFrame(err error) error {
+	body, encErr := protocol.EncodeErrorFrame(protocol.ErrorFrame{
+		Code:    1, // generic; picker errors don't need a code taxonomy in F.1
+		Message: err.Error(),
+	})
+	if encErr != nil {
+		return fmt.Errorf("encode error frame: %w", encErr)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgError,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+```
+
+Inspect `connection.go` for the actual `writeMessage` signature (it's already used by other handlers). The `connection` struct already exposes `manager` — verify by reading `connection.go`'s field declarations; if the field is named differently, adjust to match.
+
+In `internal/runtime/server/connection_handler.go`, dispatch the new message types. Add to the switch in `handleMessage` (before the `default:` case):
+
+```go
+case protocol.MsgListSessions:
+	if err := c.handleListSessions(payload); err != nil {
+		return fmt.Errorf("list sessions: %w", err)
+	}
+case protocol.MsgRecoverSession:
+	if err := c.handleRecoverSession(payload); err != nil {
+		return fmt.Errorf("recover session: %w", err)
+	}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestHandleListSessions|TestHandleRecoverSession" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/connection_session_picker.go internal/runtime/server/connection_session_picker_test.go internal/runtime/server/connection_handler.go
+git commit -m "Connection: list-sessions + recover-session handlers"
+```
+
+---
+
+### Task 12: Connection handlers — rename + delete + fetch-thumbnail
+
+**Files:**
+- Modify: `internal/runtime/server/connection_session_picker.go` (append handlers)
+- Modify: `internal/runtime/server/connection_handler.go` (dispatch)
+- Modify: `internal/runtime/server/connection_session_picker_test.go` (append tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/runtime/server/connection_session_picker_test.go`:
+
+```go
+func TestHandleRenameSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x10}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "before",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: id, NewLabel: "after"})
+	conn.send(protocol.MsgRenameSession, body)
+	// Server replies with SessionOpResponse.
+	// We piggy-back on MsgError-or-similar pattern; here we expect a
+	// dedicated MsgListSessionsResponse-shaped response. Adjust based
+	// on the implementation choice — the simplest is to reuse the
+	// MsgError envelope for ok=false and an empty MsgListSessions
+	// response for ok=true. To keep things explicit, the implementer
+	// should add a SessionOpResponse-typed reply: if a separate
+	// MessageType is desired, declare MsgSessionOpResponse in
+	// protocol/protocol.go now and update Task 1.
+	//
+	// Simpler in-scope choice: the handler responds via MsgError
+	// (for OK=false) or MsgListSessionsResponse with empty payload
+	// (for OK=true). We document this contract in the handler's
+	// docstring rather than adding another MessageType.
+	//
+	// Test asserts the in-memory rename took effect via a follow-up
+	// MsgListSessions request:
+	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	got, _ := protocol.DecodeListSessionsResponse(resp)
+	if len(got.Stored) != 1 || got.Stored[0].Label != "after" {
+		t.Fatalf("expected rename applied; got %#v", got.Stored)
+	}
+}
+
+func TestHandleDeleteSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x20}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeDeleteSessionRequest(protocol.DeleteSessionRequest{SessionID: id})
+	conn.send(protocol.MsgDeleteSession, body)
+	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	got, _ := protocol.DecodeListSessionsResponse(resp)
+	if len(got.Stored) != 0 {
+		t.Fatalf("expected empty after delete; got %d", len(got.Stored))
+	}
+}
+
+func TestHandleFetchThumbnail_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x30}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	pngPath := filepath.Join(sessions, hex.EncodeToString(id[:])+".png")
+	pngContent := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	os.WriteFile(pngPath, pngContent, 0o644)
+
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	got, err := protocol.DecodeFetchThumbnailResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("expected OK=true, got Error=%q", got.Error)
+	}
+	if string(got.PNG) != string(pngContent) {
+		t.Fatalf("PNG mismatch")
+	}
+}
+
+func TestHandleFetchThumbnail_Missing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: [16]byte{0x99}})
+	conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	got, _ := protocol.DecodeFetchThumbnailResponse(resp)
+	if got.OK {
+		t.Errorf("expected OK=false for missing PNG")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestHandleRenameSession|TestHandleDeleteSession|TestHandleFetchThumbnail" -count=1`
+Expected: FAIL — handlers undefined / not dispatched.
+
+- [ ] **Step 3: Implement handlers**
+
+Append to `internal/runtime/server/connection_session_picker.go`:
+
+```go
+// handleRenameSession applies an inline label edit. Replies with
+// MsgError on failure (OK=false implied) and an empty
+// MsgListSessionsResponse on success — this dual-purpose ack avoids
+// a dedicated MsgSessionOpResponse type while still letting the
+// client treat any non-error response as success.
+func (c *connection) handleRenameSession(payload []byte) error {
+	req, err := protocol.DecodeRenameSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode rename: %w", err)
+	}
+	if err := c.manager.RenameStored(req.SessionID, req.NewLabel); err != nil {
+		return c.sendErrorFrame(err)
+	}
+	return c.ackPickerOp()
+}
+
+func (c *connection) handleDeleteSession(payload []byte) error {
+	req, err := protocol.DecodeDeleteSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode delete: %w", err)
+	}
+	if err := c.manager.DeleteStored(req.SessionID); err != nil {
+		return c.sendErrorFrame(err)
+	}
+	return c.ackPickerOp()
+}
+
+func (c *connection) handleFetchThumbnail(payload []byte) error {
+	req, err := protocol.DecodeFetchThumbnailRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode fetch-thumb: %w", err)
+	}
+	pngPath := c.manager.sessionPNGPath(req.SessionID)
+	if pngPath == "" {
+		return c.sendThumbnailResponse(false, "persistence disabled", nil)
+	}
+	data, err := os.ReadFile(pngPath)
+	if err != nil {
+		return c.sendThumbnailResponse(false, err.Error(), nil)
+	}
+	return c.sendThumbnailResponse(true, "", data)
+}
+
+func (c *connection) sendThumbnailResponse(ok bool, errMsg string, png []byte) error {
+	body, err := protocol.EncodeFetchThumbnailResponse(protocol.FetchThumbnailResponse{
+		OK:    ok,
+		Error: errMsg,
+		PNG:   png,
+	})
+	if err != nil {
+		return fmt.Errorf("encode fetch-thumb response: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgFetchThumbnailResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+// ackPickerOp confirms a successful rename/delete by sending an empty
+// MsgListSessionsResponse. The picker treats any non-error response
+// as success and re-fires MsgListSessions to refresh its catalog.
+func (c *connection) ackPickerOp() error {
+	body, _ := protocol.EncodeListSessionsResponse(protocol.ListSessionsResponse{})
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgListSessionsResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+```
+
+Add `"os"` to the imports.
+
+In `connection_handler.go`, add the dispatch cases:
+
+```go
+case protocol.MsgRenameSession:
+	if err := c.handleRenameSession(payload); err != nil {
+		return fmt.Errorf("rename session: %w", err)
+	}
+case protocol.MsgDeleteSession:
+	if err := c.handleDeleteSession(payload); err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+case protocol.MsgFetchThumbnail:
+	if err := c.handleFetchThumbnail(payload); err != nil {
+		return fmt.Errorf("fetch thumbnail: %w", err)
+	}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestHandleRenameSession|TestHandleDeleteSession|TestHandleFetchThumbnail" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/connection_session_picker.go internal/runtime/server/connection_session_picker_test.go internal/runtime/server/connection_handler.go
+git commit -m "Connection: rename/delete/fetch-thumbnail picker handlers"
+```
+
+---
+
+### Task 13: Picker — ASCII layout algorithm (pure functions)
+
+**Files:**
+- Create: `cmd/texelation/boot/picker_ascii.go`
+- Test: `cmd/texelation/boot/picker_ascii_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cmd/texelation/boot/picker_ascii_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestRenderASCIILayout_SinglePane(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{PaneIndex: 0, Split: protocol.SplitNone}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	if len(grid) != 8 || len(grid[0]) != 20 {
+		t.Fatalf("dims = %dx%d, want 20x8", len(grid[0]), len(grid))
+	}
+	// Top-left corner, top-right corner, bottom-left, bottom-right.
+	if grid[0][0] != '┌' {
+		t.Errorf("top-left = %q, want ┌", grid[0][0])
+	}
+	if grid[0][19] != '┐' {
+		t.Errorf("top-right = %q, want ┐", grid[0][19])
+	}
+	if grid[7][0] != '└' {
+		t.Errorf("bottom-left = %q, want └", grid[7][0])
+	}
+	if grid[7][19] != '┘' {
+		t.Errorf("bottom-right = %q, want ┘", grid[7][19])
+	}
+}
+
+func TestRenderASCIILayout_HorizontalSplit(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	// Find the divider row — should have horizontal lines spanning
+	// the inner area.
+	dividerCount := 0
+	for y := 1; y < 7; y++ {
+		// horizontal split has a horizontal line at the split row
+		row := string(grid[y])
+		if strings.Count(row, "─") > 5 {
+			dividerCount++
+		}
+	}
+	if dividerCount == 0 {
+		t.Errorf("expected at least one horizontal divider row in:\n%s", debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_VerticalSplit(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitVertical,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 8, root)
+	// Vertical split should put a vertical line near the middle column.
+	verticalAtMid := 0
+	for y := 1; y < 7; y++ {
+		mid := 10
+		if grid[y][mid] == '│' {
+			verticalAtMid++
+		}
+	}
+	if verticalAtMid == 0 {
+		t.Errorf("expected vertical divider near col 10 in:\n%s", debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_NilRoot(t *testing.T) {
+	grid := renderASCIILayoutGrid(20, 8, nil)
+	// Should still draw a single bordered box.
+	if grid[0][0] != '┌' {
+		t.Errorf("nil root should fall back to single box; got %q at top-left", grid[0][0])
+	}
+}
+
+func TestRenderASCIILayout_BelowMinSize(t *testing.T) {
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.5, 0.5},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(6, 3, root)
+	// 6×3 is below the recursive split threshold; should fall back
+	// to single-box rendering of the outer container.
+	if grid[0][0] != '┌' {
+		t.Errorf("expected single-box fallback")
+	}
+}
+
+func debugGrid(grid [][]rune) string {
+	var b strings.Builder
+	for _, row := range grid {
+		b.WriteString(string(row))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestRenderASCIILayout" -count=1`
+Expected: FAIL — `renderASCIILayoutGrid` undefined.
+
+- [ ] **Step 3: Implement the algorithm**
+
+Create `cmd/texelation/boot/picker_ascii.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_ascii.go
+// Summary: Pure-function tree-snapshot to box-drawing characters.
+// Used as the fallback render path for thumbnails on terminals
+// without graphics support, and as the placeholder while a Kitty
+// thumbnail fetch is in flight.
+
+package boot
+
+import "github.com/framegrace/texelation/protocol"
+
+const (
+	asciiMinW = 8
+	asciiMinH = 4
+)
+
+// renderASCIILayoutGrid returns a (h × w) rune matrix containing the
+// box-drawing representation of root. Sub-minimum-size rects collapse
+// to a single bordered box; nil roots also fall back to a single box
+// so callers don't have to special-case missing layouts.
+func renderASCIILayoutGrid(w, h int, root *protocol.TreeNodeSnapshot) [][]rune {
+	grid := makeBlankGrid(w, h)
+	if root == nil || w < asciiMinW || h < asciiMinH {
+		drawSingleBox(grid, 0, 0, w, h)
+		return grid
+	}
+	drawNode(grid, 0, 0, w, h, root)
+	return grid
+}
+
+func makeBlankGrid(w, h int) [][]rune {
+	grid := make([][]rune, h)
+	for y := 0; y < h; y++ {
+		grid[y] = make([]rune, w)
+		for x := 0; x < w; x++ {
+			grid[y][x] = ' '
+		}
+	}
+	return grid
+}
+
+func drawNode(grid [][]rune, x, y, w, h int, n *protocol.TreeNodeSnapshot) {
+	if n.Split == protocol.SplitNone || len(n.Children) < 2 || w < asciiMinW || h < asciiMinH {
+		drawSingleBox(grid, x, y, w, h)
+		return
+	}
+	if n.Split == protocol.SplitHorizontal {
+		// Top child gets ratio[0]; bottom gets ratio[1].
+		r := splitRatio(n.SplitRatios)
+		topH := int(float32(h) * r)
+		if topH < asciiMinH {
+			topH = asciiMinH
+		}
+		if topH > h-asciiMinH {
+			topH = h - asciiMinH
+		}
+		drawNode(grid, x, y, w, topH, &n.Children[0])
+		drawNode(grid, x, y+topH-1, w, h-topH+1, &n.Children[1])
+		return
+	}
+	// Vertical split: left ratio[0], right ratio[1].
+	r := splitRatio(n.SplitRatios)
+	leftW := int(float32(w) * r)
+	if leftW < asciiMinW {
+		leftW = asciiMinW
+	}
+	if leftW > w-asciiMinW {
+		leftW = w - asciiMinW
+	}
+	drawNode(grid, x, y, leftW, h, &n.Children[0])
+	drawNode(grid, x+leftW-1, y, w-leftW+1, h, &n.Children[1])
+}
+
+func splitRatio(ratios []float32) float32 {
+	if len(ratios) < 1 {
+		return 0.5
+	}
+	return ratios[0]
+}
+
+func drawSingleBox(grid [][]rune, x, y, w, h int) {
+	if w < 2 || h < 2 {
+		return
+	}
+	maxY := y + h - 1
+	maxX := x + w - 1
+	for cy := y; cy <= maxY; cy++ {
+		for cx := x; cx <= maxX; cx++ {
+			if cy < 0 || cy >= len(grid) || cx < 0 || cx >= len(grid[cy]) {
+				continue
+			}
+			switch {
+			case cy == y && cx == x:
+				grid[cy][cx] = '┌'
+			case cy == y && cx == maxX:
+				grid[cy][cx] = '┐'
+			case cy == maxY && cx == x:
+				grid[cy][cx] = '└'
+			case cy == maxY && cx == maxX:
+				grid[cy][cx] = '┘'
+			case cy == y || cy == maxY:
+				if grid[cy][cx] == ' ' {
+					grid[cy][cx] = '─'
+				}
+			case cx == x || cx == maxX:
+				if grid[cy][cx] == ' ' {
+					grid[cy][cx] = '│'
+				}
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestRenderASCIILayout" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/texelation/boot/picker_ascii.go cmd/texelation/boot/picker_ascii_test.go
+git commit -m "Picker: ASCII tree-layout fallback render"
+```
+
+---
+
+### Task 14: Picker — state machine, navigation, render
+
+**Files:**
+- Create: `cmd/texelation/boot/picker.go`
+- Create: `cmd/texelation/boot/picker_input.go`
+- Create: `cmd/texelation/boot/picker_render.go`
+- Test: `cmd/texelation/boot/picker_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `cmd/texelation/boot/picker_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/framegrace/texelation/protocol"
+)
+
+func TestPicker_RendersStoredCards(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	p := NewPicker(screen, &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "alpha", LastActive: 100, PaneCount: 1},
+				{SessionID: [16]byte{0x02}, Label: "beta", LastActive: 50, PaneCount: 2},
+			},
+		},
+	})
+	p.RefreshCatalog()
+	p.Render()
+	contents, w, h := screenContents(screen)
+	body := contentsToString(contents, w, h)
+	if !contains(body, "alpha") {
+		t.Errorf("expected 'alpha' in render:\n%s", body)
+	}
+	if !contains(body, "beta") {
+		t.Errorf("expected 'beta' in render:\n%s", body)
+	}
+}
+
+func TestPicker_NavigationDown(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	p := NewPicker(screen, &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "first"},
+				{SessionID: [16]byte{0x02}, Label: "second"},
+			},
+		},
+	})
+	p.RefreshCatalog()
+	if got := p.SelectedIdx(); got != 0 {
+		t.Fatalf("initial selectedIdx = %d, want 0", got)
+	}
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if got := p.SelectedIdx(); got != 1 {
+		t.Fatalf("after down: selectedIdx = %d, want 1", got)
+	}
+	// Beyond the end clamps.
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if got := p.SelectedIdx(); got != 1 {
+		t.Errorf("clamp: selectedIdx = %d, want 1", got)
+	}
+}
+
+func TestPicker_EnterDispatchesRecover(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0xCC}, Label: "pickme"},
+			},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(tcell.KeyEnter, 0, 0)
+	if !fc.recoverCalled {
+		t.Errorf("expected RecoverSession dispatch on Enter")
+	}
+	if fc.recoverID != [16]byte{0xCC} {
+		t.Errorf("recoverID = %x, want CC", fc.recoverID)
+	}
+}
+
+func TestPicker_NewKeyDispatchesNew(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{response: protocol.ListSessionsResponse{}}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(0, 'n', 0)
+	if !fc.newCalled {
+		t.Errorf("expected fresh-session dispatch on 'n'")
+	}
+}
+
+// fakeClient stubs the picker's network transport for tests.
+type fakeClient struct {
+	response       protocol.ListSessionsResponse
+	recoverCalled  bool
+	recoverID      [16]byte
+	newCalled      bool
+}
+
+func (f *fakeClient) ListSessions() (protocol.ListSessionsResponse, error) {
+	return f.response, nil
+}
+func (f *fakeClient) RecoverSession(id [16]byte, newLabel string) error {
+	f.recoverCalled = true
+	f.recoverID = id
+	return nil
+}
+func (f *fakeClient) RenameSession(id [16]byte, newLabel string) error { return nil }
+func (f *fakeClient) DeleteSession(id [16]byte) error                  { return nil }
+func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error)       { return nil, nil }
+func (f *fakeClient) StartFreshSession() {
+	f.newCalled = true
+}
+
+// helpers
+func screenContents(s tcell.SimulationScreen) ([]tcell.SimCell, int, int) {
+	cells, w, h := s.GetContents()
+	return cells, w, h
+}
+
+func contentsToString(cells []tcell.SimCell, w, h int) string {
+	var b []byte
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			c := cells[y*w+x]
+			if len(c.Runes) > 0 {
+				b = append(b, []byte(string(c.Runes[0]))...)
+			} else {
+				b = append(b, ' ')
+			}
+		}
+		b = append(b, '\n')
+	}
+	return string(b)
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && (indexOf(s, sub) != -1))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1`
+Expected: FAIL — Picker undefined.
+
+- [ ] **Step 3: Implement the picker**
+
+Create `cmd/texelation/boot/picker.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker.go
+// Summary: Stored-session recovery picker UI (issue #199 Plan F.1).
+// Owns the tcell screen for the duration of the user's selection;
+// hands off to the splash + clientrt pipeline once a choice is made.
+
+package boot
+
+import (
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// PickerClient is the network surface the picker needs. The boot
+// runner constructs a real implementation against the unix socket;
+// tests inject a fake.
+type PickerClient interface {
+	ListSessions() (protocol.ListSessionsResponse, error)
+	RecoverSession(id [16]byte, newLabel string) error
+	RenameSession(id [16]byte, newLabel string) error
+	DeleteSession(id [16]byte) error
+	FetchThumbnail(id [16]byte) ([]byte, error)
+	StartFreshSession()
+}
+
+type pickerMode int
+
+const (
+	modeBrowse pickerMode = iota
+	modeRename
+	modeDeleteConfirm
+)
+
+type pickerTab int
+
+const (
+	tabLive pickerTab = iota
+	tabStored
+)
+
+// Picker holds the picker's runtime state.
+type Picker struct {
+	screen tcell.Screen
+	client PickerClient
+
+	response    protocol.ListSessionsResponse
+	activeTab   pickerTab
+	selectedIdx int
+	mode        pickerMode
+
+	renameBuf []rune
+
+	thumbCache map[[16]byte][]byte
+	pending    map[[16]byte]bool
+
+	done   bool
+	choice pickerChoice
+}
+
+type pickerChoice int
+
+const (
+	choiceNone pickerChoice = iota
+	choiceRecover
+	choiceFresh
+	choiceQuit
+)
+
+// NewPicker returns a picker bound to screen + client. Call
+// RefreshCatalog before Render so the response is populated.
+func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
+	return &Picker{
+		screen:     screen,
+		client:     client,
+		activeTab:  tabStored,
+		mode:       modeBrowse,
+		thumbCache: make(map[[16]byte][]byte),
+		pending:    make(map[[16]byte]bool),
+	}
+}
+
+// RefreshCatalog fetches the catalog from the server.
+func (p *Picker) RefreshCatalog() {
+	resp, err := p.client.ListSessions()
+	if err != nil {
+		p.response = protocol.ListSessionsResponse{}
+		return
+	}
+	p.response = resp
+	if p.selectedIdx >= len(p.response.Stored) {
+		p.selectedIdx = 0
+	}
+}
+
+// SelectedIdx returns the currently highlighted index in the active
+// tab's session list. Exposed for tests.
+func (p *Picker) SelectedIdx() int { return p.selectedIdx }
+
+// Done reports whether the picker has chosen an action; the caller's
+// run loop should exit when true.
+func (p *Picker) Done() bool { return p.done }
+
+// Choice returns what the user picked once Done() is true.
+func (p *Picker) Choice() pickerChoice { return p.choice }
+```
+
+Create `cmd/texelation/boot/picker_input.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import "github.com/gdamore/tcell/v2"
+
+// HandleKey routes a tcell key event through the picker's mode-aware
+// state machine. Tests call this directly; the run loop wraps real
+// EventKey events.
+func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
+	if p.mode == modeRename {
+		p.handleRenameKey(key, ch)
+		return
+	}
+	if p.mode == modeDeleteConfirm {
+		p.handleDeleteConfirmKey(key, ch)
+		return
+	}
+	switch key {
+	case tcell.KeyUp:
+		if p.selectedIdx > 0 {
+			p.selectedIdx--
+		}
+	case tcell.KeyDown:
+		if p.selectedIdx < len(p.response.Stored)-1 {
+			p.selectedIdx++
+		}
+	case tcell.KeyEnter:
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			_ = p.client.RecoverSession(id, "")
+			p.done = true
+			p.choice = choiceRecover
+		}
+		return
+	case tcell.KeyTab:
+		if p.activeTab == tabStored {
+			p.activeTab = tabLive
+		} else {
+			p.activeTab = tabStored
+		}
+		return
+	case tcell.KeyEsc:
+		p.done = true
+		p.choice = choiceQuit
+		return
+	default:
+	}
+	switch ch {
+	case 'j':
+		if p.selectedIdx < len(p.response.Stored)-1 {
+			p.selectedIdx++
+		}
+	case 'k':
+		if p.selectedIdx > 0 {
+			p.selectedIdx--
+		}
+	case 'n':
+		p.client.StartFreshSession()
+		p.done = true
+		p.choice = choiceFresh
+	case 'r':
+		if len(p.response.Stored) > 0 {
+			p.mode = modeRename
+			p.renameBuf = []rune(p.response.Stored[p.selectedIdx].Label)
+		}
+	case 'd':
+		if len(p.response.Stored) > 0 {
+			p.mode = modeDeleteConfirm
+		}
+	case 'q':
+		p.done = true
+		p.choice = choiceQuit
+	}
+}
+
+func (p *Picker) handleRenameKey(key tcell.Key, ch rune) {
+	switch key {
+	case tcell.KeyEsc:
+		p.mode = modeBrowse
+		p.renameBuf = nil
+		return
+	case tcell.KeyEnter:
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			newLabel := string(p.renameBuf)
+			if err := p.client.RenameSession(id, newLabel); err == nil {
+				p.response.Stored[p.selectedIdx].Label = newLabel
+			}
+		}
+		p.mode = modeBrowse
+		p.renameBuf = nil
+		return
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		if len(p.renameBuf) > 0 {
+			p.renameBuf = p.renameBuf[:len(p.renameBuf)-1]
+		}
+		return
+	}
+	if ch != 0 {
+		p.renameBuf = append(p.renameBuf, ch)
+	}
+}
+
+func (p *Picker) handleDeleteConfirmKey(key tcell.Key, ch rune) {
+	switch ch {
+	case 'y', 'Y':
+		if len(p.response.Stored) > 0 {
+			id := p.response.Stored[p.selectedIdx].SessionID
+			if err := p.client.DeleteSession(id); err == nil {
+				// Drop the entry locally so the cursor position
+				// stays meaningful even if we don't refresh.
+				p.response.Stored = append(p.response.Stored[:p.selectedIdx], p.response.Stored[p.selectedIdx+1:]...)
+				if p.selectedIdx >= len(p.response.Stored) && p.selectedIdx > 0 {
+					p.selectedIdx--
+				}
+			}
+		}
+		p.mode = modeBrowse
+	case 'n', 'N':
+		p.mode = modeBrowse
+	}
+	if key == tcell.KeyEsc {
+		p.mode = modeBrowse
+	}
+}
+```
+
+Create `cmd/texelation/boot/picker_render.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+const (
+	cardThumbW = 22
+	cardThumbH = 8
+	cardGap    = 1
+)
+
+// Render paints the picker to the screen. The caller is responsible
+// for calling screen.Show() / screen.Sync() afterwards.
+func (p *Picker) Render() {
+	w, h := p.screen.Size()
+	p.clear(w, h)
+	p.drawHeader(w)
+	p.drawTabs(w)
+	p.drawCards(w, h)
+	p.drawActionBar(w, h)
+	if p.mode == modeRename {
+		p.drawRenameOverlay(w, h)
+	}
+	if p.mode == modeDeleteConfirm {
+		p.drawDeleteConfirmOverlay(w, h)
+	}
+	p.screen.Show()
+}
+
+func (p *Picker) clear(w, h int) {
+	bg := tcell.StyleDefault
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			p.screen.SetContent(x, y, ' ', nil, bg)
+		}
+	}
+}
+
+func (p *Picker) drawHeader(w int) {
+	style := tcell.StyleDefault.Bold(true)
+	title := "texelation — recover session"
+	startX := (w - len(title)) / 2
+	if startX < 0 {
+		startX = 0
+	}
+	for i, r := range title {
+		p.screen.SetContent(startX+i, 0, r, nil, style)
+	}
+}
+
+func (p *Picker) drawTabs(w int) {
+	live := fmt.Sprintf("[ Live (%d) ]", len(p.response.Live))
+	stored := fmt.Sprintf("[ Stored (%d) ]", len(p.response.Stored))
+	x := 2
+	for i, r := range live {
+		style := tcell.StyleDefault.Foreground(tcell.ColorGray)
+		if p.activeTab == tabLive {
+			style = tcell.StyleDefault.Bold(true)
+		}
+		p.screen.SetContent(x+i, 2, r, nil, style)
+	}
+	x += len(live) + 2
+	for i, r := range stored {
+		style := tcell.StyleDefault.Foreground(tcell.ColorGray)
+		if p.activeTab == tabStored {
+			style = tcell.StyleDefault.Bold(true)
+		}
+		p.screen.SetContent(x+i, 2, r, nil, style)
+	}
+}
+
+func (p *Picker) drawCards(w, h int) {
+	if p.activeTab != tabStored {
+		return // Live tab empty in F.1
+	}
+	startY := 4
+	for i, summary := range p.response.Stored {
+		cardY := startY + i*(cardThumbH+cardGap)
+		if cardY+cardThumbH+cardGap > h-2 {
+			break
+		}
+		p.drawCard(2, cardY, summary, i == p.selectedIdx)
+	}
+}
+
+func (p *Picker) drawCard(x, y int, s protocol.SessionSummary, selected bool) {
+	bgStyle := tcell.StyleDefault
+	if selected {
+		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
+	}
+	// Thumbnail box (ASCII fallback for now; Kitty render added in Task 15)
+	grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
+	for cy := 0; cy < cardThumbH; cy++ {
+		for cx := 0; cx < cardThumbW; cx++ {
+			p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
+		}
+	}
+	// Metadata column
+	metaX := x + cardThumbW + 2
+	p.drawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
+	p.drawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
+	p.drawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
+	p.drawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
+	if s.Pinned {
+		p.drawText(metaX, y+4, "Pinned:  ★", bgStyle)
+	}
+}
+
+func (p *Picker) drawActionBar(w, h int) {
+	bar := "[Enter] recover   [n] new   [r] rename   [d] delete   [q] quit"
+	style := tcell.StyleDefault.Foreground(tcell.ColorGray)
+	startX := (w - len(bar)) / 2
+	if startX < 0 {
+		startX = 0
+	}
+	for i, r := range bar {
+		p.screen.SetContent(startX+i, h-2, r, nil, style)
+	}
+}
+
+func (p *Picker) drawRenameOverlay(w, h int) {
+	prompt := fmt.Sprintf("Rename: %s", string(p.renameBuf))
+	style := tcell.StyleDefault.Bold(true)
+	for i, r := range prompt {
+		p.screen.SetContent(2+i, h-4, r, nil, style)
+	}
+}
+
+func (p *Picker) drawDeleteConfirmOverlay(w, h int) {
+	if len(p.response.Stored) == 0 {
+		return
+	}
+	prompt := fmt.Sprintf("Delete '%s'? [y/N]", labelOrUntitled(p.response.Stored[p.selectedIdx].Label))
+	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
+	for i, r := range prompt {
+		p.screen.SetContent(2+i, h-4, r, nil, style)
+	}
+}
+
+func (p *Picker) drawText(x, y int, s string, style tcell.Style) {
+	for i, r := range s {
+		p.screen.SetContent(x+i, y, r, nil, style)
+	}
+}
+
+func labelOrUntitled(s string) string {
+	if s == "" {
+		return "Untitled"
+	}
+	return s
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}
+
+func relativeTime(unixSec int64) string {
+	if unixSec == 0 {
+		return "—"
+	}
+	d := time.Since(time.Unix(unixSec, 0))
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%d min ago", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%d h ago", int(d/time.Hour))
+	default:
+		return fmt.Sprintf("%d days ago", int(d/(24*time.Hour)))
+	}
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/texelation/boot/picker.go cmd/texelation/boot/picker_input.go cmd/texelation/boot/picker_render.go cmd/texelation/boot/picker_test.go
+git commit -m "Picker: state machine, navigation, render"
+```
+
+---
+
+### Task 15: Picker — Kitty thumbnail rendering + lazy fetch
+
+**Files:**
+- Create: `cmd/texelation/boot/picker_thumbnail.go`
+- Modify: `cmd/texelation/boot/picker.go` (wire kitty + hasGraphics flag)
+- Modify: `cmd/texelation/boot/picker_render.go` (route through `renderThumbnail`)
+- Modify: `cmd/texelation/boot/picker_test.go` (test the upgrade path)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `cmd/texelation/boot/picker_test.go`:
+
+```go
+func TestPicker_FetchThumbnailUpgradesCard(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	id := [16]byte{0xEE}
+	pngBytes := []byte("fake-png-bytes")
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: id, Label: "graphics", HasThumbnail: true},
+			},
+		},
+		thumbBytes: pngBytes,
+	}
+	p := NewPicker(screen, fc)
+	p.SetGraphicsCapable(true)
+	p.RefreshCatalog()
+	// Initial render should ASCII-fallback while fetching.
+	p.Render()
+	// Allow the fetch goroutine to deliver.
+	for i := 0; i < 100; i++ {
+		if cached, _ := p.thumbCache[id]; cached != nil {
+			break
+		}
+		// short busy-wait — production code would drive p.Render() on
+		// each tick; tests just nudge.
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got, ok := p.thumbCache[id]; !ok || string(got) != string(pngBytes) {
+		t.Errorf("expected thumbCache populated; got=%q ok=%v", got, ok)
+	}
+	if !fc.fetchCalled {
+		t.Errorf("expected FetchThumbnail dispatch")
+	}
+}
+
+func TestPicker_NoFetchWhenGraphicsAbsent(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0x10}, HasThumbnail: true}},
+		},
+		thumbBytes: []byte("nope"),
+	}
+	p := NewPicker(screen, fc)
+	p.SetGraphicsCapable(false)
+	p.RefreshCatalog()
+	p.Render()
+	time.Sleep(20 * time.Millisecond)
+	if fc.fetchCalled {
+		t.Errorf("did not expect FetchThumbnail dispatch on text-only terminal")
+	}
+}
+```
+
+Update the `fakeClient` definition at the bottom of the test file (in the same Task 14 block) to support thumbnail fetches:
+
+```go
+type fakeClient struct {
+	response      protocol.ListSessionsResponse
+	recoverCalled bool
+	recoverID     [16]byte
+	newCalled     bool
+	fetchCalled   bool
+	thumbBytes    []byte
+}
+
+func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
+	f.fetchCalled = true
+	return f.thumbBytes, nil
+}
+```
+
+Add `"time"` to imports if not present.
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_FetchThumbnailUpgradesCard|TestPicker_NoFetchWhenGraphicsAbsent" -count=1`
+Expected: FAIL — `SetGraphicsCapable` and `thumbCache` not exposed.
+
+- [ ] **Step 3: Implement the thumbnail dispatcher**
+
+Create `cmd/texelation/boot/picker_thumbnail.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_thumbnail.go
+// Summary: Kitty thumbnail rendering + lazy fetch for the picker.
+// Falls back to the ASCII layout when graphics are unavailable or
+// the fetch is still in flight.
+
+package boot
+
+// SetGraphicsCapable tells the picker whether to dispatch
+// FetchThumbnail requests + render Kitty images. False keeps the
+// ASCII fallback exclusively (no network traffic for thumbnails).
+func (p *Picker) SetGraphicsCapable(b bool) {
+	p.hasGraphics = b
+}
+
+// maybeFetchThumbnail kicks off a non-blocking fetch for id if we
+// haven't cached or pending one already. Called from the render
+// loop's per-card pass.
+func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
+	if !p.hasGraphics || !hasThumb {
+		return
+	}
+	if _, cached := p.thumbCache[id]; cached {
+		return
+	}
+	if p.pending[id] {
+		return
+	}
+	p.pending[id] = true
+	go func(targetID [16]byte) {
+		data, err := p.client.FetchThumbnail(targetID)
+		if err != nil || len(data) == 0 {
+			return
+		}
+		p.mu.Lock()
+		p.thumbCache[targetID] = data
+		delete(p.pending, targetID)
+		p.mu.Unlock()
+	}(id)
+}
+```
+
+Add a `mu sync.Mutex` and `hasGraphics bool` to the `Picker` struct in `picker.go`. Update render code in `picker_render.go` so the per-card draw calls `p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)` before rendering, and reads from `p.thumbCache` under the mutex when graphics-capable. The actual Kitty image emission stays minimal in F.1: when a cached PNG is present, draw a placeholder block character into the thumbnail rect (so the test can detect "upgraded" via a non-ASCII pattern); the full Kitty escape-sequence path is out of scope for the unit test, since SimulationScreen doesn't model the Kitty protocol.
+
+Add to the top of `drawCard`:
+
+```go
+p.mu.Lock()
+cached := p.thumbCache[s.SessionID]
+p.mu.Unlock()
+if cached != nil && p.hasGraphics {
+	// Draw a "graphics here" placeholder so tests can distinguish
+	// an upgraded card from the ASCII fallback. Real Kitty emission
+	// is wired in via state.kitty when the picker hands off — for
+	// the unit-test scope, this marker is sufficient.
+	for cy := 0; cy < cardThumbH; cy++ {
+		for cx := 0; cx < cardThumbW; cx++ {
+			p.screen.SetContent(x+cx, y+cy, '▓', nil, bgStyle)
+		}
+	}
+	// Metadata still rendered below.
+} else {
+	grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
+	for cy := 0; cy < cardThumbH; cy++ {
+		for cx := 0; cx < cardThumbW; cx++ {
+			p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
+		}
+	}
+}
+p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
+```
+
+(Replace the existing thumbnail block in `drawCard` with the conditional above.)
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/texelation/boot/picker_thumbnail.go cmd/texelation/boot/picker.go cmd/texelation/boot/picker_render.go cmd/texelation/boot/picker_test.go
+git commit -m "Picker: lazy thumbnail fetch + Kitty placeholder render"
+```
+
+---
+
+### Task 16: boot.Run integration — trigger logic + handoff
+
+**Files:**
+- Modify: `cmd/texelation/main.go` (add `--recover` flag, picker activation)
+- Create: `cmd/texelation/boot/picker_runner.go` (orchestrates picker + client transport)
+- Test: manual smoke test (no automated integration test in this task)
+
+- [ ] **Step 1: Add `--recover` flag**
+
+In `cmd/texelation/main.go` flag parsing block, add:
+
+```go
+recoverFlag := fs.Bool("recover", false, "Show the session-recovery picker even if client state is intact")
+```
+
+Pipe it through `clientrt.Options`:
+
+```go
+// Add to clientrt.Options struct in app.go (Task 14 of Plan D2 already
+// landed; Plan F.1 extends with):
+ShowRecoverPicker bool
+
+// Wire from main.go:
+clientOpts.ShowRecoverPicker = *recoverFlag
+```
+
+- [ ] **Step 2: Implement the picker runner**
+
+Create `cmd/texelation/boot/picker_runner.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_runner.go
+// Summary: Connect the picker to the texelation socket and run its
+// event loop until the user picks. Returns the chosen action so the
+// caller can decide how to proceed (recover -> normal connect path,
+// fresh -> fresh-session path, quit -> exit).
+
+package boot
+
+import (
+	"github.com/gdamore/tcell/v2"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// PickerOutcome captures what the user picked.
+type PickerOutcome struct {
+	Choice    pickerChoice
+	SessionID [16]byte // populated when Choice == choiceRecover
+}
+
+// RunPicker drives the picker against client until the user makes a
+// selection. Returns the outcome; callers translate it to a connect
+// path. The screen is shared with the splash and clientrt; this
+// function does not call Init/Fini.
+func RunPicker(screen tcell.Screen, client PickerClient, hasGraphics bool) (PickerOutcome, error) {
+	p := NewPicker(screen, client)
+	p.SetGraphicsCapable(hasGraphics)
+	p.RefreshCatalog()
+
+	for !p.Done() {
+		p.Render()
+		ev := screen.PollEvent()
+		switch e := ev.(type) {
+		case *tcell.EventKey:
+			p.HandleKey(e.Key(), e.Rune(), e.Modifiers())
+		case *tcell.EventResize:
+			screen.Sync()
+		case *tcell.EventInterrupt:
+			return PickerOutcome{Choice: choiceQuit}, nil
+		}
+	}
+
+	out := PickerOutcome{Choice: p.choice}
+	if p.choice == choiceRecover && len(p.response.Stored) > 0 {
+		out.SessionID = p.response.Stored[p.selectedIdx].SessionID
+	}
+	_ = protocol.Version // keep protocol import live in case future fields need it
+	return out, nil
+}
+```
+
+- [ ] **Step 3: Wire trigger logic into `handleUnifiedMode`**
+
+In `cmd/texelation/main.go` `handleUnifiedMode`, after `supervisor.EnsureRunning` but before constructing `clientOpts.Screen`, add the picker activation block:
+
+```go
+// Plan F.1: show the recovery picker when (a) the user passed
+// --recover, OR (b) we have no persisted client state AND the server
+// has stored sessions to offer.
+//
+// We construct a lightweight protocol client to fetch the catalog;
+// if there's nothing to show, fall through to the ordinary connect
+// path. The picker reuses the splash's tcell screen so the handoff
+// is flicker-free.
+shouldShowPicker := clientOpts.ShowRecoverPicker
+if !shouldShowPicker {
+	hasState := clientStateExists(clientOpts) // helper below
+	if !hasState {
+		// Quick probe: does the server have stored sessions?
+		probe, err := boot.ProbeStoredSessions(clientOpts.Socket)
+		if err == nil && probe > 0 {
+			shouldShowPicker = true
+		}
+	}
+}
+if shouldShowPicker {
+	splashApp.SetStage(boot.StageStarting)
+	splashApp.SetDetail("Loading session list…")
+	splashRunner.Wake()
+	pickerClient, err := boot.NewSocketPickerClient(clientOpts.Socket)
+	if err != nil {
+		log.Printf("picker: socket client setup failed: %v; skipping picker", err)
+	} else {
+		stopSplash()
+		outcome, err := boot.RunPicker(screen, pickerClient, graphics.DetectCapability() == texelcore.GraphicsKitty)
+		_ = pickerClient.Close()
+		if err != nil {
+			log.Printf("picker: %v; falling back to fresh session", err)
+		} else {
+			switch outcome.Choice {
+			case boot.PickerChoiceRecover:
+				clientOpts.RecoverSessionID = outcome.SessionID
+			case boot.PickerChoiceFresh:
+				// fall through to ordinary connect path
+			case boot.PickerChoiceQuit:
+				return nil
+			}
+		}
+		// Restart the splash so clientrt's status callbacks have
+		// somewhere to render. Cleaner alternative would be to
+		// thread directly into clientrt; for F.1 we accept the
+		// splash restart.
+		splashApp = boot.New("Texelation")
+		splashRunner = boot.NewRunner(screen, splashApp)
+		splashRunner.Start()
+		splashStopped = false
+	}
+}
+```
+
+Helper `clientStateExists`:
+
+```go
+// clientStateExists is a thin wrapper: if Plan D's persistence path
+// resolves AND the file is present and non-empty, return true. Used
+// only for the picker-trigger heuristic.
+func clientStateExists(opts clientrt.Options) bool {
+	path, err := clientrt.ResolvePath(opts.Socket, opts.ClientName)
+	if err != nil || path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.Size() == 0 {
+		return false
+	}
+	return true
+}
+```
+
+In `boot/picker_runner.go`, expose the choice constants publicly so main.go can reference them:
+
+```go
+// Public re-exports for the choice constants (private constants
+// declared in picker.go).
+const (
+	PickerChoiceNone    = choiceNone
+	PickerChoiceRecover = choiceRecover
+	PickerChoiceFresh   = choiceFresh
+	PickerChoiceQuit    = choiceQuit
+)
+```
+
+- [ ] **Step 4: Implement the socket picker client + probe**
+
+Create the `boot.SocketPickerClient` and `boot.ProbeStoredSessions` helpers. They wrap a thin protocol-level handshake:
+
+```go
+// Append to cmd/texelation/boot/picker_runner.go (or split into
+// cmd/texelation/boot/picker_client.go if the file grows).
+
+// ProbeStoredSessions performs a minimal handshake over the socket and
+// asks for the stored-session count. Returns the number of stored
+// sessions or an error. Used by the trigger logic to decide whether
+// to show the picker.
+func ProbeStoredSessions(socket string) (int, error) {
+	// Implementation hint: this can either reuse the existing
+	// `client.SimpleClient` to perform Hello/Welcome, or open a raw
+	// connection and send Hello + a zero-payload MsgListSessions.
+	// The texelation client in client/simple_client.go already has
+	// a connect helper; piggy-back on it.
+	//
+	// Pseudocode:
+	//   conn := dial(socket)
+	//   write Hello with random ClientID
+	//   read Welcome
+	//   write MsgListSessions
+	//   read MsgListSessionsResponse
+	//   decode and return len(resp.Stored)
+	//
+	// Implementor: write the actual code following the existing
+	// patterns in client/simple_client.go.
+	return 0, nil
+}
+
+// NewSocketPickerClient returns a PickerClient that wraps a real
+// protocol connection to the texelation socket.
+func NewSocketPickerClient(socket string) (*SocketPickerClient, error) {
+	// Implementor: dial the socket, run Hello/Welcome handshake,
+	// store the conn + writer for use in the PickerClient methods.
+	return &SocketPickerClient{}, nil
+}
+
+// SocketPickerClient implements PickerClient against a live socket.
+type SocketPickerClient struct {
+	// fields: conn, writer, sessionID, etc.
+}
+
+func (s *SocketPickerClient) ListSessions() (protocol.ListSessionsResponse, error)        { /* ... */ return protocol.ListSessionsResponse{}, nil }
+func (s *SocketPickerClient) RecoverSession(id [16]byte, newLabel string) error           { /* ... */ return nil }
+func (s *SocketPickerClient) RenameSession(id [16]byte, newLabel string) error            { /* ... */ return nil }
+func (s *SocketPickerClient) DeleteSession(id [16]byte) error                              { /* ... */ return nil }
+func (s *SocketPickerClient) FetchThumbnail(id [16]byte) ([]byte, error)                   { /* ... */ return nil, nil }
+func (s *SocketPickerClient) StartFreshSession()                                           { /* no-op */ }
+func (s *SocketPickerClient) Close() error                                                 { /* ... */ return nil }
+```
+
+The actual transport implementation should follow the patterns in `client/simple_client.go` (Hello / Welcome handshake, `protocol.WriteMessage` for sends, `protocol.ReadMessage` for reads). Do not invent a new framing; reuse the existing helpers.
+
+- [ ] **Step 5: Wire `clientrt.Options.RecoverSessionID` into the connect path**
+
+In `internal/runtime/client/app.go`, add a `RecoverSessionID [16]byte` field to `Options` and use it in the connect path: when set and `loadedState == nil`, call `simple.Connect(&opts.RecoverSessionID)` instead of `simple.Connect(&sessionID)` with the zero ID. The server treats this as a recover-by-ID resume (the new MsgRecoverSession path already covers this server-side; the existing ConnectRequest with a known ID also works since `LookupOrRehydrate` is keyed by ID).
+
+```go
+// Inside Run(), after loadedState resolution:
+if loadedState == nil && opts.RecoverSessionID != ([16]byte{}) {
+	sessionID = opts.RecoverSessionID
+}
+```
+
+The simpler design: just pre-seed the sessionID and let the existing `simple.Connect(&sessionID)` flow do the rest. The server's `LookupOrRehydrate` in handshake.go (or wherever the connect handler lives) will rehydrate the persisted session if it matches. This avoids needing a separate code path for picker-driven recover.
+
+- [ ] **Step 6: Manual smoke test**
+
+```bash
+make build
+# Stop any running daemon
+./bin/texelation --stop
+# Wipe client state to force the no-state branch
+rm -rf ~/.local/state/texelation
+# First run creates a session
+./bin/texelation
+# Open a few panes, then quit gracefully (Ctrl-Q or your normal quit
+# binding). The graceful shutdown should write a thumbnail.
+# Wipe client state again
+rm -rf ~/.local/state/texelation
+# Now this run should hit the picker:
+./bin/texelation
+# Expected: picker UI appears with the previously-saved session
+# listed. Pressing Enter recovers it; the session reopens with
+# the same panes.
+```
+
+- [ ] **Step 7: Run the full test suite to catch regressions**
+
+Run: `go test -race ./... -count=1`
+Expected: PASS. The protocol bump (v4 → v5) cascaded through many tests; any failures here indicate a missed update.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/texelation/main.go cmd/texelation/boot/picker_runner.go internal/runtime/client/app.go
+git commit -m "boot.Run: wire picker activation + recover handoff"
+```
+
+---
+
+## Final Steps
+
+After all 16 tasks land cleanly:
+
+- [ ] **Run race-detector across the whole repo**
+
+Run: `go test -race ./... -count=1`
+Expected: PASS, no races, no failures.
+
+- [ ] **Open a PR**
+
+```bash
+git push -u origin feature/issue-199-plan-f-session-picker
+gh pr create --title "Issue #199 Plan F.1: stored-session recovery picker" --body "$(cat <<'BODY'
+## Summary
+- Adds protocol v5 with five new picker messages (list, recover, rename, delete, fetch-thumbnail) and SessionSummary/LiveSummary wire types.
+- Server-side: manager helpers (StoredSummaries, LiveSummaries, RenameStored, DeleteStored), connection handlers, lifecycle thumbnail capture (graceful shutdown + last-disconnect).
+- Client-side: picker UI in `cmd/texelation/boot/` reusing the splash screen; ASCII fallback + Kitty placeholder; trigger logic in `boot.Run` activates picker when client state is missing AND server has stored sessions, or when `--recover` is passed.
+- Spec: `docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md`
+
+## Test plan
+- [ ] `go test -race ./... -count=1` — full suite green
+- [ ] Manual: cold-start with empty client state + populated server sessions → picker appears
+- [ ] Manual: `--recover` flag with intact client state → picker still appears
+- [ ] Manual: pick a stored session → recovers cleanly, panes restored
+- [ ] Manual: rename inline → label persists across daemon restart
+- [ ] Manual: delete a stored session → JSON + PNG both removed
+- [ ] Manual: Kitty terminal → thumbnails render; non-Kitty terminal → ASCII fallback
+
+## Follow-ups
+- F.2 issue (multi-live-sessions) to be filed after this lands; the wire format and Live tab are already in place.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+---
+
+## Forward-compat for F.2 / F.3 (no work in F.1)
+
+- `LiveSummary` slice already on the wire; F.2 wires `Manager.LiveSummaries` to actual session counts.
+- `Live` tab renders empty in F.1 (count = 0); F.2 reuses the same render path with populated data.
+- `MsgRecoverSession` semantics generalise: F.2 detects "session is live" and skips rehydration when picked.
+- `MsgFetchThumbnail` works for any session whose PNG sidecar exists; F.2 may capture on Live → Stored transitions when sessions are evicted.
+- F.3 (templates) adds a `Templates` tab and `MsgInstantiateTemplate`; SessionSummary picks up an `IsTemplate` flag.

--- a/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
+++ b/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
@@ -1,4 +1,4 @@
-# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v3)
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v3.1)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -15,6 +15,14 @@
 - The wire-level layout type is `protocol.TreeNodeSnapshot` (already exists in `protocol/messages.go`), not `TreeNodeCapture`. Tasks reference `TreeNodeSnapshot`.
 - `StoredSession` JSON shape gains a Layout field as an additive change. No `SchemaVersion` bump (existing files unmarshal cleanly with Layout=nil; old daemons reading new files ignore the unknown JSON field).
 
+**v3.1 revisions vs v3 (review-feedback fixes):**
+- **`widgets.Image` API call corrected** in Task 17 — `w.SetRect(rect)` replaced with `w.SetPosition(rect.X, rect.Y) + w.Resize(rect.W, rect.H)` (the embedded `BaseWidget` has no `SetRect` method).
+- **Task 10 `RenderSessionThumbnail` now uses real APIs:** `WalkPanes`/`ViewportSize()` were invented in v3; replaced with `GeometrySnapshot()` (existing on DesktopSink) plus a new `PrevBufferFor(paneID) [][]texel.Cell` accessor on `DesktopPublisher` that copies the per-pane buffer under the existing publisher mutex. Bounds derived from the geometry snapshot.
+- **Picker fetch goroutine now full-`png.Decode`s before caching** (Task 17), not just `DecodeConfig`. Catches truncated IDAT / bad CRC that DecodeConfig accepts; without this, `widgets.NewImage` would silently fall back to alt text and the picker would have no retry signal.
+- **Panic-loop limiter** (`failedFetches map[[16]byte]int`, `maxFetchAttempts=3`) — a deterministic panic in the fetch path no longer re-spawns the goroutine on every render.
+- **Flush + Close errors no longer discarded:** Task 16 Render's `Flush` failure logs + sets the picker's error banner; Task 18's pre-splash `Flush` cleanup logs; `pickerClient.Close()` error logs (was the carryover v2 I4 issue).
+- **`--recover` dial failure surfaces in splash detail** (Task 18) — was silently swallowed.
+
 **v3 revisions vs v2:**
 - **Picker uses `texelui/widgets.Image` + `texelui/graphics` providers** for thumbnail rendering instead of hand-rolled Kitty escape sequences (Task 17). Picker also gets half-block fallback "for free" on terminals that support it but not Kitty.
 - **Picker switches to a `[][]core.Cell` buffer + `core.Painter` rendering pipeline** (Task 16). After painting, the buffer is copied to the tcell.Screen and the graphics provider's `Flush` emits queued APC sequences. Tests run with provider=nil (ASCII fallback) and don't need to model the Kitty protocol.
@@ -25,7 +33,7 @@
 - **New server-side composition adapter** (Task 10): `DesktopSink.RenderSessionThumbnail` walks the publisher's `prevBuffers` + tree layout to build a workspace cell grid, then calls the shared primitive. Was missing in v1; the original Task 10 left this as "wire up later."
 - **New `MsgSessionOpResponse`** message type (Tasks 1, 4): replaces v1's hack of reusing `MsgListSessionsResponse` as a generic ack. Eliminates the response-type ambiguity flagged in review.
 - **Connection struct gains `manager *Manager`** field — wired in Task 13 (renumbered) which is the first task that needs it. Affects every existing test that constructs a connection (~16 files).
-- **Bug fixes baked in:** `DecodeLiveSummary` consumed-bytes off-by-16 (Task 2); `StoredSummaries` RLock-during-stat (Task 6); `DeleteStored` TOCTOU + bad guard (Task 7); Task 11 `ShutdownSessions` shown as full code, not prose; ASCII renderer's vertical-split test column + n-way split handling (Task 15); Picker `mu sync.Mutex` field declared up-front (Task 16); `maybeFetchThumbnail` reads under lock + defer-clears `pending` on error (Task 17); error surfacing in picker on Recover/Rename/Delete/RefreshCatalog failures (Task 16); thumbnail size cap + dimension cap on the fetch-thumbnail server path (Task 14); real `ProbeStoredSessions` + `SocketPickerClient` implementations (Task 18, no more `/* ... */` stubs).
+- **Bug fixes baked in:** `DecodeLiveSummary` consumed-bytes off-by-16 (Task 2); `StoredSummaries` RLock-during-stat (Task 6); `DeleteStored` TOCTOU + bad guard (Task 7); Task 12 `ShutdownSessions` shown as full code, not prose (was Task 11 in v2 before renumbering); ASCII renderer's vertical-split test column + n-way split handling (Task 15); Picker `mu sync.Mutex` field declared up-front (Task 16); `maybeFetchThumbnail` reads under lock + defer-clears `pending` on error (Task 17); error surfacing in picker on Recover/Rename/Delete/RefreshCatalog failures (Task 16); thumbnail size cap + dimension cap on the fetch-thumbnail server path (Task 14); real `ProbeStoredSessions` + `SocketPickerClient` implementations (Task 18, no more `/* ... */` stubs).
 
 ---
 
@@ -2258,6 +2266,8 @@ import (
 	texelcore "github.com/framegrace/texelui/core"
 
 	"github.com/framegrace/texelation/internal/thumbnail"
+	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelation/texel"
 )
 
 // paneRender is the per-pane input to composePaneGrid. Coordinates are
@@ -2295,14 +2305,14 @@ func composePaneGrid(workspaceW, workspaceH int, panes []paneRender) [][]texelco
 	return grid
 }
 
-// renderSessionThumbnail extracts pane buffers from the publisher
+// RenderSessionThumbnail extracts pane buffers from the publisher
 // (which already maintains them for diff generation) and renders the
 // composed grid to an image via the shared primitive. Returns
 // (nil, false) when the session has no renderable content (no panes,
 // empty publisher state).
 //
-// Wired into DesktopSink.RenderSessionThumbnail; the indirection lets
-// us unit-test composePaneGrid without a full DesktopSink.
+// The composer is the indirection that lets us unit-test
+// composePaneGrid without standing up a full DesktopSink.
 func (s *DesktopSink) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
 	if s == nil {
 		return nil, false
@@ -2312,34 +2322,106 @@ func (s *DesktopSink) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
 	if pub == nil || desktop == nil {
 		return nil, false
 	}
-	w, h := desktop.ViewportSize()
-	if w <= 0 || h <= 0 {
+	// Workspace dimensions: derive from a geometry-only snapshot so
+	// we don't trigger a full render. GeometrySnapshot already exists
+	// on DesktopSink (see desktop_sink.go) — used by handleResize.
+	geom, err := s.GeometrySnapshot()
+	if err != nil {
 		return nil, false
 	}
-	panes := make([]paneRender, 0, 8)
-	pub.WalkPanes(func(paneID [16]byte, x, y, paneW, paneH int, rows [][]texelcore.Cell) {
-		if len(rows) == 0 {
-			return
+	workspaceW, workspaceH := workspaceBounds(geom)
+	if workspaceW <= 0 || workspaceH <= 0 {
+		return nil, false
+	}
+	// Per-pane buffers + per-pane rects come from two parallel
+	// sources: the publisher holds the cell buffers in its
+	// prevBuffers map (already maintained for diff emission), the
+	// geometry snapshot holds rectangle position/size. Walk the
+	// snapshot's pane list (authoritative pane ID + rect) and look
+	// up each buffer in the publisher.
+	panes := make([]paneRender, 0, len(geom.Panes))
+	for _, p := range geom.Panes {
+		buf := pub.PrevBufferFor(p.PaneID) // see helper below
+		if len(buf) == 0 {
+			continue
 		}
 		panes = append(panes, paneRender{
-			x: x, y: y, w: paneW, h: paneH, rows: rows,
+			x:    int(p.X),
+			y:    int(p.Y),
+			w:    int(p.Width),
+			h:    int(p.Height),
+			rows: buf,
 		})
-	})
+	}
 	if len(panes) == 0 {
 		return nil, false
 	}
-	grid := composePaneGrid(w, h, panes)
+	grid := composePaneGrid(workspaceW, workspaceH, panes)
 	img, err := thumbnail.RenderGrid(grid)
 	if err != nil {
 		return nil, false
 	}
 	return img, true
 }
+
+// workspaceBounds derives (w, h) from the union of pane rects in a
+// geometry snapshot. Used because DesktopEngine does not currently
+// expose a single ViewportSize getter — adding one would touch the
+// engine in a way that's beyond Plan F.1's scope; bounding-box from
+// the existing snapshot is exact enough for thumbnail sizing.
+func workspaceBounds(snap protocol.TreeSnapshot) (int, int) {
+	maxX, maxY := 0, 0
+	for _, p := range snap.Panes {
+		if right := int(p.X) + int(p.Width); right > maxX {
+			maxX = right
+		}
+		if bottom := int(p.Y) + int(p.Height); bottom > maxY {
+			maxY = bottom
+		}
+	}
+	return maxX, maxY
+}
 ```
 
-Modify `internal/runtime/server/desktop_publisher.go` to expose a `WalkPanes` method that yields `(paneID, x, y, w, h, rows)` from the publisher's existing per-pane state. The exact source of `rows` depends on what `prevBuffers` already holds — read `desktop_publisher.go`'s field declarations and choose the per-pane buffer that already exists for diff generation; do not introduce a new copy. Document in the doc comment that `WalkPanes` is the picker thumbnail's input source so the next reader knows the contract.
+`PrevBufferFor` is a new accessor on `*DesktopPublisher` that returns
+the cached `[][]texel.Cell` for a pane ID (or nil if absent). Implement
+it in `internal/runtime/server/desktop_publisher.go` next to the
+existing `prevBuffers` field — read the field's actual name first
+(may be e.g. `prevBuf`, `lastBuffer`); rename the accessor to match
+the team's terminology if needed:
 
-If `DesktopEngine` does not currently expose `ViewportSize() (int, int)`, add a thin getter. The publisher already knows the workspace size for diff bounds, so the field exists somewhere in the desktop layer; surface it minimally.
+```go
+// PrevBufferFor returns the most recently observed cell buffer for
+// paneID, or nil if no diff has been emitted yet. Used by Plan F.1
+// thumbnail capture — the buffer already exists for diff generation
+// so we expose it rather than maintain a parallel snapshot.
+//
+// Caller must NOT mutate the returned slice; the publisher continues
+// to use it for the next diff comparison. The slice is held under
+// the publisher's existing mutex; copy if you need to retain past
+// the call.
+func (p *DesktopPublisher) PrevBufferFor(paneID [16]byte) [][]texel.Cell {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	buf, ok := p.prevBuffers[paneID]
+	if !ok {
+		return nil
+	}
+	// Copy under the lock so the caller can use the buffer outside.
+	out := make([][]texel.Cell, len(buf))
+	for y, row := range buf {
+		out[y] = make([]texel.Cell, len(row))
+		copy(out[y], row)
+	}
+	return out
+}
+```
+
+The exact name of the publisher's mutex + map may differ — check
+`desktop_publisher.go` for the real field names. The pattern is the
+load-bearing part: copy under the lock, return a buffer the caller
+owns. The thumbnail render is a one-shot consumer; the small allocation
+is acceptable.
 
 - [ ] **Step 4: Run tests, verify pass**
 
@@ -4064,6 +4146,8 @@ func TestPicker_NavigationDismissesError(t *testing.T) {
 }
 
 // fakeClient stubs the picker's network transport for tests.
+// Fields cover both Task 16 (basic ops) and Task 17 (thumbnail
+// fetch) so the type lives in one place and tasks just reference it.
 type fakeClient struct {
 	response      protocol.ListSessionsResponse
 	listErr       error
@@ -4073,6 +4157,9 @@ type fakeClient struct {
 	newCalled     bool
 	renameErr     error
 	deleteErr     error
+	fetchCalled   bool
+	thumbBytes    []byte
+	thumbErr      error
 }
 
 func (f *fakeClient) ListSessions() (protocol.ListSessionsResponse, error) {
@@ -4088,7 +4175,13 @@ func (f *fakeClient) RecoverSession(id [16]byte, newLabel string) error {
 }
 func (f *fakeClient) RenameSession(id [16]byte, newLabel string) error { return f.renameErr }
 func (f *fakeClient) DeleteSession(id [16]byte) error                  { return f.deleteErr }
-func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error)       { return nil, nil }
+func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
+	f.fetchCalled = true
+	if f.thumbErr != nil {
+		return nil, f.thumbErr
+	}
+	return f.thumbBytes, nil
+}
 func (f *fakeClient) StartFreshSession() {
 	f.newCalled = true
 }
@@ -4230,9 +4323,18 @@ type Picker struct {
 	pending    map[[16]byte]bool
 	imgCache   map[[16]byte]*widgets.Image // one widget per cached thumbnail
 
+	// failedFetches counts panics-or-permanent-failures per session
+	// ID. When the count hits maxFetchAttempts, the picker stops
+	// dispatching for that ID — otherwise a deterministic panic in
+	// the fetch path would re-spawn the goroutine on every render
+	// (the defer clears `pending`), filling the log forever.
+	failedFetches map[[16]byte]int
+
 	done   bool
 	choice pickerChoice
 }
+
+const maxFetchAttempts = 3
 
 type pickerChoice int
 
@@ -4254,9 +4356,10 @@ func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
 		client:     client,
 		activeTab:  tabStored,
 		mode:       modeBrowse,
-		thumbCache: make(map[[16]byte][]byte),
-		pending:    make(map[[16]byte]bool),
-		imgCache:   make(map[[16]byte]*widgets.Image),
+		thumbCache:    make(map[[16]byte][]byte),
+		pending:       make(map[[16]byte]bool),
+		imgCache:      make(map[[16]byte]*widgets.Image),
+		failedFetches: make(map[[16]byte]int),
 	}
 }
 
@@ -4535,11 +4638,19 @@ func (p *Picker) Render() {
 			p.screen.SetContent(x, y, ch, nil, c.Style)
 		}
 	}
-	// Flush queued graphics commands (APC sequences for Kitty,
-	// half-block cell writes already landed via the painter).
+	// Flush queued graphics commands. KittyProvider has Flush; the
+	// HalfBlockProvider does not (its writes already landed in
+	// cellBuf via Place→SetCell), so the type assertion is
+	// intentionally Kitty-only — when it fails, no flush is needed.
+	// On real Kitty failure (closed stdout, broken pipe), surface
+	// the error via the picker's error banner: a silent failure here
+	// would render thumbnails as blank rects with no feedback.
 	if p.gp != nil && p.gpFlush != nil {
 		if flusher, ok := p.gp.(interface{ Flush(io.Writer) error }); ok {
-			_ = flusher.Flush(p.gpFlush)
+			if err := flusher.Flush(p.gpFlush); err != nil {
+				log.Printf("picker: graphics flush failed: %v", err)
+				p.errMsg = "Thumbnails unavailable: " + err.Error()
+			}
 		}
 	}
 	p.screen.Show()
@@ -4855,33 +4966,7 @@ import (
 )
 ```
 
-Update the `fakeClient` definition to support fetch error injection:
-
-```go
-type fakeClient struct {
-	response      protocol.ListSessionsResponse
-	listErr       error
-	recoverCalled bool
-	recoverID     [16]byte
-	recoverErr    error
-	newCalled     bool
-	renameErr     error
-	deleteErr     error
-	fetchCalled   bool
-	thumbBytes    []byte
-	thumbErr      error
-}
-
-func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
-	f.fetchCalled = true
-	if f.thumbErr != nil {
-		return nil, f.thumbErr
-	}
-	return f.thumbBytes, nil
-}
-```
-
-(Merge into the existing `fakeClient` from Task 16 — don't duplicate.)
+The `fakeClient` type is already declared in Task 16 with `fetchCalled` / `thumbBytes` / `thumbErr` fields and the `FetchThumbnail` method that consults them. No additional declaration needed here — Task 17 tests just set `thumbBytes` / `thumbErr` on the existing struct.
 
 - [ ] **Step 2: Run tests, verify failure**
 
@@ -4956,9 +5041,11 @@ func (p *Picker) imageWidgetFor(id [16]byte) *widgets.Image {
 }
 
 // maybeFetchThumbnail kicks off a non-blocking fetch for id if we
-// haven't cached or pending one already. All map access is under
-// p.mu; the goroutine always clears pending[id] in defer so a failed
-// fetch doesn't strand the entry permanently.
+// haven't cached or pending one already, and haven't already failed
+// maxFetchAttempts times for that id. All map access is under p.mu;
+// the goroutine always clears pending[id] in defer so a failed fetch
+// doesn't strand the entry permanently. Panics increment
+// failedFetches[id] so a deterministic crash bug doesn't loop forever.
 func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 	if !p.hasGraphics() || !hasThumb {
 		return
@@ -4972,6 +5059,10 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		p.mu.Unlock()
 		return
 	}
+	if p.failedFetches[id] >= maxFetchAttempts {
+		p.mu.Unlock()
+		return
+	}
 	p.pending[id] = true
 	p.mu.Unlock()
 
@@ -4979,6 +5070,11 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		defer func() {
 			if rec := recover(); rec != nil {
 				log.Printf("picker: thumbnail fetch panic: %v", rec)
+				p.mu.Lock()
+				p.failedFetches[targetID]++
+				delete(p.pending, targetID)
+				p.mu.Unlock()
+				return
 			}
 			p.mu.Lock()
 			delete(p.pending, targetID)
@@ -4992,6 +5088,8 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		if len(data) == 0 {
 			return
 		}
+		// First-pass: header check + dimension cap. Cheap and
+		// catches non-PNG / huge-canvas attacks before full decode.
 		cfg, err := png.DecodeConfig(bytes.NewReader(data))
 		if err != nil {
 			log.Printf("picker: thumbnail decode-config %x: %v", targetID[:4], err)
@@ -5000,6 +5098,17 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		if cfg.Width > maxThumbnailDim || cfg.Height > maxThumbnailDim {
 			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)",
 				targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
+			return
+		}
+		// Second-pass: full decode. Catches truncated IDAT, bad
+		// CRCs, etc. that DecodeConfig accepts. Required because
+		// widgets.Image silently falls back to alt text on decode
+		// failure, and the picker has no retry signal — so a half-
+		// broken cache entry would leave the user staring at
+		// `[img: session-thumbnail]` forever. If full decode fails,
+		// don't cache; next render falls through to ASCII layout.
+		if _, err := png.Decode(bytes.NewReader(data)); err != nil {
+			log.Printf("picker: thumbnail decode %x: %v", targetID[:4], err)
 			return
 		}
 		p.mu.Lock()
@@ -5022,9 +5131,12 @@ In `picker_render.go`, add the `drawThumbnail` helper that `drawCard` already ca
 func (p *Picker) drawThumbnail(painter *core.Painter, rect core.Rect, s protocol.SessionSummary, bgStyle tcell.Style) {
 	if p.hasGraphics() {
 		if w := p.imageWidgetFor(s.SessionID); w != nil {
-			// widgets.Image expects a raw rect in screen coords.
-			// SetRect is on the embedded BaseWidget.
-			w.SetRect(rect)
+			// BaseWidget exposes SetPosition + Resize (no SetRect).
+			// We could also assign w.Rect = rect directly since the
+			// field is exported, but the methods are explicit about
+			// which dimension changed.
+			w.SetPosition(rect.X, rect.Y)
+			w.Resize(rect.W, rect.H)
 			w.Draw(painter)
 			p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
 			return
@@ -5172,6 +5284,14 @@ if shouldShowPicker {
 	pickerClient, err := boot.NewSocketPickerClient(clientOpts.Socket)
 	if err != nil {
 		log.Printf("picker: socket client setup failed: %v; skipping picker", err)
+		if clientOpts.ShowRecoverPicker {
+			// User explicitly asked for the picker via --recover; a
+			// silent fall-through to a fresh session would defeat the
+			// flag's intent. Surface in the splash detail so the
+			// failure is visible.
+			splashApp.SetDetail("Could not connect to daemon: " + err.Error())
+			splashRunner.Wake()
+		}
 	} else {
 		stopSplash()
 		// Build the graphics provider that matches the terminal's
@@ -5185,18 +5305,27 @@ if shouldShowPicker {
 		case texelcore.GraphicsHalfBlock:
 			gp = graphics.NewHalfBlockProvider()
 		}
-		outcome, err := boot.RunPicker(screen, pickerClient, gp, os.Stdout)
-		_ = pickerClient.Close()
+		outcome, runErr := boot.RunPicker(screen, pickerClient, gp, os.Stdout)
+		if cerr := pickerClient.Close(); cerr != nil {
+			log.Printf("picker: close socket: %v", cerr)
+		}
 		if gp != nil {
 			// Clear any image placements before splash takes the
 			// screen back so we don't leave Kitty images stranded.
+			// Failure here means stale APC placements survive into
+			// the splash — log so the symptom has a breadcrumb.
 			gp.Reset()
 			if flusher, ok := gp.(interface{ Flush(io.Writer) error }); ok {
-				_ = flusher.Flush(os.Stdout)
+				if err := flusher.Flush(os.Stdout); err != nil {
+					log.Printf("picker: clear graphics before splash handoff: %v", err)
+				}
 			}
 		}
-		if err != nil {
-			log.Printf("picker: %v; falling back to fresh session", err)
+		if runErr != nil {
+			// Picker errored mid-session. The user's selection (if
+			// any) is lost — surface that in the splash detail so
+			// they don't silently end up with a fresh session.
+			log.Printf("picker: %v; falling back to fresh session", runErr)
 		} else {
 			switch outcome.Choice {
 			case boot.PickerChoiceRecover:
@@ -5215,6 +5344,10 @@ if shouldShowPicker {
 		splashRunner = boot.NewRunner(screen, splashApp)
 		splashRunner.Start()
 		splashStopped = false
+		if runErr != nil {
+			splashApp.SetDetail("Recovery failed; starting fresh session")
+			splashRunner.Wake()
+		}
 	}
 }
 ```

--- a/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
+++ b/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
@@ -1,10 +1,10 @@
-# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a client-side stored-session recovery picker so users with lost client state can discover and rejoin sessions the daemon persisted to disk.
 
-**Architecture:** Bumps protocol v4 → v5 with five new messages (list, recover, rename, delete, fetch-thumbnail) and two wire types (SessionSummary, LiveSummary). Server-side persisted-session map (Plan D2) is exposed via new manager helpers and connection handlers; lifecycle-only thumbnail capture writes PNG sidecars next to each session JSON. Client-side picker UI lives in `cmd/texelation/boot/`, reusing the splash's tcell screen so handoff to the existing connect path is flicker-free.
+**Architecture:** Bumps protocol v4 → v5 with six new messages (list, recover, rename, delete, fetch-thumbnail, op-response) and two wire types (SessionSummary, LiveSummary). Server-side persisted-session map (Plan D2) is exposed via new manager helpers and connection handlers; lifecycle-only thumbnail capture writes PNG sidecars next to each session JSON. The renderer that produces those PNGs is the same `texelui/graphics/textrender` pipeline the client uses for user-initiated screenshots — extracted into a shared `internal/thumbnail/` primitive that both ends import. Server-side composition adapter assembles the workspace-wide cell grid from the publisher's per-pane buffers + tree layout. Client-side picker UI lives in `cmd/texelation/boot/`, reusing the splash's tcell screen so handoff to the existing connect path is flicker-free.
 
 **Tech Stack:** Go 1.24, tcell/v2 for picker UI, `texelui/graphics/textrender` for thumbnail rendering, `texelui/widgets` Image upload for Kitty graphics, existing `internal/persistence/atomicjson` for atomic writes.
 
@@ -15,6 +15,13 @@
 - The wire-level layout type is `protocol.TreeNodeSnapshot` (already exists in `protocol/messages.go`), not `TreeNodeCapture`. Tasks reference `TreeNodeSnapshot`.
 - `StoredSession` JSON shape gains a Layout field as an additive change. No `SchemaVersion` bump (existing files unmarshal cleanly with Layout=nil; old daemons reading new files ignore the unknown JSON field).
 
+**v2 revisions vs v1 (incorporates review findings):**
+- **New `internal/thumbnail/` package** (Task 9) shared by server lifecycle capture and client user-screenshot. Eliminates duplicate textrender wiring; client `screenshot.go` is refactored in Task 19 to use it.
+- **New server-side composition adapter** (Task 10): `DesktopSink.RenderSessionThumbnail` walks the publisher's `prevBuffers` + tree layout to build a workspace cell grid, then calls the shared primitive. Was missing in v1; the original Task 10 left this as "wire up later."
+- **New `MsgSessionOpResponse`** message type (Tasks 1, 4): replaces v1's hack of reusing `MsgListSessionsResponse` as a generic ack. Eliminates the response-type ambiguity flagged in review.
+- **Connection struct gains `manager *Manager`** field — wired in Task 13 (renumbered) which is the first task that needs it. Affects every existing test that constructs a connection (~16 files).
+- **Bug fixes baked in:** `DecodeLiveSummary` consumed-bytes off-by-16 (Task 2); `StoredSummaries` RLock-during-stat (Task 6); `DeleteStored` TOCTOU + bad guard (Task 7); Task 11 `ShutdownSessions` shown as full code, not prose; ASCII renderer's vertical-split test column + n-way split handling (Task 15); Picker `mu sync.Mutex` field declared up-front (Task 16); `maybeFetchThumbnail` reads under lock + defer-clears `pending` on error (Task 17); error surfacing in picker on Recover/Rename/Delete/RefreshCatalog failures (Task 16); thumbnail size cap + dimension cap on the fetch-thumbnail server path (Task 14); real `ProbeStoredSessions` + `SocketPickerClient` implementations (Task 18, no more `/* ... */` stubs).
+
 ---
 
 ## File Structure
@@ -23,52 +30,65 @@
 
 | File | Responsibility |
 |---|---|
-| `protocol/session_picker.go` | Wire types (SessionSummary, LiveSummary) and encoders/decoders for ListSessions, RecoverSession, Rename, Delete, FetchThumbnail messages |
+| `protocol/session_picker.go` | Wire types (SessionSummary, LiveSummary) + encoders/decoders for ListSessions, RecoverSession, Rename, Delete, FetchThumbnail, SessionOpResponse |
 | `protocol/session_picker_test.go` | Round-trip encode/decode tests for all new wire types |
+| `internal/thumbnail/render.go` | **Shared** primitive: `RenderGrid([][]Cell) (image.Image, error)` + `WritePNGAtomic(path, image.Image) error` + `DownscaleAspectFit(img, w, h) *image.RGBA` |
+| `internal/thumbnail/render_test.go` | Primitive tests |
 | `internal/runtime/server/manager_session_picker.go` | `StoredSummaries`, `LiveSummaries`, `RenameStored`, `DeleteStored` methods on Manager |
 | `internal/runtime/server/manager_session_picker_test.go` | Manager helper unit tests |
-| `internal/runtime/server/thumbnail.go` | `captureThumbnail`, `writePNGAtomic`, downscale helper |
-| `internal/runtime/server/thumbnail_test.go` | Thumbnail capture + atomic-write tests |
+| `internal/runtime/server/thumbnail_renderer.go` | Server-side `DesktopSink.RenderSessionThumbnail` (composes pane buffers → grid → shared primitive) |
+| `internal/runtime/server/thumbnail_renderer_test.go` | Composition + adapter tests |
+| `internal/runtime/server/thumbnail.go` | `captureThumbnail` orchestrator (calls renderer, calls primitive's `WritePNGAtomic`) |
+| `internal/runtime/server/thumbnail_test.go` | Capture trigger tests |
 | `internal/runtime/server/connection_session_picker.go` | Connection handlers: `handleListSessions`, `handleRecoverSession`, `handleRenameSession`, `handleDeleteSession`, `handleFetchThumbnail` |
 | `internal/runtime/server/connection_session_picker_test.go` | Handler unit tests via memconn |
 | `cmd/texelation/boot/picker.go` | `Picker` struct, run loop, dispatch |
 | `cmd/texelation/boot/picker_input.go` | Key handling, navigation, mode transitions |
-| `cmd/texelation/boot/picker_render.go` | Card layout, tabs, action bar |
+| `cmd/texelation/boot/picker_render.go` | Card layout, tabs, action bar, error banner |
 | `cmd/texelation/boot/picker_thumbnail.go` | Kitty image rendering, lazy fetch coordinator |
-| `cmd/texelation/boot/picker_ascii.go` | TreeNodeSnapshot → box-drawing chars |
+| `cmd/texelation/boot/picker_ascii.go` | TreeNodeSnapshot → box-drawing chars (n-way splits) |
 | `cmd/texelation/boot/picker_ascii_test.go` | Pure ASCII algorithm tests |
 | `cmd/texelation/boot/picker_test.go` | Picker render + navigation tests |
+| `cmd/texelation/boot/picker_runner.go` | `RunPicker`, `ProbeStoredSessions`, `SocketPickerClient` |
+| `cmd/texelation/boot/picker_client_test.go` | SocketPickerClient round-trip tests |
 
 **Modified files:**
 
 | File | Change |
 |---|---|
-| `protocol/protocol.go` | Bump `Version` to 5; add 7 new `MessageType` constants |
-| `internal/runtime/server/session_persistence.go` | Add `Layout *protocol.TreeNodeSnapshot` field to `StoredSession` and JSON shape |
+| `protocol/protocol.go` | Bump `Version` to 5; add 8 new `MessageType` constants (ListSessions, ListSessionsResponse, Recover, Rename, Delete, FetchThumbnail, FetchThumbnailResponse, SessionOpResponse) |
+| `internal/runtime/server/session_persistence.go` | Add `Layout *protocol.TreeNodeSnapshot` field to `StoredSession` and JSON shape; orphan-PNG cleanup in `ScanSessionsDir` |
+| `internal/runtime/server/connection.go` | Add `manager *Manager` field; thread through `newConnection` (~16 test files updated) |
 | `internal/runtime/server/connection_handler.go` | Dispatch new message types to `connection_session_picker.go` handlers |
-| `internal/runtime/server/manager.go` | Extend boot scan with HasThumbnail flag + orphan PNG cleanup; thumbnail capture in `ShutdownSessions` and `Close(id)` |
+| `internal/runtime/server/manager.go` | Thumbnail capture in `ShutdownSessions` and `Close(id)`; renderer setter |
+| `internal/runtime/server/desktop_sink.go` | Implement `ThumbnailRenderer` interface (delegates to `thumbnail_renderer.go`) |
+| `internal/runtime/client/screenshot.go` | Refactor to use shared `internal/thumbnail.RenderGrid` (dedup) |
 | `cmd/texelation/main.go` | Add `--recover` flag; wire picker activation between supervisor and `clientrt.Run` |
+| `internal/runtime/client/app.go` | Add `RecoverSessionID [16]byte` to `Options`; pre-seed sessionID when set |
 
 ---
 
-## Tasks Overview
+## Tasks Overview (v2)
 
-1. Protocol: bump version + add MessageType constants
-2. Protocol: SessionSummary + LiveSummary wire types
+1. Protocol: bump version + add MessageType constants (incl. SessionOpResponse)
+2. Protocol: SessionSummary + LiveSummary wire types (with off-by-16 fix)
 3. Protocol: ListSessions request/response
-4. Protocol: RecoverSession + Rename + Delete + FetchThumbnail messages
+4. Protocol: Recover + Rename + Delete + FetchThumbnail + SessionOpResponse messages
 5. StoredSession: add Layout field
-6. Manager: StoredSummaries + LiveSummaries
-7. Manager: RenameStored + DeleteStored
-8. Manager: HasThumbnail flag + orphan PNG cleanup at boot scan
-9. Thumbnail: writePNGAtomic + downscale + captureThumbnail core
-10. Thumbnail: capture trigger on last-disconnect + graceful shutdown
-11. Connection handlers: list + recover
-12. Connection handlers: rename + delete + fetch-thumbnail
-13. Picker: ASCII layout algorithm (pure functions)
-14. Picker: state machine, navigation, render
-15. Picker: Kitty thumbnail rendering + lazy fetch
-16. boot.Run integration: trigger logic + handoff
+6. Manager: StoredSummaries + LiveSummaries (RLock snapshot pattern)
+7. Manager: RenameStored + DeleteStored (TOCTOU-safe)
+8. Manager: orphan PNG cleanup at boot scan
+9. **Shared `internal/thumbnail/` primitive** (RenderGrid + WritePNGAtomic + Downscale)
+10. **Server-side composition adapter** (`DesktopSink.RenderSessionThumbnail`)
+11. Server: `captureThumbnail` orchestrator + capture triggers (full ShutdownSessions code)
+12. Connection: add `manager *Manager` field + ripple
+13. Connection handlers: list + recover
+14. Connection handlers: rename + delete + fetch-thumbnail (size + dim caps; uses SessionOpResponse)
+15. Picker: ASCII layout algorithm (n-way splits, divider-column-correct)
+16. Picker: state machine, navigation, render (mu, error banner, RefreshCatalog error visible)
+17. Picker: Kitty thumbnail rendering + lazy fetch (locked, defer-clear pending)
+18. boot.Run integration: real ProbeStoredSessions + SocketPickerClient + handoff
+19. Client screenshot: refactor to use shared `internal/thumbnail` primitive
 
 ---
 
@@ -110,6 +130,7 @@ func TestSessionPickerMessageTypes(t *testing.T) {
 		{"MsgDeleteSession", protocol.MsgDeleteSession, 39},
 		{"MsgFetchThumbnail", protocol.MsgFetchThumbnail, 40},
 		{"MsgFetchThumbnailResponse", protocol.MsgFetchThumbnailResponse, 41},
+		{"MsgSessionOpResponse", protocol.MsgSessionOpResponse, 42},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -165,6 +186,10 @@ Append at the end of the iota block in `protocol/protocol.go` (after `MsgBootPro
 	// terminals; non-graphics clients render an ASCII fallback instead.
 	MsgFetchThumbnail
 	MsgFetchThumbnailResponse
+	// MsgSessionOpResponse: dedicated ack for rename/delete (and any
+	// future session-mutating op). Carries OK + Error + OpType so the
+	// picker can correlate without conflating with MsgListSessionsResponse.
+	MsgSessionOpResponse
 ```
 
 - [ ] **Step 6: Run test to verify pass**
@@ -481,7 +506,8 @@ func DecodeLiveSummary(b []byte) (LiveSummary, int, error) {
 	s.AttachedClients = int32(binary.LittleEndian.Uint32(b[:4]))
 	s.PaneCount = int32(binary.LittleEndian.Uint32(b[4:8]))
 	s.LastInputAt = int64(binary.LittleEndian.Uint64(b[8:16]))
-	return s, start - (len(b) - 16), nil
+	b = b[16:]
+	return s, start - len(b), nil
 }
 ```
 
@@ -730,8 +756,10 @@ func TestRenameSessionRequest_RoundTrip(t *testing.T) {
 
 func TestSessionOpResponse_RoundTrip(t *testing.T) {
 	cases := []SessionOpResponse{
-		{OK: true},
-		{OK: false, Error: "session is live"},
+		{OpType: OpRename, OK: true},
+		{OpType: OpRename, OK: false, Error: "session not found"},
+		{OpType: OpDelete, OK: true},
+		{OpType: OpDelete, OK: false, Error: "session is live"},
 	}
 	for i, in := range cases {
 		encoded, err := EncodeSessionOpResponse(in)
@@ -903,16 +931,29 @@ func DecodeDeleteSessionRequest(b []byte) (DeleteSessionRequest, error) {
 	return r, nil
 }
 
-// SessionOpResponse is the shared shape for rename + delete responses.
-// OK=false implies a non-empty Error explaining the refusal (live
-// session, not found, IO failure).
+// SessionOpKind identifies which op a SessionOpResponse acks. The
+// picker uses this to correlate without needing in-flight request IDs.
+type SessionOpKind uint8
+
+const (
+	OpRename SessionOpKind = iota
+	OpDelete
+)
+
+// SessionOpResponse is the dedicated ack envelope for rename + delete
+// (and any future session-mutating op). OK=false implies a non-empty
+// Error explaining the refusal (live session, not found, IO failure).
+// OpType distinguishes which op this acks so the picker doesn't
+// conflate it with a coincident MsgListSessionsResponse.
 type SessionOpResponse struct {
-	OK    bool
-	Error string
+	OpType SessionOpKind
+	OK     bool
+	Error  string
 }
 
 func EncodeSessionOpResponse(r SessionOpResponse) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(byte(r.OpType))
 	if r.OK {
 		buf.WriteByte(1)
 	} else {
@@ -926,11 +967,12 @@ func EncodeSessionOpResponse(r SessionOpResponse) ([]byte, error) {
 
 func DecodeSessionOpResponse(b []byte) (SessionOpResponse, error) {
 	var r SessionOpResponse
-	if len(b) < 1 {
+	if len(b) < 2 {
 		return r, ErrPayloadShort
 	}
-	r.OK = b[0] != 0
-	msg, _, err := decodeString(b[1:])
+	r.OpType = SessionOpKind(b[0])
+	r.OK = b[1] != 0
+	msg, _, err := decodeString(b[2:])
 	if err != nil {
 		return r, err
 	}
@@ -1380,27 +1422,42 @@ import (
 // when persistence is enabled; without persistence the flag is always
 // false.
 //
-// Reads the in-memory persistedSessions map; no JSON parsing or disk
-// IO except the per-record PNG stat. Safe to call from request paths.
+// Snapshot pattern: copies persistedSessions + persistBasedir under
+// the RLock (O(N) memory, O(N) wall-clock), then runs the per-record
+// PNG stat OUTSIDE the lock. Holding the RLock during disk stat would
+// block every Manager write op (DeleteStored, RenameStored,
+// LookupOrRehydrate, Close) for the duration of N stat calls — a real
+// stall on a slow filesystem with a populous sessions dir.
 func (m *Manager) StoredSummaries() []protocol.SessionSummary {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	if len(m.persistedSessions) == 0 {
+		m.mu.RUnlock()
 		return nil
 	}
-	summaries := make([]protocol.SessionSummary, 0, len(m.persistedSessions))
+	persistDir := m.persistBasedir
+	type entry struct {
+		id  [16]byte
+		ref *StoredSession
+	}
+	snap := make([]entry, 0, len(m.persistedSessions))
 	for id, s := range m.persistedSessions {
+		snap = append(snap, entry{id: id, ref: s})
+	}
+	m.mu.RUnlock()
+
+	summaries := make([]protocol.SessionSummary, 0, len(snap))
+	for _, e := range snap {
 		summary := protocol.SessionSummary{
-			SessionID:      id,
-			Label:          s.Label,
-			LastActive:     s.LastActive.Unix(),
-			PaneCount:      int32(s.PaneCount),
-			FirstPaneTitle: s.FirstPaneTitle,
-			Pinned:         s.Pinned,
-			Layout:         s.Layout,
+			SessionID:      e.id,
+			Label:          e.ref.Label,
+			LastActive:     e.ref.LastActive.Unix(),
+			PaneCount:      int32(e.ref.PaneCount),
+			FirstPaneTitle: e.ref.FirstPaneTitle,
+			Pinned:         e.ref.Pinned,
+			Layout:         e.ref.Layout,
 		}
-		if m.persistBasedir != "" {
-			pngPath := filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+		if persistDir != "" {
+			pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(e.id[:])+".png")
 			if info, err := os.Stat(pngPath); err == nil && !info.IsDir() {
 				summary.HasThumbnail = true
 			}
@@ -1641,38 +1698,53 @@ func (m *Manager) RenameStored(id [16]byte, newLabel string) error {
 // when the session is currently live — the user must detach all
 // clients first.
 //
+// TOCTOU avoidance: the in-memory delete + the live-session refusal
+// happen under m.mu held *contiguously* with the disk removes. A
+// concurrent LookupOrRehydrate that observes the entry still in
+// persistedSessions before this method's lock acquisition will block
+// on m.mu and find it gone; one that already grabbed the entry before
+// the lock would have called delete(persistedSessions, id) itself,
+// so the !ok branch below catches that race cleanly.
+//
 // PNG removal is best-effort (a missing PNG is not an error); JSON
 // removal is authoritative — if the JSON unlink fails we leave the
 // in-memory entry alone and surface the error so the caller can
 // retry. The PNG-then-JSON order avoids leaving a JSON with stale
 // HasThumbnail expectations across a partial delete.
+//
+// We also markClosing(id) before any disk I/O so a concurrent
+// rehydrate path waits behind the unlink rather than constructing a
+// fresh Session pointing at the on-disk file we're about to remove.
 func (m *Manager) DeleteStored(id [16]byte) error {
 	m.mu.Lock()
 	if _, live := m.sessions[id]; live {
 		m.mu.Unlock()
 		return fmt.Errorf("manager: session %x is live; detach all clients first", id[:4])
 	}
-	if _, ok := m.persistedSessions[id]; !ok && m.persistBasedir == "" {
+	if _, ok := m.persistedSessions[id]; !ok {
 		m.mu.Unlock()
 		return ErrSessionNotFound
 	}
-	persistDir := m.persistBasedir
-	m.mu.Unlock()
-
-	if persistDir != "" {
-		pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(id[:])+".png")
-		if err := os.Remove(pngPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("manager: remove %s: %w", pngPath, err)
-		}
-		jsonPath := SessionFilePath(persistDir, id)
-		if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("manager: remove %s: %w", jsonPath, err)
-		}
-	}
-
-	m.mu.Lock()
 	delete(m.persistedSessions, id)
+	persistDir := m.persistBasedir
+	m.markClosing(id)
 	m.mu.Unlock()
+	defer m.unmarkClosing(id)
+
+	if persistDir == "" {
+		return nil
+	}
+	pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if err := os.Remove(pngPath); err != nil && !os.IsNotExist(err) {
+		// In-memory entry is already gone; surfacing the error
+		// to the caller is enough. A retry of DeleteStored will
+		// no-op on the in-memory side and re-attempt the unlink.
+		return fmt.Errorf("manager: remove %s: %w", pngPath, err)
+	}
+	jsonPath := SessionFilePath(persistDir, id)
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("manager: remove %s: %w", jsonPath, err)
+	}
 	return nil
 }
 ```
@@ -1794,21 +1866,24 @@ git commit -m "Boot scan: remove orphaned PNG thumbnails"
 
 ---
 
-### Task 9: Thumbnail core — writePNGAtomic + downscale + capture skeleton
+### Task 9: Shared `internal/thumbnail/` primitive package
 
 **Files:**
-- Create: `internal/runtime/server/thumbnail.go`
-- Test: `internal/runtime/server/thumbnail_test.go`
+- Create: `internal/thumbnail/render.go`
+- Create: `internal/thumbnail/render_test.go`
+- (Task 19 refactors `internal/runtime/client/screenshot.go` to consume this; Task 11 consumes it server-side.)
+
+**Goal:** One package owning the textrender pipeline + atomic PNG write + aspect-fit downscale, used by both the server lifecycle thumbnail capture and the client's user-initiated screenshot. Avoids duplicating the font detection + renderer setup. The package is pure render — it does not know about sessions, panes, or the desktop tree (those compose at the call site).
 
 - [ ] **Step 1: Write failing tests**
 
-Create `internal/runtime/server/thumbnail_test.go`:
+Create `internal/thumbnail/render_test.go`:
 
 ```go
 // Copyright © 2026 Texelation contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-package server
+package thumbnail
 
 import (
 	"image"
@@ -1817,6 +1892,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
 )
 
 func makeTestImage(w, h int) image.Image {
@@ -1829,20 +1906,45 @@ func makeTestImage(w, h int) image.Image {
 	return img
 }
 
+func TestRenderGrid_Smoke(t *testing.T) {
+	// 4x2 grid of plain ASCII; we just want a valid image back.
+	grid := [][]texelcore.Cell{
+		{{Ch: 'h'}, {Ch: 'e'}, {Ch: 'l'}, {Ch: 'l'}},
+		{{Ch: 'o'}, {Ch: ' '}, {Ch: 't'}, {Ch: 'x'}},
+	}
+	img, err := RenderGrid(grid)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("nil image")
+	}
+	if img.Bounds().Dx() <= 0 || img.Bounds().Dy() <= 0 {
+		t.Fatalf("zero-sized image: %v", img.Bounds())
+	}
+}
+
+func TestRenderGrid_EmptyGrid(t *testing.T) {
+	if _, err := RenderGrid(nil); err == nil {
+		t.Fatalf("expected error on nil grid")
+	}
+	if _, err := RenderGrid([][]texelcore.Cell{}); err == nil {
+		t.Fatalf("expected error on empty grid")
+	}
+}
+
 func TestWritePNGAtomic_HappyPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "thumb.png")
-	if err := writePNGAtomic(path, makeTestImage(40, 30)); err != nil {
+	if err := WritePNGAtomic(path, makeTestImage(40, 30)); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	// Tmp file should be gone.
 	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
 		t.Errorf("tmp file not cleaned: stat err=%v", err)
 	}
-	// Decoded image should be the same dimensions.
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatalf("open: %v", err)
@@ -1860,10 +1962,10 @@ func TestWritePNGAtomic_HappyPath(t *testing.T) {
 func TestWritePNGAtomic_OverwritesExisting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "thumb.png")
-	if err := writePNGAtomic(path, makeTestImage(20, 20)); err != nil {
+	if err := WritePNGAtomic(path, makeTestImage(20, 20)); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
-	if err := writePNGAtomic(path, makeTestImage(40, 40)); err != nil {
+	if err := WritePNGAtomic(path, makeTestImage(40, 40)); err != nil {
 		t.Fatalf("second write: %v", err)
 	}
 	f, _ := os.Open(path)
@@ -1876,23 +1978,15 @@ func TestWritePNGAtomic_OverwritesExisting(t *testing.T) {
 
 func TestDownscaleAspectFit_Wider(t *testing.T) {
 	src := makeTestImage(800, 200) // 4:1 — wider than 16:9 (480x270)
-	out := downscaleAspectFit(src, 480, 270)
+	out := DownscaleAspectFit(src, 480, 270)
 	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
 		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
 	}
 }
 
 func TestDownscaleAspectFit_Taller(t *testing.T) {
-	src := makeTestImage(200, 800) // narrow + tall
-	out := downscaleAspectFit(src, 480, 270)
-	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
-		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
-	}
-}
-
-func TestDownscaleAspectFit_AlreadySmall(t *testing.T) {
-	src := makeTestImage(100, 80)
-	out := downscaleAspectFit(src, 480, 270)
+	src := makeTestImage(200, 800)
+	out := DownscaleAspectFit(src, 480, 270)
 	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
 		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
 	}
@@ -1901,40 +1995,69 @@ func TestDownscaleAspectFit_AlreadySmall(t *testing.T) {
 
 - [ ] **Step 2: Run tests, verify failure**
 
-Run: `go test ./internal/runtime/server/ -run "TestWritePNGAtomic|TestDownscaleAspectFit" -count=1`
-Expected: FAIL — undefined `writePNGAtomic`, `downscaleAspectFit`.
+Run: `go test ./internal/thumbnail/ -count=1`
+Expected: FAIL — package doesn't exist yet.
 
-- [ ] **Step 3: Implement helpers**
+- [ ] **Step 3: Implement the primitive**
 
-Create `internal/runtime/server/thumbnail.go`:
+Create `internal/thumbnail/render.go`:
 
 ```go
 // Copyright © 2026 Texelation contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// File: internal/runtime/server/thumbnail.go
-// Summary: Lifecycle thumbnail capture for the F.1 session picker.
-// Usage: Called from Manager.ShutdownSessions and Manager.Close on
-//   the last-disconnect transition. Writes <basedir>/sessions/<id>.png.
+// File: internal/thumbnail/render.go
+// Summary: Shared image-rendering primitive used by server lifecycle
+// thumbnail capture (Plan F.1) and client user-initiated screenshots.
+// Knows about cells; does not know about sessions, panes, or sockets.
 
-package server
+package thumbnail
 
 import (
+	"errors"
 	"fmt"
 	"image"
-	"image/draw"
+	stddraw "image/draw"
 	"image/png"
 	"os"
 
-	"golang.org/x/image/draw" // golang.org/x/image is already a transitive dep via texelui
+	xdraw "golang.org/x/image/draw"
+
+	texelcore "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/graphics/textrender"
 )
 
-// writePNGAtomic encodes img to path via a temp-file-then-rename so a
-// crash mid-write doesn't leave a half-PNG (which the client would
-// then fail to decode and silently fall back to ASCII forever).
-func writePNGAtomic(path string, img image.Image) error {
+// ErrEmptyGrid is returned by RenderGrid for nil or zero-row inputs.
+var ErrEmptyGrid = errors.New("thumbnail: empty cell grid")
+
+// RenderGrid renders a cell grid to an image using the system text
+// renderer (font auto-detected). Callers are responsible for supplying
+// a non-empty grid; this function does not synthesize background fill
+// for the empty case.
+func RenderGrid(grid [][]texelcore.Cell) (image.Image, error) {
+	if len(grid) == 0 {
+		return nil, ErrEmptyGrid
+	}
+	if len(grid[0]) == 0 {
+		return nil, ErrEmptyGrid
+	}
+	fontPath, err := textrender.DetectFont()
+	if err != nil {
+		return nil, fmt.Errorf("thumbnail: font detect: %w", err)
+	}
+	renderer, err := textrender.New(textrender.Config{FontPath: fontPath})
+	if err != nil {
+		return nil, fmt.Errorf("thumbnail: renderer: %w", err)
+	}
+	return renderer.Render(grid), nil
+}
+
+// WritePNGAtomic encodes img to path via tmp+rename so a crash mid-
+// write doesn't leave a half-PNG. Used both by server lifecycle
+// capture and (eventually) by the client screenshot path.
+func WritePNGAtomic(path string, img image.Image) error {
 	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("thumbnail: create %s: %w", tmp, err)
 	}
@@ -1943,13 +2066,14 @@ func writePNGAtomic(path string, img image.Image) error {
 	closeErr := f.Close()
 	if encErr != nil || syncErr != nil || closeErr != nil {
 		_ = os.Remove(tmp)
-		if encErr != nil {
+		switch {
+		case encErr != nil:
 			return fmt.Errorf("thumbnail: encode: %w", encErr)
-		}
-		if syncErr != nil {
+		case syncErr != nil:
 			return fmt.Errorf("thumbnail: sync: %w", syncErr)
+		default:
+			return fmt.Errorf("thumbnail: close: %w", closeErr)
 		}
-		return fmt.Errorf("thumbnail: close: %w", closeErr)
 	}
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
@@ -1958,12 +2082,11 @@ func writePNGAtomic(path string, img image.Image) error {
 	return nil
 }
 
-// downscaleAspectFit returns a (targetW × targetH) RGBA image with src
+// DownscaleAspectFit returns a (targetW × targetH) RGBA image with src
 // drawn into the centred subrect that preserves src's aspect ratio.
-// The remainder is filled with theme-neutral black (zero pixels). Used
-// to standardise picker thumbnail dimensions regardless of the source
-// workspace size.
-func downscaleAspectFit(src image.Image, targetW, targetH int) *image.RGBA {
+// Background outside the scaled rect is left transparent (zero pixels);
+// callers wanting an opaque background should fill before passing.
+func DownscaleAspectFit(src image.Image, targetW, targetH int) *image.RGBA {
 	dst := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
 	srcW := src.Bounds().Dx()
 	srcH := src.Bounds().Dy()
@@ -1989,64 +2112,292 @@ func downscaleAspectFit(src image.Image, targetW, targetH int) *image.RGBA {
 	offsetX := (targetW - scaledW) / 2
 	offsetY := (targetH - scaledH) / 2
 	dstRect := image.Rect(offsetX, offsetY, offsetX+scaledW, offsetY+scaledH)
-	xdraw.ApproxBiLinear.Scale(dst, dstRect, src, src.Bounds(), draw.Over, nil)
+	xdraw.ApproxBiLinear.Scale(dst, dstRect, src, src.Bounds(), stddraw.Over, nil)
 	return dst
 }
 ```
 
-Note: the scaling import is named `xdraw "golang.org/x/image/draw"` (rename to avoid collision with stdlib `image/draw`). Adjust the import block accordingly:
-
-```go
-import (
-	"fmt"
-	"image"
-	stddraw "image/draw"
-	"image/png"
-	"os"
-
-	xdraw "golang.org/x/image/draw"
-)
-```
-
-…and replace `draw.Over` in the call site with `stddraw.Over`.
-
-If `golang.org/x/image` is not yet a direct dependency, add it via `go get golang.org/x/image/draw` before running the tests; it's already pulled in transitively by texelui's text rendering, so `go mod tidy` will resolve it without surprises.
+If `golang.org/x/image` is not yet a direct dependency (currently indirect via texelui), `go mod tidy` after adding the import will promote it. Verify with `grep "golang.org/x/image" go.mod`.
 
 - [ ] **Step 4: Run tests, verify pass**
 
-Run: `go test ./internal/runtime/server/ -run "TestWritePNGAtomic|TestDownscaleAspectFit" -count=1`
+Run: `go test ./internal/thumbnail/ -count=1`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add internal/runtime/server/thumbnail.go internal/runtime/server/thumbnail_test.go go.mod go.sum
-git commit -m "Server: writePNGAtomic + downscaleAspectFit helpers for picker thumbnails"
+git add internal/thumbnail/render.go internal/thumbnail/render_test.go go.mod go.sum
+git commit -m "Add internal/thumbnail/ shared rendering primitive"
 ```
 
 ---
 
-### Task 10: Capture trigger — wire shutdown + last-disconnect
+### Task 10: Server-side thumbnail composition adapter
 
 **Files:**
-- Modify: `internal/runtime/server/thumbnail.go` (add captureThumbnail + ThumbnailRenderer interface)
-- Modify: `internal/runtime/server/manager.go` (call from `Close` and `ShutdownSessions`)
-- Modify: `internal/runtime/server/thumbnail_test.go` (test the trigger paths)
+- Create: `internal/runtime/server/thumbnail_renderer.go`
+- Create: `internal/runtime/server/thumbnail_renderer_test.go`
+- Modify: `internal/runtime/server/desktop_sink.go` (implement `ThumbnailRenderer` interface, see Task 11)
+
+**Goal:** Bridge between the server's authoritative pane state and the shared rendering primitive. Walks the publisher's `prevBuffers` (per-pane cell snapshots maintained for diff generation) plus the desktop tree to compose a single workspace-wide cell grid, then calls `thumbnail.RenderGrid`. The composer is the only piece of new server-only code that *has* to live in the server package because no client has cross-pane visibility into authoritative state.
+
+The `ThumbnailRenderer` interface is declared in Task 11 (the orchestrator that calls it from Manager hooks). This task implements the production renderer that satisfies that interface; the test stub in Task 11 stands in for unit tests that don't want to wire a full DesktopSink.
 
 - [ ] **Step 1: Write failing tests**
 
-Append to `internal/runtime/server/thumbnail_test.go`:
+Create `internal/runtime/server/thumbnail_renderer_test.go`:
 
 ```go
-// fakeRenderer is a stub ThumbnailRenderer used by trigger tests so we
-// don't drag textrender + a real font into the unit harness.
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
+)
+
+// composePaneGrid is the pure helper. The full DesktopSink path is
+// covered by integration tests that already wire publisher state.
+func TestComposePaneGrid_SinglePane(t *testing.T) {
+	pane := paneRender{
+		x: 0, y: 0, w: 4, h: 2,
+		rows: [][]texelcore.Cell{
+			{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}, {Ch: 'd'}},
+			{{Ch: 'e'}, {Ch: 'f'}, {Ch: 'g'}, {Ch: 'h'}},
+		},
+	}
+	grid := composePaneGrid(4, 2, []paneRender{pane})
+	if len(grid) != 2 || len(grid[0]) != 4 {
+		t.Fatalf("dims = %dx%d, want 4x2", len(grid[0]), len(grid))
+	}
+	if grid[0][0].Ch != 'a' || grid[1][3].Ch != 'h' {
+		t.Errorf("content mismatch: grid=%v", grid)
+	}
+}
+
+func TestComposePaneGrid_TwoPanesSideBySide(t *testing.T) {
+	left := paneRender{
+		x: 0, y: 0, w: 2, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'L'}, {Ch: '1'}}},
+	}
+	right := paneRender{
+		x: 2, y: 0, w: 2, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'R'}, {Ch: '1'}}},
+	}
+	grid := composePaneGrid(4, 1, []paneRender{left, right})
+	if grid[0][0].Ch != 'L' || grid[0][1].Ch != '1' {
+		t.Errorf("left mis-painted: %v", grid[0])
+	}
+	if grid[0][2].Ch != 'R' || grid[0][3].Ch != '1' {
+		t.Errorf("right mis-painted: %v", grid[0])
+	}
+}
+
+func TestComposePaneGrid_OverflowClipped(t *testing.T) {
+	// Pane reports w=10 but only 4 cells of buffer; composer should
+	// not panic and should leave the rest blank.
+	pane := paneRender{
+		x: 0, y: 0, w: 10, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'x'}, {Ch: 'y'}, {Ch: 'z'}}},
+	}
+	grid := composePaneGrid(10, 1, []paneRender{pane})
+	if grid[0][0].Ch != 'x' || grid[0][1].Ch != 'y' || grid[0][2].Ch != 'z' {
+		t.Errorf("front-pad mismatch: %v", grid[0])
+	}
+	for i := 3; i < 10; i++ {
+		if grid[0][i].Ch != ' ' && grid[0][i].Ch != 0 {
+			t.Errorf("expected blank at col %d, got %q", i, grid[0][i].Ch)
+		}
+	}
+}
+
+func TestComposePaneGrid_OutOfBoundsPaneIgnored(t *testing.T) {
+	// Pane positioned outside the workspace: composer drops cells
+	// rather than panicking with an index-out-of-range.
+	pane := paneRender{
+		x: 100, y: 100, w: 4, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}, {Ch: 'd'}}},
+	}
+	_ = composePaneGrid(4, 1, []paneRender{pane}) // should not panic
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestComposePaneGrid" -count=1`
+Expected: FAIL — `paneRender`, `composePaneGrid` undefined.
+
+- [ ] **Step 3: Implement the composer + DesktopSink adapter**
+
+Create `internal/runtime/server/thumbnail_renderer.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/thumbnail_renderer.go
+// Summary: Composes per-pane buffer snapshots into a single workspace
+// cell grid for thumbnail rendering. The composer is the server-only
+// glue between the publisher's authoritative state and the shared
+// internal/thumbnail render primitive.
+
+package server
+
+import (
+	"image"
+
+	texelcore "github.com/framegrace/texelui/core"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
+)
+
+// paneRender is the per-pane input to composePaneGrid. Coordinates are
+// workspace-relative; rows[y][x] is a cell.
+type paneRender struct {
+	x, y int
+	w, h int
+	rows [][]texelcore.Cell
+}
+
+// composePaneGrid paints pane buffers onto a (workspaceW × workspaceH)
+// cell grid. Out-of-bounds cells are dropped silently. The grid is
+// initialised with zero-value Cells (Ch=0, default style) which the
+// renderer treats as blanks.
+func composePaneGrid(workspaceW, workspaceH int, panes []paneRender) [][]texelcore.Cell {
+	grid := make([][]texelcore.Cell, workspaceH)
+	for y := 0; y < workspaceH; y++ {
+		grid[y] = make([]texelcore.Cell, workspaceW)
+	}
+	for _, p := range panes {
+		for ry, row := range p.rows {
+			absY := p.y + ry
+			if absY < 0 || absY >= workspaceH {
+				continue
+			}
+			for rx, cell := range row {
+				absX := p.x + rx
+				if absX < 0 || absX >= workspaceW {
+					continue
+				}
+				grid[absY][absX] = cell
+			}
+		}
+	}
+	return grid
+}
+
+// renderSessionThumbnail extracts pane buffers from the publisher
+// (which already maintains them for diff generation) and renders the
+// composed grid to an image via the shared primitive. Returns
+// (nil, false) when the session has no renderable content (no panes,
+// empty publisher state).
+//
+// Wired into DesktopSink.RenderSessionThumbnail; the indirection lets
+// us unit-test composePaneGrid without a full DesktopSink.
+func (s *DesktopSink) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	if s == nil {
+		return nil, false
+	}
+	pub := s.Publisher()
+	desktop := s.Desktop()
+	if pub == nil || desktop == nil {
+		return nil, false
+	}
+	w, h := desktop.ViewportSize()
+	if w <= 0 || h <= 0 {
+		return nil, false
+	}
+	panes := make([]paneRender, 0, 8)
+	pub.WalkPanes(func(paneID [16]byte, x, y, paneW, paneH int, rows [][]texelcore.Cell) {
+		if len(rows) == 0 {
+			return
+		}
+		panes = append(panes, paneRender{
+			x: x, y: y, w: paneW, h: paneH, rows: rows,
+		})
+	})
+	if len(panes) == 0 {
+		return nil, false
+	}
+	grid := composePaneGrid(w, h, panes)
+	img, err := thumbnail.RenderGrid(grid)
+	if err != nil {
+		return nil, false
+	}
+	return img, true
+}
+```
+
+Modify `internal/runtime/server/desktop_publisher.go` to expose a `WalkPanes` method that yields `(paneID, x, y, w, h, rows)` from the publisher's existing per-pane state. The exact source of `rows` depends on what `prevBuffers` already holds — read `desktop_publisher.go`'s field declarations and choose the per-pane buffer that already exists for diff generation; do not introduce a new copy. Document in the doc comment that `WalkPanes` is the picker thumbnail's input source so the next reader knows the contract.
+
+If `DesktopEngine` does not currently expose `ViewportSize() (int, int)`, add a thin getter. The publisher already knows the workspace size for diff bounds, so the field exists somewhere in the desktop layer; surface it minimally.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestComposePaneGrid" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/thumbnail_renderer.go internal/runtime/server/thumbnail_renderer_test.go internal/runtime/server/desktop_publisher.go internal/runtime/server/desktop_sink.go
+git commit -m "Server: pane-grid composer + DesktopSink thumbnail adapter"
+```
+
+---
+
+### Task 11: `captureThumbnail` orchestrator + ThumbnailRenderer interface
+
+**Files:**
+- Create: `internal/runtime/server/thumbnail.go`
+- Create: `internal/runtime/server/thumbnail_test.go`
+
+The shared primitive (Task 9) handles the rendering and atomic write. Task 11 is the *orchestrator* — defines the `ThumbnailRenderer` interface (production satisfier is `*DesktopSink` from Task 10), the `captureThumbnail` function that calls renderer → downscale → write, and the test harness for the trigger paths in Task 12.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/runtime/server/thumbnail_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"encoding/hex"
+	"image"
+	"image/color"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeRenderer is a stub ThumbnailRenderer used by trigger tests so
+// we don't drag textrender + a real font into the unit harness.
 type fakeRenderer struct {
 	calls int
 }
 
 func (f *fakeRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
 	f.calls++
-	return makeTestImage(80, 24), true
+	img := image.NewRGBA(image.Rect(0, 0, 80, 24))
+	for y := 0; y < 24; y++ {
+		for x := 0; x < 80; x++ {
+			img.Set(x, y, color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF})
+		}
+	}
+	return img, true
+}
+
+type skipRenderer struct{}
+
+func (skipRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	return nil, false
 }
 
 func TestCaptureThumbnail_WritesPNG(t *testing.T) {
@@ -2071,8 +2422,7 @@ func TestCaptureThumbnail_RendererSkip(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	id := [16]byte{0x88}
-	r := skipRenderer{}
-	if err := captureThumbnail(dir, id, r); err != nil {
+	if err := captureThumbnail(dir, id, skipRenderer{}); err != nil {
 		t.Fatalf("capture: %v", err)
 	}
 	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
@@ -2081,11 +2431,128 @@ func TestCaptureThumbnail_RendererSkip(t *testing.T) {
 	}
 }
 
-type skipRenderer struct{}
-
-func (skipRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
-	return nil, false
+func TestCaptureThumbnail_NilRendererSilent(t *testing.T) {
+	if err := captureThumbnail(t.TempDir(), [16]byte{}, nil); err != nil {
+		t.Errorf("expected nil error for nil renderer, got %v", err)
+	}
 }
+
+func TestCaptureThumbnail_RendererPanicSurvives(t *testing.T) {
+	// A panicking renderer must not bring down the daemon; the
+	// orchestrator wraps the call in defer/recover.
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
+	if err := captureThumbnail(dir, [16]byte{0x99}, panicRenderer{}); err == nil {
+		t.Errorf("expected error from panicking renderer")
+	}
+}
+
+type panicRenderer struct{}
+
+func (panicRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	panic("intentional test panic")
+}
+```
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail" -count=1`
+Expected: FAIL — `captureThumbnail`, `ThumbnailRenderer` undefined.
+
+- [ ] **Step 3: Implement orchestrator + interface**
+
+Create `internal/runtime/server/thumbnail.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/thumbnail.go
+// Summary: Lifecycle thumbnail capture orchestrator (Plan F.1).
+// Usage: Called from Manager.ShutdownSessions and Manager.Close on
+//   the last-disconnect transition. Renders via a ThumbnailRenderer
+//   (production: *DesktopSink, see Task 10), downscales via the
+//   shared internal/thumbnail primitive, and atomically writes to
+//   <basedir>/sessions/<id>.png.
+
+package server
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"path/filepath"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
+)
+
+// ThumbnailRenderer produces a PNG-suitable image for a given session.
+// Implemented by *DesktopSink in production (see Task 10's
+// thumbnail_renderer.go); tests inject a stub.
+//
+// Returns ok=false when the session has nothing meaningful to capture
+// (empty workspace, no live buffer) so the caller can skip the disk
+// write rather than store an all-black PNG.
+type ThumbnailRenderer interface {
+	RenderSessionThumbnail(id [16]byte) (image.Image, bool)
+}
+
+// captureThumbnail renders id via the renderer (if non-nil), downscales
+// to 480×270 via the shared primitive, and writes the result to
+// <basedir>/sessions/<id>.png. A panicking renderer is recovered to an
+// error so a buggy implementation cannot prevent shutdown. nil renderer
+// or empty basedir is a silent no-op.
+func captureThumbnail(basedir string, id [16]byte, r ThumbnailRenderer) (retErr error) {
+	if r == nil || basedir == "" {
+		return nil
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			retErr = fmt.Errorf("thumbnail: renderer panic: %v", rec)
+		}
+	}()
+	img, ok := r.RenderSessionThumbnail(id)
+	if !ok {
+		return nil
+	}
+	if img == nil {
+		return errors.New("thumbnail: renderer returned ok=true with nil image")
+	}
+	scaled := thumbnail.DownscaleAspectFit(img, 480, 270)
+	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	return thumbnail.WritePNGAtomic(pngPath, scaled)
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail" -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/server/thumbnail.go internal/runtime/server/thumbnail_test.go
+git commit -m "Server: captureThumbnail orchestrator + ThumbnailRenderer interface"
+```
+
+---
+
+### Task 12: Capture trigger — wire `Close(id)` + `ShutdownSessions`
+
+**Files:**
+- Modify: `internal/runtime/server/manager.go` (`thumbRenderer` field, `SetThumbnailRenderer`, modified `Close` + `ShutdownSessions`)
+- Modify: `internal/runtime/server/thumbnail_test.go` (append manager-level trigger tests)
+
+The orchestrator + interface ship in Task 11. This task is the manager-side wiring: a renderer field, a setter, and the modified lifecycle methods. **Both `Close` and `ShutdownSessions` are shown in full** so a subagent doesn't have to reconstruct them from prose.
+
+- [ ] **Step 1: Append failing trigger tests**
+
+Append to `internal/runtime/server/thumbnail_test.go`:
+
+```go
+import "time"
 
 func TestManager_CaptureOnShutdown(t *testing.T) {
 	dir := t.TempDir()
@@ -2096,11 +2563,9 @@ func TestManager_CaptureOnShutdown(t *testing.T) {
 	}
 	r := &fakeRenderer{}
 	m.SetThumbnailRenderer(r)
-	sess, err := m.NewSessionWithID(id)
-	if err != nil {
+	if _, err := m.NewSessionWithID(id); err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	_ = sess
 	m.ShutdownSessions()
 	if r.calls < 1 {
 		t.Errorf("expected at least 1 thumbnail render, got %d", r.calls)
@@ -2132,56 +2597,51 @@ func TestManager_CaptureOnLastDisconnect(t *testing.T) {
 		t.Errorf("expected PNG after Close, stat err=%v", err)
 	}
 }
+
+func TestManager_NoCaptureWhenRendererUnset(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0xAA}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	m.Close(id)
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected no PNG when renderer unset, stat err=%v", err)
+	}
+}
 ```
 
 - [ ] **Step 2: Run tests, verify failure**
 
-Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail|TestManager_Capture" -count=1`
-Expected: FAIL — `captureThumbnail`, `SetThumbnailRenderer` undefined.
+Run: `go test ./internal/runtime/server/ -run "TestManager_CaptureOn|TestManager_NoCaptureWhenRendererUnset" -count=1`
+Expected: FAIL — `SetThumbnailRenderer` undefined; `Close` and `ShutdownSessions` don't fire capture.
 
-- [ ] **Step 3: Implement renderer interface + captureThumbnail**
+- [ ] **Step 3: Add renderer field, setter, and revised lifecycle methods**
 
-Append to `internal/runtime/server/thumbnail.go`:
+In `internal/runtime/server/manager.go`, extend the `Manager` struct:
 
 ```go
-// ThumbnailRenderer produces a PNG-suitable image for a given session.
-// Implemented by the desktop publisher in production; tests inject a
-// stub. Returns ok=false when the session has nothing meaningful to
-// capture (empty workspace, no live buffer) so the caller can skip the
-// disk write rather than store an all-black PNG.
-type ThumbnailRenderer interface {
-	RenderSessionThumbnail(id [16]byte) (image.Image, bool)
-}
+type Manager struct {
+	// ... existing fields ...
 
-// captureThumbnail renders id via the renderer (if present), downscales
-// to 480x270, and writes the result to <basedir>/sessions/<id>.png.
-// All errors are returned; callers are expected to log + continue —
-// thumbnail capture is a hint, not authoritative state.
-func captureThumbnail(basedir string, id [16]byte, r ThumbnailRenderer) error {
-	if r == nil || basedir == "" {
-		return nil
-	}
-	img, ok := r.RenderSessionThumbnail(id)
-	if !ok {
-		return nil
-	}
-	scaled := downscaleAspectFit(img, 480, 270)
-	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
-	return writePNGAtomic(pngPath, scaled)
+	// Plan F.1: lifecycle thumbnail capture. nil = capture disabled
+	// (tests + early boot before SetThumbnailRenderer is called).
+	thumbRenderer ThumbnailRenderer
 }
 ```
 
-Add `"path/filepath"` and `"encoding/hex"` to the imports.
-
-In `internal/runtime/server/manager.go`, add a renderer field and setter:
+Add the setter:
 
 ```go
-// On the Manager struct, add:
-//   thumbRenderer ThumbnailRenderer
-
-// SetThumbnailRenderer wires the production renderer (DesktopSink in
-// the texel-server harness, nil/stub in tests). nil renderers skip
-// capture silently — no error, no log spam.
+// SetThumbnailRenderer wires the production renderer (typically the
+// *DesktopSink that owns the publisher state — see Task 10) so
+// Close(id) and ShutdownSessions can capture lifecycle thumbnails.
+// nil renderers skip capture silently — no error, no log spam.
 func (m *Manager) SetThumbnailRenderer(r ThumbnailRenderer) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2189,50 +2649,30 @@ func (m *Manager) SetThumbnailRenderer(r ThumbnailRenderer) {
 }
 ```
 
-Then extend `ShutdownSessions` and `Close` to fire capture *before* the per-session Close:
+Replace the existing `Close(id)` body with the captured-renderer version:
 
 ```go
-// ShutdownSessions: inside the per-session loop, before session.Close():
-if m.persistBasedir != "" && m.thumbRenderer != nil {
-	if err := captureThumbnail(m.persistBasedir, id, m.thumbRenderer); err != nil {
-		log.Printf("server: shutdown thumbnail %x: %v", id[:4], err)
-	}
-}
-// (Note: m.thumbRenderer is read after m.mu was released in the
-// existing flow; capture the renderer pointer before the unlock to
-// avoid a race with SetThumbnailRenderer. Add to the locked section.)
-```
-
-For `Close(id)`:
-
-```go
-// Close(id): immediately after `delete(m.sessions, id)` and before
-// the markClosing/unlock block, capture the renderer pointer:
-basedir := m.persistBasedir
-renderer := m.thumbRenderer
-m.mu.Unlock()
-
-if basedir != "" && renderer != nil {
-	if err := captureThumbnail(basedir, id, renderer); err != nil {
-		log.Printf("server: close thumbnail %x: %v", id[:4], err)
-	}
-}
-// Then continue with markClosing + session.Close() as before.
-```
-
-Take care to preserve the existing `markClosing` / `unmarkClosing` ordering. The full revised `Close`:
-
-```go
+// Close removes the session from the live map and tears it down.
+// Plan F.1: also captures a thumbnail just before teardown so the
+// next picker invocation has something to show. The capture happens
+// OUTSIDE m.mu (PNG encoding holds memory and may sync to disk —
+// holding the lock would block every other Manager op for the
+// duration). Renderer + basedir are snapshotted under the lock so a
+// concurrent SetThumbnailRenderer doesn't race with the read.
+//
+// Plan D2 17.B: Close registers a per-ID "closing" marker before
+// dropping m.mu and clears it after session.Close returns.
+// LookupOrRehydrate consults the same marker so a fresh resume for
+// the same ID waits out the disk flush instead of constructing a
+// new Session pointing at the same on-disk path.
 func (m *Manager) Close(id [16]byte) {
 	m.mu.Lock()
 	session, ok := m.sessions[id]
-	if ok {
-		delete(m.sessions, id)
-	}
 	if !ok {
 		m.mu.Unlock()
 		return
 	}
+	delete(m.sessions, id)
 	basedir := m.persistBasedir
 	renderer := m.thumbRenderer
 	m.markClosing(id)
@@ -2244,37 +2684,126 @@ func (m *Manager) Close(id [16]byte) {
 			log.Printf("server: close thumbnail %x: %v", id[:4], err)
 		}
 	}
-	session.Close()
+	session.Close() // disk flush — outside m.mu
 }
 ```
 
-Apply the analogous adjustment to `ShutdownSessions`: capture `basedir` and `renderer` once under m.mu, then loop with both available.
+Replace the existing `ShutdownSessions` body:
+
+```go
+// ShutdownSessions closes all live sessions and (Plan F.1) captures
+// a thumbnail per session before the per-session Close. Capture runs
+// OUTSIDE m.mu — see Close for the lock-discipline rationale. Both
+// basedir and renderer are snapshotted once under the lock; a
+// concurrent SetThumbnailRenderer call after the snapshot is benign
+// (we'll just use the older renderer one final time).
+func (m *Manager) ShutdownSessions() {
+	m.mu.Lock()
+	live := m.sessions
+	m.sessions = make(map[[16]byte]*Session)
+	basedir := m.persistBasedir
+	renderer := m.thumbRenderer
+	for id := range live {
+		m.markClosing(id)
+	}
+	m.mu.Unlock()
+
+	for id, session := range live {
+		if basedir != "" && renderer != nil {
+			if err := captureThumbnail(basedir, id, renderer); err != nil {
+				log.Printf("server: shutdown thumbnail %x: %v", id[:4], err)
+			}
+		}
+		session.Close() // disk flush — outside m.mu
+		m.unmarkClosing(id)
+	}
+}
+```
+
+The `Close` change deletes from `m.sessions` *before* the early-return guard, which fixes a pre-existing minor inefficiency where `delete` ran on the not-found branch (the original code's order was `if ok { delete }; if !ok { return }`). Behavior is preserved — Go's `delete` on a missing key is a no-op.
 
 - [ ] **Step 4: Run tests, verify pass**
 
-Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail|TestManager_Capture" -count=1`
+Run: `go test ./internal/runtime/server/ -run "TestCaptureThumbnail|TestManager_CaptureOn|TestManager_NoCaptureWhenRendererUnset" -count=1`
 Expected: PASS.
 
-- [ ] **Step 5: Run the full server suite**
+- [ ] **Step 5: Run the full server suite under -race**
 
 Run: `go test -race ./internal/runtime/server/ -count=1`
-Expected: PASS — no races introduced by the new field access.
+Expected: PASS. The renderer snapshot pattern matches the existing basedir-snapshot pattern in `EnablePersistence` and avoids introducing races.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add internal/runtime/server/thumbnail.go internal/runtime/server/thumbnail_test.go internal/runtime/server/manager.go
-git commit -m "Server: capture thumbnails on shutdown + last-disconnect"
+git add internal/runtime/server/manager.go internal/runtime/server/thumbnail_test.go
+git commit -m "Server: capture thumbnails on Close + ShutdownSessions"
 ```
 
 ---
 
-### Task 11: Connection handlers — list + recover
+### Task 13: Connection handlers — list + recover (with `connection.manager` wiring)
 
 **Files:**
+- Modify: `internal/runtime/server/connection.go` (add `manager *Manager` field; thread through `newConnection`)
+- Modify: `internal/runtime/server/server.go` (pass manager to `newConnection`)
+- Modify: every existing test that calls `newConnection` (~16 files; mechanical signature update)
 - Create: `internal/runtime/server/connection_session_picker.go`
 - Modify: `internal/runtime/server/connection_handler.go` (dispatch new types)
 - Test: `internal/runtime/server/connection_session_picker_test.go`
+
+The handlers in this task and Task 14 call `c.manager.X()`, but the existing `connection` struct has no `manager` field. Step 0 is the structural wiring; Step 1 onwards is the handler work.
+
+- [ ] **Step 0: Wire `connection.manager` field**
+
+In `internal/runtime/server/connection.go`, add a field to the `connection` struct:
+
+```go
+type connection struct {
+	// ... existing fields ...
+
+	// Plan F.1: picker handlers reach into the manager for session
+	// listing, rename, delete, and rehydrate. Wired at construction
+	// time by newConnection; never reassigned. nil only in tests
+	// that use a hand-constructed connection without a manager —
+	// those tests must not exercise picker handlers.
+	manager *Manager
+}
+```
+
+Update `newConnection` (read its current signature in `connection.go` first; whatever it is, append a `*Manager` parameter):
+
+```go
+func newConnection(/* existing args */, mgr *Manager) *connection {
+	return &connection{
+		// ... existing fields ...
+		manager: mgr,
+	}
+}
+```
+
+Update `internal/runtime/server/server.go` (the only production call site of `newConnection`) to pass `s.manager`. Then run:
+
+```bash
+grep -rln "newConnection(" internal/runtime/server/ | grep _test.go
+```
+
+Each test file needs the new argument added. Most tests construct a `*Manager` already (often via `NewManager()`); pass it through. Tests that don't construct a manager should pass `nil` — they're not exercising picker handlers, and the handler code is gated by Task 14's tests, not these.
+
+Run:
+
+```bash
+go build ./internal/runtime/server/...
+go test -run NoneShouldMatchJustCheckCompile ./internal/runtime/server/ -count=1
+```
+
+Expected: build clean (some tests may still fail; the goal is just compile).
+
+Commit this structural change separately so the diff against the picker handlers stays readable:
+
+```bash
+git add internal/runtime/server/connection.go internal/runtime/server/server.go internal/runtime/server/*_test.go
+git commit -m "Connection: add manager *Manager field for picker handlers"
+```
 
 - [ ] **Step 1: Write failing tests**
 
@@ -2441,33 +2970,96 @@ func mustEncodeListSessionsRequest(t *testing.T) []byte {
 }
 ```
 
-`newPickerTestConn` is a helper to model after the existing memconn patterns. Inspect `internal/runtime/server/connection_rehydrate_resume_test.go` and `internal/runtime/server/testutil/memconn.go` and adapt the harness to drive the connection handler with arbitrary message types. If a similar helper already exists in the test corpus, reuse it. Otherwise, write a minimal helper here:
+`newPickerTestConn` is a helper modelled on `internal/runtime/server/connection_rehydrate_resume_test.go` (which already constructs `*connection` against a `net.Pipe` pair + `nopSink`). The picker variant is simpler because it doesn't need the resume-handshake choreography.
 
 ```go
-// pickerTestConn wires a connection's writer half to a buffer the test
-// reads from. The connection runs handleMessage synchronously per
-// send.
+// internal/runtime/server/connection_session_picker_test.go
+// (helper, declared once near the top of the file)
+
+import (
+	"net"
+	"sync"
+	// ... other imports ...
+
+	"github.com/framegrace/texelation/protocol"
+)
 
 type pickerTestConn struct {
-	conn      *connection
-	clientEnd interface{ /* memconn-style read interface */ }
-	cleanupFn func()
+	t          *testing.T
+	conn       *connection
+	clientEnd  net.Conn
+	serverEnd  net.Conn
+	closeOnce  sync.Once
 }
 
+// newPickerTestConn wires a *connection to a net.Pipe so the test
+// can drive handleMessage synchronously and read responses off the
+// client side. Reuses the in-package nopSink (defined in
+// test_helpers_test.go); creates a fresh session via m.NewSession.
+//
+// The returned *connection has no goroutine of its own — tests call
+// p.send to invoke handleMessage directly. This deliberately differs
+// from the production read loop to keep tests deterministic.
 func newPickerTestConn(t *testing.T, m *Manager) (*pickerTestConn, *nopSink) {
 	t.Helper()
-	// ... wire memconn pair, construct a connection bound to m,
-	// run a session via NewSession or attach one for testing
-	// ... return wrapper
-	return nil, nil
+	clientEnd, serverEnd := net.Pipe()
+	sess, err := m.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	sink := &nopSink{}
+	c := newConnection(serverEnd, sess, sink, m) // signature from Step 0
+	p := &pickerTestConn{
+		t:         t,
+		conn:      c,
+		clientEnd: clientEnd,
+		serverEnd: serverEnd,
+	}
+	return p, sink
 }
 
-func (p *pickerTestConn) send(typ protocol.MessageType, payload []byte)        { /* ... */ }
-func (p *pickerTestConn) expectResponse(t *testing.T, want protocol.MessageType) []byte { /* ... */; return nil }
-func (p *pickerTestConn) cleanup()                                                  {}
+// send invokes handleMessage with the supplied message type + payload,
+// running it on the test's goroutine so any error surfaces immediately.
+func (p *pickerTestConn) send(typ protocol.MessageType, payload []byte) {
+	p.t.Helper()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      typ,
+		Flags:     protocol.FlagChecksum,
+		SessionID: p.conn.session.ID(),
+	}
+	if err := p.conn.handleMessage("test", hdr, payload); err != nil {
+		p.t.Fatalf("handleMessage(%d): %v", typ, err)
+	}
+}
+
+// expectResponse reads the next protocol message off the client end
+// of the pipe and asserts its type matches `want`. Returns the payload.
+func (p *pickerTestConn) expectResponse(t *testing.T, want protocol.MessageType) []byte {
+	t.Helper()
+	hdr, payload, err := protocol.ReadMessage(p.clientEnd)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if hdr.Type != want {
+		t.Fatalf("response type = %d, want %d", hdr.Type, want)
+	}
+	return payload
+}
+
+func (p *pickerTestConn) cleanup() {
+	p.closeOnce.Do(func() {
+		_ = p.clientEnd.Close()
+		_ = p.serverEnd.Close()
+	})
+}
 ```
 
-When implementing this helper, refer to `connection_rehydrate_resume_test.go` lines that construct a connection with a memconn pair. Reuse the existing `nopSink` type already in the test files.
+Two concrete things to verify when implementing:
+1. `newConnection`'s real signature — adapt the call site if production wires extra arguments (fetch-pending broadcaster etc.).
+2. `nopSink` type lives in the test corpus already — confirm via `grep "nopSink" internal/runtime/server/*_test.go` before declaring a new one.
+
+`net.Pipe` is synchronous — `c.writeMessage` from a handler returns only after `clientEnd` has accepted the write, so `expectResponse` won't deadlock. If the handler writes multiple frames, call `expectResponse` once per frame in order.
 
 - [ ] **Step 2: Run tests, verify failure**
 
@@ -2597,12 +3189,14 @@ git commit -m "Connection: list-sessions + recover-session handlers"
 
 ---
 
-### Task 12: Connection handlers — rename + delete + fetch-thumbnail
+### Task 14: Connection handlers — rename + delete + fetch-thumbnail (with size cap + SessionOpResponse)
 
 **Files:**
 - Modify: `internal/runtime/server/connection_session_picker.go` (append handlers)
 - Modify: `internal/runtime/server/connection_handler.go` (dispatch)
 - Modify: `internal/runtime/server/connection_session_picker_test.go` (append tests)
+
+This task uses the dedicated `MsgSessionOpResponse` (declared in Task 1, encoded in Task 4) as the rename/delete ack. The fetch-thumbnail handler caps file size at 1 MiB to prevent local DoS via a hand-written oversized PNG.
 
 - [ ] **Step 1: Write failing tests**
 
@@ -2631,28 +3225,41 @@ func TestHandleRenameSession_HappyPath(t *testing.T) {
 	defer conn.cleanup()
 	body, _ := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: id, NewLabel: "after"})
 	conn.send(protocol.MsgRenameSession, body)
-	// Server replies with SessionOpResponse.
-	// We piggy-back on MsgError-or-similar pattern; here we expect a
-	// dedicated MsgListSessionsResponse-shaped response. Adjust based
-	// on the implementation choice — the simplest is to reuse the
-	// MsgError envelope for ok=false and an empty MsgListSessions
-	// response for ok=true. To keep things explicit, the implementer
-	// should add a SessionOpResponse-typed reply: if a separate
-	// MessageType is desired, declare MsgSessionOpResponse in
-	// protocol/protocol.go now and update Task 1.
-	//
-	// Simpler in-scope choice: the handler responds via MsgError
-	// (for OK=false) or MsgListSessionsResponse with empty payload
-	// (for OK=true). We document this contract in the handler's
-	// docstring rather than adding another MessageType.
-	//
-	// Test asserts the in-memory rename took effect via a follow-up
-	// MsgListSessions request:
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	got, err := protocol.DecodeSessionOpResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OpType != protocol.OpRename || !got.OK {
+		t.Fatalf("expected OpRename OK=true, got %#v", got)
+	}
+	// Confirm via list.
 	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
-	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
-	got, _ := protocol.DecodeListSessionsResponse(resp)
-	if len(got.Stored) != 1 || got.Stored[0].Label != "after" {
-		t.Fatalf("expected rename applied; got %#v", got.Stored)
+	listResp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	listGot, _ := protocol.DecodeListSessionsResponse(listResp)
+	if len(listGot.Stored) != 1 || listGot.Stored[0].Label != "after" {
+		t.Fatalf("expected rename applied; got %#v", listGot.Stored)
+	}
+}
+
+func TestHandleRenameSession_UnknownID(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: [16]byte{0xFF}, NewLabel: "x"})
+	conn.send(protocol.MsgRenameSession, body)
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	got, _ := protocol.DecodeSessionOpResponse(resp)
+	if got.OK || got.Error == "" {
+		t.Errorf("expected OK=false with error, got %#v", got)
+	}
+	if got.OpType != protocol.OpRename {
+		t.Errorf("OpType = %d, want OpRename", got.OpType)
 	}
 }
 
@@ -2677,11 +3284,16 @@ func TestHandleDeleteSession_HappyPath(t *testing.T) {
 	defer conn.cleanup()
 	body, _ := protocol.EncodeDeleteSessionRequest(protocol.DeleteSessionRequest{SessionID: id})
 	conn.send(protocol.MsgDeleteSession, body)
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	got, _ := protocol.DecodeSessionOpResponse(resp)
+	if got.OpType != protocol.OpDelete || !got.OK {
+		t.Fatalf("expected OpDelete OK=true, got %#v", got)
+	}
 	conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
-	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
-	got, _ := protocol.DecodeListSessionsResponse(resp)
-	if len(got.Stored) != 0 {
-		t.Fatalf("expected empty after delete; got %d", len(got.Stored))
+	listResp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	listGot, _ := protocol.DecodeListSessionsResponse(listResp)
+	if len(listGot.Stored) != 0 {
+		t.Fatalf("expected empty after delete; got %d", len(listGot.Stored))
 	}
 }
 
@@ -2725,9 +3337,7 @@ func TestHandleFetchThumbnail_HappyPath(t *testing.T) {
 
 func TestHandleFetchThumbnail_Missing(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
 	m := NewManager()
 	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
 		t.Fatalf("enable: %v", err)
@@ -2742,6 +3352,33 @@ func TestHandleFetchThumbnail_Missing(t *testing.T) {
 		t.Errorf("expected OK=false for missing PNG")
 	}
 }
+
+func TestHandleFetchThumbnail_RefusesOversize(t *testing.T) {
+	// A 2 MiB file at the predictable path must be refused with
+	// OK=false (DoS prevention). 480x270 PNGs are well under 100 KiB
+	// in practice; 1 MiB cap is generous.
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x40}
+	pngPath := filepath.Join(sessions, hex.EncodeToString(id[:])+".png")
+	if err := os.WriteFile(pngPath, make([]byte, 2*1024*1024), 0o644); err != nil {
+		t.Fatalf("write big png: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn, _ := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	got, _ := protocol.DecodeFetchThumbnailResponse(resp)
+	if got.OK {
+		t.Errorf("expected OK=false for oversized PNG, got OK=true with %d bytes", len(got.PNG))
+	}
+}
 ```
 
 - [ ] **Step 2: Run tests, verify failure**
@@ -2754,20 +3391,26 @@ Expected: FAIL — handlers undefined / not dispatched.
 Append to `internal/runtime/server/connection_session_picker.go`:
 
 ```go
-// handleRenameSession applies an inline label edit. Replies with
-// MsgError on failure (OK=false implied) and an empty
-// MsgListSessionsResponse on success — this dual-purpose ack avoids
-// a dedicated MsgSessionOpResponse type while still letting the
-// client treat any non-error response as success.
+// maxThumbnailBytes caps PNG sidecar reads to defend against a local
+// attacker writing a giant file at the predictable on-disk path. A
+// 480×270 PNG at high quality is well under 100 KiB; 1 MiB leaves
+// generous headroom while keeping the worst-case server allocation
+// bounded.
+const maxThumbnailBytes int64 = 1 << 20
+
+// handleRenameSession applies an inline label edit. Replies with a
+// MsgSessionOpResponse{OpType: OpRename, OK: ...} so the picker can
+// correlate against the op it issued (no conflation with other
+// responses on the connection).
 func (c *connection) handleRenameSession(payload []byte) error {
 	req, err := protocol.DecodeRenameSessionRequest(payload)
 	if err != nil {
 		return fmt.Errorf("decode rename: %w", err)
 	}
 	if err := c.manager.RenameStored(req.SessionID, req.NewLabel); err != nil {
-		return c.sendErrorFrame(err)
+		return c.sendOpResponse(protocol.OpRename, false, err.Error())
 	}
-	return c.ackPickerOp()
+	return c.sendOpResponse(protocol.OpRename, true, "")
 }
 
 func (c *connection) handleDeleteSession(payload []byte) error {
@@ -2776,9 +3419,9 @@ func (c *connection) handleDeleteSession(payload []byte) error {
 		return fmt.Errorf("decode delete: %w", err)
 	}
 	if err := c.manager.DeleteStored(req.SessionID); err != nil {
-		return c.sendErrorFrame(err)
+		return c.sendOpResponse(protocol.OpDelete, false, err.Error())
 	}
-	return c.ackPickerOp()
+	return c.sendOpResponse(protocol.OpDelete, true, "")
 }
 
 func (c *connection) handleFetchThumbnail(payload []byte) error {
@@ -2788,11 +3431,25 @@ func (c *connection) handleFetchThumbnail(payload []byte) error {
 	}
 	pngPath := c.manager.sessionPNGPath(req.SessionID)
 	if pngPath == "" {
-		return c.sendThumbnailResponse(false, "persistence disabled", nil)
+		return c.sendThumbnailResponse(false, "thumbnail unavailable", nil)
+	}
+	info, err := os.Stat(pngPath)
+	if err != nil {
+		// Don't leak the path; client doesn't need it.
+		if os.IsNotExist(err) {
+			return c.sendThumbnailResponse(false, "thumbnail not found", nil)
+		}
+		log.Printf("server: fetch thumbnail %x stat: %v", req.SessionID[:4], err)
+		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
+	}
+	if info.Size() > maxThumbnailBytes {
+		log.Printf("server: fetch thumbnail %x: refusing %d bytes (cap %d)", req.SessionID[:4], info.Size(), maxThumbnailBytes)
+		return c.sendThumbnailResponse(false, "thumbnail too large", nil)
 	}
 	data, err := os.ReadFile(pngPath)
 	if err != nil {
-		return c.sendThumbnailResponse(false, err.Error(), nil)
+		log.Printf("server: fetch thumbnail %x read: %v", req.SessionID[:4], err)
+		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
 	}
 	return c.sendThumbnailResponse(true, "", data)
 }
@@ -2815,14 +3472,21 @@ func (c *connection) sendThumbnailResponse(ok bool, errMsg string, png []byte) e
 	return c.writeMessage(hdr, body)
 }
 
-// ackPickerOp confirms a successful rename/delete by sending an empty
-// MsgListSessionsResponse. The picker treats any non-error response
-// as success and re-fires MsgListSessions to refresh its catalog.
-func (c *connection) ackPickerOp() error {
-	body, _ := protocol.EncodeListSessionsResponse(protocol.ListSessionsResponse{})
+// sendOpResponse confirms a rename/delete with the typed
+// SessionOpResponse envelope. The picker correlates by OpType so it
+// can ignore unrelated frames that arrive on the connection.
+func (c *connection) sendOpResponse(op protocol.SessionOpKind, ok bool, errMsg string) error {
+	body, err := protocol.EncodeSessionOpResponse(protocol.SessionOpResponse{
+		OpType: op,
+		OK:     ok,
+		Error:  errMsg,
+	})
+	if err != nil {
+		return fmt.Errorf("encode op response: %w", err)
+	}
 	hdr := protocol.Header{
 		Version:   protocol.Version,
-		Type:      protocol.MsgListSessionsResponse,
+		Type:      protocol.MsgSessionOpResponse,
 		Flags:     protocol.FlagChecksum,
 		SessionID: c.session.ID(),
 	}
@@ -2830,7 +3494,7 @@ func (c *connection) ackPickerOp() error {
 }
 ```
 
-Add `"os"` to the imports.
+Add `"log"` and `"os"` to the imports.
 
 In `connection_handler.go`, add the dispatch cases:
 
@@ -2863,7 +3527,7 @@ git commit -m "Connection: rename/delete/fetch-thumbnail picker handlers"
 
 ---
 
-### Task 13: Picker — ASCII layout algorithm (pure functions)
+### Task 15: Picker — ASCII layout algorithm (pure functions)
 
 **Files:**
 - Create: `cmd/texelation/boot/picker_ascii.go`
@@ -2944,16 +3608,46 @@ func TestRenderASCIILayout_VerticalSplit(t *testing.T) {
 		},
 	}
 	grid := renderASCIILayoutGrid(20, 8, root)
-	// Vertical split should put a vertical line near the middle column.
-	verticalAtMid := 0
+	// Vertical split: with leftW = int(20 * 0.5) = 10, the right
+	// child draws starting at x=9 (border-sharing), so the divider
+	// column is 9, not 10. The algorithm comments document this; the
+	// test pins it explicitly.
+	dividerCol := 9
+	verticalAt := 0
 	for y := 1; y < 7; y++ {
-		mid := 10
-		if grid[y][mid] == '│' {
-			verticalAtMid++
+		if grid[y][dividerCol] == '│' {
+			verticalAt++
 		}
 	}
-	if verticalAtMid == 0 {
-		t.Errorf("expected vertical divider near col 10 in:\n%s", debugGrid(grid))
+	if verticalAt == 0 {
+		t.Errorf("expected vertical divider at col %d in:\n%s", dividerCol, debugGrid(grid))
+	}
+}
+
+func TestRenderASCIILayout_NWaySplit(t *testing.T) {
+	// 3-way horizontal split (real TreeNodeSnapshot supports n>=2
+	// children — texel/tree.go produces these).
+	root := &protocol.TreeNodeSnapshot{
+		PaneIndex:   -1,
+		Split:       protocol.SplitHorizontal,
+		SplitRatios: []float32{0.34, 0.33, 0.33},
+		Children: []protocol.TreeNodeSnapshot{
+			{PaneIndex: 0, Split: protocol.SplitNone},
+			{PaneIndex: 1, Split: protocol.SplitNone},
+			{PaneIndex: 2, Split: protocol.SplitNone},
+		},
+	}
+	grid := renderASCIILayoutGrid(20, 12, root)
+	// Should not panic and should produce more than one horizontal
+	// divider row (one per inter-child boundary, so 2 dividers).
+	dividerRows := 0
+	for y := 1; y < 11; y++ {
+		if strings.Count(string(grid[y]), "─") > 5 {
+			dividerRows++
+		}
+	}
+	if dividerRows < 2 {
+		t.Errorf("expected ≥ 2 divider rows for 3-way split, got %d:\n%s", dividerRows, debugGrid(grid))
 	}
 }
 
@@ -3051,38 +3745,77 @@ func drawNode(grid [][]rune, x, y, w, h int, n *protocol.TreeNodeSnapshot) {
 		drawSingleBox(grid, x, y, w, h)
 		return
 	}
+	ratios := normaliseRatios(n.SplitRatios, len(n.Children))
 	if n.Split == protocol.SplitHorizontal {
-		// Top child gets ratio[0]; bottom gets ratio[1].
-		r := splitRatio(n.SplitRatios)
-		topH := int(float32(h) * r)
-		if topH < asciiMinH {
-			topH = asciiMinH
+		// Walk children in order, allocating rows per ratio. Each
+		// child shares its bottom border with the next child's top
+		// border (the -1 / +1 dance), so the visual divider sits on
+		// a single row and shows '─' from each side's drawSingleBox.
+		cursorY := y
+		remaining := h
+		for i, child := range n.Children {
+			var sliceH int
+			if i == len(n.Children)-1 {
+				sliceH = remaining
+			} else {
+				sliceH = int(float32(h) * ratios[i])
+				if sliceH < asciiMinH {
+					sliceH = asciiMinH
+				}
+				if sliceH > remaining-asciiMinH*(len(n.Children)-i-1) {
+					sliceH = remaining - asciiMinH*(len(n.Children)-i-1)
+				}
+			}
+			drawNode(grid, x, cursorY, w, sliceH, &child)
+			cursorY += sliceH - 1
+			remaining -= sliceH - 1
 		}
-		if topH > h-asciiMinH {
-			topH = h - asciiMinH
-		}
-		drawNode(grid, x, y, w, topH, &n.Children[0])
-		drawNode(grid, x, y+topH-1, w, h-topH+1, &n.Children[1])
 		return
 	}
-	// Vertical split: left ratio[0], right ratio[1].
-	r := splitRatio(n.SplitRatios)
-	leftW := int(float32(w) * r)
-	if leftW < asciiMinW {
-		leftW = asciiMinW
+	// Vertical split: walk children left-to-right.
+	cursorX := x
+	remaining := w
+	for i, child := range n.Children {
+		var sliceW int
+		if i == len(n.Children)-1 {
+			sliceW = remaining
+		} else {
+			sliceW = int(float32(w) * ratios[i])
+			if sliceW < asciiMinW {
+				sliceW = asciiMinW
+			}
+			if sliceW > remaining-asciiMinW*(len(n.Children)-i-1) {
+				sliceW = remaining - asciiMinW*(len(n.Children)-i-1)
+			}
+		}
+		drawNode(grid, cursorX, y, sliceW, h, &child)
+		cursorX += sliceW - 1
+		remaining -= sliceW - 1
 	}
-	if leftW > w-asciiMinW {
-		leftW = w - asciiMinW
-	}
-	drawNode(grid, x, y, leftW, h, &n.Children[0])
-	drawNode(grid, x+leftW-1, y, w-leftW+1, h, &n.Children[1])
 }
 
-func splitRatio(ratios []float32) float32 {
-	if len(ratios) < 1 {
-		return 0.5
+// normaliseRatios returns a slice of len(childCount) ratios summing to
+// ~1.0. If the input is missing/short or doesn't sum, it falls back to
+// equal allocation so n-way splits never produce zero-width children.
+func normaliseRatios(ratios []float32, count int) []float32 {
+	out := make([]float32, count)
+	if len(ratios) >= count {
+		var sum float32
+		for i := 0; i < count; i++ {
+			out[i] = ratios[i]
+			sum += ratios[i]
+		}
+		if sum > 0 {
+			for i := range out {
+				out[i] /= sum
+			}
+			return out
+		}
 	}
-	return ratios[0]
+	for i := range out {
+		out[i] = 1.0 / float32(count)
+	}
+	return out
 }
 
 func drawSingleBox(grid [][]rune, x, y, w, h int) {
@@ -3133,13 +3866,15 @@ git commit -m "Picker: ASCII tree-layout fallback render"
 
 ---
 
-### Task 14: Picker — state machine, navigation, render
+### Task 16: Picker — state machine, navigation, render (with error surfacing)
 
 **Files:**
 - Create: `cmd/texelation/boot/picker.go`
 - Create: `cmd/texelation/boot/picker_input.go`
 - Create: `cmd/texelation/boot/picker_render.go`
 - Test: `cmd/texelation/boot/picker_test.go`
+
+This task wires the Picker with `mu sync.Mutex` declared up-front (used in Task 17 for thumbnail fetches), an `errMsg` field for surfacing operation failures, and modal behavior that does NOT close the picker when Recover/Rename/Delete errors. The user sees a banner and can retry.
 
 - [ ] **Step 1: Write failing tests**
 
@@ -3152,6 +3887,7 @@ Create `cmd/texelation/boot/picker_test.go`:
 package boot
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
@@ -3250,24 +3986,101 @@ func TestPicker_NewKeyDispatchesNew(t *testing.T) {
 	}
 }
 
+func TestPicker_RecoverError_StaysOpen(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0xCC}, Label: "broken"}},
+		},
+		recoverErr: errors.New("session evicted"),
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.HandleKey(tcell.KeyEnter, 0, 0)
+	if p.Done() {
+		t.Errorf("picker exited despite Recover error")
+	}
+	if p.errMsg == "" {
+		t.Errorf("expected errMsg set after Recover failure")
+	}
+}
+
+func TestPicker_RefreshCatalogError_PreservesPriorList(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0x01}, Label: "alpha"}},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	if len(p.response.Stored) != 1 {
+		t.Fatalf("setup: expected 1 stored, got %d", len(p.response.Stored))
+	}
+	// Now force RefreshCatalog to fail.
+	fc.listErr = errors.New("socket dropped")
+	p.RefreshCatalog()
+	if len(p.response.Stored) != 1 {
+		t.Errorf("expected prior list preserved on error, got %d", len(p.response.Stored))
+	}
+	if p.errMsg == "" {
+		t.Errorf("expected errMsg set on RefreshCatalog error")
+	}
+}
+
+func TestPicker_NavigationDismissesError(t *testing.T) {
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{
+				{SessionID: [16]byte{0x01}, Label: "first"},
+				{SessionID: [16]byte{0x02}, Label: "second"},
+			},
+		},
+	}
+	p := NewPicker(screen, fc)
+	p.RefreshCatalog()
+	p.errMsg = "stale error"
+	p.HandleKey(tcell.KeyDown, 0, 0)
+	if p.errMsg != "" {
+		t.Errorf("expected errMsg cleared after navigation, got %q", p.errMsg)
+	}
+}
+
 // fakeClient stubs the picker's network transport for tests.
 type fakeClient struct {
-	response       protocol.ListSessionsResponse
-	recoverCalled  bool
-	recoverID      [16]byte
-	newCalled      bool
+	response      protocol.ListSessionsResponse
+	listErr       error
+	recoverCalled bool
+	recoverID     [16]byte
+	recoverErr    error
+	newCalled     bool
+	renameErr     error
+	deleteErr     error
 }
 
 func (f *fakeClient) ListSessions() (protocol.ListSessionsResponse, error) {
+	if f.listErr != nil {
+		return protocol.ListSessionsResponse{}, f.listErr
+	}
 	return f.response, nil
 }
 func (f *fakeClient) RecoverSession(id [16]byte, newLabel string) error {
 	f.recoverCalled = true
 	f.recoverID = id
-	return nil
+	return f.recoverErr
 }
-func (f *fakeClient) RenameSession(id [16]byte, newLabel string) error { return nil }
-func (f *fakeClient) DeleteSession(id [16]byte) error                  { return nil }
+func (f *fakeClient) RenameSession(id [16]byte, newLabel string) error { return f.renameErr }
+func (f *fakeClient) DeleteSession(id [16]byte) error                  { return f.deleteErr }
 func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error)       { return nil, nil }
 func (f *fakeClient) StartFreshSession() {
 	f.newCalled = true
@@ -3330,6 +4143,8 @@ Create `cmd/texelation/boot/picker.go`:
 package boot
 
 import (
+	"sync"
+
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/framegrace/texelation/protocol"
@@ -3363,6 +4178,10 @@ const (
 )
 
 // Picker holds the picker's runtime state.
+//
+// mu guards thumbCache + pending against concurrent access from
+// the lazy fetch goroutines spawned in Task 17. Render reads
+// thumbCache under mu; the input handler does not touch it.
 type Picker struct {
 	screen tcell.Screen
 	client PickerClient
@@ -3374,8 +4193,16 @@ type Picker struct {
 
 	renameBuf []rune
 
-	thumbCache map[[16]byte][]byte
-	pending    map[[16]byte]bool
+	// errMsg, when non-empty, is rendered as a red banner above the
+	// action bar. RefreshCatalog / Recover / Rename / Delete set it
+	// when their underlying op fails; user dismisses by pressing any
+	// navigation key.
+	errMsg string
+
+	mu          sync.Mutex
+	thumbCache  map[[16]byte][]byte
+	pending     map[[16]byte]bool
+	hasGraphics bool
 
 	done   bool
 	choice pickerChoice
@@ -3403,13 +4230,17 @@ func NewPicker(screen tcell.Screen, client PickerClient) *Picker {
 	}
 }
 
-// RefreshCatalog fetches the catalog from the server.
+// RefreshCatalog fetches the catalog from the server. On error the
+// previous response is preserved (so a transient socket blip doesn't
+// wipe a freshly-shown list) and errMsg is set so the user sees a
+// banner rather than silently emptying.
 func (p *Picker) RefreshCatalog() {
 	resp, err := p.client.ListSessions()
 	if err != nil {
-		p.response = protocol.ListSessionsResponse{}
+		p.errMsg = "Could not load sessions: " + err.Error()
 		return
 	}
+	p.errMsg = ""
 	p.response = resp
 	if p.selectedIdx >= len(p.response.Stored) {
 		p.selectedIdx = 0
@@ -3450,6 +4281,9 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 		p.handleDeleteConfirmKey(key, ch)
 		return
 	}
+	// Any key dismisses a sticky error banner, even if it doesn't
+	// otherwise navigate. The user has acknowledged the failure.
+	p.errMsg = ""
 	switch key {
 	case tcell.KeyUp:
 		if p.selectedIdx > 0 {
@@ -3462,7 +4296,13 @@ func (p *Picker) HandleKey(key tcell.Key, ch rune, mods tcell.ModMask) {
 	case tcell.KeyEnter:
 		if len(p.response.Stored) > 0 {
 			id := p.response.Stored[p.selectedIdx].SessionID
-			_ = p.client.RecoverSession(id, "")
+			if err := p.client.RecoverSession(id, ""); err != nil {
+				// Keep the picker open and surface the error so the
+				// user can pick a different session or retry. Don't
+				// signal Done — recovery hasn't actually happened.
+				p.errMsg = "Recover failed: " + err.Error()
+				return
+			}
 			p.done = true
 			p.choice = choiceRecover
 		}
@@ -3518,9 +4358,13 @@ func (p *Picker) handleRenameKey(key tcell.Key, ch rune) {
 		if len(p.response.Stored) > 0 {
 			id := p.response.Stored[p.selectedIdx].SessionID
 			newLabel := string(p.renameBuf)
-			if err := p.client.RenameSession(id, newLabel); err == nil {
-				p.response.Stored[p.selectedIdx].Label = newLabel
+			if err := p.client.RenameSession(id, newLabel); err != nil {
+				p.errMsg = "Rename failed: " + err.Error()
+				p.mode = modeBrowse
+				p.renameBuf = nil
+				return
 			}
+			p.response.Stored[p.selectedIdx].Label = newLabel
 		}
 		p.mode = modeBrowse
 		p.renameBuf = nil
@@ -3541,7 +4385,9 @@ func (p *Picker) handleDeleteConfirmKey(key tcell.Key, ch rune) {
 	case 'y', 'Y':
 		if len(p.response.Stored) > 0 {
 			id := p.response.Stored[p.selectedIdx].SessionID
-			if err := p.client.DeleteSession(id); err == nil {
+			if err := p.client.DeleteSession(id); err != nil {
+				p.errMsg = "Delete failed: " + err.Error()
+			} else {
 				// Drop the entry locally so the cursor position
 				// stays meaningful even if we don't refresh.
 				p.response.Stored = append(p.response.Stored[:p.selectedIdx], p.response.Stored[p.selectedIdx+1:]...)
@@ -3591,6 +4437,7 @@ func (p *Picker) Render() {
 	p.drawHeader(w)
 	p.drawTabs(w)
 	p.drawCards(w, h)
+	p.drawErrorBanner(w, h)
 	p.drawActionBar(w, h)
 	if p.mode == modeRename {
 		p.drawRenameOverlay(w, h)
@@ -3599,6 +4446,20 @@ func (p *Picker) Render() {
 		p.drawDeleteConfirmOverlay(w, h)
 	}
 	p.screen.Show()
+}
+
+func (p *Picker) drawErrorBanner(w, h int) {
+	if p.errMsg == "" {
+		return
+	}
+	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
+	msg := p.errMsg
+	if len(msg) > w-4 {
+		msg = msg[:w-5] + "…"
+	}
+	for i, r := range msg {
+		p.screen.SetContent(2+i, h-3, r, nil, style)
+	}
 }
 
 func (p *Picker) clear(w, h int) {
@@ -3662,7 +4523,7 @@ func (p *Picker) drawCard(x, y int, s protocol.SessionSummary, selected bool) {
 	if selected {
 		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
 	}
-	// Thumbnail box (ASCII fallback for now; Kitty render added in Task 15)
+	// Thumbnail box (ASCII fallback for now; Kitty render added in Task 17)
 	grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
 	for cy := 0; cy < cardThumbH; cy++ {
 		for cx := 0; cx < cardThumbW; cx++ {
@@ -3763,13 +4624,18 @@ git commit -m "Picker: state machine, navigation, render"
 
 ---
 
-### Task 15: Picker — Kitty thumbnail rendering + lazy fetch
+### Task 17: Picker — Kitty thumbnail rendering + lazy fetch (locked, defer-clear pending, dimension cap)
 
 **Files:**
 - Create: `cmd/texelation/boot/picker_thumbnail.go`
-- Modify: `cmd/texelation/boot/picker.go` (wire kitty + hasGraphics flag)
 - Modify: `cmd/texelation/boot/picker_render.go` (route through `renderThumbnail`)
-- Modify: `cmd/texelation/boot/picker_test.go` (test the upgrade path)
+- Modify: `cmd/texelation/boot/picker_test.go` (test the upgrade path + locked accessor)
+
+The Picker struct already has `mu` and `hasGraphics` fields from Task 16. This task adds the fetch coordinator and the render hook. **Critical correctness fixes vs v1:**
+- Reads of `thumbCache` and `pending` happen under `mu` (was: unlocked, raced with the goroutine's writes).
+- The fetch goroutine clears `pending[id]` in a `defer`, so a failed fetch doesn't strand the entry forever (was: only cleared on success → ASCII-forever bug).
+- Test uses a `ThumbCached` accessor that takes the lock instead of poking the map directly under `-race`.
+- Decoded PNG dimensions are capped via `png.DecodeConfig` before `png.Decode` to defend against pathological inputs (corrupt sidecar, hostile file at the predictable on-disk path).
 
 - [ ] **Step 1: Write failing test**
 
@@ -3794,19 +4660,16 @@ func TestPicker_FetchThumbnailUpgradesCard(t *testing.T) {
 	p := NewPicker(screen, fc)
 	p.SetGraphicsCapable(true)
 	p.RefreshCatalog()
-	// Initial render should ASCII-fallback while fetching.
-	p.Render()
-	// Allow the fetch goroutine to deliver.
-	for i := 0; i < 100; i++ {
-		if cached, _ := p.thumbCache[id]; cached != nil {
+	p.Render() // triggers the lazy fetch
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if p.ThumbCached(id) {
 			break
 		}
-		// short busy-wait — production code would drive p.Render() on
-		// each tick; tests just nudge.
 		time.Sleep(5 * time.Millisecond)
 	}
-	if got, ok := p.thumbCache[id]; !ok || string(got) != string(pngBytes) {
-		t.Errorf("expected thumbCache populated; got=%q ok=%v", got, ok)
+	if !p.ThumbCached(id) {
+		t.Fatalf("expected thumbnail cached within 500ms")
 	}
 	if !fc.fetchCalled {
 		t.Errorf("expected FetchThumbnail dispatch")
@@ -3833,32 +4696,78 @@ func TestPicker_NoFetchWhenGraphicsAbsent(t *testing.T) {
 		t.Errorf("did not expect FetchThumbnail dispatch on text-only terminal")
 	}
 }
+
+func TestPicker_FetchThumbnailErrorClearsPending(t *testing.T) {
+	// Critical regression test for the v1 bug where a failed fetch
+	// left pending[id]=true forever, preventing retry. After the
+	// goroutine returns, pending must be cleared regardless of
+	// outcome so a future Render can re-attempt (e.g., user toggles
+	// tabs and back).
+	screen := tcell.NewSimulationScreen("UTF-8")
+	screen.Init()
+	defer screen.Fini()
+	screen.SetSize(80, 24)
+	id := [16]byte{0xAB}
+	fc := &fakeClient{
+		response: protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: id, HasThumbnail: true}},
+		},
+		thumbErr: errors.New("transient"),
+	}
+	p := NewPicker(screen, fc)
+	p.SetGraphicsCapable(true)
+	p.RefreshCatalog()
+	p.Render()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !p.IsPending(id) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if p.IsPending(id) {
+		t.Fatalf("expected pending cleared after fetch error within 500ms")
+	}
+	if p.ThumbCached(id) {
+		t.Errorf("expected thumbCache empty on fetch error")
+	}
+}
 ```
 
-Update the `fakeClient` definition at the bottom of the test file (in the same Task 14 block) to support thumbnail fetches:
+Update the `fakeClient` definition to support fetch error injection:
 
 ```go
 type fakeClient struct {
 	response      protocol.ListSessionsResponse
+	listErr       error
 	recoverCalled bool
 	recoverID     [16]byte
+	recoverErr    error
 	newCalled     bool
+	renameErr     error
+	deleteErr     error
 	fetchCalled   bool
 	thumbBytes    []byte
+	thumbErr      error
 }
+
+// ... existing methods ...
 
 func (f *fakeClient) FetchThumbnail(id [16]byte) ([]byte, error) {
 	f.fetchCalled = true
+	if f.thumbErr != nil {
+		return nil, f.thumbErr
+	}
 	return f.thumbBytes, nil
 }
 ```
 
-Add `"time"` to imports if not present.
+(Merge into the existing `fakeClient` from Task 16 — don't duplicate.)
 
 - [ ] **Step 2: Run tests, verify failure**
 
-Run: `go test ./cmd/texelation/boot/ -run "TestPicker_FetchThumbnailUpgradesCard|TestPicker_NoFetchWhenGraphicsAbsent" -count=1`
-Expected: FAIL — `SetGraphicsCapable` and `thumbCache` not exposed.
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_FetchThumbnailUpgradesCard|TestPicker_NoFetchWhenGraphicsAbsent|TestPicker_FetchThumbnailErrorClearsPending" -count=1`
+Expected: FAIL — `SetGraphicsCapable`, `ThumbCached`, `IsPending` not exposed.
 
 - [ ] **Step 3: Implement the thumbnail dispatcher**
 
@@ -3875,6 +4784,20 @@ Create `cmd/texelation/boot/picker_thumbnail.go`:
 
 package boot
 
+import (
+	"bytes"
+	"image"
+	"image/png"
+	"log"
+)
+
+// maxThumbnailDim caps PNG dimensions on the decode path. A 480×270
+// PNG is well within this; anything larger is either corrupt or
+// hostile (the 16 MiB protocol cap leaves room for adversarial
+// dimension declarations within a small payload). Decoding without
+// this check can OOM the picker on corrupted inputs.
+const maxThumbnailDim = 4096
+
 // SetGraphicsCapable tells the picker whether to dispatch
 // FetchThumbnail requests + render Kitty images. False keeps the
 // ASCII fallback exclusively (no network traffic for thumbnails).
@@ -3882,80 +4805,166 @@ func (p *Picker) SetGraphicsCapable(b bool) {
 	p.hasGraphics = b
 }
 
+// ThumbCached returns true iff a PNG for id is in the local cache.
+// Locked accessor for tests; production read sites in drawCard also
+// take p.mu.
+func (p *Picker) ThumbCached(id [16]byte) bool {
+	p.mu.Lock()
+	_, ok := p.thumbCache[id]
+	p.mu.Unlock()
+	return ok
+}
+
+// IsPending reports whether a fetch is in flight for id. Locked
+// accessor for tests.
+func (p *Picker) IsPending(id [16]byte) bool {
+	p.mu.Lock()
+	v := p.pending[id]
+	p.mu.Unlock()
+	return v
+}
+
+// thumbnailFor returns the cached PNG bytes for id, or nil if not
+// cached. Caller does not need to hold p.mu — this method takes it.
+func (p *Picker) thumbnailFor(id [16]byte) []byte {
+	p.mu.Lock()
+	data := p.thumbCache[id]
+	p.mu.Unlock()
+	return data
+}
+
 // maybeFetchThumbnail kicks off a non-blocking fetch for id if we
 // haven't cached or pending one already. Called from the render
-// loop's per-card pass.
+// loop's per-card pass. All map access is under p.mu; the goroutine
+// always clears pending[id] in defer so a failed fetch doesn't
+// strand the entry permanently (previously a "card stays ASCII
+// forever" bug — see Task 17 in the plan).
 func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 	if !p.hasGraphics || !hasThumb {
 		return
 	}
+	p.mu.Lock()
 	if _, cached := p.thumbCache[id]; cached {
+		p.mu.Unlock()
 		return
 	}
 	if p.pending[id] {
+		p.mu.Unlock()
 		return
 	}
 	p.pending[id] = true
+	p.mu.Unlock()
+
 	go func(targetID [16]byte) {
+		defer func() {
+			// Clear pending unconditionally so subsequent renders
+			// can retry. Without this defer, an error path leaves
+			// pending[id]=true forever — a real bug we exorcised
+			// in v2. Recover from any panic in the client (the
+			// transport could trip a runtime fault on a dropped
+			// socket) so we don't crash the picker.
+			if rec := recover(); rec != nil {
+				log.Printf("picker: thumbnail fetch panic: %v", rec)
+			}
+			p.mu.Lock()
+			delete(p.pending, targetID)
+			p.mu.Unlock()
+		}()
 		data, err := p.client.FetchThumbnail(targetID)
-		if err != nil || len(data) == 0 {
+		if err != nil {
+			log.Printf("picker: thumbnail fetch %x: %v", targetID[:4], err)
+			return
+		}
+		if len(data) == 0 {
+			return
+		}
+		// Validate dimensions before storing. A png.DecodeConfig
+		// failure means corrupt/non-PNG bytes; refuse to cache.
+		cfg, err := png.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			log.Printf("picker: thumbnail decode-config %x: %v", targetID[:4], err)
+			return
+		}
+		if cfg.Width > maxThumbnailDim || cfg.Height > maxThumbnailDim {
+			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)", targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
 			return
 		}
 		p.mu.Lock()
 		p.thumbCache[targetID] = data
-		delete(p.pending, targetID)
 		p.mu.Unlock()
 	}(id)
 }
+
+// decodeCachedThumb decodes the PNG bytes for id into an image.Image,
+// or returns nil if the bytes can't be decoded. The dimension check
+// happens at fetch time (above), so this is purely the costlier
+// full decode for paint use. Currently only used by the (future)
+// Kitty emission path; the SimulationScreen unit tests don't exercise
+// it.
+func decodeCachedThumb(data []byte) image.Image {
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+	return img
+}
 ```
 
-Add a `mu sync.Mutex` and `hasGraphics bool` to the `Picker` struct in `picker.go`. Update render code in `picker_render.go` so the per-card draw calls `p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)` before rendering, and reads from `p.thumbCache` under the mutex when graphics-capable. The actual Kitty image emission stays minimal in F.1: when a cached PNG is present, draw a placeholder block character into the thumbnail rect (so the test can detect "upgraded" via a non-ASCII pattern); the full Kitty escape-sequence path is out of scope for the unit test, since SimulationScreen doesn't model the Kitty protocol.
-
-Add to the top of `drawCard`:
+In `picker_render.go`, replace the thumbnail-drawing block at the top of `drawCard` with the locked-read version:
 
 ```go
-p.mu.Lock()
-cached := p.thumbCache[s.SessionID]
-p.mu.Unlock()
-if cached != nil && p.hasGraphics {
-	// Draw a "graphics here" placeholder so tests can distinguish
-	// an upgraded card from the ASCII fallback. Real Kitty emission
-	// is wired in via state.kitty when the picker hands off — for
-	// the unit-test scope, this marker is sufficient.
-	for cy := 0; cy < cardThumbH; cy++ {
-		for cx := 0; cx < cardThumbW; cx++ {
-			p.screen.SetContent(x+cx, y+cy, '▓', nil, bgStyle)
+func (p *Picker) drawCard(x, y int, s protocol.SessionSummary, selected bool) {
+	bgStyle := tcell.StyleDefault
+	if selected {
+		bgStyle = bgStyle.Background(tcell.ColorDarkBlue)
+	}
+	cached := p.thumbnailFor(s.SessionID)
+	if cached != nil && p.hasGraphics {
+		// Cached thumbnail available. The full Kitty escape-sequence
+		// emission is out of scope for SimulationScreen; tests detect
+		// the upgrade by checking the placeholder block char.
+		for cy := 0; cy < cardThumbH; cy++ {
+			for cx := 0; cx < cardThumbW; cx++ {
+				p.screen.SetContent(x+cx, y+cy, '▓', nil, bgStyle)
+			}
+		}
+	} else {
+		grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
+		for cy := 0; cy < cardThumbH; cy++ {
+			for cx := 0; cx < cardThumbW; cx++ {
+				p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
+			}
 		}
 	}
-	// Metadata still rendered below.
-} else {
-	grid := renderASCIILayoutGrid(cardThumbW, cardThumbH, s.Layout)
-	for cy := 0; cy < cardThumbH; cy++ {
-		for cx := 0; cx < cardThumbW; cx++ {
-			p.screen.SetContent(x+cx, y+cy, grid[cy][cx], nil, bgStyle)
-		}
+	p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
+
+	// Metadata column (unchanged).
+	metaX := x + cardThumbW + 2
+	p.drawText(metaX, y, fmt.Sprintf("Label:   %s", labelOrUntitled(s.Label)), bgStyle.Bold(true))
+	p.drawText(metaX, y+1, fmt.Sprintf("Active:  %s", relativeTime(s.LastActive)), bgStyle)
+	p.drawText(metaX, y+2, fmt.Sprintf("Panes:   %d", s.PaneCount), bgStyle)
+	p.drawText(metaX, y+3, fmt.Sprintf("Title:   %s", truncate(s.FirstPaneTitle, 40)), bgStyle)
+	if s.Pinned {
+		p.drawText(metaX, y+4, "Pinned:  ★", bgStyle)
 	}
 }
-p.maybeFetchThumbnail(s.SessionID, s.HasThumbnail)
 ```
-
-(Replace the existing thumbnail block in `drawCard` with the conditional above.)
 
 - [ ] **Step 4: Run tests, verify pass**
 
-Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1`
-Expected: PASS.
+Run: `go test ./cmd/texelation/boot/ -run "TestPicker_" -count=1 -race`
+Expected: PASS — including under `-race`. The locked accessors are critical here.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add cmd/texelation/boot/picker_thumbnail.go cmd/texelation/boot/picker.go cmd/texelation/boot/picker_render.go cmd/texelation/boot/picker_test.go
-git commit -m "Picker: lazy thumbnail fetch + Kitty placeholder render"
+git add cmd/texelation/boot/picker_thumbnail.go cmd/texelation/boot/picker_render.go cmd/texelation/boot/picker_test.go
+git commit -m "Picker: lazy thumbnail fetch with locked cache + deferred pending clear"
 ```
 
 ---
 
-### Task 16: boot.Run integration — trigger logic + handoff
+### Task 18: boot.Run integration — trigger logic + handoff
 
 **Files:**
 - Modify: `cmd/texelation/main.go` (add `--recover` flag, picker activation)
@@ -3999,8 +5008,6 @@ package boot
 
 import (
 	"github.com/gdamore/tcell/v2"
-
-	"github.com/framegrace/texelation/protocol"
 )
 
 // PickerOutcome captures what the user picked.
@@ -4035,7 +5042,6 @@ func RunPicker(screen tcell.Screen, client PickerClient, hasGraphics bool) (Pick
 	if p.choice == choiceRecover && len(p.response.Stored) > 0 {
 		out.SessionID = p.response.Stored[p.selectedIdx].SessionID
 	}
-	_ = protocol.Version // keep protocol import live in case future fields need it
 	return out, nil
 }
 ```
@@ -4131,61 +5137,348 @@ const (
 )
 ```
 
-- [ ] **Step 4: Implement the socket picker client + probe**
+- [ ] **Step 4: Implement the socket picker client + probe (real code, no stubs)**
 
-Create the `boot.SocketPickerClient` and `boot.ProbeStoredSessions` helpers. They wrap a thin protocol-level handshake:
+Create `cmd/texelation/boot/picker_client.go`:
 
 ```go
-// Append to cmd/texelation/boot/picker_runner.go (or split into
-// cmd/texelation/boot/picker_client.go if the file grows).
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: cmd/texelation/boot/picker_client.go
+// Summary: Socket-backed PickerClient + ProbeStoredSessions. Performs
+// the protocol Hello/Welcome handshake and round-trips picker
+// messages over a unix socket. Modelled on client/simple_client.go's
+// dial-and-handshake helper.
 
-// ProbeStoredSessions performs a minimal handshake over the socket and
-// asks for the stored-session count. Returns the number of stored
-// sessions or an error. Used by the trigger logic to decide whether
-// to show the picker.
+package boot
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// dialAndHandshake opens a unix socket connection to the texelation
+// daemon and runs the Hello/Welcome handshake. Returns the conn +
+// the assigned sessionID. The caller closes the conn.
+func dialAndHandshake(socket string) (net.Conn, [16]byte, error) {
+	var sid [16]byte
+	conn, err := net.DialTimeout("unix", socket, 5*time.Second)
+	if err != nil {
+		return nil, sid, fmt.Errorf("dial %s: %w", socket, err)
+	}
+	var clientID [16]byte
+	if _, err := rand.Read(clientID[:]); err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("rand client id: %w", err)
+	}
+	helloBody, err := protocol.EncodeHello(protocol.Hello{ClientID: clientID, ClientName: "texelation-picker"})
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("encode hello: %w", err)
+	}
+	helloHdr := protocol.Header{
+		Version: protocol.Version,
+		Type:    protocol.MsgHello,
+		Flags:   protocol.FlagChecksum,
+	}
+	if err := protocol.WriteMessage(conn, helloHdr, helloBody); err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("write hello: %w", err)
+	}
+	hdr, payload, err := protocol.ReadMessage(conn)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("read welcome: %w", err)
+	}
+	if hdr.Type != protocol.MsgWelcome {
+		conn.Close()
+		return nil, sid, fmt.Errorf("expected welcome, got message type %d", hdr.Type)
+	}
+	welcome, err := protocol.DecodeWelcome(payload)
+	if err != nil {
+		conn.Close()
+		return nil, sid, fmt.Errorf("decode welcome: %w", err)
+	}
+	return conn, welcome.SessionID, nil
+}
+
+// ProbeStoredSessions performs Hello/Welcome + MsgListSessions and
+// returns the count of stored sessions. The ephemeral session created
+// by the handshake is left dangling on the server's side and gets
+// reaped via the daemon's normal idle-session cleanup; the cost is
+// tiny (one new session record, no panes ever attached).
 func ProbeStoredSessions(socket string) (int, error) {
-	// Implementation hint: this can either reuse the existing
-	// `client.SimpleClient` to perform Hello/Welcome, or open a raw
-	// connection and send Hello + a zero-payload MsgListSessions.
-	// The texelation client in client/simple_client.go already has
-	// a connect helper; piggy-back on it.
-	//
-	// Pseudocode:
-	//   conn := dial(socket)
-	//   write Hello with random ClientID
-	//   read Welcome
-	//   write MsgListSessions
-	//   read MsgListSessionsResponse
-	//   decode and return len(resp.Stored)
-	//
-	// Implementor: write the actual code following the existing
-	// patterns in client/simple_client.go.
-	return 0, nil
+	conn, _, err := dialAndHandshake(socket)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	body, _ := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	hdr := protocol.Header{
+		Version: protocol.Version,
+		Type:    protocol.MsgListSessions,
+		Flags:   protocol.FlagChecksum,
+	}
+	if err := protocol.WriteMessage(conn, hdr, body); err != nil {
+		return 0, fmt.Errorf("write list-sessions: %w", err)
+	}
+	respHdr, respPayload, err := protocol.ReadMessage(conn)
+	if err != nil {
+		return 0, fmt.Errorf("read list-sessions: %w", err)
+	}
+	if respHdr.Type != protocol.MsgListSessionsResponse {
+		return 0, fmt.Errorf("expected list-sessions response, got %d", respHdr.Type)
+	}
+	resp, err := protocol.DecodeListSessionsResponse(respPayload)
+	if err != nil {
+		return 0, fmt.Errorf("decode list-sessions: %w", err)
+	}
+	return len(resp.Stored), nil
 }
 
-// NewSocketPickerClient returns a PickerClient that wraps a real
-// protocol connection to the texelation socket.
-func NewSocketPickerClient(socket string) (*SocketPickerClient, error) {
-	// Implementor: dial the socket, run Hello/Welcome handshake,
-	// store the conn + writer for use in the PickerClient methods.
-	return &SocketPickerClient{}, nil
-}
-
-// SocketPickerClient implements PickerClient against a live socket.
+// SocketPickerClient implements PickerClient against a live socket
+// for the duration of the picker's UI session. One connection per
+// picker invocation; closed when the picker exits.
 type SocketPickerClient struct {
-	// fields: conn, writer, sessionID, etc.
+	conn      net.Conn
+	sessionID [16]byte
+
+	// mu serializes request/response round-trips so concurrent
+	// picker callers (e.g., a goroutine fetching thumbnails while
+	// the foreground render fires ListSessions) don't interleave
+	// frames on the wire. Real picker traffic is rare enough that
+	// the lock contention is irrelevant.
+	mu sync.Mutex
+
+	closeOnce sync.Once
 }
 
-func (s *SocketPickerClient) ListSessions() (protocol.ListSessionsResponse, error)        { /* ... */ return protocol.ListSessionsResponse{}, nil }
-func (s *SocketPickerClient) RecoverSession(id [16]byte, newLabel string) error           { /* ... */ return nil }
-func (s *SocketPickerClient) RenameSession(id [16]byte, newLabel string) error            { /* ... */ return nil }
-func (s *SocketPickerClient) DeleteSession(id [16]byte) error                              { /* ... */ return nil }
-func (s *SocketPickerClient) FetchThumbnail(id [16]byte) ([]byte, error)                   { /* ... */ return nil, nil }
-func (s *SocketPickerClient) StartFreshSession()                                           { /* no-op */ }
-func (s *SocketPickerClient) Close() error                                                 { /* ... */ return nil }
+// NewSocketPickerClient dials the socket and runs the handshake.
+// Returns a client ready for use; caller must Close() when done.
+func NewSocketPickerClient(socket string) (*SocketPickerClient, error) {
+	conn, sid, err := dialAndHandshake(socket)
+	if err != nil {
+		return nil, err
+	}
+	return &SocketPickerClient{conn: conn, sessionID: sid}, nil
+}
+
+// roundTrip serialises a request frame, writes it, reads one response
+// frame, and returns the response header + payload. The caller
+// validates the response type. mu is held for the duration so
+// interleaved sends from concurrent picker code can't garble each
+// other.
+func (s *SocketPickerClient) roundTrip(reqType protocol.MessageType, body []byte) (protocol.Header, []byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      reqType,
+		Flags:     protocol.FlagChecksum,
+		SessionID: s.sessionID,
+	}
+	if err := protocol.WriteMessage(s.conn, hdr, body); err != nil {
+		return protocol.Header{}, nil, fmt.Errorf("write %d: %w", reqType, err)
+	}
+	respHdr, respPayload, err := protocol.ReadMessage(s.conn)
+	if err != nil {
+		return protocol.Header{}, nil, fmt.Errorf("read response: %w", err)
+	}
+	return respHdr, respPayload, nil
+}
+
+func (s *SocketPickerClient) ListSessions() (protocol.ListSessionsResponse, error) {
+	body, _ := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	hdr, payload, err := s.roundTrip(protocol.MsgListSessions, body)
+	if err != nil {
+		return protocol.ListSessionsResponse{}, err
+	}
+	if hdr.Type != protocol.MsgListSessionsResponse {
+		return protocol.ListSessionsResponse{}, fmt.Errorf("unexpected response type %d", hdr.Type)
+	}
+	return protocol.DecodeListSessionsResponse(payload)
+}
+
+func (s *SocketPickerClient) RecoverSession(id [16]byte, newLabel string) error {
+	body, err := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: id, NewLabel: newLabel})
+	if err != nil {
+		return err
+	}
+	hdr, payload, err := s.roundTrip(protocol.MsgRecoverSession, body)
+	if err != nil {
+		return err
+	}
+	switch hdr.Type {
+	case protocol.MsgConnectAccept:
+		// Recovery succeeded server-side; the picker hands off to
+		// the connect path which will re-attach with this session ID.
+		return nil
+	case protocol.MsgError:
+		ef, _ := protocol.DecodeErrorFrame(payload)
+		return errors.New(ef.Message)
+	default:
+		return fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+}
+
+func (s *SocketPickerClient) RenameSession(id [16]byte, newLabel string) error {
+	body, err := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: id, NewLabel: newLabel})
+	if err != nil {
+		return err
+	}
+	return s.opRoundTrip(protocol.MsgRenameSession, body, protocol.OpRename)
+}
+
+func (s *SocketPickerClient) DeleteSession(id [16]byte) error {
+	body, err := protocol.EncodeDeleteSessionRequest(protocol.DeleteSessionRequest{SessionID: id})
+	if err != nil {
+		return err
+	}
+	return s.opRoundTrip(protocol.MsgDeleteSession, body, protocol.OpDelete)
+}
+
+func (s *SocketPickerClient) opRoundTrip(reqType protocol.MessageType, body []byte, expectOp protocol.SessionOpKind) error {
+	hdr, payload, err := s.roundTrip(reqType, body)
+	if err != nil {
+		return err
+	}
+	if hdr.Type != protocol.MsgSessionOpResponse {
+		return fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+	resp, err := protocol.DecodeSessionOpResponse(payload)
+	if err != nil {
+		return err
+	}
+	if resp.OpType != expectOp {
+		return fmt.Errorf("op mismatch: got %d, want %d", resp.OpType, expectOp)
+	}
+	if !resp.OK {
+		return errors.New(resp.Error)
+	}
+	return nil
+}
+
+func (s *SocketPickerClient) FetchThumbnail(id [16]byte) ([]byte, error) {
+	body, err := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	if err != nil {
+		return nil, err
+	}
+	hdr, payload, err := s.roundTrip(protocol.MsgFetchThumbnail, body)
+	if err != nil {
+		return nil, err
+	}
+	if hdr.Type != protocol.MsgFetchThumbnailResponse {
+		return nil, fmt.Errorf("unexpected response %d", hdr.Type)
+	}
+	resp, err := protocol.DecodeFetchThumbnailResponse(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.OK {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.PNG, nil
+}
+
+// StartFreshSession is a no-op for the socket client — the picker
+// simply exits with choiceFresh and main.go takes the ordinary
+// connect path (zero sessionID).
+func (s *SocketPickerClient) StartFreshSession() {}
+
+// Close shuts down the underlying socket. Safe to call multiple times.
+func (s *SocketPickerClient) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		err = s.conn.Close()
+	})
+	return err
+}
 ```
 
-The actual transport implementation should follow the patterns in `client/simple_client.go` (Hello / Welcome handshake, `protocol.WriteMessage` for sends, `protocol.ReadMessage` for reads). Do not invent a new framing; reuse the existing helpers.
+The `_ = protocol.Version` placeholder previously in `picker_runner.go` is removed — the protocol package is now genuinely used.
+
+Add a basic round-trip test in `cmd/texelation/boot/picker_client_test.go`:
+
+```go
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package boot
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// TestSocketPickerClient_ListSessions wires a fake server-side
+// listener that speaks just enough protocol to validate the picker
+// client's round-trip. We don't bring up a real texel-server; just
+// verify the framing.
+func TestSocketPickerClient_ListSessions(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read Hello, write Welcome.
+		hdr, _, err := protocol.ReadMessage(conn)
+		if err != nil || hdr.Type != protocol.MsgHello {
+			return
+		}
+		welBody, _ := protocol.EncodeWelcome(protocol.Welcome{SessionID: [16]byte{0xAA}, ServerName: "test"})
+		welHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgWelcome, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
+		_ = protocol.WriteMessage(conn, welHdr, welBody)
+
+		// Read MsgListSessions, write a 1-entry response.
+		_, _, _ = protocol.ReadMessage(conn)
+		respBody, _ := protocol.EncodeListSessionsResponse(protocol.ListSessionsResponse{
+			Stored: []protocol.SessionSummary{{SessionID: [16]byte{0xBB}, Label: "test", LastActive: 1, PaneCount: 1}},
+		})
+		respHdr := protocol.Header{Version: protocol.Version, Type: protocol.MsgListSessionsResponse, Flags: protocol.FlagChecksum, SessionID: [16]byte{0xAA}}
+		_ = protocol.WriteMessage(conn, respHdr, respBody)
+	}()
+
+	// Give the listener a moment to be ready for accept.
+	time.Sleep(20 * time.Millisecond)
+
+	c, err := NewSocketPickerClient(socket)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	defer c.Close()
+
+	resp, err := c.ListSessions()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(resp.Stored) != 1 || resp.Stored[0].Label != "test" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}
+```
+
+Run: `go test ./cmd/texelation/boot/ -run "TestSocketPickerClient_" -count=1`
+Expected: PASS.
 
 - [ ] **Step 5: Wire `clientrt.Options.RecoverSessionID` into the connect path**
 
@@ -4229,15 +5522,147 @@ Expected: PASS. The protocol bump (v4 → v5) cascaded through many tests; any f
 - [ ] **Step 8: Commit**
 
 ```bash
-git add cmd/texelation/main.go cmd/texelation/boot/picker_runner.go internal/runtime/client/app.go
+git add cmd/texelation/main.go cmd/texelation/boot/picker_runner.go cmd/texelation/boot/picker_client.go cmd/texelation/boot/picker_client_test.go internal/runtime/client/app.go
 git commit -m "boot.Run: wire picker activation + recover handoff"
+```
+
+---
+
+### Task 19: Client screenshot — refactor to use shared `internal/thumbnail` primitive
+
+**Files:**
+- Modify: `internal/runtime/client/screenshot.go`
+
+The existing `takeScreenshot` does the same `textrender.DetectFont` + `textrender.New` + render pipeline that the shared primitive (Task 9) now exposes. Refactoring removes the duplicate setup and ensures any future improvements to the rendering path benefit both code paths.
+
+- [ ] **Step 1: Read the current screenshot path**
+
+Run: `cat internal/runtime/client/screenshot.go`
+Expected: see the existing `takeScreenshot` function with `textrender.DetectFont`, `textrender.New`, `renderer.Render(grid)`.
+
+- [ ] **Step 2: Replace the rendering call with the shared primitive**
+
+Modify `internal/runtime/client/screenshot.go`:
+
+```go
+package clientruntime
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/png"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	texelcore "github.com/framegrace/texelui/core"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
+)
+
+// takeScreenshot renders the current workspace buffer to a PNG file
+// and copies it to the system clipboard. Uses the shared
+// internal/thumbnail rendering primitive — same code path as the
+// server's lifecycle thumbnail capture.
+func takeScreenshot(state *clientState) {
+	buf := state.prevBuffer
+	if len(buf) == 0 {
+		return
+	}
+
+	coreGrid := make([][]texelcore.Cell, len(buf))
+	for y, row := range buf {
+		coreGrid[y] = make([]texelcore.Cell, len(row))
+		for x := range row {
+			coreGrid[y][x] = texelcore.Cell{
+				Ch:    row[x].Ch,
+				Style: row[x].Style,
+			}
+		}
+	}
+
+	img, err := thumbnail.RenderGrid(coreGrid)
+	if err != nil {
+		log.Printf("[SCREENSHOT] Render failed: %v", err)
+		return
+	}
+
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".texelation", "screenshots")
+	os.MkdirAll(dir, 0o755)
+	filename := filepath.Join(dir, fmt.Sprintf("screenshot-%s.png", time.Now().Format("2006-01-02_15-04-05")))
+
+	if err := thumbnail.WritePNGAtomic(filename, img); err != nil {
+		log.Printf("[SCREENSHOT] Write failed: %v", err)
+		return
+	}
+
+	log.Printf("[SCREENSHOT] Saved to %s", filename)
+	copyImageToClipboard(img, filename)
+}
+
+// copyImageToClipboard copies a PNG image to the system clipboard.
+// Unchanged from the previous implementation.
+func copyImageToClipboard(img image.Image, filePath string) {
+	if path, err := exec.LookPath("wl-copy"); err == nil {
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, img); err == nil {
+			cmd := exec.Command(path, "-t", "image/png")
+			cmd.Stdin = &buf
+			if err := cmd.Run(); err == nil {
+				return
+			}
+		}
+	}
+	if path, err := exec.LookPath("xclip"); err == nil {
+		var buf bytes.Buffer
+		if err := png.Encode(&buf, img); err == nil {
+			cmd := exec.Command(path, "-selection", "clipboard", "-t", "image/png")
+			cmd.Stdin = &buf
+			if err := cmd.Run(); err == nil {
+				return
+			}
+		}
+	}
+	if path, err := exec.LookPath("osascript"); err == nil {
+		script := fmt.Sprintf(`set the clipboard to (read (POSIX file %q) as «class PNGf»)`, filePath)
+		exec.Command(path, "-e", script).Run()
+	}
+}
+```
+
+The `textrender` import is dropped from this file (the primitive owns it now). The `image/png` import stays for the clipboard helpers' re-encode step.
+
+- [ ] **Step 3: Build and run existing client tests to confirm no regressions**
+
+Run: `go build ./internal/runtime/client/... && go test ./internal/runtime/client/ -count=1`
+Expected: PASS. If `screenshot.go` had no dedicated tests, the build passing is the gate.
+
+- [ ] **Step 4: Manual verification**
+
+```bash
+make build
+./bin/texelation
+# Trigger the screenshot keybinding (default is the existing binding)
+# Confirm: file lands in ~/.texelation/screenshots/, clipboard contains
+# the PNG. Behavior should be identical to before the refactor.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/runtime/client/screenshot.go
+git commit -m "Client screenshot: use shared internal/thumbnail primitive"
 ```
 
 ---
 
 ## Final Steps
 
-After all 16 tasks land cleanly:
+After all 19 tasks land cleanly:
 
 - [ ] **Run race-detector across the whole repo**
 
@@ -4250,9 +5675,12 @@ Expected: PASS, no races, no failures.
 git push -u origin feature/issue-199-plan-f-session-picker
 gh pr create --title "Issue #199 Plan F.1: stored-session recovery picker" --body "$(cat <<'BODY'
 ## Summary
-- Adds protocol v5 with five new picker messages (list, recover, rename, delete, fetch-thumbnail) and SessionSummary/LiveSummary wire types.
-- Server-side: manager helpers (StoredSummaries, LiveSummaries, RenameStored, DeleteStored), connection handlers, lifecycle thumbnail capture (graceful shutdown + last-disconnect).
-- Client-side: picker UI in `cmd/texelation/boot/` reusing the splash screen; ASCII fallback + Kitty placeholder; trigger logic in `boot.Run` activates picker when client state is missing AND server has stored sessions, or when `--recover` is passed.
+- Adds protocol v5 with six new picker messages (list, recover, rename, delete, fetch-thumbnail, op-response) and SessionSummary/LiveSummary wire types.
+- New shared `internal/thumbnail/` rendering primitive used by both server-side lifecycle capture and client-side user screenshots.
+- Server-side: manager helpers (StoredSummaries, LiveSummaries, RenameStored, DeleteStored), connection handlers (with thumbnail size cap), lifecycle thumbnail capture (graceful shutdown + last-disconnect), pane-buffer composition adapter on DesktopSink.
+- Client-side: picker UI in `cmd/texelation/boot/` reusing the splash screen; ASCII fallback (n-way splits) + lazy Kitty thumbnail fetch with locked map access and deferred pending clear; in-picker error banners on Recover/Rename/Delete/RefreshCatalog failures.
+- Trigger logic in `boot.Run` activates picker when client state is missing AND server has stored sessions, or when `--recover` is passed.
+- Client `takeScreenshot` refactored to use the shared primitive (dedup).
 - Spec: `docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md`
 
 ## Test plan
@@ -4263,6 +5691,8 @@ gh pr create --title "Issue #199 Plan F.1: stored-session recovery picker" --bod
 - [ ] Manual: rename inline → label persists across daemon restart
 - [ ] Manual: delete a stored session → JSON + PNG both removed
 - [ ] Manual: Kitty terminal → thumbnails render; non-Kitty terminal → ASCII fallback
+- [ ] Manual: client screenshot keybinding still works (uses shared primitive)
+- [ ] Manual: simulate stored-session network failure → error banner displayed, picker stays open
 
 ## Follow-ups
 - F.2 issue (multi-live-sessions) to be filed after this lands; the wire format and Live tab are already in place.

--- a/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
+++ b/docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md
@@ -1,4 +1,4 @@
-# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v3.1)
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Implementation Plan (v3.2)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -14,6 +14,14 @@
 - Protocol uses strict version equality (`protocol/protocol.go:178`). v4 ↔ v5 cross-talk is impossible by design — `ErrUnsupportedVer` rejects mismatched headers. Plan ships v5 as a hard cutover; the spec's "v4 fallback UX" risk does not materialize because old clients see a connect error and cannot reach the picker code path. Documented but not implemented as graceful fallback.
 - The wire-level layout type is `protocol.TreeNodeSnapshot` (already exists in `protocol/messages.go`), not `TreeNodeCapture`. Tasks reference `TreeNodeSnapshot`.
 - `StoredSession` JSON shape gains a Layout field as an additive change. No `SchemaVersion` bump (existing files unmarshal cleanly with Layout=nil; old daemons reading new files ignore the unknown JSON field).
+
+**v3.2 revisions vs v3.1 (round-4 review fixes):**
+- **`SocketPickerClient.FetchThumbnail` errors now count toward `failedFetches`** (Task 17). All four server-side OK=false cases (path empty, file missing, oversize, IO error) are permanent for the session's lifetime; without counting, the goroutine re-spawns every render. Same fix for the empty-PNG contract violation.
+- **`flushErrMsg` separated from `errMsg`** (Task 16). User-action errors (Recover/Rename/Delete) stay sticky-until-dismissed; transient per-frame Flush errors auto-clear on the next successful Flush so a single hiccup doesn't pin a stale "Thumbnails unavailable" banner forever.
+- **`log` import added to picker_render.go** (Task 16) — required by the Flush-error log call introduced in v3.1.
+- **`markFetchFailed(id)` helper** consolidates the locked failure-counter increment used by the fetch goroutine's panic recover, DecodeConfig error, dimension-cap rejection, and full-decode error branches (Task 17). Permanent failure modes now exhaust attempts after `maxFetchAttempts`.
+- **`PrevBufferFor` switched to `RLock`/`RUnlock`** (Task 10) — read-only accessor against the publisher's `sync.RWMutex`.
+- **Boot scan removes orphan `*.png.tmp`** files (Task 8) — picker thumbnail capture writes via tmp+rename, so a crashed mid-write leaves a `.tmp` behind that lingers indefinitely without this sweep.
 
 **v3.1 revisions vs v3 (review-feedback fixes):**
 - **`widgets.Image` API call corrected** in Task 17 — `w.SetRect(rect)` replaced with `w.SetPosition(rect.X, rect.Y) + w.Resize(rect.W, rect.H)` (the embedded `BaseWidget` has no `SetRect` method).
@@ -1837,28 +1845,35 @@ In `internal/runtime/server/session_persistence.go`, after the existing `for _, 
 // ... existing loop populating `out` ...
 
 // Plan F.1: clean up orphaned PNG sidecars (a PNG whose matching
-// JSON was deleted, or whose JSON failed to load above). Keeping
+// JSON was deleted, or whose JSON failed to load above) and any
+// `.png.tmp` files left behind by a crashed atomic write. Keeping
 // them would silently inflate the picker's HasThumbnail flag for
-// nonexistent entries and leak disk space across restarts.
+// nonexistent entries (orphans) and leak disk space (tmp files).
 for _, e := range entries {
 	if e.IsDir() {
 		continue
 	}
 	name := e.Name()
-	if !strings.HasSuffix(name, ".png") {
-		continue
-	}
-	hexPart := strings.TrimSuffix(name, ".png")
-	var id [16]byte
-	if err := decodeHex16Session(hexPart, &id); err != nil {
-		continue // unrecognised filename; leave alone
-	}
-	if _, ok := out[id]; ok {
-		continue // matched a loaded JSON; keep
-	}
-	pngPath := filepath.Join(dir, name)
-	if err := os.Remove(pngPath); err != nil {
-		log.Printf("server: orphan PNG cleanup: %s: %v", pngPath, err)
+	switch {
+	case strings.HasSuffix(name, ".png.tmp"):
+		// Crashed mid-rename; safe to remove unconditionally.
+		tmpPath := filepath.Join(dir, name)
+		if err := os.Remove(tmpPath); err != nil {
+			log.Printf("server: orphan tmp cleanup: %s: %v", tmpPath, err)
+		}
+	case strings.HasSuffix(name, ".png"):
+		hexPart := strings.TrimSuffix(name, ".png")
+		var id [16]byte
+		if err := decodeHex16Session(hexPart, &id); err != nil {
+			continue // unrecognised filename; leave alone
+		}
+		if _, ok := out[id]; ok {
+			continue // matched a loaded JSON; keep
+		}
+		pngPath := filepath.Join(dir, name)
+		if err := os.Remove(pngPath); err != nil {
+			log.Printf("server: orphan PNG cleanup: %s: %v", pngPath, err)
+		}
 	}
 }
 
@@ -2401,8 +2416,9 @@ the team's terminology if needed:
 // the publisher's existing mutex; copy if you need to retain past
 // the call.
 func (p *DesktopPublisher) PrevBufferFor(paneID [16]byte) [][]texel.Cell {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	// Read-only access — RLock since the publisher's mu is sync.RWMutex.
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	buf, ok := p.prevBuffers[paneID]
 	if !ok {
 		return nil
@@ -4299,8 +4315,17 @@ type Picker struct {
 	// errMsg, when non-empty, is rendered as a red banner above the
 	// action bar. RefreshCatalog / Recover / Rename / Delete set it
 	// when their underlying op fails; user dismisses by pressing any
-	// navigation key.
+	// navigation key. Sticky-until-dismissed because it's tied to a
+	// discrete user action (the user clicked, the action failed,
+	// they need to know).
 	errMsg string
+
+	// flushErrMsg is the per-frame variant of errMsg, set when the
+	// graphics provider's Flush fails during Render. Cleared on the
+	// next successful Flush so a single hiccup doesn't pin a stale
+	// banner forever — a Flush error is a transient frame condition,
+	// not a user action.
+	flushErrMsg string
 
 	// gp drives image rendering through the texelui widgets.Image
 	// pipeline. nil = ASCII-only fallback (tests). Production wires
@@ -4566,6 +4591,7 @@ package boot
 import (
 	"fmt"
 	"io"
+	"log"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
@@ -4649,7 +4675,12 @@ func (p *Picker) Render() {
 		if flusher, ok := p.gp.(interface{ Flush(io.Writer) error }); ok {
 			if err := flusher.Flush(p.gpFlush); err != nil {
 				log.Printf("picker: graphics flush failed: %v", err)
-				p.errMsg = "Thumbnails unavailable: " + err.Error()
+				p.flushErrMsg = "Thumbnails unavailable: " + err.Error()
+			} else {
+				// Clear the per-frame error so a transient hiccup
+				// doesn't pin a stale "unavailable" banner once
+				// rendering recovers.
+				p.flushErrMsg = ""
 			}
 		}
 	}
@@ -4657,11 +4688,16 @@ func (p *Picker) Render() {
 }
 
 func (p *Picker) drawErrorBanner(painter *core.Painter, w, h int) {
-	if p.errMsg == "" {
+	// User-action errors (errMsg) take priority; transient flush
+	// errors fall through if no user-action error is active.
+	msg := p.errMsg
+	if msg == "" {
+		msg = p.flushErrMsg
+	}
+	if msg == "" {
 		return
 	}
 	style := tcell.StyleDefault.Foreground(tcell.ColorRed).Bold(true)
-	msg := p.errMsg
 	if len(msg) > w-4 {
 		msg = msg[:w-5] + "…"
 	}
@@ -5022,6 +5058,17 @@ func (p *Picker) IsPending(id [16]byte) bool {
 	return v
 }
 
+// markFetchFailed bumps the failure counter for id. Called when a
+// permanent failure (bad bytes, dimension cap, decode failure) is
+// observed — distinct from a transient FetchThumbnail network error,
+// which retries indefinitely. Used by both the goroutine error
+// branches and the panic recover.
+func (p *Picker) markFetchFailed(id [16]byte) {
+	p.mu.Lock()
+	p.failedFetches[id]++
+	p.mu.Unlock()
+}
+
 // imageWidgetFor returns the widgets.Image bound to id's cached PNG,
 // constructing one on first use. nil if no PNG cached. Held under
 // p.mu since imgCache and thumbCache must be observed atomically.
@@ -5070,11 +5117,7 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		defer func() {
 			if rec := recover(); rec != nil {
 				log.Printf("picker: thumbnail fetch panic: %v", rec)
-				p.mu.Lock()
-				p.failedFetches[targetID]++
-				delete(p.pending, targetID)
-				p.mu.Unlock()
-				return
+				p.markFetchFailed(targetID)
 			}
 			p.mu.Lock()
 			delete(p.pending, targetID)
@@ -5082,22 +5125,43 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		}()
 		data, err := p.client.FetchThumbnail(targetID)
 		if err != nil {
+			// All four server-side OK=false branches (path empty,
+			// file missing, oversize, IO error) collapse into err
+			// here. Any of those is permanent — the file will not
+			// magically appear next render — so we count toward the
+			// limiter. A purely transient socket blip would also
+			// count, but maxFetchAttempts=3 means three blips in a
+			// row to give up, which is acceptable and prevents a
+			// render-storm against a hopeless ID.
 			log.Printf("picker: thumbnail fetch %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
 			return
 		}
 		if len(data) == 0 {
+			// Server returned OK=true with empty PNG — contract
+			// violation, but harmless if we count it. Without the
+			// increment a misbehaving server pins the picker into
+			// a render-storm.
+			log.Printf("picker: thumbnail fetch %x: empty response", targetID[:4])
+			p.markFetchFailed(targetID)
 			return
 		}
 		// First-pass: header check + dimension cap. Cheap and
 		// catches non-PNG / huge-canvas attacks before full decode.
+		// Decode-stage errors are bytes-permanent (the same bytes
+		// will fail the same way next time), so they count toward
+		// failedFetches — otherwise a corrupt sidecar re-dispatches
+		// a goroutine every render until the daemon is restarted.
 		cfg, err := png.DecodeConfig(bytes.NewReader(data))
 		if err != nil {
 			log.Printf("picker: thumbnail decode-config %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
 			return
 		}
 		if cfg.Width > maxThumbnailDim || cfg.Height > maxThumbnailDim {
 			log.Printf("picker: thumbnail %x: refusing %dx%d (cap %d)",
 				targetID[:4], cfg.Width, cfg.Height, maxThumbnailDim)
+			p.markFetchFailed(targetID)
 			return
 		}
 		// Second-pass: full decode. Catches truncated IDAT, bad
@@ -5106,9 +5170,11 @@ func (p *Picker) maybeFetchThumbnail(id [16]byte, hasThumb bool) {
 		// failure, and the picker has no retry signal — so a half-
 		// broken cache entry would leave the user staring at
 		// `[img: session-thumbnail]` forever. If full decode fails,
-		// don't cache; next render falls through to ASCII layout.
+		// don't cache and count toward the limiter; next render
+		// falls through to ASCII layout.
 		if _, err := png.Decode(bytes.NewReader(data)); err != nil {
 			log.Printf("picker: thumbnail decode %x: %v", targetID[:4], err)
+			p.markFetchFailed(targetID)
 			return
 		}
 		p.mu.Lock()

--- a/docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md
+++ b/docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md
@@ -1,0 +1,574 @@
+# Issue #199 Plan F.1 — Stored-Session Recovery Picker — Design
+
+**Date:** 2026-05-03
+**Status:** Approved for plan
+**Issue:** [#199](https://github.com/framegrace/texelation/issues/199) (Plan F.1 of the rollout)
+
+## Problem
+
+A texelation user with lost client state — wiped state file, fresh machine,
+reinstall, or first launch with persisted server-side sessions — currently has
+no way to discover and rejoin sessions the daemon has on disk. Plans D and D2
+already persist session metadata (`LastActive`, `Label`, `PaneCount`,
+`FirstPaneTitle`, `Pinned`) and `StoredSession` JSON sidecars. Plan F.1 adds
+the discovery + recovery UX.
+
+This spec covers F.1 only — recovery of *stored* (fossilized) sessions. F.2
+(multi-live-sessions) and F.3 (templates) will be filed as follow-up issues
+after F.1 lands; F.1's UI scaffolding is built so F.2 can populate the empty
+"Live" tab without restructuring.
+
+## Session-state taxonomy (F.1 / F.2 framing)
+
+| State | Meaning | Reachable in F.1? |
+|---|---|---|
+| **Live-Attached** | In memory, ≥1 client attached | Through normal connect; not in picker |
+| **Live-Detached** | In memory, no clients attached | Through normal connect (sessionID match); F.2 surfaces in picker |
+| **Stored** | Fossilized to disk, not in memory | F.1 picker — primary target |
+| **Template** | Named, persistent, multi-instance | F.3 — out of scope |
+
+F.1's picker shows a `Live` tab (always empty in F.1, populated by F.2) and
+a `Stored` tab (the F.1 target).
+
+## Out of scope
+
+- **F.2: multi-live-sessions** — listing live detached sessions, attaching to
+  one from a second client, etc. The wire format reserves `LiveSummary` so
+  F.2 doesn't require another protocol bump.
+- **F.3: templates** — user-named persistent layouts that spawn fresh
+  instances on pick.
+- **In-app rename UI** — F.1 only allows renames from the picker. A texel
+  command palette / status-bar action for renaming a live session is a later
+  initiative.
+- **Periodic thumbnail capture** — F.1 captures lifecycle-only (graceful
+  shutdown + last client disconnect). Continuous or rate-limited capture is
+  rejected for F.1 (cost vs. value: staleness is acceptable for a hint).
+- **Cold-start hydration performance** ([#230](https://github.com/framegrace/texelation/issues/230)) — orthogonal investigation.
+- **Compatibility with v4 servers** — beyond a clear "this server is too old"
+  message and fall-through to the existing connect path. We don't backport.
+
+## Trigger model
+
+Picker activation logic in `cmd/texelation/boot`:
+
+```
+if clientStateFile exists AND has valid sessionID:
+    skip picker, take normal connect path
+else if --recover flag set:
+    always show picker (even if 0 stored — just shows "no sessions")
+else:
+    request MsgListSessions
+    if response has ≥1 stored OR ≥1 live:
+        show picker
+    else:
+        skip picker, take fresh-session path
+```
+
+This avoids interrupting first-time users (no flag, no state, no stored
+sessions = silent fast-path) while making recovery automatic when the disk
+already has sessions.
+
+## Architecture
+
+```
+┌────────────────── client (cmd/texelation) ──────────────────┐
+│                                                             │
+│   boot.Run(opts)                                            │
+│      │                                                      │
+│      ├── normal path (existing) ────────► splash ───► run   │
+│      │                                                      │
+│      └── picker path (NEW) ──┐                              │
+│                              ▼                              │
+│                       picker UI (tcell)                     │
+│                       ├ Live tab (empty F.1)                │
+│                       └ Stored tab (cards)                  │
+│                              │                              │
+│                              ▼                              │
+│                  recover/new/rename/delete ─► protocol      │
+└─────────────────────────────────┬───────────────────────────┘
+                                  │ unix socket
+┌─────────────────────────────────▼───────────────────────────┐
+│                      server (texel-server)                  │
+│                                                             │
+│   connection.go handler:                                    │
+│      MsgListSessions       → manager.list()                 │
+│      MsgRecoverSession     → manager.hydrate() ──► normal   │
+│                                                  connect    │
+│      MsgRenameSession      → updates StoredSession JSON     │
+│      MsgDeleteSession      → unlinks JSON + PNG sidecar     │
+│      MsgFetchThumbnail     → reads <id>.png                 │
+│                                                             │
+│   thumbnail.go (NEW):                                       │
+│      captureThumbnail(sess) — on graceful shutdown          │
+│                              + on last client disconnect    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Protocol (v4 → v5)
+
+### Wire types
+
+```go
+// SessionSummary describes a stored session on disk.
+type SessionSummary struct {
+    SessionID      [16]byte
+    Label          string            // empty -> rendered as "Untitled"
+    LastActive     int64             // unix seconds
+    PaneCount      int
+    FirstPaneTitle string
+    Pinned         bool
+    HasThumbnail   bool              // <sessionID>.png exists
+    LayoutCapture  *TreeNodeCapture  // for ASCII fallback render
+}
+
+// LiveSummary describes a hydrated session.
+// Empty in F.1; reserved for F.2.
+type LiveSummary struct {
+    SessionID       [16]byte
+    Label           string
+    AttachedClients int
+    PaneCount       int
+    LastInputAt     int64
+}
+```
+
+### New messages
+
+**`MsgListSessions`** (client → server):
+```go
+type ListSessionsRequest struct {
+    // Reserved for F.2 filters.
+}
+```
+
+**`MsgListSessionsResponse`** (server → client):
+```go
+type ListSessionsResponse struct {
+    Live   []LiveSummary    // empty in F.1
+    Stored []SessionSummary // sorted: pinned desc, then LastActive desc
+}
+```
+
+**`MsgRecoverSession`** (client → server):
+```go
+type RecoverSessionRequest struct {
+    SessionID [16]byte
+    NewLabel  string  // optional inline rename
+}
+```
+Response: ordinary `MsgConnectAccept` + `MsgTreeSnapshot` flow — picker hands
+off to the existing connect path with no special-casing downstream.
+
+**`MsgRenameSession`** (client → server):
+```go
+type RenameSessionRequest struct {
+    SessionID [16]byte
+    NewLabel  string
+}
+type RenameSessionResponse struct {
+    OK    bool
+    Error string
+}
+```
+
+**`MsgDeleteSession`** (client → server):
+```go
+type DeleteSessionRequest struct {
+    SessionID [16]byte
+}
+type DeleteSessionResponse struct {
+    OK    bool
+    Error string
+}
+```
+Refuses with error if session is currently live (only relevant once F.2 lands;
+F.1 has no live sessions through the picker).
+
+**`MsgFetchThumbnail`** (client → server, lazy):
+```go
+type FetchThumbnailRequest struct {
+    SessionID [16]byte
+}
+type FetchThumbnailResponse struct {
+    OK    bool
+    Error string
+    PNG   []byte
+}
+```
+
+### Version handshake
+
+- v4 → v5 because messages are added.
+- Old (v4) clients ignore the new types entirely; servers continue to serve
+  v4 protocol on negotiated v4 connections.
+- New (v5) clients on v4 servers: detect via `MsgWelcome.Version`, render a
+  one-line "this server doesn't support session listing" message in the
+  picker, and fall through to the existing connect path.
+
+## Server-side implementation
+
+### List handler
+
+```go
+// internal/runtime/server/connection_list_sessions.go (new)
+
+func (c *connection) handleListSessions(req *protocol.ListSessionsRequest) {
+    stored := c.manager.StoredSummaries()
+    live := c.manager.LiveSummaries() // returns nil in F.1
+
+    sort.Slice(stored, func(i, j int) bool {
+        if stored[i].Pinned != stored[j].Pinned {
+            return stored[i].Pinned
+        }
+        return stored[i].LastActive > stored[j].LastActive
+    })
+
+    c.send(&protocol.ListSessionsResponse{Live: live, Stored: stored})
+}
+```
+
+Reads from the existing `manager.persistedSessions` map populated at boot
+scan; no disk IO at request time. `LayoutCapture` is reconstructed from the
+StoredSession JSON's tree on first call and cached on the in-memory record.
+
+### Recover handler
+
+```go
+// internal/runtime/server/connection_recover_session.go (new)
+
+func (c *connection) handleRecoverSession(req *protocol.RecoverSessionRequest) {
+    if req.NewLabel != "" {
+        if err := c.manager.RenameStored(req.SessionID, req.NewLabel); err != nil {
+            c.sendError(err)
+            return
+        }
+    }
+
+    sess, err := c.manager.HydrateStored(req.SessionID)
+    if err != nil {
+        c.sendError(err)
+        return
+    }
+
+    // Reuses existing connect path.
+    c.attachToSession(sess)
+    c.sendConnectAccept(sess)
+    c.sendTreeSnapshot(sess)
+}
+```
+
+`HydrateStored` is the existing rehydrate path used by `MsgResumeRequest`,
+extracted into a function the picker can also call.
+
+### Rename / delete handlers
+
+Both update `manager.persistedSessions` under the existing manager mutex,
+write through to disk via the existing snapshot store helpers, and remove
+sidecar PNG on delete.
+
+```go
+// internal/runtime/server/manager_session_files.go (new)
+
+func (m *Manager) DeleteStored(id [16]byte) error {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    if _, live := m.live[id]; live {
+        return fmt.Errorf("session is live; detach all clients first")
+    }
+    if _, ok := m.persistedSessions[id]; !ok {
+        return fmt.Errorf("session not found")
+    }
+    delete(m.persistedSessions, id)
+    _ = os.Remove(filepath.Join(m.sessionDir, idString(id)+".png"))
+    return os.Remove(filepath.Join(m.sessionDir, idString(id)+".json"))
+}
+```
+
+### Thumbnail capture
+
+Two trigger points wired into existing manager hooks:
+
+```go
+// internal/runtime/server/thumbnail.go (new)
+
+func (m *Manager) captureThumbnail(sess *Session) {
+    if !sess.HasContent() {
+        return // empty workspace, skip
+    }
+    grid := sess.workspace.RenderToGrid()
+    img, err := textrender.Render(grid, textrender.DefaultOptions())
+    if err != nil {
+        log.Printf("thumbnail: render: %v", err)
+        return
+    }
+    img = downscaleAspectFit(img, 480, 270)
+
+    path := filepath.Join(m.sessionDir, idString(sess.ID)+".png")
+    if err := writePNGAtomic(path, img); err != nil {
+        log.Printf("thumbnail: write: %v", err)
+    }
+}
+```
+
+**Trigger 1 — graceful shutdown:** `manager.Shutdown()` walks live sessions
+before flushing the snapshot store and calls `captureThumbnail` for each.
+
+**Trigger 2 — last client disconnect:** `manager.detachClient()` checks
+`attachedClients == 0` after detach and fires `captureThumbnail` async (fire-
+and-forget — failure logs and is non-fatal).
+
+`writePNGAtomic` writes to `path + ".tmp"`, `Sync`s, and `Rename`s, so a
+crash mid-write doesn't leave a half-PNG.
+
+### Boot scan extension
+
+`manager.scanSessionsDir` already populates `persistedSessions` from `*.json`
+files. Add a `Stat` for `<id>.png` to set `HasThumbnail` on the in-memory
+record. Orphaned PNGs (no matching JSON) are removed during the scan.
+
+### Fetch thumbnail handler
+
+```go
+func (c *connection) handleFetchThumbnail(req *protocol.FetchThumbnailRequest) {
+    path := filepath.Join(c.manager.sessionDir, idString(req.SessionID)+".png")
+    data, err := os.ReadFile(path)
+    if err != nil {
+        c.send(&protocol.FetchThumbnailResponse{OK: false, Error: err.Error()})
+        return
+    }
+    c.send(&protocol.FetchThumbnailResponse{OK: true, PNG: data})
+}
+```
+
+## Client-side picker UI
+
+### Package layout
+
+```
+cmd/texelation/boot/
+  picker.go             — Picker struct, event loop, dispatch
+  picker_render.go      — Layout + drawing
+  picker_thumbnail.go   — Kitty + ASCII fallback rendering
+  picker_ascii.go       — TreeNodeCapture → box-drawing chars
+  picker_input.go       — Key handling, navigation
+  picker_test.go        — Render, navigation, fallback tests
+  picker_ascii_test.go  — Pure-function ASCII algorithm tests
+```
+
+### State machine
+
+```go
+type Picker struct {
+    screen      tcell.Screen
+    conn        protocol.Conn
+    hasGraphics bool
+
+    response    *protocol.ListSessionsResponse
+    activeTab   tab // tabLive | tabStored
+    selectedIdx int
+
+    mode       mode // modeBrowse | modeRename | modeDeleteConfirm
+    renameBuf  []rune
+    thumbCache map[[16]byte][]byte // PNG bytes by session ID
+    pending    map[[16]byte]bool   // outstanding fetches
+}
+```
+
+### Layout (single-screen)
+
+```
+┌─ texelation ────────────────────────────────────────────────────┐
+│                                                                 │
+│  [ Live (0) ]  [ Stored (3) ]                                   │
+│                                                                 │
+│  ╔═════════════════╗  Label:    work-laptop                     │
+│  ║  thumbnail or   ║  Active:   2 hours ago                     │
+│  ║  ASCII layout   ║  Panes:    4                               │
+│  ║                 ║  Title:    nvim · texelation/cmd/...       │
+│  ╚═════════════════╝  Pinned:   ★                               │
+│                                                                 │
+│  ╔═════════════════╗  Label:    debug-cluster                   │
+│  ║                 ║  Active:   yesterday                       │
+│  ║                 ║  Panes:    2                               │
+│  ║                 ║  Title:    bash                            │
+│  ╚═════════════════╝                                            │
+│                                                                 │
+│  [Enter] recover   [n] new   [r] rename   [d] delete   [q] quit │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Card thumbnail rect: ~22×8 cells, fixed. Cards stack vertically; viewport
+scrolls when overflowing.
+
+### Hotkeys (browse mode)
+
+| Key | Action |
+|---|---|
+| ↑ / k | Move selection up |
+| ↓ / j | Move selection down |
+| Tab | Switch tab |
+| Enter | Recover selected |
+| n | Start fresh session |
+| r | Enter rename mode |
+| d | Enter delete-confirm mode |
+| q / Esc | Exit picker (defaults to fresh) |
+
+### Inline rename
+
+`r` overlays a single-line text editor on the selected card's metadata
+column:
+- Label is preselected; typing replaces.
+- Enter sends `MsgRenameSession`; on OK, updates local card label.
+- Esc cancels.
+
+### Delete confirmation
+
+`d` overlays `Delete '<label>'? [y/N]` prompt at the bottom of the card.
+Pinned cards add `(this session is pinned)` before the prompt.
+
+### Thumbnail rendering
+
+```go
+// picker_thumbnail.go
+
+func (p *Picker) renderThumbnail(rect Rect, summary protocol.SessionSummary) {
+    cached, ok := p.thumbCache[summary.SessionID]
+    if p.hasGraphics && summary.HasThumbnail && ok {
+        renderKittyThumbnail(p.screen, rect, cached)
+        return
+    }
+    if p.hasGraphics && summary.HasThumbnail && !p.pending[summary.SessionID] {
+        p.pending[summary.SessionID] = true
+        go p.fetchThumbnail(summary.SessionID)
+    }
+    renderASCIILayout(p.screen, rect, summary.LayoutCapture)
+}
+```
+
+ASCII fallback always renders first; the Kitty image upgrades the card on
+fetch completion.
+
+### ASCII layout algorithm
+
+```go
+// picker_ascii.go
+
+func renderASCIILayout(s tcell.Screen, r Rect, root *protocol.TreeNodeCapture) {
+    if r.W < 8 || r.H < 4 || root == nil {
+        drawSingleBox(s, r)
+        return
+    }
+    drawNode(s, r, root)
+}
+
+func drawNode(s tcell.Screen, r Rect, n *protocol.TreeNodeCapture) {
+    if n.IsLeaf() {
+        drawSingleBox(s, r)
+        if n.Focused {
+            highlightBorder(s, r)
+        }
+        return
+    }
+    a, b := splitRect(r, n.SplitRatio, n.IsHSplit)
+    drawNode(s, a, n.LeftOrTop)
+    drawNode(s, b, n.RightOrBottom)
+    drawDivider(s, r, n.SplitRatio, n.IsHSplit)
+}
+```
+
+Box-drawing chars: `┌─┐│└─┘├┤┬┴┼─│`. Round-off errors absorbed by clamping
+the right/bottom child to fill remaining cells. Sub-minimum-size rects
+collapse to a single bordered box.
+
+### Handoff to splash
+
+On recover/new selection:
+1. Picker tears down its UI (clears the screen region, releases input handler).
+2. Calls into the existing splash entry point with the same `tcell.Screen`.
+3. Splash renders boot progress (existing flow); on `OnStatus(StageReady)`
+   the runtime client takes over.
+
+No screen flicker — tcell is held throughout.
+
+## Testing
+
+### Server-side unit tests (`internal/runtime/server/`)
+
+1. `TestListSessions_EmptyOnFreshDaemon` — fresh daemon, no JSONs, empty response.
+2. `TestListSessions_StoredOnly` — 3 fixtures, ordered pinned-then-LastActive desc.
+3. `TestListSessions_HasThumbnailFlag` — 2 JSONs, 1 PNG → flag differentiates.
+4. `TestListSessions_LayoutCaptureCached` — second call doesn't re-parse JSONs.
+5. `TestRecoverSession_HappyPath` — pick stored, expect ConnectAccept + TreeSnapshot.
+6. `TestRecoverSession_UnknownID` — random UUID → error response, no crash.
+7. `TestRecoverSession_WithRename` — `NewLabel` updates JSON; subsequent list reflects.
+8. `TestDeleteStored_RemovesBothFiles` — JSON + PNG both gone; map entry removed.
+9. `TestDeleteStored_PNGMissing` — JSON-only delete still succeeds.
+10. `TestDeleteStored_RefusesLive` — live session present (manual setup) → error.
+11. `TestRenameStored_PersistsAcrossReload` — rename, re-scan dir, label survives.
+12. `TestCaptureThumbnail_OnLastDisconnect` — attach + detach → PNG appears.
+13. `TestCaptureThumbnail_OnGracefulShutdown` — manager.Shutdown() captures live sessions.
+14. `TestCaptureThumbnail_AtomicWrite` — write failure → no `<id>.png` left, JSON intact.
+15. `TestBootScan_OrphanPNGRemoved` — PNG without JSON cleaned during scan.
+16. `TestFetchThumbnail_HappyPath` — PNG bytes returned correctly.
+17. `TestFetchThumbnail_MissingFile` — error response, no crash.
+
+### Client-side picker tests (`cmd/texelation/boot/`)
+
+18. `TestPicker_RendersStoredCards` — 3 summaries → 3 card regions painted.
+19. `TestPicker_NavigationKeys` — j/k/arrows move, Enter dispatches recover, n dispatches new.
+20. `TestPicker_TabSwitch` — Tab toggles between Live and Stored tabs.
+21. `TestPicker_LiveTabEmptyState` — Live tab shows "no live sessions" when empty (F.1 default).
+22. `TestPicker_RenameInline` — r enters edit mode, Enter commits via MsgRenameSession.
+23. `TestPicker_RenameEsc_Cancels` — Esc reverts to original label.
+24. `TestPicker_DeleteConfirmation_Y` — d → y → MsgDeleteSession dispatched, card removed.
+25. `TestPicker_DeleteConfirmation_N` — d → n → no message, card retained.
+26. `TestPicker_FallsBackToASCII_OnNoGraphics` — graphics=none → no Kitty escapes, only box chars.
+27. `TestPicker_FetchThumbnailUpgradesCard` — Kitty + async response → card re-renders with image.
+28. `TestPicker_TooSmallScreen_CollapsesToList` — sub-40×15 → name-only list mode.
+
+### ASCII layout pure-function tests (`cmd/texelation/boot/`)
+
+29. `TestRenderASCIILayout_SinglePane` — leaf-only → single bordered box.
+30. `TestRenderASCIILayout_HorizontalSplit` — h-split → `─` divider mid-rect.
+31. `TestRenderASCIILayout_VerticalSplit` — v-split → `│` divider mid-rect.
+32. `TestRenderASCIILayout_NestedSplits` — 4 leaves → correct T-junctions.
+33. `TestRenderASCIILayout_FocusHighlight` — `Focused: true` leaf gets highlight color.
+34. `TestRenderASCIILayout_RoundOff` — 7-cell width × 0.33 ratio → no gaps.
+35. `TestRenderASCIILayout_BelowMinSize` — 6×3 rect → falls back to single box.
+
+### Integration tests (`internal/runtime/server/`)
+
+36. `TestPickerEndToEnd_RecoverFlow` — memconn loop: list → recover → ConnectAccept → buffers.
+37. `TestPickerEndToEnd_RenameThenRecover` — rename via picker, verify label persisted post-recover.
+
+## Risks
+
+- **Stale thumbnails.** External edits to a stored session's tree won't
+  reflect in the thumbnail until next live capture. Acceptable — thumbnail
+  is a hint; metadata is authoritative.
+- **Sidecar PNG bloat.** Hundreds of stored sessions × ~50 KB → tens of MB.
+  Cleanup is wired through the existing StoredSession retention path; one
+  line addition.
+- **TreeNodeCapture wire size in list response.** Typical 1-5 panes ≈
+  ~100 bytes per summary — negligible. Won't bother with a separate fetch.
+- **Tiny terminal rendering.** Sub-40×15 cells auto-collapse to name-only
+  list mode; no thumbnails, single-line cards.
+- **Concurrent rename + delete races.** Two clients with picker open: one
+  renames, the other deletes. Server serializes via manager mutex; second
+  op gets a clear error and the picker re-fetches its list.
+- **Shutdown delay from thumbnail capture.** 50 stored sessions × ~100 ms
+  render = 5 s. Realistic case is 1-3 live sessions; F.1 accepts the worst-
+  case delay. F.2 adds dirty-since-last-capture tracking if needed.
+- **v4 server fallback UX.** Picker on a v5 client connecting to a v4 server
+  shows a clear one-liner and falls through. Not silent, not crashing.
+
+## Forward-compat for F.2 / F.3
+
+- `LiveSummary` slice already on the wire — F.2 just populates it.
+- `Live` tab renders empty in F.1 — F.2 just changes its content source.
+- `MsgRecoverSession` semantics naturally extend: F.2 can branch on "is the
+  picked session live?" and skip rehydration when it's already in memory.
+- `MsgFetchThumbnail` works for live sessions too once F.2 wires capture
+  on transitions from Live-Detached → Stored (planned daemon-shutdown path).
+- F.3 (templates) adds a `Templates` tab and a `MsgInstantiateTemplate`
+  message; SessionSummary picks up an `IsTemplate` flag.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gdamore/tcell/v2 v2.13.8
 	github.com/go-enry/go-enry/v2 v2.9.4
 	github.com/mattn/go-runewidth v0.0.16
+	golang.org/x/image v0.38.0
 	golang.org/x/term v0.37.0
 	modernc.org/sqlite v1.44.3
 )
@@ -25,7 +26,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
-	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	modernc.org/libc v1.67.6 // indirect

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -220,7 +220,14 @@ func Run(opts Options) error {
 	// received yet, no panes rendered). The persisted PaneViewports
 	// from disk are what feed the resume; live trackers are only used
 	// for the same-process --reconnect case where they may be populated.
-	shouldResume := opts.Reconnect || loadedState != nil
+	// Plan F.1: when the picker handed us a RecoverSessionID, we need
+	// to send MsgResumeRequest to drive the server's awaitResume
+	// connection out of its block — without it the server sits
+	// waiting and the splash hangs on "Capturing snapshot". The
+	// PaneViewports slice will be empty (no client-side state to
+	// supply), which is correct: the server treats empty as
+	// "fresh-connect semantics" while still rehydrating the session.
+	shouldResume := opts.Reconnect || loadedState != nil || opts.RecoverSessionID != ([16]byte{})
 	if shouldResume {
 		// Prefer persisted PaneViewports (fresh process, trackers map
 		// is empty); fall back to live trackers for the same-process

--- a/internal/runtime/client/app.go
+++ b/internal/runtime/client/app.go
@@ -71,6 +71,16 @@ type Options struct {
 	// OnStatus, when set, is called at startup milestones (see Stage
 	// constants) so an external splash can update its display. nil-safe.
 	OnStatus StatusFn
+
+	// RecoverSessionID, when non-zero AND no persisted client state
+	// exists, pre-seeds the sessionID for the connect attempt so
+	// LookupOrRehydrate picks up the matching stored session. Set by
+	// the picker handoff in cmd/texelation/main.go (issue #199 F.1).
+	RecoverSessionID [16]byte
+
+	// ShowRecoverPicker forces the recovery picker to open even when
+	// the client has intact state. Driven by the --recover flag.
+	ShowRecoverPicker bool
 }
 
 func Run(opts Options) error {
@@ -106,6 +116,12 @@ func Run(opts Options) error {
 	var sessionID [16]byte
 	if loadedState != nil {
 		sessionID = loadedState.SessionID
+	} else if opts.RecoverSessionID != ([16]byte{}) {
+		// Plan F.1: picker handed us a session ID to recover. The
+		// server's existing connect path looks this up via
+		// LookupOrRehydrate, which is exactly what we want — no new
+		// code path needed downstream.
+		sessionID = opts.RecoverSessionID
 	}
 
 	emitStatus := func(stage Stage, detail string) {

--- a/internal/runtime/client/screenshot.go
+++ b/internal/runtime/client/screenshot.go
@@ -12,11 +12,14 @@ import (
 	"time"
 
 	texelcore "github.com/framegrace/texelui/core"
-	"github.com/framegrace/texelui/graphics/textrender"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
 )
 
 // takeScreenshot renders the current workspace buffer to a PNG file
-// and copies it to the system clipboard.
+// and copies it to the system clipboard. Uses the shared
+// internal/thumbnail rendering primitive — same code path as the
+// server's lifecycle thumbnail capture.
 func takeScreenshot(state *clientState) {
 	buf := state.prevBuffer
 	if len(buf) == 0 {
@@ -34,34 +37,19 @@ func takeScreenshot(state *clientState) {
 		}
 	}
 
-	fontPath, err := textrender.DetectFont()
+	img, err := thumbnail.RenderGrid(coreGrid)
 	if err != nil {
-		log.Printf("[SCREENSHOT] Font detection failed: %v", err)
+		log.Printf("[SCREENSHOT] Render failed: %v", err)
 		return
 	}
-
-	renderer, err := textrender.New(textrender.Config{FontPath: fontPath})
-	if err != nil {
-		log.Printf("[SCREENSHOT] Renderer creation failed: %v", err)
-		return
-	}
-
-	img := renderer.Render(coreGrid)
 
 	home, _ := os.UserHomeDir()
 	dir := filepath.Join(home, ".texelation", "screenshots")
 	os.MkdirAll(dir, 0o755)
 	filename := filepath.Join(dir, fmt.Sprintf("screenshot-%s.png", time.Now().Format("2006-01-02_15-04-05")))
 
-	f, err := os.Create(filename)
-	if err != nil {
-		log.Printf("[SCREENSHOT] Failed to create file: %v", err)
-		return
-	}
-	defer f.Close()
-
-	if err := png.Encode(f, img); err != nil {
-		log.Printf("[SCREENSHOT] Failed to encode PNG: %v", err)
+	if err := thumbnail.WritePNGAtomic(filename, img); err != nil {
+		log.Printf("[SCREENSHOT] Write failed: %v", err)
 		return
 	}
 
@@ -71,7 +59,6 @@ func takeScreenshot(state *clientState) {
 
 // copyImageToClipboard copies a PNG image to the system clipboard.
 func copyImageToClipboard(img image.Image, filePath string) {
-	// Wayland
 	if path, err := exec.LookPath("wl-copy"); err == nil {
 		var buf bytes.Buffer
 		if err := png.Encode(&buf, img); err == nil {
@@ -82,8 +69,6 @@ func copyImageToClipboard(img image.Image, filePath string) {
 			}
 		}
 	}
-
-	// X11
 	if path, err := exec.LookPath("xclip"); err == nil {
 		var buf bytes.Buffer
 		if err := png.Encode(&buf, img); err == nil {
@@ -94,8 +79,6 @@ func copyImageToClipboard(img image.Image, filePath string) {
 			}
 		}
 	}
-
-	// macOS
 	if path, err := exec.LookPath("osascript"); err == nil {
 		script := fmt.Sprintf(`set the clipboard to (read (POSIX file %q) as «class PNGf»)`, filePath)
 		exec.Command(path, "-e", script).Run()

--- a/internal/runtime/server/client_integration_test.go
+++ b/internal/runtime/server/client_integration_test.go
@@ -73,7 +73,7 @@ func TestClientResumeReceivesSnapshot(t *testing.T) {
 			firstErr <- err
 			return
 		}
-		conn := newConnection(firstServer, session, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(firstServer, session, sink, nil, resuming, false /*rehydrated*/)
 		firstErr <- conn.serve()
 	}()
 
@@ -156,7 +156,7 @@ func TestClientResumeReceivesSnapshot(t *testing.T) {
 		}
 		publisher := NewDesktopPublisher(desktop, session)
 		sink.SetPublisher(publisher)
-		conn := newConnection(resumeServer, session, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(resumeServer, session, sink, nil, resuming, false /*rehydrated*/)
 		resumeErr <- conn.serve()
 	}()
 

--- a/internal/runtime/server/client_tree_operations_test.go
+++ b/internal/runtime/server/client_tree_operations_test.go
@@ -115,7 +115,7 @@ func handleTreeTestConnection(conn net.Conn, mgr *Manager, desktop *texel.Deskto
 
 	_ = publisher.Publish()
 
-	connHandler := newConnection(conn, session, sink, resuming, false /*rehydrated*/)
+	connHandler := newConnection(conn, session, sink, nil, resuming, false /*rehydrated*/)
 	_ = connHandler.serve()
 }
 

--- a/internal/runtime/server/clipboard_theme_mem_test.go
+++ b/internal/runtime/server/clipboard_theme_mem_test.go
@@ -82,7 +82,7 @@ func TestClipboardAndThemeRoundTrip(t *testing.T) {
 		_ = pub.Publish()
 		srv := &Server{manager: mgr, sink: sink, desktopSink: sink}
 		srv.sendSnapshot(serverConn, sess)
-		errCh <- newConnection(serverConn, sess, sink, resuming, false /*rehydrated*/).serve()
+		errCh <- newConnection(serverConn, sess, sink, nil, resuming, false /*rehydrated*/).serve()
 	}()
 
 	// initial handshake

--- a/internal/runtime/server/connection.go
+++ b/internal/runtime/server/connection.go
@@ -22,6 +22,7 @@ import (
 type connection struct {
 	conn                net.Conn
 	session             *Session
+	manager             *Manager // Plan F.1: picker handlers reach into manager for list/rename/delete/rehydrate
 	lastSent            uint64
 	lastAcked           uint64
 	sink                EventSink
@@ -54,11 +55,11 @@ type protocolMessage struct {
 	payload []byte
 }
 
-func newConnection(conn net.Conn, session *Session, sink EventSink, awaitResume, rehydrated bool) *connection {
+func newConnection(conn net.Conn, session *Session, sink EventSink, mgr *Manager, awaitResume, rehydrated bool) *connection {
 	if sink == nil {
 		sink = nopSink{}
 	}
-	c := &connection{conn: conn, session: session, sink: sink, awaitResume: awaitResume, rehydrated: rehydrated}
+	c := &connection{conn: conn, session: session, manager: mgr, sink: sink, awaitResume: awaitResume, rehydrated: rehydrated}
 	c.incoming = make(chan protocolMessage, 32)
 	c.readErr = make(chan error, 1)
 	c.pending = make(chan struct{}, 1)

--- a/internal/runtime/server/connection_handler.go
+++ b/internal/runtime/server/connection_handler.go
@@ -343,6 +343,26 @@ func (c *connection) handleMessage(prefix string, header protocol.Header, payloa
 		if err := c.handleFetchRange(payload); err != nil {
 			return fmt.Errorf("fetch range: %w", err)
 		}
+	case protocol.MsgListSessions:
+		if err := c.handleListSessions(payload); err != nil {
+			return fmt.Errorf("list sessions: %w", err)
+		}
+	case protocol.MsgRecoverSession:
+		if err := c.handleRecoverSession(payload); err != nil {
+			return fmt.Errorf("recover session: %w", err)
+		}
+	case protocol.MsgRenameSession:
+		if err := c.handleRenameSession(payload); err != nil {
+			return fmt.Errorf("rename session: %w", err)
+		}
+	case protocol.MsgDeleteSession:
+		if err := c.handleDeleteSession(payload); err != nil {
+			return fmt.Errorf("delete session: %w", err)
+		}
+	case protocol.MsgFetchThumbnail:
+		if err := c.handleFetchThumbnail(payload); err != nil {
+			return fmt.Errorf("fetch thumbnail: %w", err)
+		}
 	default:
 		debugLog.Printf("%s ignoring message type %d", prefix, header.Type)
 	}

--- a/internal/runtime/server/connection_rehydrate_resume_test.go
+++ b/internal/runtime/server/connection_rehydrate_resume_test.go
@@ -79,7 +79,7 @@ func TestConnection_RehydratedResume_ZerosLastAcked(t *testing.T) {
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, true /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, true /*rehydrated*/)
 
 	errCh := driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID:    sessionID,
@@ -114,7 +114,7 @@ func TestConnection_NonRehydratedResume_HonorsLastAcked(t *testing.T) {
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, false /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, false /*rehydrated*/)
 
 	errCh := driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID:    sessionID,
@@ -155,7 +155,7 @@ func TestConnection_RehydratedResume_LeavesInitialSnapshotSentFalse(t *testing.T
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, true /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, true /*rehydrated*/)
 
 	errCh := driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID: sessionID,
@@ -190,7 +190,7 @@ func TestConnection_NonRehydratedResume_FlipsInitialSnapshotSent(t *testing.T) {
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, false /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, false /*rehydrated*/)
 
 	errCh := driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID: sessionID,
@@ -232,7 +232,7 @@ func TestConnection_RehydratedResume_SkipsEarlySnapshot(t *testing.T) {
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, true /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, true /*rehydrated*/)
 
 	_ = driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID: sessionID,
@@ -269,7 +269,7 @@ func TestConnection_NonRehydratedResume_SendsEarlySnapshot(t *testing.T) {
 	defer clientConn.Close()
 	defer serverConn.Close()
 
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, false /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, false /*rehydrated*/)
 
 	_ = driveResumeRequest(t, conn, clientConn, protocol.ResumeRequest{
 		SessionID: sessionID,

--- a/internal/runtime/server/connection_session_picker.go
+++ b/internal/runtime/server/connection_session_picker.go
@@ -1,0 +1,191 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/connection_session_picker.go
+// Summary: Picker request handlers (Plan F.1) — listing, recovery,
+//   rename, delete, and lazy thumbnail fetch.
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// maxThumbnailBytes caps PNG sidecar reads to defend against a local
+// attacker writing a giant file at the predictable on-disk path. A
+// 480×270 PNG at high quality is well under 100 KiB; 1 MiB leaves
+// generous headroom while keeping the worst-case server allocation
+// bounded.
+const maxThumbnailBytes int64 = 1 << 20
+
+func (c *connection) handleListSessions(payload []byte) error {
+	if _, err := protocol.DecodeListSessionsRequest(payload); err != nil {
+		return fmt.Errorf("decode list-sessions: %w", err)
+	}
+	resp := protocol.ListSessionsResponse{
+		Live:   c.manager.LiveSummaries(),
+		Stored: c.manager.StoredSummaries(),
+	}
+	body, err := protocol.EncodeListSessionsResponse(resp)
+	if err != nil {
+		return fmt.Errorf("encode list-sessions: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgListSessionsResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+func (c *connection) handleRecoverSession(payload []byte) error {
+	req, err := protocol.DecodeRecoverSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode recover-session: %w", err)
+	}
+	if req.NewLabel != "" {
+		if rerr := c.manager.RenameStored(req.SessionID, req.NewLabel); rerr != nil && !errors.Is(rerr, ErrSessionNotFound) {
+			return c.sendErrorFrame(rerr)
+		}
+	}
+	sess, _, err := c.manager.LookupOrRehydrate(req.SessionID)
+	if err != nil {
+		return c.sendErrorFrame(err)
+	}
+	c.session = sess
+	accept := protocol.ConnectAccept{
+		SessionID:       sess.ID(),
+		ResumeSupported: true,
+	}
+	body, err := protocol.EncodeConnectAccept(accept)
+	if err != nil {
+		return fmt.Errorf("encode accept: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgConnectAccept,
+		Flags:     protocol.FlagChecksum,
+		SessionID: sess.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+// handleRenameSession applies an inline label edit. Replies with a
+// MsgSessionOpResponse{OpType: OpRename, OK: ...} so the picker can
+// correlate against the op it issued (no conflation with other
+// responses on the connection).
+func (c *connection) handleRenameSession(payload []byte) error {
+	req, err := protocol.DecodeRenameSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode rename: %w", err)
+	}
+	if err := c.manager.RenameStored(req.SessionID, req.NewLabel); err != nil {
+		return c.sendOpResponse(protocol.OpRename, false, err.Error())
+	}
+	return c.sendOpResponse(protocol.OpRename, true, "")
+}
+
+func (c *connection) handleDeleteSession(payload []byte) error {
+	req, err := protocol.DecodeDeleteSessionRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode delete: %w", err)
+	}
+	if err := c.manager.DeleteStored(req.SessionID); err != nil {
+		return c.sendOpResponse(protocol.OpDelete, false, err.Error())
+	}
+	return c.sendOpResponse(protocol.OpDelete, true, "")
+}
+
+func (c *connection) handleFetchThumbnail(payload []byte) error {
+	req, err := protocol.DecodeFetchThumbnailRequest(payload)
+	if err != nil {
+		return fmt.Errorf("decode fetch-thumb: %w", err)
+	}
+	pngPath := c.manager.sessionPNGPath(req.SessionID)
+	if pngPath == "" {
+		return c.sendThumbnailResponse(false, "thumbnail unavailable", nil)
+	}
+	info, err := os.Stat(pngPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c.sendThumbnailResponse(false, "thumbnail not found", nil)
+		}
+		log.Printf("server: fetch thumbnail %x stat: %v", req.SessionID[:4], err)
+		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
+	}
+	if info.Size() > maxThumbnailBytes {
+		log.Printf("server: fetch thumbnail %x: refusing %d bytes (cap %d)", req.SessionID[:4], info.Size(), maxThumbnailBytes)
+		return c.sendThumbnailResponse(false, "thumbnail too large", nil)
+	}
+	data, err := os.ReadFile(pngPath)
+	if err != nil {
+		log.Printf("server: fetch thumbnail %x read: %v", req.SessionID[:4], err)
+		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
+	}
+	return c.sendThumbnailResponse(true, "", data)
+}
+
+func (c *connection) sendThumbnailResponse(ok bool, errMsg string, png []byte) error {
+	body, err := protocol.EncodeFetchThumbnailResponse(protocol.FetchThumbnailResponse{
+		OK:    ok,
+		Error: errMsg,
+		PNG:   png,
+	})
+	if err != nil {
+		return fmt.Errorf("encode fetch-thumb response: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgFetchThumbnailResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+// sendOpResponse confirms a rename/delete with the typed
+// SessionOpResponse envelope. The picker correlates by OpType so it
+// can ignore unrelated frames that arrive on the connection.
+func (c *connection) sendOpResponse(op protocol.SessionOpKind, ok bool, errMsg string) error {
+	body, err := protocol.EncodeSessionOpResponse(protocol.SessionOpResponse{
+		OpType: op,
+		OK:     ok,
+		Error:  errMsg,
+	})
+	if err != nil {
+		return fmt.Errorf("encode op response: %w", err)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgSessionOpResponse,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}
+
+// sendErrorFrame surfaces an error to the client without aborting the
+// connection. Used for picker handlers that don't have a dedicated
+// response envelope (recover, list).
+func (c *connection) sendErrorFrame(err error) error {
+	body, encErr := protocol.EncodeErrorFrame(protocol.ErrorFrame{
+		Code:    1,
+		Message: err.Error(),
+	})
+	if encErr != nil {
+		return fmt.Errorf("encode error frame: %w", encErr)
+	}
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      protocol.MsgError,
+		Flags:     protocol.FlagChecksum,
+		SessionID: c.session.ID(),
+	}
+	return c.writeMessage(hdr, body)
+}

--- a/internal/runtime/server/connection_session_picker.go
+++ b/internal/runtime/server/connection_session_picker.go
@@ -54,13 +54,26 @@ func (c *connection) handleRecoverSession(payload []byte) error {
 			return c.sendErrorFrame(rerr)
 		}
 	}
-	sess, _, err := c.manager.LookupOrRehydrate(req.SessionID)
-	if err != nil {
-		return c.sendErrorFrame(err)
+	// Just validate that the session exists — do NOT consume it from
+	// persistedSessions or claim it for this connection. Earlier
+	// versions called LookupOrRehydrate here, which left the session
+	// live in m.sessions and caused the subsequent client reconnect
+	// to take the in-process resume path (rehydrated=false). That
+	// branch sets initialSnapshotSent=true, which then short-circuits
+	// handleClientReady — meaning the desktop never gets
+	// SetViewportSize'd to the new client's dimensions. Symptom: the
+	// recovered workspace renders at the daemon's default tiny size.
+	//
+	// The picker's role is purely UI: validate + return. The actual
+	// recovery happens when main.go calls clientrt.Run with
+	// RecoverSessionID, which goes through the normal Hello/Welcome/
+	// ConnectRequest path → LookupOrRehydrate → rehydrated=true →
+	// handleClientReady runs the full SetViewportSize + snapshot flow.
+	if !c.manager.HasSession(req.SessionID) {
+		return c.sendErrorFrame(ErrSessionNotFound)
 	}
-	c.session = sess
 	accept := protocol.ConnectAccept{
-		SessionID:       sess.ID(),
+		SessionID:       req.SessionID,
 		ResumeSupported: true,
 	}
 	body, err := protocol.EncodeConnectAccept(accept)
@@ -71,7 +84,7 @@ func (c *connection) handleRecoverSession(payload []byte) error {
 		Version:   protocol.Version,
 		Type:      protocol.MsgConnectAccept,
 		Flags:     protocol.FlagChecksum,
-		SessionID: sess.ID(),
+		SessionID: c.session.ID(),
 	}
 	return c.writeMessage(hdr, body)
 }

--- a/internal/runtime/server/connection_session_picker.go
+++ b/internal/runtime/server/connection_session_picker.go
@@ -112,12 +112,21 @@ func (c *connection) handleFetchThumbnail(payload []byte) error {
 		return c.sendThumbnailResponse(false, "thumbnail unavailable", nil)
 	}
 	info, err := os.Stat(pngPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return c.sendThumbnailResponse(false, "thumbnail not found", nil)
-		}
+	if err != nil && !os.IsNotExist(err) {
 		log.Printf("server: fetch thumbnail %x stat: %v", req.SessionID[:4], err)
 		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
+	}
+	// Plan F.1: when the PNG is missing but the session is currently
+	// live, render one on demand from the publisher's prevBuffers via
+	// the wired ThumbnailRenderer. The result is also written to disk
+	// so subsequent fetches hit the fast path. For stored sessions
+	// with no cached PNG we still return "not found" — there's no
+	// in-memory state to render from.
+	if os.IsNotExist(err) {
+		if data, ok := c.manager.captureLiveThumbnailBytes(req.SessionID); ok {
+			return c.sendThumbnailResponse(true, "", data)
+		}
+		return c.sendThumbnailResponse(false, "thumbnail not found", nil)
 	}
 	if info.Size() > maxThumbnailBytes {
 		log.Printf("server: fetch thumbnail %x: refusing %d bytes (cap %d)", req.SessionID[:4], info.Size(), maxThumbnailBytes)

--- a/internal/runtime/server/connection_session_picker.go
+++ b/internal/runtime/server/connection_session_picker.go
@@ -107,26 +107,26 @@ func (c *connection) handleFetchThumbnail(payload []byte) error {
 	if err != nil {
 		return fmt.Errorf("decode fetch-thumb: %w", err)
 	}
+	// Plan F.1: live sessions render fresh every time — their state
+	// changes continuously (typing, new output) so any cached PNG
+	// would be stale. The disk PNG is updated only by the lifecycle
+	// hooks (Close, ShutdownSessions) when the session transitions
+	// out of live state.
+	if data, ok := c.manager.RenderLiveThumbnailBytes(req.SessionID); ok {
+		return c.sendThumbnailResponse(true, "", data)
+	}
+	// Stored sessions: serve from disk.
 	pngPath := c.manager.sessionPNGPath(req.SessionID)
 	if pngPath == "" {
 		return c.sendThumbnailResponse(false, "thumbnail unavailable", nil)
 	}
 	info, err := os.Stat(pngPath)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c.sendThumbnailResponse(false, "thumbnail not found", nil)
+		}
 		log.Printf("server: fetch thumbnail %x stat: %v", req.SessionID[:4], err)
 		return c.sendThumbnailResponse(false, "thumbnail io error", nil)
-	}
-	// Plan F.1: when the PNG is missing but the session is currently
-	// live, render one on demand from the publisher's prevBuffers via
-	// the wired ThumbnailRenderer. The result is also written to disk
-	// so subsequent fetches hit the fast path. For stored sessions
-	// with no cached PNG we still return "not found" — there's no
-	// in-memory state to render from.
-	if os.IsNotExist(err) {
-		if data, ok := c.manager.captureLiveThumbnailBytes(req.SessionID); ok {
-			return c.sendThumbnailResponse(true, "", data)
-		}
-		return c.sendThumbnailResponse(false, "thumbnail not found", nil)
 	}
 	if info.Size() > maxThumbnailBytes {
 		log.Printf("server: fetch thumbnail %x: refusing %d bytes (cap %d)", req.SessionID[:4], info.Size(), maxThumbnailBytes)

--- a/internal/runtime/server/connection_session_picker_test.go
+++ b/internal/runtime/server/connection_session_picker_test.go
@@ -1,0 +1,423 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/protocol"
+)
+
+// pickerTestConn wires a *connection to a net.Pipe so the test can
+// drive handleMessage synchronously and read responses off the client
+// side.
+type pickerTestConn struct {
+	t         *testing.T
+	conn      *connection
+	clientEnd net.Conn
+	serverEnd net.Conn
+	closeOnce sync.Once
+}
+
+func newPickerTestConn(t *testing.T, m *Manager) *pickerTestConn {
+	t.Helper()
+	clientEnd, serverEnd := net.Pipe()
+	sess, err := m.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	c := newConnection(serverEnd, sess, nopSink{}, m, false, false)
+	return &pickerTestConn{
+		t:         t,
+		conn:      c,
+		clientEnd: clientEnd,
+		serverEnd: serverEnd,
+	}
+}
+
+// send invokes handleMessage with the supplied message type + payload
+// on a goroutine — handleMessage may write a response that blocks on
+// the pipe until the test reads it.
+func (p *pickerTestConn) send(typ protocol.MessageType, payload []byte) <-chan error {
+	p.t.Helper()
+	hdr := protocol.Header{
+		Version:   protocol.Version,
+		Type:      typ,
+		Flags:     protocol.FlagChecksum,
+		SessionID: p.conn.session.ID(),
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- p.conn.handleMessage("test", hdr, payload)
+	}()
+	return done
+}
+
+// expectResponse reads the next protocol message off the client end
+// of the pipe and asserts its type matches `want`. Returns the payload.
+func (p *pickerTestConn) expectResponse(t *testing.T, want protocol.MessageType) []byte {
+	t.Helper()
+	hdr, payload, err := protocol.ReadMessage(p.clientEnd)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if hdr.Type != want {
+		t.Fatalf("response type = %d, want %d", hdr.Type, want)
+	}
+	return payload
+}
+
+func (p *pickerTestConn) cleanup() {
+	p.closeOnce.Do(func() {
+		_ = p.clientEnd.Close()
+		_ = p.serverEnd.Close()
+	})
+}
+
+func mustEncodeListSessionsRequest(t *testing.T) []byte {
+	t.Helper()
+	out, err := protocol.EncodeListSessionsRequest(protocol.ListSessionsRequest{})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return out
+}
+
+func TestHandleListSessions_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	doneCh := conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, err := protocol.DecodeListSessionsResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Stored) != 0 || len(got.Live) != 0 {
+		t.Fatalf("expected empty, got Stored=%d Live=%d", len(got.Stored), len(got.Live))
+	}
+}
+
+func TestHandleListSessions_StoredPopulated(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id1 := [16]byte{0x01}
+	id2 := [16]byte{0x02}
+	for i, fixture := range []*StoredSession{
+		{SchemaVersion: StoredSessionSchemaVersion, SessionID: id1, LastActive: time.Unix(100, 0), Label: "older", PaneCount: 1},
+		{SchemaVersion: StoredSessionSchemaVersion, SessionID: id2, LastActive: time.Unix(200, 0), Label: "newer", PaneCount: 2},
+	} {
+		data, _ := json.Marshal(fixture)
+		path := filepath.Join(sessions, hex.EncodeToString(fixture.SessionID[:])+".json")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	doneCh := conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	resp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, err := protocol.DecodeListSessionsResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Stored) != 2 {
+		t.Fatalf("expected 2 stored, got %d", len(got.Stored))
+	}
+	if got.Stored[0].Label != "newer" {
+		t.Errorf("expected newer first, got %q", got.Stored[0].Label)
+	}
+}
+
+func TestHandleRecoverSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xAA}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "rec-me",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	if err := os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, err := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: id})
+	if err != nil {
+		t.Fatalf("encode req: %v", err)
+	}
+	doneCh := conn.send(protocol.MsgRecoverSession, body)
+	resp := conn.expectResponse(t, protocol.MsgConnectAccept)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	accept, err := protocol.DecodeConnectAccept(resp)
+	if err != nil {
+		t.Fatalf("decode accept: %v", err)
+	}
+	if accept.SessionID != id {
+		t.Fatalf("accept SessionID = %x, want %x", accept.SessionID, id)
+	}
+}
+
+func TestHandleRenameSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x10}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "before",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: id, NewLabel: "after"})
+	doneCh := conn.send(protocol.MsgRenameSession, body)
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, err := protocol.DecodeSessionOpResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OpType != protocol.OpRename || !got.OK {
+		t.Fatalf("expected OpRename OK=true, got %#v", got)
+	}
+	doneCh = conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	listResp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("list handler: %v", err)
+	}
+	listGot, _ := protocol.DecodeListSessionsResponse(listResp)
+	if len(listGot.Stored) != 1 || listGot.Stored[0].Label != "after" {
+		t.Fatalf("expected rename applied; got %#v", listGot.Stored)
+	}
+}
+
+func TestHandleRenameSession_UnknownID(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRenameSessionRequest(protocol.RenameSessionRequest{SessionID: [16]byte{0xFF}, NewLabel: "x"})
+	doneCh := conn.send(protocol.MsgRenameSession, body)
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, _ := protocol.DecodeSessionOpResponse(resp)
+	if got.OK || got.Error == "" {
+		t.Errorf("expected OK=false with error, got %#v", got)
+	}
+	if got.OpType != protocol.OpRename {
+		t.Errorf("OpType = %d, want OpRename", got.OpType)
+	}
+}
+
+func TestHandleDeleteSession_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x20}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeDeleteSessionRequest(protocol.DeleteSessionRequest{SessionID: id})
+	doneCh := conn.send(protocol.MsgDeleteSession, body)
+	resp := conn.expectResponse(t, protocol.MsgSessionOpResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, _ := protocol.DecodeSessionOpResponse(resp)
+	if got.OpType != protocol.OpDelete || !got.OK {
+		t.Fatalf("expected OpDelete OK=true, got %#v", got)
+	}
+	doneCh = conn.send(protocol.MsgListSessions, mustEncodeListSessionsRequest(t))
+	listResp := conn.expectResponse(t, protocol.MsgListSessionsResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("list handler: %v", err)
+	}
+	listGot, _ := protocol.DecodeListSessionsResponse(listResp)
+	if len(listGot.Stored) != 0 {
+		t.Fatalf("expected empty after delete; got %d", len(listGot.Stored))
+	}
+}
+
+func TestHandleFetchThumbnail_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x30}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(filepath.Join(sessions, hex.EncodeToString(id[:])+".json"), data, 0o644)
+	pngPath := filepath.Join(sessions, hex.EncodeToString(id[:])+".png")
+	pngContent := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	os.WriteFile(pngPath, pngContent, 0o644)
+
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	doneCh := conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, err := protocol.DecodeFetchThumbnailResponse(resp)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("expected OK=true, got Error=%q", got.Error)
+	}
+	if string(got.PNG) != string(pngContent) {
+		t.Fatalf("PNG mismatch")
+	}
+}
+
+func TestHandleFetchThumbnail_Missing(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: [16]byte{0x99}})
+	doneCh := conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, _ := protocol.DecodeFetchThumbnailResponse(resp)
+	if got.OK {
+		t.Errorf("expected OK=false for missing PNG")
+	}
+}
+
+func TestHandleFetchThumbnail_RefusesOversize(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	os.MkdirAll(sessions, 0o755)
+	id := [16]byte{0x40}
+	pngPath := filepath.Join(sessions, hex.EncodeToString(id[:])+".png")
+	if err := os.WriteFile(pngPath, make([]byte, 2*1024*1024), 0o644); err != nil {
+		t.Fatalf("write big png: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeFetchThumbnailRequest(protocol.FetchThumbnailRequest{SessionID: id})
+	doneCh := conn.send(protocol.MsgFetchThumbnail, body)
+	resp := conn.expectResponse(t, protocol.MsgFetchThumbnailResponse)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, _ := protocol.DecodeFetchThumbnailResponse(resp)
+	if got.OK {
+		t.Errorf("expected OK=false for oversized PNG, got OK=true with %d bytes", len(got.PNG))
+	}
+}
+
+func TestHandleRecoverSession_UnknownID(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	conn := newPickerTestConn(t, m)
+	defer conn.cleanup()
+	body, _ := protocol.EncodeRecoverSessionRequest(protocol.RecoverSessionRequest{SessionID: [16]byte{0xFF}})
+	doneCh := conn.send(protocol.MsgRecoverSession, body)
+	resp := conn.expectResponse(t, protocol.MsgError)
+	if err := <-doneCh; err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	got, err := protocol.DecodeErrorFrame(resp)
+	if err != nil {
+		t.Fatalf("decode error frame: %v", err)
+	}
+	if got.Message == "" {
+		t.Errorf("expected non-empty error message")
+	}
+}

--- a/internal/runtime/server/connection_sync_test.go
+++ b/internal/runtime/server/connection_sync_test.go
@@ -54,7 +54,7 @@ func newPipedSendingConnection(t *testing.T, queueSize int) (*connection, net.Co
 	t.Cleanup(func() { _ = clientConn.Close() })
 	t.Cleanup(func() { _ = serverConn.Close() })
 
-	conn := newConnection(serverConn, session, nopSink{}, false /*awaitResume*/, false /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, false /*awaitResume*/, false /*rehydrated*/)
 	return conn, clientConn
 }
 

--- a/internal/runtime/server/connection_test.go
+++ b/internal/runtime/server/connection_test.go
@@ -31,7 +31,7 @@ func TestConnectionFlushesPendingDiffsOnNudge(t *testing.T) {
 	sessionID := [16]byte{1}
 	session := NewSession(sessionID, 16)
 
-	conn := newConnection(serverConn, session, nopSink{}, false, false)
+	conn := newConnection(serverConn, session, nopSink{}, nil, false, false)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -181,7 +181,7 @@ func TestConnectionHandlesResizeBroadcastsSnapshot(t *testing.T) {
 		drainInitialMessages(clientConn, stopInitial)
 	}()
 
-	conn := newConnection(serverConn, session, sink, false, false)
+	conn := newConnection(serverConn, session, sink, nil, false, false)
 
 	close(stopInitial)
 	initialWG.Wait()
@@ -281,7 +281,7 @@ func TestConnectionClipboardRoundTrip(t *testing.T) {
 		drainInitialMessages(clientConn, stopInitial)
 	}()
 
-	conn := newConnection(serverConn, session, sink, false, false)
+	conn := newConnection(serverConn, session, sink, nil, false, false)
 
 	close(stopInitial)
 	initialWG.Wait()
@@ -355,7 +355,7 @@ func TestConnectionResumeFlushesPendingDiffs(t *testing.T) {
 	sink, _, cleanup := newDesktopSink(t)
 	defer cleanup()
 
-	conn := newConnection(serverConn, session, sink, true, false)
+	conn := newConnection(serverConn, session, sink, nil, true, false)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -507,7 +507,7 @@ func TestApplyResume_EvictedSessionWithPaneViewports(t *testing.T) {
 
 	// awaitResume=true means the connection holds back outbound diffs until
 	// a MsgResumeRequest arrives — exactly the reconnect scenario.
-	conn := newConnection(serverConn, session, nopSink{}, true /*awaitResume*/, false /*rehydrated*/)
+	conn := newConnection(serverConn, session, nopSink{}, nil, true /*awaitResume*/, false /*rehydrated*/)
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/runtime/server/desktop_publisher.go
+++ b/internal/runtime/server/desktop_publisher.go
@@ -93,6 +93,29 @@ func (p *DesktopPublisher) SetNotifier(fn func()) {
 	p.notify = fn
 }
 
+// PrevBufferFor returns the most recently observed cell buffer for
+// paneID, or nil if no diff has been emitted yet. Used by Plan F.1
+// thumbnail capture — the buffer already exists for diff generation
+// so we expose it rather than maintain a parallel snapshot.
+//
+// Returns a defensive copy under the read lock so the caller can use
+// the buffer outside the publisher's mutex without coordinating with
+// the diff hot path.
+func (p *DesktopPublisher) PrevBufferFor(paneID [16]byte) [][]texel.Cell {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	buf, ok := p.prevBuffers[paneID]
+	if !ok {
+		return nil
+	}
+	out := make([][]texel.Cell, len(buf))
+	for y, row := range buf {
+		out[y] = make([]texel.Cell, len(row))
+		copy(out[y], row)
+	}
+	return out
+}
+
 // RevisionFor returns the latest revision stamped for paneID. Returns 0 if
 // the pane has not been published yet under this publisher's session.
 func (p *DesktopPublisher) RevisionFor(paneID [16]byte) uint32 {

--- a/internal/runtime/server/integration_test.go
+++ b/internal/runtime/server/integration_test.go
@@ -64,7 +64,7 @@ func TestConnectionSendsDiffProcessesAckAndKeyEvents(t *testing.T) {
 			return
 		}
 
-		conn := newConnection(srv, session, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(srv, session, sink, nil, resuming, false /*rehydrated*/)
 		errCh <- conn.serve()
 	}()
 

--- a/internal/runtime/server/manager.go
+++ b/internal/runtime/server/manager.go
@@ -339,7 +339,31 @@ func (m *Manager) Close(id [16]byte) {
 			log.Printf("server: close thumbnail %x: %v", id[:4], err)
 		}
 	}
+	// Snapshot the session's persisted state BEFORE Close() nils the
+	// writer — schedulePersist runs against the writer pointer.
+	var snapshot *StoredSession
+	if basedir != "" {
+		s := session.CurrentStoredSnapshot()
+		// Skip ephemeral sessions (picker handshake connections,
+		// fresh-but-never-used sessions). Without this filter, every
+		// `texelation --recover` invocation would leave a phantom
+		// "Untitled, 0 panes" entry behind for next time.
+		if s.PaneCount > 0 || len(s.PaneViewports) > 0 {
+			snapshot = &s
+		}
+	}
 	session.Close() // disk flush — outside m.mu
+
+	// Plan F.1: re-add the session to persistedSessions so the picker
+	// sees it on a subsequent --recover invocation. Without this, the
+	// session's JSON exists on disk but the in-memory persistedSessions
+	// map (populated only at boot scan + consumed on rehydrate) is
+	// empty, and StoredSummaries returns nothing.
+	if snapshot != nil {
+		m.mu.Lock()
+		m.persistedSessions[id] = snapshot
+		m.mu.Unlock()
+	}
 }
 
 // ShutdownSessions closes all live sessions, synchronously flushing

--- a/internal/runtime/server/manager.go
+++ b/internal/runtime/server/manager.go
@@ -41,6 +41,20 @@ type Manager struct {
 	// LookupOrRehydrate waits while a marker exists for its ID.
 	closingMu sync.Mutex
 	closing   map[[16]byte]chan struct{}
+
+	// Plan F.1: lifecycle thumbnail capture. nil = capture disabled
+	// (tests + early boot before SetThumbnailRenderer is called).
+	thumbRenderer ThumbnailRenderer
+}
+
+// SetThumbnailRenderer wires the production renderer (typically the
+// *DesktopSink that owns the publisher state) so Close(id) and
+// ShutdownSessions can capture lifecycle thumbnails. nil renderers
+// skip capture silently — no error, no log spam.
+func (m *Manager) SetThumbnailRenderer(r ThumbnailRenderer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.thumbRenderer = r
 }
 
 func NewManager() *Manager {
@@ -297,21 +311,34 @@ func (m *Manager) SetDiffRetentionLimit(limit int) {
 // LookupOrRehydrate consults the same marker so a fresh resume for
 // the same ID waits out the disk flush instead of constructing a
 // new Session pointing at the same on-disk path.
+//
+// Plan F.1: also captures a thumbnail just before teardown so the
+// next picker invocation has something to show. The capture happens
+// OUTSIDE m.mu (PNG encoding holds memory and may sync to disk —
+// holding the lock would block every other Manager op for the
+// duration). Renderer + basedir are snapshotted under the lock so a
+// concurrent SetThumbnailRenderer doesn't race with the read.
 func (m *Manager) Close(id [16]byte) {
 	m.mu.Lock()
 	session, ok := m.sessions[id]
-	if ok {
-		delete(m.sessions, id)
-	}
 	if !ok {
 		m.mu.Unlock()
 		return
 	}
+	delete(m.sessions, id)
+	basedir := m.persistBasedir
+	renderer := m.thumbRenderer
 	// Mark before dropping m.mu so any LookupOrRehydrate that grabs
 	// m.mu next sees the marker via waitClosing on its way in.
 	m.markClosing(id)
 	m.mu.Unlock()
 	defer m.unmarkClosing(id)
+
+	if basedir != "" && renderer != nil {
+		if err := captureThumbnail(basedir, id, renderer); err != nil {
+			log.Printf("server: close thumbnail %x: %v", id[:4], err)
+		}
+	}
 	session.Close() // disk flush — outside m.mu
 }
 
@@ -333,6 +360,8 @@ func (m *Manager) ShutdownSessions() {
 	m.mu.Lock()
 	live := m.sessions
 	m.sessions = make(map[[16]byte]*Session)
+	basedir := m.persistBasedir
+	renderer := m.thumbRenderer
 	// Mark every live session as closing under m.mu so any concurrent
 	// LookupOrRehydrate after we release m.mu blocks until the per-
 	// session flush completes (Plan D2 17.B).
@@ -342,6 +371,11 @@ func (m *Manager) ShutdownSessions() {
 	m.mu.Unlock()
 
 	for id, session := range live {
+		if basedir != "" && renderer != nil {
+			if err := captureThumbnail(basedir, id, renderer); err != nil {
+				log.Printf("server: shutdown thumbnail %x: %v", id[:4], err)
+			}
+		}
 		session.Close() // disk flush — outside m.mu
 		m.unmarkClosing(id)
 	}

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -8,13 +8,16 @@
 package server
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
+	"image/png"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/framegrace/texelation/internal/persistence/atomicjson"
+	"github.com/framegrace/texelation/internal/thumbnail"
 	"github.com/framegrace/texelation/protocol"
 )
 
@@ -134,37 +137,33 @@ func (m *Manager) sessionPNGPath(id [16]byte) string {
 	return filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
 }
 
-// captureLiveThumbnailBytes renders a fresh thumbnail for a live
-// session on demand and writes it to the PNG sidecar (so subsequent
-// fetches hit the fast path). Returns the PNG bytes + ok=true on
-// success. Returns ok=false when the session isn't live, the renderer
-// is unwired, the renderer skips, or write/read fails.
+// RenderLiveThumbnailBytes renders a fresh PNG for a live session
+// every time it's called — live sessions change state continuously
+// (typing, output, focus changes), so any cached PNG would be stale
+// the moment it's written. The result is NOT persisted to disk; the
+// lifecycle hooks (Close, ShutdownSessions) handle disk persistence
+// when the session transitions out of live state.
 //
-// Used by handleFetchThumbnail for live sessions whose PNG hasn't
-// been captured yet (the lifecycle hooks only fire on Close +
-// shutdown — a live session viewed by a second --recover invocation
-// hits this path).
-func (m *Manager) captureLiveThumbnailBytes(id [16]byte) ([]byte, bool) {
+// Returns ok=false when the session isn't live, the renderer is
+// unwired, or render/encode fails.
+func (m *Manager) RenderLiveThumbnailBytes(id [16]byte) ([]byte, bool) {
 	m.mu.RLock()
 	_, live := m.sessions[id]
-	basedir := m.persistBasedir
 	renderer := m.thumbRenderer
 	m.mu.RUnlock()
-	if !live || basedir == "" || renderer == nil {
+	if !live || renderer == nil {
 		return nil, false
 	}
-	if err := captureThumbnail(basedir, id, renderer); err != nil {
-		// captureThumbnail logs internally on the bigger errors; this
-		// log captures the short-circuit failure modes so a chronic
-		// "no thumbnail" symptom has a breadcrumb.
+	img, ok := renderer.RenderSessionThumbnail(id)
+	if !ok || img == nil {
 		return nil, false
 	}
-	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
-	data, err := os.ReadFile(pngPath)
-	if err != nil {
+	scaled := thumbnail.DownscaleAspectFit(img, 480, 270)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, scaled); err != nil {
 		return nil, false
 	}
-	return data, true
+	return buf.Bytes(), true
 }
 
 // RenameStored updates the persisted session's Label both in-memory

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -1,0 +1,164 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/manager_session_picker.go
+// Summary: Session-picker helpers on Manager — list / rename / delete
+// stored sessions for the F.1 recovery flow.
+
+package server
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/framegrace/texelation/internal/persistence/atomicjson"
+	"github.com/framegrace/texelation/protocol"
+)
+
+// StoredSummaries returns a slice of SessionSummary records for every
+// known persisted session, sorted pinned-first then LastActive desc.
+// HasThumbnail is set per record by stat-ing the on-disk PNG sidecar
+// when persistence is enabled; without persistence the flag is always
+// false.
+//
+// Snapshot pattern: copies persistedSessions + persistBasedir under
+// the RLock (O(N) memory, O(N) wall-clock), then runs the per-record
+// PNG stat OUTSIDE the lock. Holding the RLock during disk stat would
+// block every Manager write op (DeleteStored, RenameStored,
+// LookupOrRehydrate, Close) for the duration of N stat calls — a real
+// stall on a slow filesystem with a populous sessions dir.
+func (m *Manager) StoredSummaries() []protocol.SessionSummary {
+	m.mu.RLock()
+	if len(m.persistedSessions) == 0 {
+		m.mu.RUnlock()
+		return nil
+	}
+	persistDir := m.persistBasedir
+	type entry struct {
+		id  [16]byte
+		ref *StoredSession
+	}
+	snap := make([]entry, 0, len(m.persistedSessions))
+	for id, s := range m.persistedSessions {
+		snap = append(snap, entry{id: id, ref: s})
+	}
+	m.mu.RUnlock()
+
+	summaries := make([]protocol.SessionSummary, 0, len(snap))
+	for _, e := range snap {
+		summary := protocol.SessionSummary{
+			SessionID:      e.id,
+			Label:          e.ref.Label,
+			LastActive:     e.ref.LastActive.Unix(),
+			PaneCount:      int32(e.ref.PaneCount),
+			FirstPaneTitle: e.ref.FirstPaneTitle,
+			Pinned:         e.ref.Pinned,
+			Layout:         e.ref.Layout,
+		}
+		if persistDir != "" {
+			pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(e.id[:])+".png")
+			if info, err := os.Stat(pngPath); err == nil && !info.IsDir() {
+				summary.HasThumbnail = true
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].Pinned != summaries[j].Pinned {
+			return summaries[i].Pinned
+		}
+		return summaries[i].LastActive > summaries[j].LastActive
+	})
+	return summaries
+}
+
+// LiveSummaries returns the live (in-memory, attached or detached)
+// session catalog. F.1 always returns nil — F.2 will populate this
+// from m.sessions and per-session attached-client counts.
+func (m *Manager) LiveSummaries() []protocol.LiveSummary {
+	return nil
+}
+
+// sessionPNGPath builds the PNG sidecar path for id. Returns empty
+// string if persistence is disabled.
+func (m *Manager) sessionPNGPath(id [16]byte) string {
+	if m.persistBasedir == "" {
+		return ""
+	}
+	return filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+}
+
+// RenameStored updates the persisted session's Label both in-memory
+// and on disk. Acquires m.mu so concurrent StoredSummaries / Recover
+// calls observe a consistent state. The disk write goes through
+// atomicjson.Save to retain the existing crash-safety guarantees.
+//
+// Returns ErrSessionNotFound when the ID is unknown to the in-memory
+// index. On disk-write failures, in-memory state is rolled back so a
+// subsequent retry sees the original Label rather than a half-applied
+// rename.
+func (m *Manager) RenameStored(id [16]byte, newLabel string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	stored, ok := m.persistedSessions[id]
+	if !ok {
+		return ErrSessionNotFound
+	}
+	prev := stored.Label
+	stored.Label = newLabel
+	if m.persistBasedir == "" {
+		return nil
+	}
+	if err := atomicjson.Save(SessionFilePath(m.persistBasedir, id), stored); err != nil {
+		stored.Label = prev
+		return fmt.Errorf("manager: rename %x: %w", id[:4], err)
+	}
+	return nil
+}
+
+// DeleteStored removes the session's JSON sidecar, PNG sidecar (if
+// present), and the in-memory persisted entry. Refuses with an error
+// when the session is currently live — the user must detach all
+// clients first.
+//
+// TOCTOU avoidance: the in-memory delete + the live-session refusal
+// happen under m.mu held *contiguously* with markClosing(id), which
+// blocks any concurrent rehydrate path until the unlink completes.
+//
+// PNG removal is best-effort (a missing PNG is not an error); JSON
+// removal is authoritative — if the JSON unlink fails we surface the
+// error so the caller can retry. The PNG-then-JSON order avoids
+// leaving a JSON with stale HasThumbnail expectations across a
+// partial delete.
+func (m *Manager) DeleteStored(id [16]byte) error {
+	m.mu.Lock()
+	if _, live := m.sessions[id]; live {
+		m.mu.Unlock()
+		return fmt.Errorf("manager: session %x is live; detach all clients first", id[:4])
+	}
+	if _, ok := m.persistedSessions[id]; !ok {
+		m.mu.Unlock()
+		return ErrSessionNotFound
+	}
+	delete(m.persistedSessions, id)
+	persistDir := m.persistBasedir
+	m.markClosing(id)
+	m.mu.Unlock()
+	defer m.unmarkClosing(id)
+
+	if persistDir == "" {
+		return nil
+	}
+	pngPath := filepath.Join(persistDir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if err := os.Remove(pngPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("manager: remove %s: %w", pngPath, err)
+	}
+	jsonPath := SessionFilePath(persistDir, id)
+	if err := os.Remove(jsonPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("manager: remove %s: %w", jsonPath, err)
+	}
+	return nil
+}

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -134,6 +134,39 @@ func (m *Manager) sessionPNGPath(id [16]byte) string {
 	return filepath.Join(m.persistBasedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
 }
 
+// captureLiveThumbnailBytes renders a fresh thumbnail for a live
+// session on demand and writes it to the PNG sidecar (so subsequent
+// fetches hit the fast path). Returns the PNG bytes + ok=true on
+// success. Returns ok=false when the session isn't live, the renderer
+// is unwired, the renderer skips, or write/read fails.
+//
+// Used by handleFetchThumbnail for live sessions whose PNG hasn't
+// been captured yet (the lifecycle hooks only fire on Close +
+// shutdown — a live session viewed by a second --recover invocation
+// hits this path).
+func (m *Manager) captureLiveThumbnailBytes(id [16]byte) ([]byte, bool) {
+	m.mu.RLock()
+	_, live := m.sessions[id]
+	basedir := m.persistBasedir
+	renderer := m.thumbRenderer
+	m.mu.RUnlock()
+	if !live || basedir == "" || renderer == nil {
+		return nil, false
+	}
+	if err := captureThumbnail(basedir, id, renderer); err != nil {
+		// captureThumbnail logs internally on the bigger errors; this
+		// log captures the short-circuit failure modes so a chronic
+		// "no thumbnail" symptom has a breadcrumb.
+		return nil, false
+	}
+	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	data, err := os.ReadFile(pngPath)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
 // RenameStored updates the persisted session's Label both in-memory
 // and on disk. Acquires m.mu so concurrent StoredSummaries / Recover
 // calls observe a consistent state. The disk write goes through

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -84,6 +84,21 @@ func (m *Manager) StoredSummaries() []protocol.SessionSummary {
 	return summaries
 }
 
+// HasSession reports whether id is known to the manager — either as
+// a live session or a persisted one. Used by handleRecoverSession to
+// validate the user's pick without claiming the session, so the
+// subsequent client reconnect can take the normal LookupOrRehydrate
+// path (which is what makes resume + handleClientReady fire properly).
+func (m *Manager) HasSession(id [16]byte) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if _, live := m.sessions[id]; live {
+		return true
+	}
+	_, stored := m.persistedSessions[id]
+	return stored
+}
+
 // LiveSummaries returns the live (in-memory, attached or detached)
 // session catalog. F.1 surfaces sessions currently held in m.sessions
 // so a user running `--recover` while the daemon already has an

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -49,6 +49,12 @@ func (m *Manager) StoredSummaries() []protocol.SessionSummary {
 
 	summaries := make([]protocol.SessionSummary, 0, len(snap))
 	for _, e := range snap {
+		// Defensively skip empty/ephemeral sessions that may have
+		// landed on disk via past versions or odd flush timing —
+		// the picker shouldn't show them.
+		if e.ref.PaneCount <= 0 && len(e.ref.PaneViewports) == 0 {
+			continue
+		}
 		summary := protocol.SessionSummary{
 			SessionID:      e.id,
 			Label:          e.ref.Label,

--- a/internal/runtime/server/manager_session_picker.go
+++ b/internal/runtime/server/manager_session_picker.go
@@ -82,10 +82,47 @@ func (m *Manager) StoredSummaries() []protocol.SessionSummary {
 }
 
 // LiveSummaries returns the live (in-memory, attached or detached)
-// session catalog. F.1 always returns nil — F.2 will populate this
-// from m.sessions and per-session attached-client counts.
+// session catalog. F.1 surfaces sessions currently held in m.sessions
+// so a user running `--recover` while the daemon already has an
+// attached session can still see + pick it. AttachedClients is
+// populated from a stub heuristic for F.1 (1 if anyone is attached,
+// 0 otherwise — the manager doesn't track per-session client counts
+// today); F.2 will replace that with real counts.
+//
+// Empty/ephemeral sessions (PaneCount==0, no viewports) are skipped
+// — same filter as StoredSummaries — so the picker's own dial doesn't
+// show up in its own list.
 func (m *Manager) LiveSummaries() []protocol.LiveSummary {
-	return nil
+	m.mu.RLock()
+	if len(m.sessions) == 0 {
+		m.mu.RUnlock()
+		return nil
+	}
+	type entry struct {
+		id  [16]byte
+		ref *Session
+	}
+	snap := make([]entry, 0, len(m.sessions))
+	for id, s := range m.sessions {
+		snap = append(snap, entry{id: id, ref: s})
+	}
+	m.mu.RUnlock()
+
+	out := make([]protocol.LiveSummary, 0, len(snap))
+	for _, e := range snap {
+		stored := e.ref.CurrentStoredSnapshot()
+		if stored.PaneCount <= 0 && len(stored.PaneViewports) == 0 {
+			continue
+		}
+		out = append(out, protocol.LiveSummary{
+			SessionID:       e.id,
+			Label:           stored.Label,
+			AttachedClients: 1, // F.1 stub; F.2 fills in real counts
+			PaneCount:       int32(stored.PaneCount),
+			LastInputAt:     stored.LastActive.Unix(),
+		})
+	}
+	return out
 }
 
 // sessionPNGPath builds the PNG sidecar path for id. Returns empty

--- a/internal/runtime/server/manager_session_picker_test.go
+++ b/internal/runtime/server/manager_session_picker_test.go
@@ -1,0 +1,207 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/framegrace/texelation/internal/persistence/atomicjson"
+)
+
+func pickerHexID(id [16]byte) string {
+	return hex.EncodeToString(id[:])
+}
+
+func TestStoredSummaries_EmptyOnFreshManager(t *testing.T) {
+	m := NewManager()
+	got := m.StoredSummaries()
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %d entries", len(got))
+	}
+}
+
+func TestStoredSummaries_OrderedPinnedThenLastActive(t *testing.T) {
+	m := NewManager()
+	m.SetPersistedSessions(map[[16]byte]*StoredSession{
+		{0x01}: {SessionID: [16]byte{0x01}, Label: "old-pinned", LastActive: time.Unix(100, 0), Pinned: true, PaneCount: 1},
+		{0x02}: {SessionID: [16]byte{0x02}, Label: "newest", LastActive: time.Unix(300, 0), PaneCount: 2},
+		{0x03}: {SessionID: [16]byte{0x03}, Label: "middle", LastActive: time.Unix(200, 0), PaneCount: 3},
+	})
+	got := m.StoredSummaries()
+	if len(got) != 3 {
+		t.Fatalf("expected 3 summaries, got %d", len(got))
+	}
+	if got[0].Label != "old-pinned" {
+		t.Fatalf("[0] expected pinned first, got %q", got[0].Label)
+	}
+	if got[1].Label != "newest" {
+		t.Fatalf("[1] expected newest second, got %q", got[1].Label)
+	}
+	if got[2].Label != "middle" {
+		t.Fatalf("[2] expected middle third, got %q", got[2].Label)
+	}
+}
+
+func TestStoredSummaries_HasThumbnailFlag(t *testing.T) {
+	dir := t.TempDir()
+	sessionsDir := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	withPNG := [16]byte{0x10}
+	withoutPNG := [16]byte{0x20}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	// Write the PNG AFTER EnablePersistence so the boot scan's
+	// orphan cleanup doesn't reap it (no matching JSON exists).
+	if err := os.WriteFile(filepath.Join(sessionsDir, pickerHexID(withPNG)+".png"), []byte("fake"), 0o644); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	m.SetPersistedSessions(map[[16]byte]*StoredSession{
+		withPNG:    {SessionID: withPNG, LastActive: time.Unix(200, 0), PaneCount: 1},
+		withoutPNG: {SessionID: withoutPNG, LastActive: time.Unix(100, 0), PaneCount: 1},
+	})
+	got := m.StoredSummaries()
+	by := make(map[[16]byte]bool)
+	for _, s := range got {
+		by[s.SessionID] = s.HasThumbnail
+	}
+	if !by[withPNG] {
+		t.Errorf("expected HasThumbnail=true for %x", withPNG)
+	}
+	if by[withoutPNG] {
+		t.Errorf("expected HasThumbnail=false for %x", withoutPNG)
+	}
+}
+
+func TestLiveSummaries_EmptyInF1(t *testing.T) {
+	m := NewManager()
+	if got := m.LiveSummaries(); got != nil {
+		t.Fatalf("expected nil (F.2 will populate), got %#v", got)
+	}
+}
+
+func TestRenameStored_UpdatesInMemoryAndDisk(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xAA}
+	original := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		Label:         "before",
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(original)
+	if err := os.WriteFile(SessionFilePath(dir, id), data, 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable persistence: %v", err)
+	}
+	if err := m.RenameStored(id, "after"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	got := m.StoredSummaries()
+	if len(got) != 1 || got[0].Label != "after" {
+		t.Fatalf("in-memory rename failed; got %#v", got)
+	}
+	reloaded, err := atomicjson.Load[StoredSession](SessionFilePath(dir, id))
+	if err != nil || reloaded == nil {
+		t.Fatalf("reload: err=%v reloaded=%v", err, reloaded)
+	}
+	if reloaded.Label != "after" {
+		t.Fatalf("on-disk Label=%q, want %q", reloaded.Label, "after")
+	}
+}
+
+func TestRenameStored_UnknownID(t *testing.T) {
+	m := NewManager()
+	if err := m.EnablePersistence(t.TempDir(), 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.RenameStored([16]byte{0xFF}, "nope"); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestDeleteStored_RemovesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xBB}
+	jsonPath := SessionFilePath(dir, id)
+	pngPath := filepath.Join(dir, SessionsDirName, pickerHexID(id)+".png")
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(jsonPath, data, 0o644)
+	os.WriteFile(pngPath, []byte("fake-png"), 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.DeleteStored(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(jsonPath); !os.IsNotExist(err) {
+		t.Errorf("expected JSON gone, stat err=%v", err)
+	}
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected PNG gone, stat err=%v", err)
+	}
+	if got := m.StoredSummaries(); len(got) != 0 {
+		t.Errorf("expected empty after delete, got %d entries", len(got))
+	}
+}
+
+func TestDeleteStored_PNGMissingStillSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0xCC}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     id,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	os.WriteFile(SessionFilePath(dir, id), data, 0o644)
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25*time.Millisecond); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if err := m.DeleteStored(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestDeleteStored_RefusesLive(t *testing.T) {
+	id := [16]byte{0xDD}
+	m := NewManager()
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	err := m.DeleteStored(id)
+	if err == nil {
+		t.Fatalf("expected error refusing live session, got nil")
+	}
+}

--- a/internal/runtime/server/offline_resume_mem_test.go
+++ b/internal/runtime/server/offline_resume_mem_test.go
@@ -170,7 +170,7 @@ func initialHandshake(t *testing.T, srv *Server, sink *DesktopSink, desktop *tex
 		_ = pub.Publish()
 		srv.sendSnapshot(serverConn, sess)
 		sessCh <- sess
-		conn := newConnection(serverConn, sess, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(serverConn, sess, sink, nil, resuming, false /*rehydrated*/)
 		errCh <- conn.serve()
 	}()
 
@@ -266,7 +266,7 @@ func resumeClientFlow(t *testing.T, srv *Server, sink *DesktopSink, desktop *tex
 		}
 		pub := NewDesktopPublisher(desktop, sess)
 		sink.SetPublisher(pub)
-		errCh <- newConnection(serverConn, sess, sink, resuming, false /*rehydrated*/).serve()
+		errCh <- newConnection(serverConn, sess, sink, nil, resuming, false /*rehydrated*/).serve()
 	}()
 
 	helloPayload, _ := protocol.EncodeHello(protocol.Hello{ClientName: "client"})

--- a/internal/runtime/server/resume_viewport_integration_test.go
+++ b/internal/runtime/server/resume_viewport_integration_test.go
@@ -430,7 +430,7 @@ func TestIntegration_FullReconnectLifecycle(t *testing.T) {
 		}
 		pub := NewDesktopPublisher(h.desktop, sess)
 		h.sink.SetPublisher(pub)
-		conn := newConnection(newServerConn, sess, h.sink, resuming, false /*rehydrated*/)
+		conn := newConnection(newServerConn, sess, h.sink, nil, resuming, false /*rehydrated*/)
 		pub.SetNotifier(conn.nudge)
 		resumedSessCh <- sess
 		serveErrCh2 <- conn.serve()

--- a/internal/runtime/server/server.go
+++ b/internal/runtime/server/server.go
@@ -163,7 +163,7 @@ func (s *Server) acceptLoop(l net.Listener) {
 			if err != nil {
 				return
 			}
-			conn := newConnection(c, session, s.sink, resuming, rehydrated)
+			conn := newConnection(c, session, s.sink, s.manager, resuming, rehydrated)
 			publisher := (*DesktopPublisher)(nil)
 			if s.publisherFactory != nil {
 				publisher = s.publisherFactory(session)

--- a/internal/runtime/server/server_desktop_integration_test.go
+++ b/internal/runtime/server/server_desktop_integration_test.go
@@ -93,7 +93,7 @@ func TestServerDesktopIntegrationProducesDiffsAndHandlesKeys(t *testing.T) {
 		}
 		_ = publisher.Publish()
 
-		conn := newConnection(srvConn, session, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(srvConn, session, sink, nil, resuming, false /*rehydrated*/)
 		errCh <- conn.serve()
 	}()
 

--- a/internal/runtime/server/session.go
+++ b/internal/runtime/server/session.go
@@ -356,6 +356,45 @@ func (s *Session) Close() {
 	}
 }
 
+// CurrentStoredSnapshot builds a StoredSession from the session's
+// current in-memory state, mirroring what schedulePersist would write
+// to disk. Used by Manager.Close (Plan F.1) to repopulate
+// persistedSessions after a session detaches, so the picker's
+// StoredSummaries call sees the session without waiting for the next
+// daemon boot to re-scan the disk.
+//
+// Returns a value, not a pointer, so the caller can store a pointer
+// into the persistedSessions map without retaining a reference to
+// the live Session's internals.
+func (s *Session) CurrentStoredSnapshot() StoredSession {
+	s.storedMu.Lock()
+	meta := s.storedMeta
+	s.storedMu.Unlock()
+
+	vps := s.viewports.Snapshot()
+	stored := StoredSession{
+		SchemaVersion:  StoredSessionSchemaVersion,
+		SessionID:      s.id,
+		LastActive:     time.Now().UTC(),
+		Pinned:         meta.pinned,
+		Label:          meta.label,
+		PaneCount:      meta.paneCount,
+		FirstPaneTitle: meta.firstPaneTitle,
+		PaneViewports:  make([]StoredPaneViewport, 0, len(vps)),
+	}
+	for paneID, v := range vps {
+		stored.PaneViewports = append(stored.PaneViewports, StoredPaneViewport{
+			PaneID:        paneID,
+			AltScreen:     v.AltScreen,
+			AutoFollow:    v.AutoFollow,
+			ViewBottomIdx: v.ViewBottomIdx,
+			Rows:          v.Rows,
+			Cols:          v.Cols,
+		})
+	}
+	return stored
+}
+
 func (s *Session) MarkSnapshot(now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/runtime/server/session_persistence.go
+++ b/internal/runtime/server/session_persistence.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/framegrace/texelation/internal/persistence/atomicjson"
+	"github.com/framegrace/texelation/protocol"
 )
 
 // StoredSessionSchemaVersion is the on-disk format version. Bump on
@@ -41,6 +42,10 @@ type StoredSession struct {
 	Label          string
 	PaneCount      int
 	FirstPaneTitle string
+	// Plan F.1: pane-tree layout for the recovery picker's ASCII
+	// fallback render. Nil for sessions written before F.1 — the
+	// picker handles that as a single-box placeholder.
+	Layout *protocol.TreeNodeSnapshot
 }
 
 // StoredPaneViewport is the per-pane element. JSON encoding for this
@@ -57,14 +62,15 @@ type StoredPaneViewport struct {
 }
 
 type sessionJSONShape struct {
-	SchemaVersion  int                     `json:"schemaVersion"`
-	SessionID      string                  `json:"sessionID"`
-	LastActive     time.Time               `json:"lastActive"`
-	Pinned         bool                    `json:"pinned"`
-	PaneViewports  []paneViewportJSONShape `json:"paneViewports"`
-	Label          string                  `json:"label"`
-	PaneCount      int                     `json:"paneCount"`
-	FirstPaneTitle string                  `json:"firstPaneTitle"`
+	SchemaVersion  int                        `json:"schemaVersion"`
+	SessionID      string                     `json:"sessionID"`
+	LastActive     time.Time                  `json:"lastActive"`
+	Pinned         bool                       `json:"pinned"`
+	PaneViewports  []paneViewportJSONShape    `json:"paneViewports"`
+	Label          string                     `json:"label"`
+	PaneCount      int                        `json:"paneCount"`
+	FirstPaneTitle string                     `json:"firstPaneTitle"`
+	Layout         *protocol.TreeNodeSnapshot `json:"layout,omitempty"`
 }
 
 type paneViewportJSONShape struct {
@@ -86,6 +92,7 @@ func (s StoredSession) MarshalJSON() ([]byte, error) {
 		Label:          s.Label,
 		PaneCount:      s.PaneCount,
 		FirstPaneTitle: s.FirstPaneTitle,
+		Layout:         s.Layout,
 	}
 	out.PaneViewports = make([]paneViewportJSONShape, len(s.PaneViewports))
 	for i, p := range s.PaneViewports {
@@ -116,6 +123,7 @@ func (s *StoredSession) UnmarshalJSON(data []byte) error {
 	s.Label = in.Label
 	s.PaneCount = in.PaneCount
 	s.FirstPaneTitle = in.FirstPaneTitle
+	s.Layout = in.Layout
 	s.PaneViewports = make([]StoredPaneViewport, len(in.PaneViewports))
 	for i, p := range in.PaneViewports {
 		var pid [16]byte
@@ -212,6 +220,38 @@ func ScanSessionsDir(basedir string) (map[[16]byte]*StoredSession, error) {
 			continue
 		}
 		out[s.SessionID] = s
+	}
+
+	// Plan F.1: clean up orphaned PNG sidecars (a PNG whose matching
+	// JSON was deleted, or whose JSON failed to load above) and any
+	// `.png.tmp` files left behind by a crashed atomic write. Keeping
+	// them would silently inflate the picker's HasThumbnail flag for
+	// nonexistent entries (orphans) and leak disk space (tmp files).
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		switch {
+		case strings.HasSuffix(name, ".png.tmp"):
+			tmpPath := filepath.Join(dir, name)
+			if err := os.Remove(tmpPath); err != nil {
+				log.Printf("server: orphan tmp cleanup: %s: %v", tmpPath, err)
+			}
+		case strings.HasSuffix(name, ".png"):
+			hexPart := strings.TrimSuffix(name, ".png")
+			var id [16]byte
+			if err := decodeHex16Session(hexPart, &id); err != nil {
+				continue
+			}
+			if _, ok := out[id]; ok {
+				continue
+			}
+			pngPath := filepath.Join(dir, name)
+			if err := os.Remove(pngPath); err != nil {
+				log.Printf("server: orphan PNG cleanup: %s: %v", pngPath, err)
+			}
+		}
 	}
 	return out, nil
 }

--- a/internal/runtime/server/session_persistence_test.go
+++ b/internal/runtime/server/session_persistence_test.go
@@ -5,10 +5,126 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/framegrace/texelation/protocol"
 )
+
+func TestStoredSession_LayoutRoundTrip(t *testing.T) {
+	in := StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     [16]byte{0xAA, 0xBB, 0xCC},
+		LastActive:    time.Unix(1714752000, 0).UTC(),
+		Pinned:        true,
+		Label:         "with-layout",
+		PaneCount:     2,
+		Layout: &protocol.TreeNodeSnapshot{
+			PaneIndex:   -1,
+			Split:       protocol.SplitHorizontal,
+			SplitRatios: []float32{0.5, 0.5},
+			Children: []protocol.TreeNodeSnapshot{
+				{PaneIndex: 0, Split: protocol.SplitNone},
+				{PaneIndex: 1, Split: protocol.SplitNone},
+			},
+		},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out StoredSession
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Layout == nil {
+		t.Fatalf("expected Layout populated, got nil")
+	}
+	if !reflect.DeepEqual(in.Layout, out.Layout) {
+		t.Fatalf("layout round-trip mismatch:\n in=%#v\nout=%#v", in.Layout, out.Layout)
+	}
+}
+
+func TestScanSessionsDir_RemovesOrphanPNGs(t *testing.T) {
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, SessionsDirName)
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	keepID := [16]byte{0x01}
+	stored := &StoredSession{
+		SchemaVersion: StoredSessionSchemaVersion,
+		SessionID:     keepID,
+		LastActive:    time.Unix(100, 0),
+		PaneCount:     1,
+	}
+	data, _ := json.Marshal(stored)
+	keepHex := pickerHex16(keepID)
+	if err := os.WriteFile(filepath.Join(sessions, keepHex+".json"), data, 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sessions, keepHex+".png"), []byte("matched"), 0o644); err != nil {
+		t.Fatalf("write keep png: %v", err)
+	}
+	orphanID := [16]byte{0xDE}
+	orphanPath := filepath.Join(sessions, pickerHex16(orphanID)+".png")
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan png: %v", err)
+	}
+	tmpPath := filepath.Join(sessions, "00112233445566778899aabbccddeeff.png.tmp")
+	if err := os.WriteFile(tmpPath, []byte("crashed"), 0o644); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	if _, err := ScanSessionsDir(dir); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Errorf("expected orphan PNG removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("expected orphan tmp removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessions, keepHex+".png")); err != nil {
+		t.Errorf("expected matched PNG retained, stat err=%v", err)
+	}
+}
+
+// pickerHex16 mirrors hex.EncodeToString without pulling encoding/hex
+// into this test file's imports.
+func pickerHex16(id [16]byte) string {
+	const digits = "0123456789abcdef"
+	out := make([]byte, 32)
+	for i, b := range id {
+		out[2*i] = digits[b>>4]
+		out[2*i+1] = digits[b&0x0F]
+	}
+	return string(out)
+}
+
+func TestStoredSession_LayoutAbsentInOlderJSON(t *testing.T) {
+	older := []byte(`{
+		"schemaVersion": 1,
+		"sessionID": "aabbccddeeff00112233445566778899",
+		"lastActive": "2026-04-26T00:00:00Z",
+		"pinned": false,
+		"paneViewports": [],
+		"label": "legacy",
+		"paneCount": 1,
+		"firstPaneTitle": ""
+	}`)
+	var out StoredSession
+	if err := json.Unmarshal(older, &out); err != nil {
+		t.Fatalf("unmarshal pre-F.1 JSON: %v", err)
+	}
+	if out.Layout != nil {
+		t.Fatalf("expected Layout=nil for legacy JSON, got %#v", out.Layout)
+	}
+	if out.Label != "legacy" {
+		t.Fatalf("expected Label preserved, got %q", out.Label)
+	}
+}
 
 func TestStoredSessionRoundTrip(t *testing.T) {
 	in := StoredSession{

--- a/internal/runtime/server/test_client_validation_test.go
+++ b/internal/runtime/server/test_client_validation_test.go
@@ -131,7 +131,7 @@ func handleTestConnection(conn net.Conn, mgr *Manager, desktop *texel.DesktopEng
 	_ = publisher.Publish()
 
 	// Create and serve connection
-	connHandler := newConnection(conn, session, sink, resuming, false /*rehydrated*/)
+	connHandler := newConnection(conn, session, sink, nil, resuming, false /*rehydrated*/)
 	_ = connHandler.serve()
 }
 

--- a/internal/runtime/server/thumbnail.go
+++ b/internal/runtime/server/thumbnail.go
@@ -1,0 +1,59 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/thumbnail.go
+// Summary: Lifecycle thumbnail capture orchestrator (Plan F.1).
+// Usage: Called from Manager.ShutdownSessions and Manager.Close on
+//   the last-disconnect transition. Renders via a ThumbnailRenderer
+//   (production: *DesktopSink, see thumbnail_renderer.go), downscales
+//   via the shared internal/thumbnail primitive, and atomically writes
+//   to <basedir>/sessions/<id>.png.
+
+package server
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"image"
+	"path/filepath"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
+)
+
+// ThumbnailRenderer produces a PNG-suitable image for a given session.
+// Implemented by *DesktopSink in production (see thumbnail_renderer.go);
+// tests inject a stub.
+//
+// Returns ok=false when the session has nothing meaningful to capture
+// (empty workspace, no live buffer) so the caller can skip the disk
+// write rather than store an all-black PNG.
+type ThumbnailRenderer interface {
+	RenderSessionThumbnail(id [16]byte) (image.Image, bool)
+}
+
+// captureThumbnail renders id via the renderer (if non-nil), downscales
+// to 480×270 via the shared primitive, and writes the result to
+// <basedir>/sessions/<id>.png. A panicking renderer is recovered to an
+// error so a buggy implementation cannot prevent shutdown. nil renderer
+// or empty basedir is a silent no-op.
+func captureThumbnail(basedir string, id [16]byte, r ThumbnailRenderer) (retErr error) {
+	if r == nil || basedir == "" {
+		return nil
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			retErr = fmt.Errorf("thumbnail: renderer panic: %v", rec)
+		}
+	}()
+	img, ok := r.RenderSessionThumbnail(id)
+	if !ok {
+		return nil
+	}
+	if img == nil {
+		return errors.New("thumbnail: renderer returned ok=true with nil image")
+	}
+	scaled := thumbnail.DownscaleAspectFit(img, 480, 270)
+	pngPath := filepath.Join(basedir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	return thumbnail.WritePNGAtomic(pngPath, scaled)
+}

--- a/internal/runtime/server/thumbnail_renderer.go
+++ b/internal/runtime/server/thumbnail_renderer.go
@@ -1,0 +1,129 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/runtime/server/thumbnail_renderer.go
+// Summary: Composes per-pane buffer snapshots into a single workspace
+// cell grid for thumbnail rendering. The composer is the server-only
+// glue between the publisher's authoritative state and the shared
+// internal/thumbnail render primitive.
+
+package server
+
+import (
+	"image"
+
+	texelcore "github.com/framegrace/texelui/core"
+
+	"github.com/framegrace/texelation/internal/thumbnail"
+	"github.com/framegrace/texelation/protocol"
+	"github.com/framegrace/texelation/texel"
+)
+
+// paneRender is the per-pane input to composePaneGrid. Coordinates are
+// workspace-relative; rows[y][x] is a cell.
+type paneRender struct {
+	x, y int
+	w, h int
+	rows [][]texelcore.Cell
+}
+
+// composePaneGrid paints pane buffers onto a (workspaceW × workspaceH)
+// cell grid. Out-of-bounds cells are dropped silently. The grid is
+// initialised with zero-value Cells (Ch=0, default style) which the
+// renderer treats as blanks.
+func composePaneGrid(workspaceW, workspaceH int, panes []paneRender) [][]texelcore.Cell {
+	grid := make([][]texelcore.Cell, workspaceH)
+	for y := 0; y < workspaceH; y++ {
+		grid[y] = make([]texelcore.Cell, workspaceW)
+	}
+	for _, p := range panes {
+		for ry, row := range p.rows {
+			absY := p.y + ry
+			if absY < 0 || absY >= workspaceH {
+				continue
+			}
+			for rx, cell := range row {
+				absX := p.x + rx
+				if absX < 0 || absX >= workspaceW {
+					continue
+				}
+				grid[absY][absX] = cell
+			}
+		}
+	}
+	return grid
+}
+
+// workspaceBounds derives (w, h) from the union of pane rects in a
+// geometry snapshot. We bound-box rather than expose a separate
+// ViewportSize getter on the engine — the geometry snapshot already
+// has the data, and a separate getter would be a wider engine change
+// than F.1 needs.
+func workspaceBounds(snap protocol.TreeSnapshot) (int, int) {
+	maxX, maxY := 0, 0
+	for _, p := range snap.Panes {
+		if right := int(p.X) + int(p.Width); right > maxX {
+			maxX = right
+		}
+		if bottom := int(p.Y) + int(p.Height); bottom > maxY {
+			maxY = bottom
+		}
+	}
+	return maxX, maxY
+}
+
+// RenderSessionThumbnail extracts pane buffers from the publisher
+// (which already maintains them for diff generation) and renders the
+// composed grid to an image via the shared primitive. Returns
+// (nil, false) when the session has no renderable content (no panes,
+// empty publisher state, geometry-snapshot failure).
+//
+// Implements the ThumbnailRenderer interface declared in thumbnail.go.
+func (s *DesktopSink) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	if s == nil {
+		return nil, false
+	}
+	pub := s.Publisher()
+	desktop := s.Desktop()
+	if pub == nil || desktop == nil {
+		return nil, false
+	}
+	geom, err := s.GeometrySnapshot()
+	if err != nil {
+		return nil, false
+	}
+	workspaceW, workspaceH := workspaceBounds(geom)
+	if workspaceW <= 0 || workspaceH <= 0 {
+		return nil, false
+	}
+	panes := make([]paneRender, 0, len(geom.Panes))
+	for _, p := range geom.Panes {
+		buf := pub.PrevBufferFor(p.PaneID)
+		if len(buf) == 0 {
+			continue
+		}
+		// texel.Cell == texelcore.Cell via the alias in
+		// texel/core_aliases.go, so the slice types are identical.
+		coreRows := make([][]texelcore.Cell, len(buf))
+		for y, row := range buf {
+			coreRows[y] = ([]texelcore.Cell)(row)
+			_ = texel.Cell{} // keep texel import live; alias is referenced
+		}
+		panes = append(panes, paneRender{
+			x:    int(p.X),
+			y:    int(p.Y),
+			w:    int(p.Width),
+			h:    int(p.Height),
+			rows: coreRows,
+		})
+	}
+	if len(panes) == 0 {
+		return nil, false
+	}
+	grid := composePaneGrid(workspaceW, workspaceH, panes)
+	img, err := thumbnail.RenderGrid(grid)
+	if err != nil {
+		return nil, false
+	}
+	return img, true
+}

--- a/internal/runtime/server/thumbnail_renderer.go
+++ b/internal/runtime/server/thumbnail_renderer.go
@@ -4,7 +4,7 @@
 // File: internal/runtime/server/thumbnail_renderer.go
 // Summary: Composes per-pane buffer snapshots into a single workspace
 // cell grid for thumbnail rendering. The composer is the server-only
-// glue between the publisher's authoritative state and the shared
+// glue between the desktop's authoritative pane state and the shared
 // internal/thumbnail render primitive.
 
 package server
@@ -15,7 +15,6 @@ import (
 	texelcore "github.com/framegrace/texelui/core"
 
 	"github.com/framegrace/texelation/internal/thumbnail"
-	"github.com/framegrace/texelation/protocol"
 	"github.com/framegrace/texelation/texel"
 )
 
@@ -54,73 +53,62 @@ func composePaneGrid(workspaceW, workspaceH int, panes []paneRender) [][]texelco
 	return grid
 }
 
-// workspaceBounds derives (w, h) from the union of pane rects in a
-// geometry snapshot. We bound-box rather than expose a separate
-// ViewportSize getter on the engine — the geometry snapshot already
-// has the data, and a separate getter would be a wider engine change
-// than F.1 needs.
-func workspaceBounds(snap protocol.TreeSnapshot) (int, int) {
-	maxX, maxY := 0, 0
-	for _, p := range snap.Panes {
-		if right := int(p.X) + int(p.Width); right > maxX {
-			maxX = right
-		}
-		if bottom := int(p.Y) + int(p.Height); bottom > maxY {
-			maxY = bottom
-		}
-	}
-	return maxX, maxY
-}
-
-// RenderSessionThumbnail extracts pane buffers from the publisher
-// (which already maintains them for diff generation) and renders the
-// composed grid to an image via the shared primitive. Returns
-// (nil, false) when the session has no renderable content (no panes,
-// empty publisher state, geometry-snapshot failure).
+// RenderSessionThumbnail renders the desktop's current pane buffers to
+// an image via the shared primitive. Returns (nil, false) when the
+// desktop has no renderable content.
+//
+// We pull from desktop.SnapshotBuffers (the authoritative pane state)
+// rather than publisher.prevBuffers because the latter is per-publisher
+// — the picker's own connection installs its own empty publisher into
+// the sink, which would replace the live session's populated one and
+// produce blank thumbnails. SnapshotBuffers has no such ambiguity:
+// the desktop is single-instance.
+//
+// The id parameter is informational (used by callers to key the
+// on-disk PNG file). Once F.2 lands and per-session pane state becomes
+// a thing, this method may need to switch on id; for F.1 the active
+// desktop is the only thing we render.
 //
 // Implements the ThumbnailRenderer interface declared in thumbnail.go.
 func (s *DesktopSink) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
 	if s == nil {
 		return nil, false
 	}
-	pub := s.Publisher()
 	desktop := s.Desktop()
-	if pub == nil || desktop == nil {
+	if desktop == nil {
 		return nil, false
 	}
-	geom, err := s.GeometrySnapshot()
-	if err != nil {
+	snaps := desktop.SnapshotBuffers()
+	if len(snaps) == 0 {
 		return nil, false
 	}
-	workspaceW, workspaceH := workspaceBounds(geom)
-	if workspaceW <= 0 || workspaceH <= 0 {
-		return nil, false
-	}
-	panes := make([]paneRender, 0, len(geom.Panes))
-	for _, p := range geom.Panes {
-		buf := pub.PrevBufferFor(p.PaneID)
-		if len(buf) == 0 {
+	maxX, maxY := 0, 0
+	panes := make([]paneRender, 0, len(snaps))
+	for _, ps := range snaps {
+		if len(ps.Buffer) == 0 {
 			continue
 		}
 		// texel.Cell == texelcore.Cell via the alias in
 		// texel/core_aliases.go, so the slice types are identical.
-		coreRows := make([][]texelcore.Cell, len(buf))
-		for y, row := range buf {
+		coreRows := make([][]texelcore.Cell, len(ps.Buffer))
+		for y, row := range ps.Buffer {
 			coreRows[y] = ([]texelcore.Cell)(row)
-			_ = texel.Cell{} // keep texel import live; alias is referenced
 		}
-		panes = append(panes, paneRender{
-			x:    int(p.X),
-			y:    int(p.Y),
-			w:    int(p.Width),
-			h:    int(p.Height),
-			rows: coreRows,
-		})
+		_ = texel.Cell{} // keep texel import live; alias is referenced
+		px, py := ps.Rect.X, ps.Rect.Y
+		pw, ph := ps.Rect.Width, ps.Rect.Height
+		panes = append(panes, paneRender{x: px, y: py, w: pw, h: ph, rows: coreRows})
+		if right := px + pw; right > maxX {
+			maxX = right
+		}
+		if bottom := py + ph; bottom > maxY {
+			maxY = bottom
+		}
 	}
-	if len(panes) == 0 {
+	if len(panes) == 0 || maxX <= 0 || maxY <= 0 {
 		return nil, false
 	}
-	grid := composePaneGrid(workspaceW, workspaceH, panes)
+	grid := composePaneGrid(maxX, maxY, panes)
 	img, err := thumbnail.RenderGrid(grid)
 	if err != nil {
 		return nil, false

--- a/internal/runtime/server/thumbnail_renderer_test.go
+++ b/internal/runtime/server/thumbnail_renderer_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
+)
+
+func TestComposePaneGrid_SinglePane(t *testing.T) {
+	pane := paneRender{
+		x: 0, y: 0, w: 4, h: 2,
+		rows: [][]texelcore.Cell{
+			{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}, {Ch: 'd'}},
+			{{Ch: 'e'}, {Ch: 'f'}, {Ch: 'g'}, {Ch: 'h'}},
+		},
+	}
+	grid := composePaneGrid(4, 2, []paneRender{pane})
+	if len(grid) != 2 || len(grid[0]) != 4 {
+		t.Fatalf("dims = %dx%d, want 4x2", len(grid[0]), len(grid))
+	}
+	if grid[0][0].Ch != 'a' || grid[1][3].Ch != 'h' {
+		t.Errorf("content mismatch: grid=%v", grid)
+	}
+}
+
+func TestComposePaneGrid_TwoPanesSideBySide(t *testing.T) {
+	left := paneRender{
+		x: 0, y: 0, w: 2, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'L'}, {Ch: '1'}}},
+	}
+	right := paneRender{
+		x: 2, y: 0, w: 2, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'R'}, {Ch: '1'}}},
+	}
+	grid := composePaneGrid(4, 1, []paneRender{left, right})
+	if grid[0][0].Ch != 'L' || grid[0][1].Ch != '1' {
+		t.Errorf("left mis-painted: %v", grid[0])
+	}
+	if grid[0][2].Ch != 'R' || grid[0][3].Ch != '1' {
+		t.Errorf("right mis-painted: %v", grid[0])
+	}
+}
+
+func TestComposePaneGrid_OverflowClipped(t *testing.T) {
+	pane := paneRender{
+		x: 0, y: 0, w: 10, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'x'}, {Ch: 'y'}, {Ch: 'z'}}},
+	}
+	grid := composePaneGrid(10, 1, []paneRender{pane})
+	if grid[0][0].Ch != 'x' || grid[0][1].Ch != 'y' || grid[0][2].Ch != 'z' {
+		t.Errorf("front-pad mismatch: %v", grid[0])
+	}
+	for i := 3; i < 10; i++ {
+		if grid[0][i].Ch != ' ' && grid[0][i].Ch != 0 {
+			t.Errorf("expected blank at col %d, got %q", i, grid[0][i].Ch)
+		}
+	}
+}
+
+func TestComposePaneGrid_OutOfBoundsPaneIgnored(t *testing.T) {
+	pane := paneRender{
+		x: 100, y: 100, w: 4, h: 1,
+		rows: [][]texelcore.Cell{{{Ch: 'a'}, {Ch: 'b'}, {Ch: 'c'}, {Ch: 'd'}}},
+	}
+	_ = composePaneGrid(4, 1, []paneRender{pane}) // should not panic
+}

--- a/internal/runtime/server/thumbnail_test.go
+++ b/internal/runtime/server/thumbnail_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package server
+
+import (
+	"encoding/hex"
+	"image"
+	"image/color"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeRenderer is a stub ThumbnailRenderer used by trigger tests so
+// we don't drag textrender + a real font into the unit harness.
+type fakeRenderer struct {
+	calls int
+}
+
+func (f *fakeRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	f.calls++
+	img := image.NewRGBA(image.Rect(0, 0, 80, 24))
+	for y := 0; y < 24; y++ {
+		for x := 0; x < 80; x++ {
+			img.Set(x, y, color.RGBA{R: 0x40, G: 0x40, B: 0x40, A: 0xFF})
+		}
+	}
+	return img, true
+}
+
+type skipRenderer struct{}
+
+func (skipRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	return nil, false
+}
+
+type panicRenderer struct{}
+
+func (panicRenderer) RenderSessionThumbnail(id [16]byte) (image.Image, bool) {
+	panic("intentional test panic")
+}
+
+func TestCaptureThumbnail_WritesPNG(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0x77}
+	r := &fakeRenderer{}
+	if err := captureThumbnail(dir, id, r); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Fatalf("stat png: %v", err)
+	}
+}
+
+func TestCaptureThumbnail_RendererSkip(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	id := [16]byte{0x88}
+	if err := captureThumbnail(dir, id, skipRenderer{}); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected no PNG when renderer skips, stat err=%v", err)
+	}
+}
+
+func TestCaptureThumbnail_NilRendererSilent(t *testing.T) {
+	if err := captureThumbnail(t.TempDir(), [16]byte{}, nil); err != nil {
+		t.Errorf("expected nil error for nil renderer, got %v", err)
+	}
+}
+
+func TestCaptureThumbnail_RendererPanicSurvives(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755)
+	if err := captureThumbnail(dir, [16]byte{0x99}, panicRenderer{}); err == nil {
+		t.Errorf("expected error from panicking renderer")
+	}
+}
+
+func TestManager_CaptureOnShutdown(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0x55}
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25_000_000); err != nil { // 25ms in ns
+		t.Fatalf("enable: %v", err)
+	}
+	r := &fakeRenderer{}
+	m.SetThumbnailRenderer(r)
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	m.ShutdownSessions()
+	if r.calls < 1 {
+		t.Errorf("expected at least 1 thumbnail render, got %d", r.calls)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Errorf("expected PNG after shutdown, stat err=%v", err)
+	}
+}
+
+func TestManager_CaptureOnLastDisconnect(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0x66}
+	if err := os.MkdirAll(filepath.Join(dir, SessionsDirName), 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25_000_000); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	r := &fakeRenderer{}
+	m.SetThumbnailRenderer(r)
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	m.Close(id)
+	if r.calls < 1 {
+		t.Errorf("expected thumbnail render on Close, got %d", r.calls)
+	}
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Errorf("expected PNG after Close, stat err=%v", err)
+	}
+}
+
+func TestManager_NoCaptureWhenRendererUnset(t *testing.T) {
+	dir := t.TempDir()
+	id := [16]byte{0xAA}
+	m := NewManager()
+	if err := m.EnablePersistence(dir, 25_000_000); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if _, err := m.NewSessionWithID(id); err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	m.Close(id)
+	pngPath := filepath.Join(dir, SessionsDirName, hex.EncodeToString(id[:])+".png")
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Errorf("expected no PNG when renderer unset, stat err=%v", err)
+	}
+}

--- a/internal/runtime/server/viewport_integration_test.go
+++ b/internal/runtime/server/viewport_integration_test.go
@@ -544,7 +544,7 @@ func newMemHarnessOpts(t *testing.T, opts memHarnessOpts) *memHarness {
 		}
 		pub := NewDesktopPublisher(desktop, sess)
 		sink.SetPublisher(pub)
-		conn := newConnection(h.serverConn, sess, sink, resuming, false /*rehydrated*/)
+		conn := newConnection(h.serverConn, sess, sink, nil, resuming, false /*rehydrated*/)
 		// Wire nudge so sendPending fires when publisher queues diffs.
 		pub.SetNotifier(conn.nudge)
 		h.mu.Lock()
@@ -1158,7 +1158,7 @@ func (h *memHarness) Restart(t *testing.T) {
 		}
 		pub := NewDesktopPublisher(h.desktop, sess)
 		h.sink.SetPublisher(pub)
-		conn := newConnection(h.serverConn, sess, h.sink, resuming, true /*rehydrated*/)
+		conn := newConnection(h.serverConn, sess, h.sink, nil, resuming, true /*rehydrated*/)
 		pub.SetNotifier(conn.nudge)
 		h.mu.Lock()
 		h.session = sess

--- a/internal/thumbnail/render.go
+++ b/internal/thumbnail/render.go
@@ -1,0 +1,112 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: internal/thumbnail/render.go
+// Summary: Shared image-rendering primitive used by server lifecycle
+// thumbnail capture (Plan F.1) and client user-initiated screenshots.
+// Knows about cells; does not know about sessions, panes, or sockets.
+
+package thumbnail
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	stddraw "image/draw"
+	"image/png"
+	"os"
+
+	xdraw "golang.org/x/image/draw"
+
+	texelcore "github.com/framegrace/texelui/core"
+	"github.com/framegrace/texelui/graphics/textrender"
+)
+
+// ErrEmptyGrid is returned by RenderGrid for nil or zero-row inputs.
+var ErrEmptyGrid = errors.New("thumbnail: empty cell grid")
+
+// RenderGrid renders a cell grid to an image using the system text
+// renderer (font auto-detected). Callers are responsible for supplying
+// a non-empty grid; this function does not synthesize background fill
+// for the empty case.
+func RenderGrid(grid [][]texelcore.Cell) (image.Image, error) {
+	if len(grid) == 0 {
+		return nil, ErrEmptyGrid
+	}
+	if len(grid[0]) == 0 {
+		return nil, ErrEmptyGrid
+	}
+	fontPath, err := textrender.DetectFont()
+	if err != nil {
+		return nil, fmt.Errorf("thumbnail: font detect: %w", err)
+	}
+	renderer, err := textrender.New(textrender.Config{FontPath: fontPath})
+	if err != nil {
+		return nil, fmt.Errorf("thumbnail: renderer: %w", err)
+	}
+	return renderer.Render(grid), nil
+}
+
+// WritePNGAtomic encodes img to path via tmp+rename so a crash mid-
+// write doesn't leave a half-PNG. Used both by server lifecycle
+// capture and by the client screenshot path.
+func WritePNGAtomic(path string, img image.Image) error {
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("thumbnail: create %s: %w", tmp, err)
+	}
+	encErr := png.Encode(f, img)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if encErr != nil || syncErr != nil || closeErr != nil {
+		_ = os.Remove(tmp)
+		switch {
+		case encErr != nil:
+			return fmt.Errorf("thumbnail: encode: %w", encErr)
+		case syncErr != nil:
+			return fmt.Errorf("thumbnail: sync: %w", syncErr)
+		default:
+			return fmt.Errorf("thumbnail: close: %w", closeErr)
+		}
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("thumbnail: rename %s: %w", path, err)
+	}
+	return nil
+}
+
+// DownscaleAspectFit returns a (targetW × targetH) RGBA image with src
+// drawn into the centred subrect that preserves src's aspect ratio.
+// Background outside the scaled rect is left transparent (zero pixels);
+// callers wanting an opaque background should fill before passing.
+func DownscaleAspectFit(src image.Image, targetW, targetH int) *image.RGBA {
+	dst := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
+	srcW := src.Bounds().Dx()
+	srcH := src.Bounds().Dy()
+	if srcW == 0 || srcH == 0 {
+		return dst
+	}
+	srcRatio := float64(srcW) / float64(srcH)
+	dstRatio := float64(targetW) / float64(targetH)
+	var scaledW, scaledH int
+	if srcRatio > dstRatio {
+		scaledW = targetW
+		scaledH = int(float64(targetW) / srcRatio)
+	} else {
+		scaledH = targetH
+		scaledW = int(float64(targetH) * srcRatio)
+	}
+	if scaledW < 1 {
+		scaledW = 1
+	}
+	if scaledH < 1 {
+		scaledH = 1
+	}
+	offsetX := (targetW - scaledW) / 2
+	offsetY := (targetH - scaledH) / 2
+	dstRect := image.Rect(offsetX, offsetY, offsetX+scaledW, offsetY+scaledH)
+	xdraw.ApproxBiLinear.Scale(dst, dstRect, src, src.Bounds(), stddraw.Over, nil)
+	return dst
+}

--- a/internal/thumbnail/render_test.go
+++ b/internal/thumbnail/render_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package thumbnail
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	texelcore "github.com/framegrace/texelui/core"
+)
+
+func makeTestImage(w, h int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0x80, A: 0xFF})
+		}
+	}
+	return img
+}
+
+func TestRenderGrid_Smoke(t *testing.T) {
+	grid := [][]texelcore.Cell{
+		{{Ch: 'h'}, {Ch: 'e'}, {Ch: 'l'}, {Ch: 'l'}},
+		{{Ch: 'o'}, {Ch: ' '}, {Ch: 't'}, {Ch: 'x'}},
+	}
+	img, err := RenderGrid(grid)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("nil image")
+	}
+	if img.Bounds().Dx() <= 0 || img.Bounds().Dy() <= 0 {
+		t.Fatalf("zero-sized image: %v", img.Bounds())
+	}
+}
+
+func TestRenderGrid_EmptyGrid(t *testing.T) {
+	if _, err := RenderGrid(nil); err == nil {
+		t.Fatalf("expected error on nil grid")
+	}
+	if _, err := RenderGrid([][]texelcore.Cell{}); err == nil {
+		t.Fatalf("expected error on empty grid")
+	}
+}
+
+func TestWritePNGAtomic_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thumb.png")
+	if err := WritePNGAtomic(path, makeTestImage(40, 30)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("tmp file not cleaned: stat err=%v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	img, err := png.Decode(f)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if img.Bounds().Dx() != 40 || img.Bounds().Dy() != 30 {
+		t.Fatalf("decoded dims = %dx%d, want 40x30", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestWritePNGAtomic_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "thumb.png")
+	if err := WritePNGAtomic(path, makeTestImage(20, 20)); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := WritePNGAtomic(path, makeTestImage(40, 40)); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	f, _ := os.Open(path)
+	defer f.Close()
+	img, _ := png.Decode(f)
+	if img.Bounds().Dx() != 40 {
+		t.Fatalf("expected overwrite to 40x40, got %dx%d", img.Bounds().Dx(), img.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_Wider(t *testing.T) {
+	src := makeTestImage(800, 200)
+	out := DownscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_Taller(t *testing.T) {
+	src := makeTestImage(200, 800)
+	out := DownscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}
+
+func TestDownscaleAspectFit_AlreadySmall(t *testing.T) {
+	src := makeTestImage(100, 80)
+	out := DownscaleAspectFit(src, 480, 270)
+	if out.Bounds().Dx() != 480 || out.Bounds().Dy() != 270 {
+		t.Fatalf("expected 480x270 canvas, got %dx%d", out.Bounds().Dx(), out.Bounds().Dy())
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -40,7 +40,16 @@ const (
 // progress messages during expensive resume processing so the boot
 // splash can render fine-grained text instead of "Loading session…"
 // for the full WAL-replay window.
-const Version uint8 = 4
+//
+// v5 (issue #199 Plan F.1): adds MsgListSessions, MsgListSessionsResponse,
+// MsgRecoverSession, MsgRenameSession, MsgDeleteSession, MsgFetchThumbnail,
+// MsgFetchThumbnailResponse, MsgSessionOpResponse plus SessionSummary /
+// LiveSummary wire types. Strict version equality means old (v4) clients
+// fail at the header check — there is no in-band fallback path; users on
+// the old client see a generic connect error and must upgrade. Single-binary
+// deployment makes this acceptable; revisit if a multi-version client
+// population emerges.
+const Version uint8 = 5
 
 // MessageType enumerates the canonical message categories exchanged between
 // client and server.
@@ -88,6 +97,29 @@ const (
 	// splash; missing this message is harmless — the splash falls back
 	// to the static "Loading session" stage.
 	MsgBootProgress
+	// MsgListSessions / MsgListSessionsResponse drive the F.1 stored-
+	// session recovery picker. Request has no payload; response carries
+	// Live and Stored slices.
+	MsgListSessions
+	MsgListSessionsResponse
+	// MsgRecoverSession: client picks a stored session to hydrate.
+	// Server replies with the ordinary MsgConnectAccept + MsgTreeSnapshot
+	// flow; picker hands off to the existing connect path.
+	MsgRecoverSession
+	// MsgRenameSession: edit a stored session's label without recovering.
+	MsgRenameSession
+	// MsgDeleteSession: remove a stored session's JSON + PNG sidecar.
+	// Refused with error if the session is currently live.
+	MsgDeleteSession
+	// MsgFetchThumbnail / MsgFetchThumbnailResponse: lazy pull of a
+	// stored session's PNG thumbnail. Only fires for graphics-capable
+	// terminals; non-graphics clients render an ASCII fallback instead.
+	MsgFetchThumbnail
+	MsgFetchThumbnailResponse
+	// MsgSessionOpResponse: dedicated ack for rename/delete (and any
+	// future session-mutating op). Carries OK + Error + OpType so the
+	// picker can correlate without conflating with MsgListSessionsResponse.
+	MsgSessionOpResponse
 )
 
 // Header describes the fixed portion of every frame exchanged over the wire.

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -127,8 +127,34 @@ func TestReadMessage_PayloadTooLarge(t *testing.T) {
 	}
 }
 
-func TestProtocolVersionIs4(t *testing.T) {
-	if Version != 4 {
-		t.Fatalf("expected Version=4, got %d", Version)
+func TestProtocolVersionIs5(t *testing.T) {
+	if Version != 5 {
+		t.Fatalf("expected Version=5, got %d", Version)
+	}
+}
+
+func TestSessionPickerMessageTypes(t *testing.T) {
+	// Pin iota positions so an accidental reorder of preceding entries
+	// doesn't silently shift these to a MsgType already on the wire.
+	cases := []struct {
+		name string
+		got  MessageType
+		want MessageType
+	}{
+		{"MsgListSessions", MsgListSessions, 36},
+		{"MsgListSessionsResponse", MsgListSessionsResponse, 37},
+		{"MsgRecoverSession", MsgRecoverSession, 38},
+		{"MsgRenameSession", MsgRenameSession, 39},
+		{"MsgDeleteSession", MsgDeleteSession, 40},
+		{"MsgFetchThumbnail", MsgFetchThumbnail, 41},
+		{"MsgFetchThumbnailResponse", MsgFetchThumbnailResponse, 42},
+		{"MsgSessionOpResponse", MsgSessionOpResponse, 43},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.got != c.want {
+				t.Fatalf("%s = %d, want %d", c.name, c.got, c.want)
+			}
+		})
 	}
 }

--- a/protocol/session_picker.go
+++ b/protocol/session_picker.go
@@ -1,0 +1,485 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// File: protocol/session_picker.go
+// Summary: Wire types and encoders for the F.1 session-recovery picker.
+// Usage: Used by the server's connection handler to advertise stored
+//   sessions and by the client's boot-package picker to consume them.
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// SessionSummary describes a stored (fossilized) session on disk.
+// HasThumbnail indicates whether <sessionID>.png exists alongside the
+// JSON sidecar; the client fetches the PNG lazily via MsgFetchThumbnail.
+// Layout is optional — nil when the StoredSession was written before
+// Plan F.1 added the Layout field, in which case the picker falls back
+// to a single-box ASCII placeholder.
+type SessionSummary struct {
+	SessionID      [16]byte
+	Label          string
+	LastActive     int64 // unix seconds
+	PaneCount      int32
+	FirstPaneTitle string
+	Pinned         bool
+	HasThumbnail   bool
+	Layout         *TreeNodeSnapshot
+}
+
+// LiveSummary describes a hydrated (in-memory) session. Populated only
+// by F.2; F.1 always sends an empty slice.
+type LiveSummary struct {
+	SessionID       [16]byte
+	Label           string
+	AttachedClients int32
+	PaneCount       int32
+	LastInputAt     int64
+}
+
+// EncodeSessionSummary writes a SessionSummary in the picker wire format.
+// Layout is preceded by a uint8 flag (1 = present, 0 = nil) to handle
+// the optional case without needing a sentinel TreeNodeSnapshot.
+func EncodeSessionSummary(s SessionSummary) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(s.SessionID[:])
+	if err := encodeString(buf, s.Label); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.LastActive); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.PaneCount); err != nil {
+		return nil, err
+	}
+	if err := encodeString(buf, s.FirstPaneTitle); err != nil {
+		return nil, err
+	}
+	flags := byte(0)
+	if s.Pinned {
+		flags |= 0x01
+	}
+	if s.HasThumbnail {
+		flags |= 0x02
+	}
+	buf.WriteByte(flags)
+	if s.Layout == nil {
+		buf.WriteByte(0)
+	} else {
+		buf.WriteByte(1)
+		if err := encodeTreeNode(buf, *s.Layout); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeSessionSummary reads a SessionSummary and returns the number of
+// bytes consumed so callers parsing slices of summaries can advance.
+func DecodeSessionSummary(b []byte) (SessionSummary, int, error) {
+	var s SessionSummary
+	start := len(b)
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	copy(s.SessionID[:], b[:16])
+	b = b[16:]
+	label, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.Label = label
+	b = rest
+	if len(b) < 8 {
+		return s, 0, ErrPayloadShort
+	}
+	s.LastActive = int64(binary.LittleEndian.Uint64(b[:8]))
+	b = b[8:]
+	if len(b) < 4 {
+		return s, 0, ErrPayloadShort
+	}
+	s.PaneCount = int32(binary.LittleEndian.Uint32(b[:4]))
+	b = b[4:]
+	title, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.FirstPaneTitle = title
+	b = rest
+	if len(b) < 1 {
+		return s, 0, ErrPayloadShort
+	}
+	flags := b[0]
+	s.Pinned = flags&0x01 != 0
+	s.HasThumbnail = flags&0x02 != 0
+	b = b[1:]
+	if len(b) < 1 {
+		return s, 0, ErrPayloadShort
+	}
+	hasLayout := b[0]
+	b = b[1:]
+	if hasLayout != 0 {
+		node, rest, err := decodeTreeNode(b)
+		if err != nil {
+			return s, 0, err
+		}
+		s.Layout = &node
+		b = rest
+	}
+	return s, start - len(b), nil
+}
+
+// EncodeLiveSummary writes a LiveSummary in the picker wire format.
+func EncodeLiveSummary(s LiveSummary) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(s.SessionID[:])
+	if err := encodeString(buf, s.Label); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.AttachedClients); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.PaneCount); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, s.LastInputAt); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeLiveSummary reads a LiveSummary and returns bytes consumed.
+func DecodeLiveSummary(b []byte) (LiveSummary, int, error) {
+	var s LiveSummary
+	start := len(b)
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	copy(s.SessionID[:], b[:16])
+	b = b[16:]
+	label, rest, err := decodeString(b)
+	if err != nil {
+		return s, 0, err
+	}
+	s.Label = label
+	b = rest
+	if len(b) < 16 {
+		return s, 0, ErrPayloadShort
+	}
+	s.AttachedClients = int32(binary.LittleEndian.Uint32(b[:4]))
+	s.PaneCount = int32(binary.LittleEndian.Uint32(b[4:8]))
+	s.LastInputAt = int64(binary.LittleEndian.Uint64(b[8:16]))
+	b = b[16:]
+	return s, start - len(b), nil
+}
+
+// ListSessionsRequest is the client-side trigger for the recovery
+// picker's catalog. Empty payload in v5; reserved for filters in F.2.
+type ListSessionsRequest struct{}
+
+// EncodeListSessionsRequest returns an empty payload (no fields in v5).
+func EncodeListSessionsRequest(r ListSessionsRequest) ([]byte, error) {
+	return nil, nil
+}
+
+// DecodeListSessionsRequest tolerates trailing bytes for forward-compat
+// with future filter additions.
+func DecodeListSessionsRequest(b []byte) (ListSessionsRequest, error) {
+	return ListSessionsRequest{}, nil
+}
+
+// ListSessionsResponse carries the catalog of recoverable sessions.
+// Live is empty in F.1; populated by F.2.
+type ListSessionsResponse struct {
+	Live   []LiveSummary
+	Stored []SessionSummary
+}
+
+// EncodeListSessionsResponse writes Live and Stored slices.
+func EncodeListSessionsResponse(r ListSessionsResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if len(r.Live) > 0xFFFF {
+		return nil, ErrStringTooLong
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Live))); err != nil {
+		return nil, err
+	}
+	for _, l := range r.Live {
+		raw, err := EncodeLiveSummary(l)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(raw)
+	}
+	if len(r.Stored) > 0xFFFF {
+		return nil, ErrStringTooLong
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint16(len(r.Stored))); err != nil {
+		return nil, err
+	}
+	for _, s := range r.Stored {
+		raw, err := EncodeSessionSummary(s)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(raw)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeListSessionsResponse parses Live then Stored slices in order.
+func DecodeListSessionsResponse(b []byte) (ListSessionsResponse, error) {
+	var r ListSessionsResponse
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	liveCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if liveCount > 0 {
+		r.Live = make([]LiveSummary, 0, liveCount)
+		for i := uint16(0); i < liveCount; i++ {
+			l, consumed, err := DecodeLiveSummary(b)
+			if err != nil {
+				return ListSessionsResponse{}, err
+			}
+			r.Live = append(r.Live, l)
+			b = b[consumed:]
+		}
+	}
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	storedCount := binary.LittleEndian.Uint16(b[:2])
+	b = b[2:]
+	if storedCount > 0 {
+		r.Stored = make([]SessionSummary, 0, storedCount)
+		for i := uint16(0); i < storedCount; i++ {
+			s, consumed, err := DecodeSessionSummary(b)
+			if err != nil {
+				return ListSessionsResponse{}, err
+			}
+			r.Stored = append(r.Stored, s)
+			b = b[consumed:]
+		}
+	}
+	return r, nil
+}
+
+// RecoverSessionRequest hydrates a stored session and connects to it.
+// NewLabel is optional — empty string means leave the label unchanged.
+type RecoverSessionRequest struct {
+	SessionID [16]byte
+	NewLabel  string
+}
+
+// EncodeRecoverSessionRequest writes the recovery request payload.
+func EncodeRecoverSessionRequest(r RecoverSessionRequest) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(r.SessionID[:])
+	if err := encodeString(buf, r.NewLabel); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeRecoverSessionRequest reads the recovery request payload.
+func DecodeRecoverSessionRequest(b []byte) (RecoverSessionRequest, error) {
+	var r RecoverSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	label, _, err := decodeString(b[16:])
+	if err != nil {
+		return r, err
+	}
+	r.NewLabel = label
+	return r, nil
+}
+
+// RenameSessionRequest edits a stored session's label without recovering.
+type RenameSessionRequest struct {
+	SessionID [16]byte
+	NewLabel  string
+}
+
+// EncodeRenameSessionRequest writes the rename request payload.
+func EncodeRenameSessionRequest(r RenameSessionRequest) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.Write(r.SessionID[:])
+	if err := encodeString(buf, r.NewLabel); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeRenameSessionRequest reads the rename request payload.
+func DecodeRenameSessionRequest(b []byte) (RenameSessionRequest, error) {
+	var r RenameSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	label, _, err := decodeString(b[16:])
+	if err != nil {
+		return r, err
+	}
+	r.NewLabel = label
+	return r, nil
+}
+
+// DeleteSessionRequest removes a stored session's JSON + PNG sidecar.
+type DeleteSessionRequest struct {
+	SessionID [16]byte
+}
+
+// EncodeDeleteSessionRequest writes the delete request payload.
+func EncodeDeleteSessionRequest(r DeleteSessionRequest) ([]byte, error) {
+	out := make([]byte, 16)
+	copy(out, r.SessionID[:])
+	return out, nil
+}
+
+// DecodeDeleteSessionRequest reads the delete request payload.
+func DecodeDeleteSessionRequest(b []byte) (DeleteSessionRequest, error) {
+	var r DeleteSessionRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	return r, nil
+}
+
+// SessionOpKind identifies which op a SessionOpResponse acks. The
+// picker uses this to correlate without needing in-flight request IDs.
+type SessionOpKind uint8
+
+const (
+	OpRename SessionOpKind = iota
+	OpDelete
+)
+
+// SessionOpResponse is the dedicated ack envelope for rename + delete
+// (and any future session-mutating op). OK=false implies a non-empty
+// Error explaining the refusal (live session, not found, IO failure).
+// OpType distinguishes which op this acks so the picker doesn't
+// conflate it with a coincident MsgListSessionsResponse.
+type SessionOpResponse struct {
+	OpType SessionOpKind
+	OK     bool
+	Error  string
+}
+
+// EncodeSessionOpResponse writes the op-response payload.
+func EncodeSessionOpResponse(r SessionOpResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	buf.WriteByte(byte(r.OpType))
+	if r.OK {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	if err := encodeString(buf, r.Error); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeSessionOpResponse reads the op-response payload.
+func DecodeSessionOpResponse(b []byte) (SessionOpResponse, error) {
+	var r SessionOpResponse
+	if len(b) < 2 {
+		return r, ErrPayloadShort
+	}
+	r.OpType = SessionOpKind(b[0])
+	r.OK = b[1] != 0
+	msg, _, err := decodeString(b[2:])
+	if err != nil {
+		return r, err
+	}
+	r.Error = msg
+	return r, nil
+}
+
+// FetchThumbnailRequest pulls a stored session's PNG sidecar.
+type FetchThumbnailRequest struct {
+	SessionID [16]byte
+}
+
+// EncodeFetchThumbnailRequest writes the fetch-thumbnail request payload.
+func EncodeFetchThumbnailRequest(r FetchThumbnailRequest) ([]byte, error) {
+	out := make([]byte, 16)
+	copy(out, r.SessionID[:])
+	return out, nil
+}
+
+// DecodeFetchThumbnailRequest reads the fetch-thumbnail request payload.
+func DecodeFetchThumbnailRequest(b []byte) (FetchThumbnailRequest, error) {
+	var r FetchThumbnailRequest
+	if len(b) < 16 {
+		return r, ErrPayloadShort
+	}
+	copy(r.SessionID[:], b[:16])
+	return r, nil
+}
+
+// FetchThumbnailResponse carries the PNG bytes (or an error explanation
+// if OK=false). PNGs over 16MiB are rejected at the framing layer
+// (MaxPayloadLen); typical sidecars are tens of KB.
+type FetchThumbnailResponse struct {
+	OK    bool
+	Error string
+	PNG   []byte
+}
+
+// EncodeFetchThumbnailResponse writes the fetch-thumbnail response payload.
+func EncodeFetchThumbnailResponse(r FetchThumbnailResponse) ([]byte, error) {
+	buf := bytes.NewBuffer(nil)
+	if r.OK {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+	if err := encodeString(buf, r.Error); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, uint32(len(r.PNG))); err != nil {
+		return nil, err
+	}
+	if len(r.PNG) > 0 {
+		if _, err := buf.Write(r.PNG); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeFetchThumbnailResponse reads the fetch-thumbnail response payload.
+func DecodeFetchThumbnailResponse(b []byte) (FetchThumbnailResponse, error) {
+	var r FetchThumbnailResponse
+	if len(b) < 1 {
+		return r, ErrPayloadShort
+	}
+	r.OK = b[0] != 0
+	b = b[1:]
+	msg, rest, err := decodeString(b)
+	if err != nil {
+		return r, err
+	}
+	r.Error = msg
+	if len(rest) < 4 {
+		return r, ErrPayloadShort
+	}
+	pngLen := binary.LittleEndian.Uint32(rest[:4])
+	rest = rest[4:]
+	if uint32(len(rest)) < pngLen {
+		return r, ErrPayloadShort
+	}
+	if pngLen > 0 {
+		r.PNG = append([]byte(nil), rest[:pngLen]...)
+	}
+	return r, nil
+}

--- a/protocol/session_picker_test.go
+++ b/protocol/session_picker_test.go
@@ -1,0 +1,272 @@
+// Copyright © 2026 Texelation contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package protocol
+
+import (
+	"reflect"
+	"testing"
+)
+
+func makePickerID(b byte) [16]byte {
+	var id [16]byte
+	for i := range id {
+		id[i] = b
+	}
+	return id
+}
+
+func TestSessionSummary_RoundTrip(t *testing.T) {
+	in := SessionSummary{
+		SessionID:      makePickerID(0xAB),
+		Label:          "work-laptop",
+		LastActive:     1714752000,
+		PaneCount:      4,
+		FirstPaneTitle: "nvim · texelation/cmd/texelation",
+		Pinned:         true,
+		HasThumbnail:   true,
+		Layout: &TreeNodeSnapshot{
+			PaneIndex:   -1,
+			Split:       SplitHorizontal,
+			SplitRatios: []float32{0.5, 0.5},
+			Children: []TreeNodeSnapshot{
+				{PaneIndex: 0, Split: SplitNone},
+				{PaneIndex: 1, Split: SplitNone},
+			},
+		},
+	}
+	encoded, err := EncodeSessionSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, consumed, err := DecodeSessionSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if consumed != len(encoded) {
+		t.Fatalf("consumed=%d, len=%d", consumed, len(encoded))
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestSessionSummary_NilLayout(t *testing.T) {
+	in := SessionSummary{
+		SessionID:    makePickerID(0x01),
+		Label:        "untitled",
+		LastActive:   100,
+		PaneCount:    1,
+		HasThumbnail: false,
+		Layout:       nil,
+	}
+	encoded, err := EncodeSessionSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, _, err := DecodeSessionSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Layout != nil {
+		t.Fatalf("expected nil Layout after round-trip, got %#v", out.Layout)
+	}
+}
+
+func TestLiveSummary_RoundTrip(t *testing.T) {
+	in := LiveSummary{
+		SessionID:       makePickerID(0xCD),
+		Label:           "debug-cluster",
+		AttachedClients: 2,
+		PaneCount:       3,
+		LastInputAt:     1714752100,
+	}
+	encoded, err := EncodeLiveSummary(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, consumed, err := DecodeLiveSummary(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if consumed != len(encoded) {
+		t.Fatalf("consumed=%d, len=%d", consumed, len(encoded))
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestListSessionsRequest_RoundTrip(t *testing.T) {
+	in := ListSessionsRequest{}
+	encoded, err := EncodeListSessionsRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(encoded) != 0 {
+		t.Fatalf("expected empty payload for v5 request, got %d bytes", len(encoded))
+	}
+	out, err := DecodeListSessionsRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestListSessionsResponse_RoundTrip(t *testing.T) {
+	in := ListSessionsResponse{
+		Live: []LiveSummary{
+			{SessionID: makePickerID(0xAA), Label: "live-1", PaneCount: 2, LastInputAt: 200},
+		},
+		Stored: []SessionSummary{
+			{SessionID: makePickerID(0xBB), Label: "stored-1", LastActive: 100, PaneCount: 1},
+			{SessionID: makePickerID(0xCC), Label: "stored-2", LastActive: 50, PaneCount: 4, Pinned: true, HasThumbnail: true},
+		},
+	}
+	encoded, err := EncodeListSessionsResponse(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeListSessionsResponse(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch:\n in=%#v\nout=%#v", in, out)
+	}
+}
+
+func TestListSessionsResponse_EmptyBoth(t *testing.T) {
+	in := ListSessionsResponse{}
+	encoded, err := EncodeListSessionsResponse(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeListSessionsResponse(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Live) != 0 || len(out.Stored) != 0 {
+		t.Fatalf("expected empty slices, got Live=%d Stored=%d", len(out.Live), len(out.Stored))
+	}
+}
+
+func TestRecoverSessionRequest_RoundTrip(t *testing.T) {
+	in := RecoverSessionRequest{
+		SessionID: makePickerID(0xFF),
+		NewLabel:  "renamed-on-recover",
+	}
+	encoded, err := EncodeRecoverSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeRecoverSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestRenameSessionRequest_RoundTrip(t *testing.T) {
+	in := RenameSessionRequest{SessionID: makePickerID(0x11), NewLabel: "edit"}
+	encoded, err := EncodeRenameSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeRenameSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestSessionOpResponse_RoundTrip(t *testing.T) {
+	cases := []SessionOpResponse{
+		{OpType: OpRename, OK: true},
+		{OpType: OpRename, OK: false, Error: "session not found"},
+		{OpType: OpDelete, OK: true},
+		{OpType: OpDelete, OK: false, Error: "session is live"},
+	}
+	for i, in := range cases {
+		encoded, err := EncodeSessionOpResponse(in)
+		if err != nil {
+			t.Fatalf("[%d] encode: %v", i, err)
+		}
+		out, err := DecodeSessionOpResponse(encoded)
+		if err != nil {
+			t.Fatalf("[%d] decode: %v", i, err)
+		}
+		if !reflect.DeepEqual(in, out) {
+			t.Fatalf("[%d] round-trip mismatch: in=%#v out=%#v", i, in, out)
+		}
+	}
+}
+
+func TestDeleteSessionRequest_RoundTrip(t *testing.T) {
+	in := DeleteSessionRequest{SessionID: makePickerID(0x22)}
+	encoded, err := EncodeDeleteSessionRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeDeleteSessionRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestFetchThumbnailRequest_RoundTrip(t *testing.T) {
+	in := FetchThumbnailRequest{SessionID: makePickerID(0x33)}
+	encoded, err := EncodeFetchThumbnailRequest(in)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out, err := DecodeFetchThumbnailRequest(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestFetchThumbnailResponse_RoundTrip(t *testing.T) {
+	cases := []FetchThumbnailResponse{
+		{OK: true, PNG: []byte{0x89, 0x50, 0x4E, 0x47}},
+		{OK: false, Error: "missing"},
+		{OK: true, PNG: nil},
+	}
+	for i, in := range cases {
+		encoded, err := EncodeFetchThumbnailResponse(in)
+		if err != nil {
+			t.Fatalf("[%d] encode: %v", i, err)
+		}
+		out, err := DecodeFetchThumbnailResponse(encoded)
+		if err != nil {
+			t.Fatalf("[%d] decode: %v", i, err)
+		}
+		if !pickerBytesEqual(in.PNG, out.PNG) || in.OK != out.OK || in.Error != out.Error {
+			t.Fatalf("[%d] round-trip mismatch: in=%#v out=%#v", i, in, out)
+		}
+	}
+}
+
+func pickerBytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Implements the stored-session recovery picker for issue #199 Plan F.1 — a user with lost client state (wiped state file, fresh machine, reinstall) can now discover and rejoin sessions the daemon has on disk.

**Bumps protocol v4 → v5** with eight new messages (list, list-response, recover, rename, delete, fetch-thumbnail, fetch-thumbnail-response, op-response) and three wire types (`SessionSummary`, `LiveSummary`, `SessionOpResponse`). Strict version equality enforced — old (v4) clients fail at the header check; this is a hard cutover.

**New shared rendering primitive** `internal/thumbnail/` (RenderGrid + WritePNGAtomic + DownscaleAspectFit) used by both server-side lifecycle thumbnail capture and client-side user screenshots — eliminates duplicate textrender wiring.

**Server-side lifecycle thumbnail capture:** `Manager.Close(id)` and `Manager.ShutdownSessions()` capture a thumbnail of each session's workspace before teardown. `DesktopSink.RenderSessionThumbnail` composes per-pane buffers from the publisher's authoritative state into a workspace-shaped cell grid, then renders via the shared primitive. PNGs land at `~/.texelation/sessions/<sessionID>.png` next to the existing JSON sidecar. Boot scan removes orphan PNGs (no matching JSON) and crashed-mid-write `.png.tmp` files.

**Server-side picker handlers:** `Manager.StoredSummaries` (snapshot pattern — RLock + per-record os.Stat outside the lock so disk-bound stats don't block writers), `LiveSummaries` (nil in F.1, populated by F.2), `RenameStored` (rollback on disk-write failure), `DeleteStored` (TOCTOU-safe via `markClosing` held across the unlink). New connection-level handlers: list, recover, rename, delete, fetch-thumbnail (1 MiB stat-cap to defend against local DoS).

**Client-side picker UI** (`cmd/texelation/boot/`): Painter-based rendering pipeline that copies a `[][]core.Cell` buffer to the tcell.Screen and flushes the graphics provider. Real-screenshot thumbnails delegate to `texelui/widgets.Image` (Kitty + half-block + alt-text auto-fallback handled inside the widget); structural layout previews stay as ASCII box-drawing tree from `TreeNodeSnapshot` (legible at 22×8). Lazy fetch with locked map access, deferred pending-clear on goroutine exit, and a `failedFetches` limiter (max 3 attempts) so permanent failures don't render-storm. Two-tier error display: sticky user-action errors (`errMsg`) + transient per-frame Flush errors (`flushErrMsg` that auto-clear).

**Trigger logic in `boot.Run`:** Picker activates when (a) `--recover` flag is passed, OR (b) client state is missing AND the server has stored sessions to offer. Probe → list → user picks → outcome translated to `clientrt.Options.RecoverSessionID`, which the existing connect path consumes via `LookupOrRehydrate`. Picker dial failure surfaces in the splash detail line when `--recover` was explicit (so the user knows their intent failed).

**Client `takeScreenshot` refactored** to use the shared primitive (deduplicates ~10 lines of textrender setup).

## Plan and design

- Spec: [docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md](docs/superpowers/specs/2026-05-03-issue-199-plan-f-session-picker-design.md)
- Plan (v3.2): [docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md](docs/superpowers/plans/2026-05-03-issue-199-plan-f-session-picker.md)

The plan went through four review rounds (general-purpose / code-correctness / silent-failure-hunter agents) before execution; v3.2 incorporates all blocker + important fixes flagged across all rounds.

## Test plan

- [x] \`go test -race ./... -count=1\` — full repo green
- [x] \`go build ./...\` — clean
- [ ] Manual: cold-start with empty client state + populated server sessions → picker appears
- [ ] Manual: \`--recover\` flag with intact client state → picker still appears
- [ ] Manual: pick a stored session → recovers cleanly, panes restored
- [ ] Manual: rename inline → label persists across daemon restart
- [ ] Manual: delete a stored session → JSON + PNG both removed
- [ ] Manual: Kitty terminal → thumbnails render; non-Kitty (half-block) terminal → half-block render; non-graphics terminal → ASCII fallback
- [ ] Manual: client screenshot keybinding still works (uses shared primitive)
- [ ] Manual: simulate stored-session network failure (kill daemon mid-picker) → error banner displayed, picker stays open

## Follow-ups

- F.2 issue (multi-live-sessions) to be filed after this lands; the wire format and Live tab are already in place — F.2 only needs to populate \`Manager.LiveSummaries\` with real data and the picker's Live tab will render it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)